### PR TITLE
Fix/PN-1943 Salvataggio dei TOS va in errore e si consente comunque di accedere all'applicazione

### DIFF
--- a/packages/pn-personafisica-webapp/src/pages/TermsOfService.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/TermsOfService.page.tsx
@@ -23,8 +23,12 @@ const TermsOfService = () => {
   const redirectToSLink = () => window.location.assign(`${URL_DIGITAL_NOTIFICATIONS}${PRIVACY_LINK_RELATIVE_PATH}`);
 
   const handleAccept = () => {
-    void dispatch(acceptToS()).then(() => {
+    void dispatch(acceptToS()).unwrap()
+    .then(() => {
       navigate(routes.NOTIFICHE);
+    })
+    .catch(_ => {
+      
     });
   };
 


### PR DESCRIPTION
fix: allow the user to access the application only if the ToS acceptance request is successfully sent