### PR TITLE
Feature/pn 1699 fe nel caso in cui una notifica venga annullata non deve piu essere possibile accedere ai documenti forniti dalla pa

### DIFF
--- a/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
@@ -74,7 +74,8 @@
     },
     "acts_files": {
       "downloadable_acts": "Puoi scaricare gli atti entro 120 giorni dalla data di perfezionamento. Oltre questo termine, dovrai rivolgerti al mittente.",
-      "not_downloadable_acts": "Poiché sono trascorsi 120 giorni dalla data di perfezionamento, se vuoi ottenere gli atti devi rivolgerti al mittente."
+      "not_downloadable_acts": "Poiché sono trascorsi 120 giorni dalla data di perfezionamento, se vuoi ottenere gli atti devi rivolgerti al mittente.",
+      "notification_cancelled": "Poiché questa notifica è stata annullata, i documenti allegati non sono disponibili."
     }
   },
   "delegatorTitle": "Le notifiche di {{name}}"

--- a/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
@@ -206,7 +206,7 @@ const NotificationDetail = () => {
           {!isMobile && breadcrumb}
           <Stack spacing={3}>
             <NotificationDetailTable rows={detailTableRows} />
-            {currentRecipient?.payment && creditorTaxId && noticeCode &&
+            {!isCancelled && currentRecipient?.payment && creditorTaxId && noticeCode &&
               <NotificationPayment
                 iun={notification.iun}
                 notificationPayment={currentRecipient.payment}

--- a/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
@@ -1,4 +1,4 @@
-import { Fragment, ReactNode, useEffect } from 'react';
+import { Fragment, ReactNode, useCallback, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Grid, Box, Paper, Stack, Typography } from '@mui/material';
@@ -14,6 +14,7 @@ import {
   NotificationDetailTimeline,
   useIsMobile,
   PnBreadcrumb,
+  NotificationStatus,
 } from '@pagopa-pn/pn-commons';
 
 import * as routes from '../navigation/routes.const';
@@ -140,6 +141,21 @@ const NotificationDetail = () => {
     /* eslint-enable functional/immutable-data */
   };
 
+  const isCancelled = notification.notificationStatus === NotificationStatus.CANCELLED ? true : false;
+
+  const hasDocumentsAvailable = (isCancelled || !notification.documentsAvailable) ? false : true;
+
+  const getDownloadFilesMessage = useCallback((): string => {
+    if(isCancelled) {
+      return t('detail.acts_files.notification_cancelled', { ns: 'notifiche' });
+    } else if (hasDocumentsAvailable) {
+      return t('detail.acts_files.downloadable_acts', { ns: 'notifiche' });
+    } else {
+      return t('detail.acts_files.not_downloadable_acts', { ns: 'notifiche' });
+    }
+  }, [isCancelled, hasDocumentsAvailable]);
+
+
   useEffect(() => {
     if (id) {
       void dispatch(getReceivedNotification({iun: id, mandateId}));
@@ -201,14 +217,10 @@ const NotificationDetail = () => {
             <Paper sx={{ p: 3 }} className="paperContainer">
               <NotificationDetailDocuments
                 title={t('detail.acts', { ns: 'notifiche' })}
-                documents={notification.documents}
+                documents={isCancelled ? [] : notification.documents}
                 clickHandler={documentDowloadHandler}
-                documentsAvailable={notification.documentsAvailable}
-                downloadFilesMessage={
-                  notification.documentsAvailable
-                    ? t('detail.acts_files.downloadable_acts', { ns: 'notifiche' })
-                    : t('detail.acts_files.not_downloadable_acts', { ns: 'notifiche' })
-                }
+                documentsAvailable={hasDocumentsAvailable}
+                downloadFilesMessage={getDownloadFilesMessage()}
               />
             </Paper>
             {/* TODO decommentare con pn-841

--- a/packages/pn-personafisica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
@@ -4,7 +4,7 @@ import { RenderResult } from '@testing-library/react';
 import { NotificationDetail as INotificationDetail } from '@pagopa-pn/pn-commons';
 import * as actions from '../../redux/notification/actions';
 import * as hooks from '../../redux/hooks';
-import { getNotification, notificationToFe } from '../../redux/notification/__test__/test-utils';
+import { getCancelledNotification, getNotification, getUnavailableDocsNotification, notificationToFe } from '../../redux/notification/__test__/test-utils';
 import { axe, render } from '../../__test__/test-utils';
 import NotificationDetail from '../NotificationDetail.page';
 
@@ -26,7 +26,7 @@ jest.mock('react-router-dom', () => ({
 jest.mock('@pagopa-pn/pn-commons', () => ({
   ...jest.requireActual('@pagopa-pn/pn-commons'),
   NotificationDetailTable: () => <div>Table</div>,
-  NotificationDetailDocuments: () => <div>Documents</div>,
+  // NotificationDetailDocuments: () => <div>Documents</div>,
   NotificationDetailTimeline: () => <div>Timeline</div>,
 }));
 
@@ -73,7 +73,7 @@ describe('NotificationDetail Page', () => {
     expect(result?.container.querySelector('h4')).toHaveTextContent(notificationToFe.subject);
     expect(result?.container).toHaveTextContent('mocked-abstract');
     expect(result?.container).toHaveTextContent(/Table/i);
-    expect(result?.container).toHaveTextContent(/Documents/i);
+    expect(result?.container).toHaveTextContent("detail.acts");
     expect(result?.container).toHaveTextContent(/Timeline/i);
     expect(result?.container).toHaveTextContent(/Payment/i);
     expect(mockDispatchFn).toBeCalledTimes(1);
@@ -89,7 +89,7 @@ describe('NotificationDetail Page', () => {
     expect(result?.container.querySelector('h4')).toHaveTextContent(notificationToFe.subject);
     expect(result?.container).toHaveTextContent('mocked-abstract');
     expect(result?.container).toHaveTextContent(/Table/i);
-    expect(result?.container).toHaveTextContent(/Documents/i);
+    expect(result?.container).toHaveTextContent("detail.acts");
     expect(result?.container).toHaveTextContent(/Timeline/i);
     expect(result?.container).not.toHaveTextContent(/Payment/i);
     expect(mockDispatchFn).toBeCalledTimes(1);
@@ -105,7 +105,7 @@ describe('NotificationDetail Page', () => {
     expect(result?.container.querySelector('h4')).toHaveTextContent(notificationToFe.subject);
     expect(result?.container).toHaveTextContent('mocked-abstract');
     expect(result?.container).toHaveTextContent(/Table/i);
-    expect(result?.container).toHaveTextContent(/Documents/i);
+    expect(result?.container).toHaveTextContent("detail.acts");
     expect(result?.container).toHaveTextContent(/Timeline/i);
     expect(result?.container).not.toHaveTextContent(/Payment/i);
     expect(mockDispatchFn).toBeCalledTimes(1);
@@ -121,7 +121,7 @@ describe('NotificationDetail Page', () => {
     expect(result?.container.querySelector('h4')).toHaveTextContent(notificationToFe.subject);
     expect(result?.container).toHaveTextContent('mocked-abstract');
     expect(result?.container).toHaveTextContent(/Table/i);
-    expect(result?.container).toHaveTextContent(/Documents/i);
+    expect(result?.container).toHaveTextContent("detail.acts");
     expect(result?.container).toHaveTextContent(/Timeline/i);
     expect(result?.container).not.toHaveTextContent(/Payment/i);
     expect(mockDispatchFn).toBeCalledTimes(1);
@@ -137,7 +137,7 @@ describe('NotificationDetail Page', () => {
     expect(result?.container.querySelector('h4')).toHaveTextContent(notificationToFe.subject);
     expect(result?.container).toHaveTextContent('mocked-abstract');
     expect(result?.container).toHaveTextContent(/Table/i);
-    expect(result?.container).toHaveTextContent(/Documents/i);
+    expect(result?.container).toHaveTextContent("detail.acts");
     expect(result?.container).toHaveTextContent(/Timeline/i);
     expect(result?.container).not.toHaveTextContent(/Payment/i);
     expect(mockDispatchFn).toBeCalledTimes(1);
@@ -146,4 +146,40 @@ describe('NotificationDetail Page', () => {
     expect(await axe(result?.container as Element)).toHaveNoViolations(); // Accesibility test
     result = resetResult();
   });
+
+  test('renders NotificationDetail if documents are available', async () => {
+    result = renderComponent(getNotification());
+    
+    const downloadDocumentBtn = result.getByRole("button", { name: "Mocked document" });
+    expect(downloadDocumentBtn).toBeInTheDocument();
+
+    const documentsText = result.getByText("detail.acts_files.downloadable_acts");
+    expect(documentsText).toBeInTheDocument();
+
+    result = resetResult();
+  });
+
+  test('renders NotificationDetail if documents are not available', async () => {
+    result = renderComponent(getUnavailableDocsNotification());
+    
+    const documentTitle = result.queryByText("Mocked document");
+    expect(documentTitle).toBeInTheDocument();
+
+    const documentsText = result.getByText("detail.acts_files.not_downloadable_acts");
+    expect(documentsText).toBeInTheDocument();
+
+    result = resetResult();
+  });
+
+  test('renders NotificationDetail if status is cancelled', async () => {
+    result = renderComponent(getCancelledNotification());
+    
+    // even if documentsAvailable is set to true the component will not display any document
+    const documentTitle = result.queryByText("Mocked document");
+    expect(documentTitle).not.toBeInTheDocument();
+
+    const documentsText = result.getByText("detail.acts_files.notification_cancelled");
+    expect(documentsText).toBeInTheDocument();
+  });
+
 });

--- a/packages/pn-personafisica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
@@ -174,9 +174,11 @@ describe('NotificationDetail Page', () => {
   test('renders NotificationDetail if status is cancelled', async () => {
     result = renderComponent(getCancelledNotification());
     
-    // even if documentsAvailable is set to true the component will not display any document
+    // payment component and documents should be hidden if notification
+    // status is "cancelled" even though documentsAvailable is true
     const documentTitle = result.queryByText("Mocked document");
     expect(documentTitle).not.toBeInTheDocument();
+    expect(result?.container).not.toHaveTextContent(/Payment/i);
 
     const documentsText = result.getByText("detail.acts_files.notification_cancelled");
     expect(documentsText).toBeInTheDocument();

--- a/packages/pn-personafisica-webapp/src/redux/notification/__test__/test-utils.ts
+++ b/packages/pn-personafisica-webapp/src/redux/notification/__test__/test-utils.ts
@@ -223,5 +223,21 @@ export const getNotification = (payment?: {noticeCode?: string; creditorTaxId?: 
   return parseNotificationDetail(notification);
 };
 
+export const getUnavailableDocsNotification = (): NotificationDetail => {
+  const notification = {...notificationFromBe};
+  // eslint-disable-next-line functional/immutable-data
+  notification.documentsAvailable = false;
+
+  return parseNotificationDetail(notification);
+};
+
+export const getCancelledNotification = (): NotificationDetail => {
+  const notification = {...notificationFromBe};
+  // eslint-disable-next-line functional/immutable-data
+  notification.notificationStatus = NotificationStatus.CANCELLED;
+
+  return parseNotificationDetail(notification);
+};
+
 export const notificationToFe = parseNotificationDetail(notificationFromBe);
 


### PR DESCRIPTION
feat: hide documents for cancelled notification