### PR TITLE
fix: PN-2577 Multi recipients - resolve bugs related to payment files management

### DIFF
--- a/packages/pn-pa-webapp/src/pages/components/NewNotification/Attachments.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/NewNotification/Attachments.tsx
@@ -102,19 +102,18 @@ type Props = {
   attachmentsData?: Array<NewNotificationDocument>;
 };
 
+const emptyFileData = {
+  uint8Array: undefined,
+  sha256: { hashBase64: '', hashHex: '' },
+  name: '',
+  size: 0,
+};
+
 const newAttachmentDocument = (id: string, idx: number): NewNotificationDocument => ({
   id,
   idx,
   contentType: 'application/pdf',
-  file: {
-    uint8Array: undefined,
-    name: '',
-    size: 0,
-    sha256: {
-      hashBase64: '',
-      hashHex: '',
-    },
-  },
+  file: emptyFileData,
   name: '',
   ref: {
     key: '',
@@ -212,12 +211,18 @@ const Attachments = ({ onConfirm, onPreviousStep, attachmentsData }: Props) => {
     });
   };
 
-  const removeFileHandler = async (id: string) => {
-    await formik.setFieldValue(`${id}.ref`, {
-      key: '',
-      versionToken: '',
-    });
-    await formik.setFieldValue(`${id}.file`, '');
+  const removeFileHandler = async (id: string, index: number) => {
+    await formik.setFieldValue(
+      id,
+      {
+        ...formik.values.documents[index],
+        file: emptyFileData,
+        ref: {
+          key: '',
+          versionToken: '',
+        }
+      }
+    );
   };
 
   const addDocumentHandler = async () => {
@@ -290,7 +295,7 @@ const Attachments = ({ onConfirm, onPreviousStep, attachmentsData }: Props) => {
             }
             onFieldTouched={handleChangeTouched}
             onFileUploaded={fileUploadedHandler}
-            onRemoveFile={removeFileHandler}
+            onRemoveFile={(id) => removeFileHandler(id, i)}
             sx={{ marginTop: i > 0 ? '30px' : '10px' }}
           />
         ))}

--- a/packages/pn-pa-webapp/src/pages/components/NewNotification/__test__/PaymentMethods.test.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/NewNotification/__test__/PaymentMethods.test.tsx
@@ -82,10 +82,11 @@ describe('PaymentMethods Component', () => {
     expect(result.container).toHaveTextContent(/back-to-attachments/i);
   });
 
-  it('adds first pagoPa document (confirm disabled)', async () => {
+  it('adds first and second pagoPa documents (confirm disabled)', async () => {
     const form = result.container.querySelector('form');
     const paymentBoxes = result.queryAllByTestId('paymentBox');
     uploadDocument(paymentBoxes[0].parentNode!);
+    uploadDocument(paymentBoxes[2].parentNode!);
     const buttons = await waitFor(() => form?.querySelectorAll('button'));
     // Avendo cambiato posizione nella lista dei bottoni (in modo da avere sempre il bottone "continua" a dx, qui vado a prendere il primo bottone)
     // vedi flexDirection row-reverse
@@ -93,10 +94,11 @@ describe('PaymentMethods Component', () => {
     expect(buttons![0]).toBeDisabled();
   });
 
-  it('adds first and second pagoPa documents and clicks on confirm', async () => {
+  it('adds all payment documents and clicks on confirm', async () => {
     const form = result.container.querySelector('form');
     const paymentBoxes = result.queryAllByTestId('paymentBox');
     uploadDocument(paymentBoxes[0].parentNode!);
+    uploadDocument(paymentBoxes[1].parentNode!);
     uploadDocument(paymentBoxes[2].parentNode!);
     uploadDocument(paymentBoxes[3].parentNode!);
     const buttons = await waitFor(() => form?.querySelectorAll('button'));
@@ -134,13 +136,13 @@ describe('PaymentMethods Component', () => {
             idx: 0,
             name: 'pagopa-notice-f24',
             file: {
-              name: index === 0 ? '' : 'Mocked file',
+              name: 'Mocked file',
               sha256: {
-                hashBase64: index === 0 ? '' : 'mocked-hasBase64',
-                hashHex: index === 0 ? '' : 'mocked-hashHex'
+                hashBase64: 'mocked-hasBase64',
+                hashHex: 'mocked-hashHex'
               },
-              size: index === 0 ? 0 : 14,
-              uint8Array: index === 0 ? undefined : new Uint8Array()
+              size: 14,
+              uint8Array: new Uint8Array()
             },
             contentType: 'application/pdf',
             ref: {


### PR DESCRIPTION
## Short description
This pr fixes the following bugs:
- "Send" button not disabling after deleting an F24 payment file
- Error trying removing a tracked payment document and then going back to step "attachments"
- Attachment box not refreshing after removing the corresponding file (clicking the "x" icon)

## List of changes proposed in this pull request
- change yup validation schema in PaymentMethods component to set F24 payment document as mandatory when the correspondig option has been selected in step 1 of the notification creation procedure
- change removeFileHandler in PaymentMethods and Attachments components to use a single setFieldValue and fix the default data to store file info properly to fix errors removing a tracked payment document and attachment box not re-rendering properly
- test: fix PaymentMethods.test.tsx not working after changes

## How to test
### Replicate the bugs:
- choose either option 2 or 3 as "Modello di pagamento" in step 1, then at step 4 add every pagoPA document only. Verify that the "Send" button is disabled
- go to step 4, add a document, than click on "Back to Attachments" to ensure the information is stored and the added file is tracked, than click on "Next", remove the previously added file and click again on "Back to Attachments". You should notice a console error and the "Back to Attachments" command not responding.
- go to "Attachments" and add an attachment, click on the "x" icon to remove it. You should notice the "Next" button becoming disabled (the file has been removed properly) but the attachment box not changing its status. If you go back to recipients and forward again now the box is shown properly