### PR TITLE
PN-2281 - non si vede l'opzione di 'i tuoi dati' se non hai accettato le TOS

### DIFF
--- a/packages/pn-personafisica-webapp/src/App.tsx
+++ b/packages/pn-personafisica-webapp/src/App.tsx
@@ -74,8 +74,9 @@ const App = () => {
   );
 
   const userActions = useMemo(
-    () => [
-      {
+
+    () => {
+      const profiloAction = {
         id: 'profile',
         label: t('menu.profilo'),
         onClick: () => {
@@ -83,15 +84,16 @@ const App = () => {
           navigate(routes.PROFILO);
         },
         icon: <SettingsIcon fontSize="small" color="inherit" />,
-      },
-      {
+      };
+      const logoutAction = {
         id: 'logout',
         label: t('header.logout'),
         onClick: () => handleUserLogout(),
         icon: <LogoutRoundedIcon fontSize="small" color="inherit" />,
-      },
-    ],
-    []
+      };
+      return tos ? [ profiloAction, logoutAction ] : [ logoutAction ];
+    },
+    [tos]
   );
 
   useUnload(() => {


### PR DESCRIPTION
## Short description
Ho semplicemente modificato la definizione di userActions (il menu in alto a destra) per pf-webapp, se l'utente non ha accettato le TOS non viene inclusa l'opzione che fa vedere il profilo (in italiano "i tuoi dati"), e cioè non si può accedere tramite click alla gestione di recapiti.

## How to test
Basta entrare con un utente che non abbia accettato le TOS, ad es. garibaldi in ambiente DEV (ad oggi, 2022.10.04). Se si entra con un utente che abbia accettato le TOS (ad es. ada in ambiente DEV), si dovrebbe accedere a tutta la funzionalità, inclusa l'opzione di profilo nel menu in alto a destra.
