### PR TITLE
PN-1287/fix: add zero pad to hours and minutes in timeline with less than 2 d…

### DIFF
--- a/packages/pn-commons/src/utils/date.utility.ts
+++ b/packages/pn-commons/src/utils/date.utility.ts
@@ -14,5 +14,8 @@ export function getDay(dateString: string): string {
 
 export function getTime(dateString: string): string {
   const date = new Date(dateString);
-  return `${date.getHours()}:${date.getMinutes()}`;
+  return `${date.getHours().toString().padStart(2, '0')}:${date
+    .getMinutes()
+    .toString()
+    .padStart(2, '0')}`;
 }


### PR DESCRIPTION
### Description

- add zero pad to hours and minutes in timeline with less than 2 digits

tests run correctly