### PR TITLE
fix: change tokenExchange from get to post

### DIFF
--- a/packages/pn-pa-webapp/src/api/auth/Auth.api.ts
+++ b/packages/pn-pa-webapp/src/api/auth/Auth.api.ts
@@ -5,7 +5,7 @@ import { AUTH_TOKEN_EXCHANGE } from "./auth.routes";
 export const AuthApi = {
     exchangeToken: (selfCareToken: string): Promise<User> => {
         const params = new URLSearchParams([['authorizationToken', selfCareToken]]);
-        return authClient.get<User>(AUTH_TOKEN_EXCHANGE(), { params })
+        return authClient.post<User>(AUTH_TOKEN_EXCHANGE(), params)
             .then((response) => response.data);
     }
 };

--- a/packages/pn-pa-webapp/src/api/auth/__test__/Auth.api.test.ts
+++ b/packages/pn-pa-webapp/src/api/auth/__test__/Auth.api.test.ts
@@ -8,7 +8,7 @@ import { AUTH_TOKEN_EXCHANGE } from '../auth.routes';
 export async function mockedExchangeToken() {
   const token = 'mocked-token';
   const axiosMock = new MockAdapter(authClient);
-  axiosMock.onGet(AUTH_TOKEN_EXCHANGE()).reply(200, userResponse);
+  axiosMock.onPost(AUTH_TOKEN_EXCHANGE()).reply(200, userResponse);
   const res = await AuthApi.exchangeToken(token);
   axiosMock.reset();
   axiosMock.restore();

--- a/packages/pn-personafisica-webapp/src/api/auth/Auth.api.ts
+++ b/packages/pn-personafisica-webapp/src/api/auth/Auth.api.ts
@@ -5,7 +5,7 @@ import { AUTH_TOKEN_EXCHANGE } from "./auth.routes";
 export const AuthApi = {
     exchangeToken: (spidToken: string): Promise<User> => {
         const params = new URLSearchParams([['authorizationToken', spidToken]]);
-        return authClient.get<User>(AUTH_TOKEN_EXCHANGE(), { params })
+        return authClient.post<User>(AUTH_TOKEN_EXCHANGE(), params)
             .then((response) => response.data);
     }
 };

--- a/packages/pn-personafisica-webapp/src/api/auth/__test__/Auth.api.test.ts
+++ b/packages/pn-personafisica-webapp/src/api/auth/__test__/Auth.api.test.ts
@@ -7,7 +7,7 @@ import { authClient } from '../../axios';
 export async function mockedExchangeToken() {
   const token = 'mocked-token';
   const axiosMock = new MockAdapter(authClient);
-  axiosMock.onGet(`/token-exchange`).reply(200, userResponse);
+  axiosMock.onPost(`/token-exchange`).reply(200, userResponse);
   const res = await AuthApi.exchangeToken(token);
   axiosMock.reset();
   axiosMock.restore();


### PR DESCRIPTION
### Description

- Change tokenExchange API call from get to post

Test run correctly