### PR TITLE
boolean and optional keys management

### DIFF
--- a/packages/pn-validator/src/types/TypeRules.ts
+++ b/packages/pn-validator/src/types/TypeRules.ts
@@ -4,20 +4,41 @@ import { DateRuleValidator } from './../ruleValidators/DateRuleValidator';
 import { ObjectRuleValidator } from '../ruleValidators/ObjectRuleValidator';
 import { ArrayRuleValidator } from './../ruleValidators/ArrayRuleValidator';
 import { CommonRuleValidator } from '../ruleValidators/CommonRuleValidator';
+import { Validator } from '../Validator';
 
-type MixedType = String | Number | Date | Boolean | undefined | null;
+type MixedType = String | Number | Date | Boolean;
 
-export type TypeRules<TModel, TValue> = (TValue extends String | undefined | null
+type StringTypeRules<TModel, TValue> = [TValue] extends [String | undefined | null]
   ? StringRuleValidator<TModel, TValue>
-  : {}) &
-  (TValue extends Number | undefined | null ? NumberRuleValidator<TModel, TValue> : {}) &
-  (TValue extends Date | undefined | null ? DateRuleValidator<TModel, TValue> : {}) &
-  (TValue extends Boolean | undefined | null ? CommonRuleValidator<TModel, TValue> : {}) &
-  (TValue extends Array<infer _TEachValue> | undefined | null ? ArrayRuleValidator<TModel, TValue> : {}) &
-  (TValue extends object | undefined | null
-    ? TValue extends Array<infer _TEachValue> | undefined | null
-      ? {}
-      : TValue extends MixedType
-      ? {}
-      : ObjectRuleValidator<TModel, TValue>
-    : {});
+  : {};
+
+type NumberTypeRules<TModel, TValue> = [TValue] extends [Number | undefined | null]
+  ? NumberRuleValidator<TModel, TValue>
+  : {};
+
+type DateTypeRules<TModel, TValue> = [TValue] extends [Date | undefined | null]
+  ? DateRuleValidator<TModel, TValue>
+  : {};
+
+type BoolenaTypeRules<TModel, TValue> = [TValue] extends [Boolean | undefined | null]
+  ? CommonRuleValidator<TModel, TValue>
+  : {};
+
+type ArrayTypeRules<TModel, TValue> = [TValue] extends [Array<infer _TEachValue> | undefined | null]
+  ? ArrayRuleValidator<TModel, TValue>
+  : {};
+
+type ObjectTypeRules<TModel, TValue> = [TValue] extends [object | undefined | null]
+  ? TValue extends Array<infer _TEachValue>
+    ? {}
+    : TValue extends MixedType
+    ? {}
+    : ObjectRuleValidator<TModel, TValue>
+  : {};
+
+export type TypeRules<TModel, TValue> = StringTypeRules<TModel, TValue> &
+  NumberTypeRules<TModel, TValue> &
+  DateTypeRules<TModel, TValue> &
+  BoolenaTypeRules<TModel, TValue> &
+  ArrayTypeRules<TModel, TValue> &
+  ObjectTypeRules<TModel, TValue>;

--- a/packages/pn-validator/src/types/TypeRules.ts
+++ b/packages/pn-validator/src/types/TypeRules.ts
@@ -1,19 +1,22 @@
+import { Validator } from '@pagopa-pn/pn-validator';
 import { NumberRuleValidator } from './../ruleValidators/NumberRuleValidator';
 import { StringRuleValidator } from './../ruleValidators/StringRuleValidator';
 import { DateRuleValidator } from './../ruleValidators/DateRuleValidator';
 import { ObjectRuleValidator } from '../ruleValidators/ObjectRuleValidator';
 import { ArrayRuleValidator } from './../ruleValidators/ArrayRuleValidator';
+import { CommonRuleValidator } from '../ruleValidators/CommonRuleValidator';
 
-type MixedType = String | Number | Date;
+type MixedType = String | Number | Date | Boolean | undefined | null;
 
-export type TypeRules<TModel, TValue> = (TValue extends String
+export type TypeRules<TModel, TValue> = (TValue extends String | undefined | null
   ? StringRuleValidator<TModel, TValue>
   : {}) &
-  (TValue extends Number ? NumberRuleValidator<TModel, TValue> : {}) &
-  (TValue extends Date ? DateRuleValidator<TModel, TValue> : {}) &
-  (TValue extends Array<infer _TEachValue> ? ArrayRuleValidator<TModel, TValue> : {}) &
-  (TValue extends object
-    ? TValue extends Array<infer _TEachValue>
+  (TValue extends Number | undefined | null ? NumberRuleValidator<TModel, TValue> : {}) &
+  (TValue extends Date | undefined | null ? DateRuleValidator<TModel, TValue> : {}) &
+  (TValue extends Boolean | undefined | null ? CommonRuleValidator<TModel, TValue> : {}) &
+  (TValue extends Array<infer _TEachValue> | undefined | null ? ArrayRuleValidator<TModel, TValue> : {}) &
+  (TValue extends object | undefined | null
+    ? TValue extends Array<infer _TEachValue> | undefined | null
       ? {}
       : TValue extends MixedType
       ? {}

--- a/packages/pn-validator/src/types/TypeRules.ts
+++ b/packages/pn-validator/src/types/TypeRules.ts
@@ -1,4 +1,3 @@
-import { Validator } from '@pagopa-pn/pn-validator';
 import { NumberRuleValidator } from './../ruleValidators/NumberRuleValidator';
 import { StringRuleValidator } from './../ruleValidators/StringRuleValidator';
 import { DateRuleValidator } from './../ruleValidators/DateRuleValidator';

--- a/packages/pn-validator/src/types/TypeRules.ts
+++ b/packages/pn-validator/src/types/TypeRules.ts
@@ -4,7 +4,6 @@ import { DateRuleValidator } from './../ruleValidators/DateRuleValidator';
 import { ObjectRuleValidator } from '../ruleValidators/ObjectRuleValidator';
 import { ArrayRuleValidator } from './../ruleValidators/ArrayRuleValidator';
 import { CommonRuleValidator } from '../ruleValidators/CommonRuleValidator';
-import { Validator } from '../Validator';
 
 type MixedType = String | Number | Date | Boolean;
 


### PR DESCRIPTION
## Short description
Now pn-validator works with boolean and optional properties

## List of changes proposed in this pull request
- Modified TypeRules to manage this two cases

## How to test
Create a class with boolean and optional properties. Create validator for this class and check that ide suggests correct rules for these properties