### PR TITLE
fix: PN-1633 does not remove the name when closing verification modal

### DIFF
--- a/packages/pn-personafisica-webapp/src/redux/delegation/__test__/reducers.test.ts
+++ b/packages/pn-personafisica-webapp/src/redux/delegation/__test__/reducers.test.ts
@@ -157,7 +157,7 @@ describe('delegation redux state tests', () => {
 
     expect(closeAction.type).toBe('closeAcceptModal');
     const closeModalState = store.getState().delegationsState.acceptModalState;
-    expect(closeModalState).toEqual({ id: '', open: false, name: '', error: false });
+    expect(closeModalState).toEqual({ id: '', open: false, name: 'test name', error: false });
   });
 
   it('sets the delegates sorting by test in ascendant order', () => {

--- a/packages/pn-personafisica-webapp/src/redux/delegation/reducers.ts
+++ b/packages/pn-personafisica-webapp/src/redux/delegation/reducers.ts
@@ -102,7 +102,6 @@ const delegationsSlice = createSlice({
     });
     builder.addCase(closeAcceptModal, (state) => {
       state.acceptModalState.open = false;
-      state.acceptModalState.name = '';
       state.acceptModalState.id = '';
     });
     builder.addCase(setDelegatesSorting, (state, action) => {


### PR DESCRIPTION
### Description

- name doesn't get removed when closing the verification modal