### PR TITLE
Fix/pn 1071 sidemenu delegations not loaded

### DIFF
--- a/packages/pn-personafisica-webapp/src/App.tsx
+++ b/packages/pn-personafisica-webapp/src/App.tsx
@@ -16,12 +16,14 @@ const App = () => {
   const dispatch = useAppDispatch();
   const { t } = useTranslation('common');
   const [pendingDelegatorsState, setPendingDelegatorsState] = useState(0);
-
+  const sessionToken = useAppSelector((state: RootState) => state.userState.user.sessionToken);
   const { pendingDelegators, delegators } = useAppSelector((state: RootState) => state.userState);
 
   useEffect(() => {
-    void dispatch(getNumberDelegator());
-  }, []);
+    if (sessionToken !== '') {
+      void dispatch(getNumberDelegator());
+    }
+  }, [sessionToken]);
 
   useEffect(() => {
     setPendingDelegatorsState(pendingDelegators);

--- a/packages/pn-personafisica-webapp/src/redux/auth/actions.ts
+++ b/packages/pn-personafisica-webapp/src/redux/auth/actions.ts
@@ -46,12 +46,13 @@ export const logout = createAsyncThunk<User>('logout', async () => {
   } as User;
 });
 
-export const getNumberDelegator =  createAsyncThunk<Array<Delegation>>('getNumberDelegator', async()=>{
-  try{  
-    return await DelegationsApi.getDelegators();
-    // return delegators.filter((delegator)=>delegator.status === "pending").length;
+export const getNumberDelegator = createAsyncThunk<Array<Delegation>>(
+  'getNumberDelegator',
+  async () => {
+    try {
+      return await DelegationsApi.getDelegators();
+    } catch {
+      return [];
+    }
   }
-  catch { 
-    return [];
-  } 
-});
+);

--- a/packages/pn-personafisica-webapp/src/redux/auth/reducers.ts
+++ b/packages/pn-personafisica-webapp/src/redux/auth/reducers.ts
@@ -37,8 +37,10 @@ const userSlice = createSlice({
       state.user = action.payload;
     });
     builder.addCase(getNumberDelegator.fulfilled, (state, action) => {
-      state.pendingDelegators = action.payload.filter((delegator)=>delegator.status === "pending").length;
-      state.delegators = action.payload; // TODO Filter by pending
+      state.pendingDelegators = action.payload.filter(
+        (delegator) => delegator.status === 'pending'
+      ).length;
+      state.delegators = action.payload.filter((delegator) => delegator.status !== 'pending');
     });
   },
 });


### PR DESCRIPTION
### Description

- delegators are fetched only when there is an active session
- adds filter to active delegators