### PR TITLE
fix: remove 1.5 line-height for Typography-Root in both apps

### DIFF
--- a/packages/pn-pa-webapp/src/index.css
+++ b/packages/pn-pa-webapp/src/index.css
@@ -3,7 +3,3 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
-
-.MuiTypography-root {
-  line-height: 1.5 !important;
-}

--- a/packages/pn-personafisica-webapp/src/index.css
+++ b/packages/pn-personafisica-webapp/src/index.css
@@ -3,7 +3,3 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
-
-.MuiTypography-root {
-  line-height: 1.5 !important;
-}


### PR DESCRIPTION
### Description

- Removes forced line-height for Typography elements in both apps