### PR TITLE
Pn 2483 dettaglio notifica multi destinatario assenza nome e cognome destinatario

### DIFF
--- a/packages/pn-pa-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/NotificationDetail.page.tsx
@@ -121,7 +121,7 @@ const NotificationDetail = () => {
         <>
           {recipients.map((recipient, i) => (
             <Box key={i} fontWeight={600}>
-              {recipient.taxId}
+              {`${recipient.taxId} - ${recipient.denomination}`}
             </Box>
           ))}
         </>


### PR DESCRIPTION
## Short description
Added denomination data to recipients list

## List of changes proposed in this pull request
- Recipients list was previously liste by taxId only. Now it's by 'taxId + denomination'

## How to test
Open a multi recipients notification detail and check for recipients list.