### PR TITLE
fix(pn-2198): added right validation rule for groups in manual sending

### DIFF
--- a/packages/pn-pa-webapp/src/pages/components/NewNotification/PreliminaryInformations.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/NewNotification/PreliminaryInformations.tsx
@@ -15,7 +15,7 @@ import {
 import { PhysicalCommunicationType, CustomDropdown } from '@pagopa-pn/pn-commons';
 
 import { NewNotification, PaymentModel } from '../../../models/NewNotification';
-import { GroupStatus } from '../../../models/user';
+import { GroupStatus, PNRole } from '../../../models/user';
 import { useAppDispatch, useAppSelector } from '../../../redux/hooks';
 import { setPreliminaryInformations } from '../../../redux/newNotification/reducers';
 import { getUserGroups } from '../../../redux/newNotification/actions';
@@ -33,6 +33,10 @@ type Props = {
 const PreliminaryInformations = ({ notification, onConfirm }: Props) => {
   const dispatch = useAppDispatch();
   const groups = useAppSelector((state: RootState) => state.newNotificationState.groups);
+
+  const loggedUser = useAppSelector((state: RootState) => state.userState.user);
+  const isAdmin = loggedUser.organization?.roles[0].role === PNRole.ADMIN;
+
   const { t } = useTranslation(['notifiche'], {
     keyPrefix: 'new-notification.steps.preliminary-informations',
   });
@@ -52,7 +56,7 @@ const PreliminaryInformations = ({ notification, onConfirm }: Props) => {
     subject: yup.string().required(`${t('subject')} ${tc('common:required')}`),
     physicalCommunicationType: yup.string().required(),
     paymentMode: yup.string().required(),
-    group: groups.length > 0 ? yup.string().required() : yup.string(),
+    group: groups.length > 0 && !isAdmin ? yup.string().required() : yup.string(),
   });
 
   const formik = useFormik({
@@ -128,7 +132,7 @@ const PreliminaryInformations = ({ notification, onConfirm }: Props) => {
         />
         <CustomDropdown
           id="group"
-          label={`${t('group')}${groups.length > 0 ? '*' : ''}`}
+          label={`${t('group')}${groups.length > 0 && !isAdmin ? '*' : ''}`}
           fullWidth
           name="group"
           size="small"


### PR DESCRIPTION
## Short description
In notification manual sending it has been fixed the condition on groups choice by user.

## List of changes proposed in this pull request
- An user with admin role has to be able to see the list of all the groups in its PA but should have the possibility to not choose a group when sending a notification

## How to test
Access the PA backoffice with an admin user for a PA which has a list of groups and check that the groups dropdown in "Informazioni preliminari" is filled with the list of groups. Groups are not mandatory for admin role, therefore you should be able to continue to step 2 without choosing a group.