### PR TITLE
notifications without payment

### DIFF
--- a/packages/pn-pa-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/it/notifiche.json
@@ -164,7 +164,8 @@
         "payment-method": "Modello di pagamento",
         "pagopa-notice": "Avviso pagoPA",
         "pagopa-notice-f24-flatrate": "Avviso pagoPA e Modello F24 forfettario",
-        "pagopa-notice-f24": "Avviso pagoPA e Modello F24"
+        "pagopa-notice-f24": "Avviso pagoPA e Modello F24",
+        "nothing": "Nessuno"
       },
       "recipient": {
         "title": "Destinatario",
@@ -218,6 +219,7 @@
         "attach-pagopa-notice": "Allega Avviso pagoPA",
         "attach-f24-flatrate": "Allega Modello F24 forfettario",
         "attach-f24": "Allega Modello F24",
+        "nothing": "<0>Se questa notifica prevede un pagamento, torna a </0><1>Informazioni preliminari</1><2> e seleziona un modello. Poi, torna qui per caricarlo.</2>",
         "back-to-attachments": "Torna a Allegati"
       },
       "sync-feedback": {

--- a/packages/pn-pa-webapp/src/models/NewNotification.ts
+++ b/packages/pn-pa-webapp/src/models/NewNotification.ts
@@ -11,6 +11,7 @@ export enum PaymentModel {
   PAGO_PA_NOTICE = 'PAGO_PA_NOTICE',
   PAGO_PA_NOTICE_F24_FLATRATE = 'PAGO_PA_NOTICE_F24_FLATRATE',
   PAGO_PA_NOTICE_F24 = 'PAGO_PA_NOTICE_F24',
+  NOTHING = 'NOTHING'
 }
 
 interface BaseNewNotification {

--- a/packages/pn-pa-webapp/src/pages/components/NewNotification/PreliminaryInformations.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/NewNotification/PreliminaryInformations.tsx
@@ -201,6 +201,12 @@ const PreliminaryInformations = ({ notification, onConfirm }: Props) => {
               label={t('pagopa-notice-f24')}
               data-testid="paymentMethodRadio"
             />
+            <FormControlLabel
+              value={PaymentModel.NOTHING}
+              control={<Radio />}
+              label={t('nothing')}
+              data-testid="paymentMethodRadio"
+            />
           </RadioGroup>
         </FormControl>
       </NewNotificationCard>

--- a/packages/pn-pa-webapp/src/pages/components/NewNotification/__test__/PreliminaryInformations.test.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/NewNotification/__test__/PreliminaryInformations.test.tsx
@@ -77,6 +77,7 @@ describe('PreliminaryInformations Component', () => {
       'pagopa-notice',
       'pagopa-notice-f24-flatrate',
       'pagopa-notice-f24',
+      'nothing'
     ]);
     const button = form?.querySelector('button');
     expect(button!).toBeDisabled();

--- a/packages/pn-pa-webapp/src/redux/newNotification/__test__/reducers.test.ts
+++ b/packages/pn-pa-webapp/src/redux/newNotification/__test__/reducers.test.ts
@@ -19,6 +19,7 @@ import {
   setAttachments,
   resetState,
   setPaymentDocuments,
+  setIsCompleted
 } from '../reducers';
 import { newNotification } from './test-utils';
 
@@ -179,6 +180,13 @@ describe('New notification redux state tests', () => {
         },
       },
     });
+  });
+
+  it('Should be able to set isCompleted status', () => {
+    const action = store.dispatch(setIsCompleted());
+    const payload = action.payload;
+    expect(action.type).toBe('newNotificationSlice/setIsCompleted');
+    expect(payload).toEqual(void 0);
   });
 
   it('Should be able to create new notification', async () => {

--- a/packages/pn-pa-webapp/src/redux/newNotification/reducers.ts
+++ b/packages/pn-pa-webapp/src/redux/newNotification/reducers.ts
@@ -57,6 +57,11 @@ const newNotificationSlice = createSlice({
         // in questa fase la notificationFeePolicy viene assegnata di default a FLAT_RATE
         // Carlotta Dimatteo 10/08/2022
         notificationFeePolicy: NotificationFeePolicy.FLAT_RATE,
+        // reset payment data if payment mode has changed
+        payment:
+          state.notification.paymentMode !== action.payload.paymentMode
+            ? {}
+            : state.notification.payment,
       };
     },
     saveRecipients: (
@@ -79,6 +84,9 @@ const newNotificationSlice = createSlice({
         ...state.notification,
         payment: action.payload.paymentDocuments,
       };
+    },
+    setIsCompleted: (state) => {
+      state.isCompleted = true;
     },
     resetState: () => initialState,
   },
@@ -104,6 +112,7 @@ export const {
   setAttachments,
   setPaymentDocuments,
   resetState,
+  setIsCompleted,
 } = newNotificationSlice.actions;
 
 export default newNotificationSlice;

--- a/packages/pn-pa-webapp/src/utils/notification.utility.ts
+++ b/packages/pn-pa-webapp/src/utils/notification.utility.ts
@@ -7,6 +7,7 @@ import {
   NewNotificationDTO,
   NewNotification,
   PaymentObject,
+  PaymentModel
 } from '../models/NewNotification';
 
 const checkFisicalAddress = (recipient: NewNotificationRecipient) => {
@@ -33,7 +34,8 @@ const checkFisicalAddress = (recipient: NewNotificationRecipient) => {
 };
 
 const newNotificationRecipientsMapper = (
-  recipients: Array<NewNotificationRecipient>
+  recipients: Array<NewNotificationRecipient>,
+  paymentMethod?: PaymentModel
 ): Array<NotificationDetailRecipient> =>
   recipients.map((recipient) => {
     const digitalDomicile = recipient.digitalDomicile
@@ -46,7 +48,7 @@ const newNotificationRecipientsMapper = (
       denomination: recipient.recipientType === RecipientType.PG ? recipient.firstName : `${recipient.firstName} ${recipient.lastName}`,
       recipientType: recipient.recipientType,
       taxId: recipient.taxId,
-      payment: {
+      payment: paymentMethod === PaymentModel.NOTHING ? undefined : {
         creditorTaxId: recipient.creditorTaxId,
         noticeCode: recipient.noticeCode,
         pagoPaForm: {
@@ -121,11 +123,11 @@ export function newNotificationMapper(newNotification: NewNotification): NewNoti
     documents: [],
   };
   // format recipients
-  newNotificationParsed.recipients = newNotificationRecipientsMapper(newNotification.recipients);
+  newNotificationParsed.recipients = newNotificationRecipientsMapper(newNotification.recipients, newNotification.paymentMode);
   // format attachments
   newNotificationParsed.documents = newNotificationAttachmentsMapper(newNotification.documents);
   // format payments
-  if (newNotification.payment) {
+  if (newNotification.payment && Object.keys(newNotification.payment).length > 0) {
     newNotificationParsed.recipients = newNotificationPaymentDocumentsMapper(
       newNotificationParsed.recipients,
       newNotification.payment


### PR DESCRIPTION
## Short description
Now it is possible to create notification without payment

## List of changes proposed in this pull request
- Added choice "Nothing" under payment method in preliminary informations section
- Added an empty state in payment methods section, with a button to go back to preliminary informations section

## How to test
- Log with m.messina - INAIL
- Go to new notification page
- Select "Nothing" choice under payment method in preliminary informations section
- Fill required informations
- Check that the notification i correctly created