### PR TITLE
substitute uploaded file #pn-2347

### DIFF
--- a/packages/pn-pa-webapp/src/pages/components/NewNotification/Attachments.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/NewNotification/Attachments.tsx
@@ -73,7 +73,7 @@ const AttachmentBox = ({
         onFileUploaded={(file, sha256, name, size) =>
           onFileUploaded(`${id}.file`, file, sha256, name, size)
         }
-        onRemoveFile={() => onRemoveFile(`${id}.file`)}
+        onRemoveFile={() => onRemoveFile(id)}
         sx={{ marginTop: '10px' }}
         fileFormat="uint8Array"
         calcSha256
@@ -207,12 +207,16 @@ const Attachments = ({ onConfirm, onPreviousStep, attachmentsData }: Props) => {
       size,
       uint8Array: file,
       sha256,
-      name,
+      name
     });
   };
 
   const removeFileHandler = async (id: string) => {
-    await formik.setFieldValue(id, '');
+    await formik.setFieldValue(`${id}.ref`, {
+      key: '',
+      versionToken: '',
+    });
+    await formik.setFieldValue(`${id}.file`, '');
   };
 
   const addDocumentHandler = async () => {

--- a/packages/pn-pa-webapp/src/pages/components/NewNotification/PaymentMethods.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/NewNotification/PaymentMethods.tsx
@@ -43,7 +43,7 @@ const PaymentBox = ({ id, title, onFileUploaded, onRemoveFile, fileUploaded }: P
         uploadText={t('new-notification.drag-doc')}
         accept="application/pdf"
         onFileUploaded={(file, sha256, name, size) =>
-          onFileUploaded(id, file as Uint8Array, sha256, name, size)
+          onFileUploaded(`${id}.file`, file as Uint8Array, sha256, name, size)
         }
         onRemoveFile={() => onRemoveFile(id)}
         sx={{ marginTop: '10px' }}
@@ -232,7 +232,11 @@ const PaymentMethods = ({ notification, onConfirm, isCompleted, onPreviousStep }
   };
 
   const removeFileHandler = async (id: string) => {
-    await formik.setFieldValue(id, '');
+    await formik.setFieldValue(`${id}.ref`, {
+      key: '',
+      versionToken: '',
+    });
+    await formik.setFieldValue(`${id}.file`, '');
   };
 
   return (
@@ -254,7 +258,7 @@ const PaymentMethods = ({ notification, onConfirm, isCompleted, onPreviousStep }
               {t('payment-models')} {recipient.firstName} {recipient.lastName}
             </Typography>
             <PaymentBox
-              id={`${recipient.taxId}.pagoPaForm.file`}
+              id={`${recipient.taxId}.pagoPaForm`}
               title={`${t('attach-pagopa-notice')}*`}
               onFileUploaded={fileUploadedHandler}
               onRemoveFile={removeFileHandler}
@@ -262,7 +266,7 @@ const PaymentMethods = ({ notification, onConfirm, isCompleted, onPreviousStep }
             />
             {notification.paymentMode === PaymentModel.PAGO_PA_NOTICE_F24_FLATRATE && (
               <PaymentBox
-                id={`${recipient.taxId}.f24flatRate.file`}
+                id={`${recipient.taxId}.f24flatRate`}
                 title={t('attach-f24-flatrate')}
                 onFileUploaded={fileUploadedHandler}
                 onRemoveFile={removeFileHandler}
@@ -271,7 +275,7 @@ const PaymentMethods = ({ notification, onConfirm, isCompleted, onPreviousStep }
             )}
             {notification.paymentMode === PaymentModel.PAGO_PA_NOTICE_F24 && (
               <PaymentBox
-                id={`${recipient.taxId}.f24standard.file`}
+                id={`${recipient.taxId}.f24standard`}
                 title={t('attach-f24')}
                 onFileUploaded={fileUploadedHandler}
                 onRemoveFile={removeFileHandler}


### PR DESCRIPTION
## Short description
Include a summary of the changes.

## List of changes proposed in this pull request
- new notification -> substitute an uploaded document (attachment or payment document)

## How to test
Start notification creation workflow. At third step, upload one or more documents. Go to the next step, go back and substitute one of the uploaded documents. Verify that preload and upload apis are called.