### PR TITLE
feat: reformat confirmation modal , connect reject api call to UI

### DIFF
--- a/packages/pn-personafisica-webapp/src/pages/Deleghe.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/Deleghe.page.tsx
@@ -1,19 +1,55 @@
 import { Box } from '@mui/material';
 import { TitleAndDescription } from '@pagopa-pn/pn-commons';
 
+import { useAppDispatch, useAppSelector } from '../redux/hooks';
+import { RootState } from '../redux/store';
+import {
+  closeRevocationModal,
+  rejectDelegation,
+  revokeDelegation,
+} from '../redux/delegation/actions';
 import Delegates from './components/Deleghe/Delegates';
 import Delegators from './components/Deleghe/Delegators';
+import ConfirmationModal from './components/Deleghe/ConfirmationModal';
 
-const Deleghe = () => (
-  <Box sx={{ marginRight: 2 }}>
-    <TitleAndDescription title={'Deleghe'}>
-      Qui puoi gestire <b>i tuoi delegati</b> e le <b>deleghe a tuo carico</b>. I primi sono le
-      persone fisiche o giuridiche che hai autorizzato alla visualizzazione e gestione delle tue
-      notifiche, le seconde sono color che hanno autorizzato te.
-    </TitleAndDescription>
-    <Delegates />
-    <Delegators />
-  </Box>
-);
+const Deleghe = () => {
+  const { id, open, type } = useAppSelector((state: RootState) => state.revocationModalState);
+  const dispatch = useAppDispatch();
+
+  const handleCloseModal = () => {
+    dispatch(closeRevocationModal());
+  };
+
+  const handleConfirmClick = () => {
+    if (type === 'delegate') {
+      void dispatch(revokeDelegation(id));
+    } else {
+      void dispatch(rejectDelegation(id));
+    }
+  };
+
+  return (
+    <Box sx={{ marginRight: 2 }}>
+      <ConfirmationModal
+        open={open}
+        title={
+          type === 'delegates'
+            ? 'Vuoi davvero revocare la delega?'
+            : 'Vuoi davvero rifiutare la delega?'
+        }
+        handleClose={handleCloseModal}
+        onConfirm={handleConfirmClick}
+        onConfirmLabel={type === 'delegates' ? 'Revoca la delega' : 'Rifiuta la delega'}
+      />
+      <TitleAndDescription title={'Deleghe'}>
+        Qui puoi gestire <b>i tuoi delegati</b> e le <b>deleghe a tuo carico</b>. I primi sono le
+        persone fisiche o giuridiche che hai autorizzato alla visualizzazione e gestione delle tue
+        notifiche, le seconde sono color che hanno autorizzato te.
+      </TitleAndDescription>
+      <Delegates />
+      <Delegators />
+    </Box>
+  );
+};
 
 export default Deleghe;

--- a/packages/pn-personafisica-webapp/src/pages/components/Deleghe/Delegates.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/components/Deleghe/Delegates.tsx
@@ -4,11 +4,7 @@ import { NotificationsTable as Table, OutlinedButton, Row } from '@pagopa-pn/pn-
 import { useTheme } from '@mui/material/styles';
 
 import { DelegationStatus } from '../../../utils/status.utility';
-import { useAppDispatch, useAppSelector } from '../../../redux/hooks';
-import { RootState } from '../../../redux/store';
-import { closeRevocationModal, revokeDelegation } from '../../../redux/delegation/actions';
 import { delegatesColumns } from './delegationsColumns';
