### PR TITLE
refactor: move the 'back' button near breadcrumbs in NotificationDeta…

### DIFF
--- a/packages/pn-pa-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/NotificationDetail.page.tsx
@@ -1,8 +1,9 @@
 import { useParams, Link, useNavigate } from 'react-router-dom';
 import { useEffect, Fragment } from 'react';
-import { Breadcrumbs, Grid, Typography, Box, Paper, Button, styled } from '@mui/material';
+import { Breadcrumbs, Grid, Typography, Box, Paper, Button, styled, Stack } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import EmailIcon from '@mui/icons-material/Email';
+import { ArrowBack } from '@mui/icons-material';
 import {
   NotificationStatus,
   TitleBox,
@@ -13,7 +14,7 @@ import {
   NotificationDetailTimeline,
   useIsMobile,
 } from '@pagopa-pn/pn-commons';
-import { Tag, TagGroup } from '@pagopa/mui-italia';
+import { ButtonNaked, Tag, TagGroup } from '@pagopa/mui-italia';
 
 import * as routes from '../navigation/routes.const';
 import { useAppDispatch, useAppSelector } from '../redux/hooks';
@@ -145,19 +146,24 @@ const NotificationDetail = () => {
 
   const breadcrumb = (
     <Fragment>
-      <Breadcrumbs aria-label="breadcrumb">
-        <StyledLink to={routes.DASHBOARD}>
-          <EmailIcon sx={{ mr: 0.5 }} />
-          Notifiche
-        </StyledLink>
-        <Typography
-          color="text.primary"
-          fontWeight={600}
-          sx={{ display: 'flex', alignItems: 'center' }}
-        >
-          Dettaglio notifica
-        </Typography>
-      </Breadcrumbs>
+      <Stack direction={{ xs: 'column', sm: 'row' }} alignItems={{ xs: 'start', sm: 'center' }} justifyContent="start" spacing={3}>
+        <ButtonNaked onClick={() => navigate(-1)} startIcon={<ArrowBack />} color="primary" size="medium" >
+          Indietro
+        </ButtonNaked>
+        <Breadcrumbs aria-label="breadcrumb">
+          <StyledLink to={routes.DASHBOARD}>
+            <EmailIcon sx={{ mr: 0.5 }} />
+            Notifiche
+          </StyledLink>
+          <Typography
+            color="text.primary"
+            fontWeight={600}
+            sx={{ display: 'flex', alignItems: 'center' }}
+          >
+            Dettaglio notifica
+          </Typography>
+        </Breadcrumbs>
+      </Stack>
       <TitleBox variantTitle="h4" title={notification.subject} sx={{ pt: '20px' }}></TitleBox>
       {notification.notificationStatus !== NotificationStatus.PAID && (
         <Button sx={{ margin: '10px 0' }} variant="outlined">
@@ -182,14 +188,6 @@ const NotificationDetail = () => {
               documentsAvailable={true}
             />
           </Paper>
-          <Button
-            data-testid="backButton"
-            sx={{ margin: '10px 0' }}
-            variant="outlined"
-            onClick={() => navigate(-1)}
-          >
-            Indietro
-          </Button>
         </Grid>
         <Grid item lg={5} xs={12}>
           <Box sx={{ backgroundColor: 'white', height: '100%', padding: '24px' }}>

--- a/packages/pn-pa-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
+++ b/packages/pn-pa-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
@@ -85,7 +85,7 @@ describe('NotificationDetail Page', () => {
   });
 
   test('clicks on the back button', () => {
-    const backButton = result?.getByTestId('backButton');
+    const backButton = result?.getByRole('button', { name: /indietro/i });
     fireEvent.click(backButton!);
     expect(mockNavigateFn).toBeCalledTimes(1);
   });

--- a/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
@@ -1,9 +1,11 @@
 import { useParams, useNavigate } from 'react-router-dom';
 import { Fragment, ReactNode, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Breadcrumbs, Grid, Typography, Box, Paper, Button } from '@mui/material';
+import { Breadcrumbs, Grid, Typography, Box, Paper, Stack } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import EmailIcon from '@mui/icons-material/Email';
+import { ArrowBack } from '@mui/icons-material';
+import { ButtonNaked } from '@pagopa/mui-italia';
 import {
   TitleBox,
   LegalFactId,
@@ -121,19 +123,24 @@ const NotificationDetail = () => {
 
   const breadcrumb = (
     <Fragment>
-      <Breadcrumbs aria-label="breadcrumb">
-        <StyledLink to={routes.NOTIFICHE}>
-          <EmailIcon sx={{ mr: 0.5 }} />
-          {t('detail.breadcrumb-root', { ns: 'notifiche' })}
-        </StyledLink>
-        <Typography
-          color="text.primary"
-          fontWeight={600}
-          sx={{ display: 'flex', alignItems: 'center' }}
-        >
-          {t('detail.breadcrumb-leaf', { ns: 'notifiche' })}
-        </Typography>
-      </Breadcrumbs>
+      <Stack direction={{ xs: 'column', sm: 'row' }} alignItems={{ xs: 'start', sm: 'center' }} justifyContent="start" spacing={3}>
+        <ButtonNaked onClick={() => navigate(-1)} startIcon={<ArrowBack />} color="primary" size="medium" >
+          {t('button.indietro', { ns: 'common' })}
+        </ButtonNaked>
+        <Breadcrumbs saria-label="breadcrumb">
+          <StyledLink to={routes.NOTIFICHE}>
+            <EmailIcon sx={{ mr: 0.5 }} />
+            {t('detail.breadcrumb-root', { ns: 'notifiche' })}
+          </StyledLink>
+          <Typography
+            color="text.primary"
+            fontWeight={600}
+            sx={{ display: 'flex', alignItems: 'center' }}
+          >
+            {t('detail.breadcrumb-leaf', { ns: 'notifiche' })}
+          </Typography>
+        </Breadcrumbs>
+      </Stack>
       <TitleBox variantTitle="h4" title={notification.subject} sx={{ pt: '20px' }}></TitleBox>
     </Fragment>
   );
@@ -179,9 +186,7 @@ const NotificationDetail = () => {
             />              
           </Paper>
               */}
-          <Button sx={{ margin: '10px 0' }} variant="outlined" onClick={() => navigate(-1)}>
-            {t('button.indietro', { ns: 'common' })}
-          </Button>
+          
         </Grid>
         <Grid item lg={5} xs={12}>
           <Box sx={{ backgroundColor: 'white', height: '100%', padding: '24px' }}>

--- a/packages/pn-personafisica-webapp/src/pages/NuovaDelega.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/NuovaDelega.page.tsx
@@ -29,7 +29,9 @@ import DesktopDatePicker from '@mui/lab/DesktopDatePicker';
 import DateAdapter from '@mui/lab/AdapterMoment';
 import { CourtesyPage, fiscalCodeRegex, TitleBox } from '@pagopa-pn/pn-commons';
 import PeopleIcon from '@mui/icons-material/People';
+import { ButtonNaked } from '@pagopa/mui-italia';
 import { useIsMobile } from '@pagopa-pn/pn-commons';
+import { ArrowBack } from '@mui/icons-material';
 import { useAppDispatch, useAppSelector } from '../redux/hooks';
 import { createDelegation, resetNewDelegation } from '../redux/newDelegation/actions';
 import { RootState } from '../redux/store';
@@ -120,21 +122,30 @@ const NuovaDelega = () => {
     []
   );
 
+  const breadcrumbs = (
+    <Fragment>
+      <Stack direction={{ xs: 'column', sm: 'row' }} alignItems={{ xs: 'start', sm: 'center' }} justifyContent="start" spacing={3}>
+        <ButtonNaked onClick={() => navigate(-1)} startIcon={<ArrowBack />} color="primary" size="medium" >
+          {t('button.indietro', { ns: 'common' })}
+        </ButtonNaked>
+        <Breadcrumbs aria-label="breadcrumb">
+          <StyledLink to={routes.DELEGHE}>
+            <PeopleIcon sx={{ mr: 0.5 }} />
+            {t('nuovaDelega.title')}
+          </StyledLink>
+          <Typography color="text.primary" fontWeight={600}>
+            {t('Nuova Delega')}
+          </Typography>
+        </Breadcrumbs>
+      </Stack>
+    </Fragment>
+  );
+
   return (
     <Fragment>
       {!created && (
         <Box mt={3} sx={{ padding: isMobile ? '30px' : null }}>
-          {!isMobile && (
-            <Breadcrumbs aria-label="breadcrumb">
-              <StyledLink to={routes.DELEGHE}>
-                <PeopleIcon sx={{ mr: 0.5 }} />
-                {t('nuovaDelega.title')}
-              </StyledLink>
-              <Typography color="text.primary" fontWeight={600}>
-                {t('Nuova Delega')}
-              </Typography>
-            </Breadcrumbs>
-          )}
+          {breadcrumbs}
           <TitleBox
             title={t('nuovaDelega.title')}
             subTitle={t('nuovaDelega.subtitle')}
@@ -350,13 +361,6 @@ const NuovaDelega = () => {
               )}
             </Formik>
           </Card>
-          <Button
-            variant="outlined"
-            sx={{ mt: '1rem', mb: '1rem' }}
-            onClick={() => navigate(routes.DELEGHE)}
-          >
-            {t('button.indietro', { ns: 'common' })}
-          </Button>
         </Box>
       )}
       {created && (


### PR DESCRIPTION
refactor: move the 'back' button near breadcrumbs in NotificationDetail.page (both pf and pa) and NuovaDelega.page

test: fix NotificationDetail.page.test no more able to find the button after changes because it was accessing element by testId