### PR TITLE
Fix/pn 1750 fe destinatario filtri su start date e end date prendono range sbagliati escludendo oggi per un delegante

### DIFF
--- a/packages/pn-personafisica-webapp/src/redux/dashboard/reducers.ts
+++ b/packages/pn-personafisica-webapp/src/redux/dashboard/reducers.ts
@@ -68,8 +68,8 @@ const dashboardSlice = createSlice({
       state.filters = {
         iunMatch: undefined,
         mandateId: action.payload,
-        startDate: tenYearsAgo.toISOString(),
-        endDate: today.toISOString()
+        startDate: formatToTimezoneString(tenYearsAgo),
+        endDate: formatToTimezoneString(getNextDay(today)),
       };
       // reset pagination
       state.pagination.size = 10;


### PR DESCRIPTION
fix: reset filtered dates properly changing recipient in notifications page