-import ConfirmationModal from './ConfirmationModal';
 
 const StyledStack = styled(Stack)`
   border-radius: 4px;
@@ -18,16 +14,6 @@ const StyledStack = styled(Stack)`
 
 const Delegates = () => {
   const theme = useTheme();
-  const { id, open } = useAppSelector((state: RootState) => state.revocationModalState);
-  const dispatch = useAppDispatch();
-
-  const handleCloseModal = () => {
-    dispatch(closeRevocationModal());
-  };
-
-  const handleConfirmClick = () => {
-    void dispatch(revokeDelegation(id));
-  };
 
   const rows: Array<Row> = [
     {
@@ -48,13 +34,6 @@ const Delegates = () => {
 
   return (
     <Box mb={8}>
-      <ConfirmationModal
-        open={open}
-        title={'Vuoi davvero revocare la delega?'}
-        handleClose={handleCloseModal}
-        onConfirm={handleConfirmClick}
-        onConfirmLabel={'Revoca la delega'}
-      />
       <Stack direction={'row'} justifyContent={'space-between'} alignItems={'center'}>
         <h2>I tuoi delegati</h2>
         <div>

--- a/packages/pn-personafisica-webapp/src/pages/components/Deleghe/Delegators.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/components/Deleghe/Delegators.tsx
@@ -7,7 +7,7 @@ import { delegatorsColumns } from './delegationsColumns';
 const Delegators = () => {
   const rows: Array<Row> = [
     {
-      id: '0',
+      id: '1',
       name: 'Jimmy',
       startDate: 'ciao',
       endDate: 'arrivederci',

--- a/packages/pn-personafisica-webapp/src/pages/components/Deleghe/delegationsColumns.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/components/Deleghe/delegationsColumns.tsx
@@ -74,8 +74,8 @@ const Menu = (props: any) => {
   const open = Boolean(anchorEl);
   const dispatch = useAppDispatch();
 
-  const handleRevokeClick = () => {
-    dispatch(openRevocationModal(props.id));
+  const handleOpenModalClick = () => {
+    dispatch(openRevocationModal({ id: props.id, type: props.menuType }));
   };
 
   const handleClick = (event: any) => {
@@ -94,13 +94,13 @@ const Menu = (props: any) => {
           {/*
             <MenuItem onClick={handleClose}>Modifica</MenuItem>
           */}
-          <MenuItem onClick={handleRevokeClick}>Revoca</MenuItem>
+          <MenuItem onClick={handleOpenModalClick}>Revoca</MenuItem>
         </>
       );
     } else {
       return (
         <>
-          <MenuItem onClick={handleClose}>Rifiuta</MenuItem>
+          <MenuItem onClick={handleOpenModalClick}>Rifiuta</MenuItem>
         </>
       );
     }
@@ -161,11 +161,11 @@ export const delegatorsColumns = [
     },
   },
   {
-    id: 'actionsMenu',
+    id: 'id',
     label: '',
     width: '5%',
-    getCellLabel() {
-      return <Menu menuType={'delegators'} />;
+    getCellLabel(value: string) {
+      return <Menu menuType={'delegators'} id={value} />;
     },
   },
 ];

--- a/packages/pn-personafisica-webapp/src/redux/delegation/actions.ts
+++ b/packages/pn-personafisica-webapp/src/redux/delegation/actions.ts
@@ -37,6 +37,7 @@ export const rejectDelegation = createAsyncThunk<'success' | 'error', string>(
   }
 );
 
-export const openRevocationModal = createAction<string>('openRevocationModal');
+export const openRevocationModal =
+  createAction<{ id: string; type: string }>('openRevocationModal');
 
 export const closeRevocationModal = createAction<void>('closeRevocationModal');

--- a/packages/pn-personafisica-webapp/src/redux/delegation/reducers.ts
+++ b/packages/pn-personafisica-webapp/src/redux/delegation/reducers.ts
@@ -3,6 +3,7 @@ import {
   closeRevocationModal,
   delegations,
   openRevocationModal,
+  rejectDelegation,
   revokeDelegation,
 } from './actions';
 import { DelegationsList, RevocationModalProps } from './types';
@@ -31,18 +32,23 @@ export const revocationModalSlice = createSlice({
   initialState: {
     open: false,
     id: '',
+    type: '',
   } as RevocationModalProps,
   reducers: {},
   extraReducers: (builder) => {
     builder.addCase(openRevocationModal, (state, action) => {
-      state.id = action.payload;
+      state.id = action.payload.id;
       state.open = true;
+      state.type = action.payload.type;
     });
     builder.addCase(closeRevocationModal, (state) => {
       state.id = '';
       state.open = false;
     });
     builder.addCase(revokeDelegation.fulfilled, (state) => {
+      state.open = false;
+    });
+    builder.addCase(rejectDelegation.fulfilled, (state) => {
       state.open = false;
     });
   },

--- a/packages/pn-personafisica-webapp/src/redux/delegation/types.ts
+++ b/packages/pn-personafisica-webapp/src/redux/delegation/types.ts
@@ -26,4 +26,5 @@ export interface OrganizationId {
 export interface RevocationModalProps {
   open: boolean;
   id: string;
+  type: string;
 }


### PR DESCRIPTION
### Description

- connect refuse delegation api call to UI
- reformat confirmation modal to both revocate and reject