### PR TITLE
fix: remove index.html ending from landing app links

### DIFF
--- a/packages/pn-commons/src/utils/costants.tsx
+++ b/packages/pn-commons/src/utils/costants.tsx
@@ -7,13 +7,10 @@ export const LANGUAGES = {
   en: { it: 'Italian', en: 'English' },
 };
 
-const isDev = process.env.NODE_ENV === 'development';
-const pathEnd = isDev ? '' : 'index.html';
-
 export const URL_DIGITAL_NOTIFICATIONS = 'https://www.notifichedigitali.pagopa.it/';
 export const PRIVACY_LINK_RELATIVE_PATH = '/informativa-privacy';
 export const TOS_LINK_RELATIVE_PATH = '/termini-di-servizio';
-const ACCESSIBILITY_LINK_RELATIVE_PATH = 'cittadini/accessibilita/' + pathEnd;
+const ACCESSIBILITY_LINK_RELATIVE_PATH = 'cittadini/accessibilita/';
 
 const getFooterLinkLabels = (
   link: string,

--- a/packages/pn-landing-webapp/src/components/NavigationBar.tsx
+++ b/packages/pn-landing-webapp/src/components/NavigationBar.tsx
@@ -6,10 +6,8 @@ const NavigationBar = () => {
   const { pathname } = useRouter();
   const [index, setIndex] = useState(0);
 
-  const isDev = process.env.NODE_ENV === "development";
-  const pathEnding = isDev ? "" : "index.html";
-  const cittadiniPath = "/cittadini/" + pathEnding;
-  const paPath = "/pubbliche-amministrazioni/" + pathEnding;
+  const cittadiniPath = "/cittadini/";
+  const paPath = "/pubbliche-amministrazioni/";
 
   function a11yProps(index: number) {
     return {

--- a/packages/pn-landing-webapp/src/layout/footer.constants.tsx
+++ b/packages/pn-landing-webapp/src/layout/footer.constants.tsx
@@ -1,8 +1,5 @@
 import { FooterLinksType, PreLoginFooterLinksType } from "@pagopa/mui-italia";
 
-const isDev = process.env.NODE_ENV === "development";
-const pathEnding = isDev ? "" : "index.html";
-
 export const LANGUAGES = {
   it: { it: "Italiano", en: "Inglese" },
   en: { it: "Italian", en: "English" },
@@ -61,7 +58,7 @@ export const preLoginLinks = (): PreLoginFooterLinksType => ({
     links: [
       {
         label: "Privacy Policy",
-        href: `/informativa-privacy/` + pathEnding,
+        href: `/informativa-privacy/`,
         ariaLabel: "Vai al link: Privacy Policy",
         linkType: "internal",
       },


### PR DESCRIPTION
## Short description
Removes explicit index.html in link in landing webapp footer

## How to test
- Start pn-landing-webapp
- click on 'Privacy Policy', 'Terms of Service', 'Cittadini', 'Aziende'  links
- urls should not end with index.html