### PR TITLE
Fix/pn 1724 fe entrando come delegato in una notifica vedo il mio nome al posto di quello del delegante

### DIFF
--- a/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
@@ -43,10 +43,19 @@ const NotificationDetail = () => {
   const { t } = useTranslation(['common', 'notifiche']);
   const isMobile = useIsMobile();
   const notification = useAppSelector((state: RootState) => state.notificationState.notification);
-  const currentUser = useAppSelector((state: RootState) => state.userState.user);
-  const currentRecipient = notification.recipients.filter(
-    (recipient) => recipient.taxId === currentUser.fiscal_number
-  )[0];
+  const currentRecipient = notification.recipients[0];
+  /**
+   * REFERS TO: PN-1724
+   * The following code has been commented out and substituted with the line above
+   * due to issue PN-1724 since we currently do not have enough information to pick
+   * the right recipient assuming a multi-recipient notification, but this feature 
+   * is beyond the MVP scope. 
+   * 
+   const currentUser = useAppSelector((state: RootState) => state.userState.user);
+   const currentRecipient = notification.recipients.find(
+     (recipient) => recipient.taxId === currentUser.fiscal_number
+   );
+   */
   const documentDownloadUrl = useAppSelector(
     (state: RootState) => state.notificationState.documentDownloadUrl
   );


### PR DESCRIPTION
fix: use recipients[0] to get the recipient in NotificationDetail.page (pf)

use this work-around assuming every notification will only have one recipient
in MVP scope and considering we currently do not have enough information to
pick the right recipient when acting as a delegate in a multi-recipient
context

refers to PN-1724