### PR TITLE
bugs when filter notifications #pn-2433

### DIFF
--- a/packages/pn-pa-webapp/src/redux/dashboard/actions.ts
+++ b/packages/pn-pa-webapp/src/redux/dashboard/actions.ts
@@ -1,8 +1,7 @@
-import { createAction, createAsyncThunk } from '@reduxjs/toolkit';
-import { GetNotificationsParams, GetNotificationsResponse, Sort } from '@pagopa-pn/pn-commons';
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import { GetNotificationsParams, GetNotificationsResponse } from '@pagopa-pn/pn-commons';
 
 import { NotificationsApi } from '../../api/notifications/Notifications.api';
-import { NotificationColumn } from '../../models/Notifications';
 
 export const getSentNotifications = createAsyncThunk<
   GetNotificationsResponse,
@@ -14,10 +13,3 @@ export const getSentNotifications = createAsyncThunk<
     return rejectWithValue(e);
   }
 });
-
-export const setPagination = createAction<{ page: number; size: number }>('setPagination');
-
-export const setSorting = createAction<Sort<NotificationColumn>>('setSorting');
-
-export const setNotificationFilters =
-  createAction<GetNotificationsParams>('setNotificationFilters');

--- a/packages/pn-personafisica-webapp/src/component/Notifications/FilterNotifications.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Notifications/FilterNotifications.tsx
@@ -57,7 +57,7 @@ const initialValues = (
   emptyValues: {
     startDate: string;
     endDate: string;
-    iunMatch: undefined;
+    iunMatch: string;
     mandateId: string | undefined;
   }
 ) => {
@@ -83,7 +83,7 @@ const FilterNotifications = forwardRef(({ showFilters, currentDelegator }: Props
   const emptyValues = {
     startDate: formatToTimezoneString(tenYearsAgo),
     endDate: formatToTimezoneString(today),
-    iunMatch: undefined,
+    iunMatch: '',
     mandateId: currentDelegator?.mandateId,
   };
 

--- a/packages/pn-personafisica-webapp/src/component/Notifications/__test__/FilterNotifications.test.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Notifications/__test__/FilterNotifications.test.tsx
@@ -192,7 +192,7 @@ describe('Filter Notifications Table Component', () => {
         payload: {
           startDate: formatToTimezoneString(tenYearsAgo),
           endDate: formatToTimezoneString(today),
-          iunMatch: undefined,
+          iunMatch: '',
         },
         type: 'dashboardSlice/setNotificationFilters',
       });

--- a/packages/pn-personafisica-webapp/src/pages/Notifiche.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/Notifiche.page.tsx
@@ -1,7 +1,17 @@
 import { useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Box } from '@mui/material';
-import { calculatePages, CustomPagination, PaginationData, Sort, TitleBox, useIsMobile, getNextDay, formatToTimezoneString, ApiErrorWrapper } from '@pagopa-pn/pn-commons';
+import {
+  calculatePages,
+  CustomPagination,
+  PaginationData,
+  Sort,
+  TitleBox,
+  useIsMobile,
+  getNextDay,
+  formatToTimezoneString,
+  ApiErrorWrapper,
+} from '@pagopa-pn/pn-commons';
 
 import { useParams } from 'react-router-dom';
 import { DASHBOARD_ACTIONS, getReceivedNotifications } from '../redux/dashboard/actions';
@@ -12,17 +22,15 @@ import DesktopNotifications from '../component/Notifications/DesktopNotification
 import MobileNotifications from '../component/Notifications/MobileNotifications';
 import DomicileBanner from '../component/DomicileBanner/DomicileBanner';
 import { Delegator } from '../redux/delegation/types';
-import { trackEventByType } from "../utils/mixpanel";
-import { TrackEventType } from "../utils/events";
+import { trackEventByType } from '../utils/mixpanel';
+import { TrackEventType } from '../utils/events';
 import { NotificationColumn } from '../models/Notifications';
-
-
 
 const Notifiche = () => {
   const dispatch = useAppDispatch();
   const { t } = useTranslation(['notifiche']);
   const { mandateId } = useParams();
-  
+
   const { notifications, filters, sort, pagination } = useAppSelector(
     (state: RootState) => state.dashboardState
   );
@@ -60,13 +68,19 @@ const Notifiche = () => {
         pagination.page === 0 ? undefined : pagination.nextPagesKey[pagination.page - 1],
     };
 
-    void dispatch(getReceivedNotifications({
-      ...params,
-      endDate: formatToTimezoneString(getNextDay(new Date(params.endDate)))
-    }));
-  }, [filters, pagination.size, pagination.page, pagination.nextPagesKey]);
-  
-
+    void dispatch(
+      getReceivedNotifications({
+        ...params,
+        endDate: formatToTimezoneString(getNextDay(new Date(params.endDate))),
+      })
+    );
+  }, [filters, pagination.size, pagination.page]);
+  // PN-2433
+  /*
+  From dependencies of useCallback has been removed pagination.nextPagesKey.
+  This parameters can be updated when the notification list api is called and this can causes an update of the function and another api call.
+  Because this parameter is closely related to other dependencies and never change alone, it can be removed from dependency array.
+  */
 
   // Pagination handlers
   const handleChangePage = (paginationData: PaginationData) => {
@@ -95,7 +109,10 @@ const Notifiche = () => {
     <Box p={3}>
       <DomicileBanner />
       <TitleBox variantTitle="h4" title={pageTitle} mbTitle={isMobile ? 3 : undefined} />
-      <ApiErrorWrapper apiId={DASHBOARD_ACTIONS.GET_RECEIVED_NOTIFICATIONS} reloadAction={fetchNotifications}>
+      <ApiErrorWrapper
+        apiId={DASHBOARD_ACTIONS.GET_RECEIVED_NOTIFICATIONS}
+        reloadAction={fetchNotifications}
+      >
         {isMobile ? (
           <MobileNotifications
             notifications={notifications}

--- a/packages/pn-personafisica-webapp/src/redux/dashboard/__test__/reducers.test.ts
+++ b/packages/pn-personafisica-webapp/src/redux/dashboard/__test__/reducers.test.ts
@@ -24,7 +24,8 @@ describe('Dashbaord redux state tests', () => {
       notifications: [],
       filters: {
         startDate: formatToTimezoneString(tenYearsAgo),
-        endDate: formatToTimezoneString(today)
+        endDate: formatToTimezoneString(today),
+        iunMatch: ''
       },
       pagination: {
         nextPagesKey: [],

--- a/packages/pn-personafisica-webapp/src/redux/dashboard/actions.ts
+++ b/packages/pn-personafisica-webapp/src/redux/dashboard/actions.ts
@@ -1,8 +1,7 @@
-import { GetNotificationsParams, GetNotificationsResponse, performThunkAction, Sort } from '@pagopa-pn/pn-commons';
-import { createAction, createAsyncThunk } from '@reduxjs/toolkit';
+import { GetNotificationsParams, GetNotificationsResponse, performThunkAction } from '@pagopa-pn/pn-commons';
+import { createAsyncThunk } from '@reduxjs/toolkit';
 
 import { NotificationsApi } from '../../api/notifications/Notifications.api';
-import { NotificationColumn } from '../../models/Notifications';
 
 export enum DASHBOARD_ACTIONS  {
   GET_RECEIVED_NOTIFICATIONS = 'getReceivedNotifications',
@@ -14,13 +13,3 @@ export const getReceivedNotifications = createAsyncThunk<
 >(DASHBOARD_ACTIONS.GET_RECEIVED_NOTIFICATIONS, 
   performThunkAction((params: GetNotificationsParams) => NotificationsApi.getReceivedNotifications(params))
 );
-
-
-export const setPagination = createAction<{ page: number; size: number }>('setPagination');
-
-export const setSorting = createAction<Sort<NotificationColumn>>('setSorting');
-
-export const setNotificationFilters =
-  createAction<GetNotificationsParams>('setNotificationFilters');
-
-export const setMandateId = createAction<string | undefined>('setMandateId');

--- a/packages/pn-personafisica-webapp/src/redux/dashboard/reducers.ts
+++ b/packages/pn-personafisica-webapp/src/redux/dashboard/reducers.ts
@@ -20,7 +20,7 @@ const dashboardSlice = createSlice({
     filters: {
       startDate: formatToTimezoneString(tenYearsAgo),
       endDate: formatToTimezoneString(today),
-      iunMatch: undefined,
+      iunMatch: '',
       mandateId: undefined,
     } as GetNotificationsParams,
     pagination: {
@@ -57,7 +57,7 @@ const dashboardSlice = createSlice({
     setMandateId: (state, action: PayloadAction<string | undefined>) => {
       state.notifications = [];
       state.filters = {
-        iunMatch: undefined,
+        iunMatch: '',
         mandateId: action.payload,
         startDate: formatToTimezoneString(tenYearsAgo),
         endDate: formatToTimezoneString(today),


### PR DESCRIPTION
## Short description
Fixed two main bugs that occur when filter notification list (pf):
- Filter button enabled when no filters are applied
- Multiple notification list api calls

## List of changes proposed in this pull request
- To resolve the first bug, I changed the condition under wihich the filter button is disabled
- To resolve the second bug, I removed nextPagesKey from array dependencies of the function fetchNotifications

## How to test
First bug:
- log with pf -> check that filter button is disabled
- log with pf -> add filters -> remove filters by clicking the button -> check that filter button is disabled
- log with pf -> add filters but not confirm -> remove filters emptying inputs -> check that filter button is disabled

Second bug:
- log with pf -> open console -> apply and remove some filter -> check that the notification list api is colled once