### PR TITLE
fix: pn-2487 adds multiple recipient with same notice code warning

### DIFF
--- a/packages/pn-pa-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/it/notifiche.json
@@ -172,7 +172,7 @@
         "title": "Destinatario",
         "fiscal-code-error": "Il codice fiscale inserito non è corretto",
         "identical-fiscal-codes-error": "C'è già un destinatario con questo Codice Fiscale. Inseriscine uno diverso.",
-        "identical-notice-codes-error": "Hai già utilizzato questo Codice avviso per questo Ente Creditore. Inseriscine uno diverso.",
+        "identical-notice-codes-error": "C’è già un destinatario con questo Codice Avviso. Inseriscine uno diverso.",
         "notice-code-error": "Inserisci un codice di 18 caratteri numerici",
         "pec-error": "Indirizzo PEC non valido",
         "too-long-denomination-error-PF": "La lunghezza totale di nome e cognome non può superare gli 80 caratteri",

--- a/packages/pn-pa-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/it/notifiche.json
@@ -172,6 +172,7 @@
         "title": "Destinatario",
         "fiscal-code-error": "Il codice fiscale inserito non è corretto",
         "identical-fiscal-codes-error": "C'è già un destinatario con questo Codice Fiscale. Inseriscine uno diverso.",
+        "identical-notice-codes-error": "Hai già utilizzato questo Codice avviso per questo Ente Creditore. Inseriscine uno diverso.",
         "notice-code-error": "Inserisci un codice di 18 caratteri numerici",
         "pec-error": "Indirizzo PEC non valido",
         "too-long-denomination-error-PF": "La lunghezza totale di nome e cognome non può superare gli 80 caratteri",

--- a/packages/pn-pa-webapp/src/pages/components/NewNotification/Recipient.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/NewNotification/Recipient.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable functional/no-let */
-
 import { ChangeEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
@@ -19,11 +17,13 @@ import {
 } from '@mui/material';
 import { ButtonNaked } from '@pagopa/mui-italia';
 import { DigitalDomicileType, RecipientType, dataRegex } from '@pagopa-pn/pn-commons';
+
 import { saveRecipients } from '../../../redux/newNotification/reducers';
 import { useAppDispatch } from '../../../redux/hooks';
 import { NewNotificationRecipient } from '../../../models/NewNotification';
 import { trackEventByType } from '../../../utils/mixpanel';
 import { TrackEventType } from '../../../utils/events';
+import { getDuplicateValuesByKeys } from "../../../utils/notification.utility";
 import PhysicalAddress from './PhysicalAddress';
 import FormTextField from './FormTextField';
 import NewNotificationCard from './NewNotificationCard';
@@ -49,19 +49,6 @@ const singleRecipient = {
   showDigitalDomicile: false,
   showPhysicalAddress: false,
 };
-
-function getDuplicateValuesByKeys<T>(recipientsList: Array<T>, keys: Array<keyof T>): Array<string> {
-  const getIUV = (item: T) => {
-    let IUV = '';
-    for (let i = 0; i < keys.length; i++) {
-      IUV += item[keys[i]] ?? '';
-    }
-    return IUV;
-  };
-  return recipientsList
-    .map((recipient) => getIUV(recipient))
-    .filter((iuv, i, iuvList) => iuvList.indexOf(iuv) !== i);
-}
 
 type Props = {
   onConfirm: () => void;

--- a/packages/pn-pa-webapp/src/pages/components/NewNotification/__test__/Recipient.test.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/NewNotification/__test__/Recipient.test.tsx
@@ -218,12 +218,32 @@ describe('Recipient Component', () => {
     expect(submitButton).toBeDisabled();
   }, 20000);
 
+  it('tests form validation with correct data', async () => {
+    const form = result.container.querySelector('form') as HTMLFormElement;
+    const submitButton = form.querySelector('button[type="submit"]');
+    const addButton = result.queryByText('add-recipient');
+    fireEvent.click(addButton!);
+    await populateFormMultipleRecipients(form);
+    expect(submitButton).toBeEnabled();
+  }, 20000);
+
   it('tests form validation (identical taxId)', async () => {
     const form = result.container.querySelector('form') as HTMLFormElement;
     const submitButton = form.querySelector('button[type="submit"]');
     const addButton = result.queryByText('add-recipient');
     fireEvent.click(addButton!);
     await populateFormMultipleRecipients(form);
+    await testInput(form, `recipients[1].taxId`, newNotification.recipients[0].taxId);
+    expect(submitButton).toBeDisabled();
+  }, 20000);
+
+  it('tests form validation (identical creditorTaxId and noticeCode)', async () => {
+    const form = result.container.querySelector('form') as HTMLFormElement;
+    const submitButton = form.querySelector('button[type="submit"]');
+    const addButton = result.queryByText('add-recipient');
+    fireEvent.click(addButton!);
+    await populateFormMultipleRecipients(form);
+    await testInput(form, `recipients[1].noticeCode`, newNotification.recipients[0].noticeCode);
     expect(submitButton).toBeDisabled();
   }, 20000);
 

--- a/packages/pn-pa-webapp/src/redux/newNotification/__test__/test-utils.ts
+++ b/packages/pn-pa-webapp/src/redux/newNotification/__test__/test-utils.ts
@@ -21,7 +21,7 @@ const newNotificationRecipients: Array<NewNotificationRecipient> = [
     lastName: 'Rossi',
     recipientType: RecipientType.PF,
     creditorTaxId: '12345678910',
-    noticeCode: '123456789123456789',
+    noticeCode: '123456789123456788',
     type: DigitalDomicileType.PEC,
     digitalDomicile: 'mocked@mail.it',
     address: 'address',
@@ -150,7 +150,7 @@ export const newNotificationDTO: NewNotificationDTO = {
       },
       payment: {
         creditorTaxId: '12345678910',
-        noticeCode: '123456789123456789',
+        noticeCode: '123456789123456788',
         pagoPaForm: {
           title: 'mocked-name',
           digests: {

--- a/packages/pn-pa-webapp/src/redux/newNotification/__test__/test-utils.ts
+++ b/packages/pn-pa-webapp/src/redux/newNotification/__test__/test-utils.ts
@@ -229,9 +229,7 @@ export const newNotificationDTO: NewNotificationDTO = {
 };
 
 export const newNotificationWithEmptyAddress: NewNotification = {
-  paProtocolNumber: '',
-  subject: '',
-  cancelledIun: '',
+  ...newNotification,
   recipients: [{
     idx: 0,
     taxId: 'MRARSS90P08H501Q',
@@ -249,26 +247,10 @@ export const newNotificationWithEmptyAddress: NewNotification = {
     province: 'province',
     foreignState: 'foreignState',
   }],
-  documents: [newNotificationDocument],
-  payment: {
-    'MRARSS90P08H501Q': {
-      pagoPaForm: {...newNotificationPagoPa},
-    },
-    'SRAGLL00P48H501U': {
-      pagoPaForm: {...newNotificationPagoPa},
-      f24standard: {...newNotificationF24Standard},
-    },
-  },
-  physicalCommunicationType: '' as PhysicalCommunicationType,
-  paymentMode: PaymentModel.PAGO_PA_NOTICE_F24,
-  group: '',
-  notificationFeePolicy: '' as NotificationFeePolicy,
 };
 
 export const newNotificationDTOWithUndefinedAddress: NewNotificationDTO = {
-  paProtocolNumber: '',
-  subject: '',
-  cancelledIun: '',
+  ...newNotificationDTO,
   recipients: [
     {
       taxId: 'MRARSS90P08H501Q',
@@ -296,20 +278,4 @@ export const newNotificationDTOWithUndefinedAddress: NewNotificationDTO = {
       },
     }
   ],
-  documents: [
-    {
-      title: 'mocked-name',
-      digests: {
-        sha256: 'mocked-sha256',
-      },
-      contentType: 'text/plain',
-      ref: {
-        key: '',
-        versionToken: '',
-      },
-    }
-  ],
-  physicalCommunicationType: '' as PhysicalCommunicationType,
-  group: '',
-  notificationFeePolicy: '' as NotificationFeePolicy,
 };

--- a/packages/pn-pa-webapp/src/redux/newNotification/__test__/test-utils.ts
+++ b/packages/pn-pa-webapp/src/redux/newNotification/__test__/test-utils.ts
@@ -25,7 +25,7 @@ const newNotificationRecipients: Array<NewNotificationRecipient> = [
     type: DigitalDomicileType.PEC,
     digitalDomicile: 'mocked@mail.it',
     address: 'address',
-    houseNumber: 'houseNumber',
+    houseNumber: '1',
     zip: 'zip',
     municipality: 'municipality',
     province: 'province',
@@ -41,12 +41,12 @@ const newNotificationRecipients: Array<NewNotificationRecipient> = [
     noticeCode: '123456789123456789',
     type: DigitalDomicileType.PEC,
     digitalDomicile: 'mocked@mail.it',
-    address: '',
-    houseNumber: '',
-    zip: '',
-    municipality: '',
-    province: '',
-    foreignState: '',
+    address: 'address',
+    houseNumber: '2',
+    zip: 'zip',
+    municipality: 'municipality',
+    province: 'province',
+    foreignState: 'foreignState',
   },
 ];
 
@@ -139,7 +139,7 @@ export const newNotificationDTO: NewNotificationDTO = {
         address: 'mocked@mail.it',
       },
       physicalAddress: {
-        address: 'address houseNumber',
+        address: 'address 1',
         addressDetails: undefined,
         at: undefined,
         zip: 'zip',
@@ -172,7 +172,16 @@ export const newNotificationDTO: NewNotificationDTO = {
         type: DigitalDomicileType.PEC,
         address: 'mocked@mail.it',
       },
-      physicalAddress: undefined,
+      physicalAddress:  {
+         address: "address 2",
+         addressDetails: undefined,
+         at: undefined,
+         foreignState: "foreignState",
+         municipality: "municipality",
+         municipalityDetails: undefined,
+         province: "province",
+         zip: "zip",
+      },
       payment: {
         creditorTaxId: '12345678910',
         noticeCode: '123456789123456789',
@@ -200,6 +209,92 @@ export const newNotificationDTO: NewNotificationDTO = {
         }
       },
     },
+  ],
+  documents: [
+    {
+      title: 'mocked-name',
+      digests: {
+        sha256: 'mocked-sha256',
+      },
+      contentType: 'text/plain',
+      ref: {
+        key: '',
+        versionToken: '',
+      },
+    }
+  ],
+  physicalCommunicationType: '' as PhysicalCommunicationType,
+  group: '',
+  notificationFeePolicy: '' as NotificationFeePolicy,
+};
+
+export const newNotificationWithEmptyAddress: NewNotification = {
+  paProtocolNumber: '',
+  subject: '',
+  cancelledIun: '',
+  recipients: [{
+    idx: 0,
+    taxId: 'MRARSS90P08H501Q',
+    firstName: 'Mario',
+    lastName: 'Rossi',
+    recipientType: RecipientType.PF,
+    creditorTaxId: '12345678910',
+    noticeCode: '123456789123456788',
+    type: DigitalDomicileType.PEC,
+    digitalDomicile: 'mocked@mail.it',
+    address: '',
+    houseNumber: '',
+    zip: 'zip',
+    municipality: 'municipality',
+    province: 'province',
+    foreignState: 'foreignState',
+  }],
+  documents: [newNotificationDocument],
+  payment: {
+    'MRARSS90P08H501Q': {
+      pagoPaForm: {...newNotificationPagoPa},
+    },
+    'SRAGLL00P48H501U': {
+      pagoPaForm: {...newNotificationPagoPa},
+      f24standard: {...newNotificationF24Standard},
+    },
+  },
+  physicalCommunicationType: '' as PhysicalCommunicationType,
+  paymentMode: PaymentModel.PAGO_PA_NOTICE_F24,
+  group: '',
+  notificationFeePolicy: '' as NotificationFeePolicy,
+};
+
+export const newNotificationDTOWithUndefinedAddress: NewNotificationDTO = {
+  paProtocolNumber: '',
+  subject: '',
+  cancelledIun: '',
+  recipients: [
+    {
+      taxId: 'MRARSS90P08H501Q',
+      denomination: 'Mario Rossi',
+      recipientType: RecipientType.PF,
+      digitalDomicile: {
+        type: DigitalDomicileType.PEC,
+        address: 'mocked@mail.it',
+      },
+      physicalAddress: undefined,
+      payment: {
+        creditorTaxId: '12345678910',
+        noticeCode: '123456789123456788',
+        pagoPaForm: {
+          title: 'mocked-name',
+          digests: {
+            sha256: 'mocked-pa-sha256',
+          },
+          contentType: 'text/plain',
+          ref: {
+            key: '',
+            versionToken: '',
+          },
+        },
+      },
+    }
   ],
   documents: [
     {

--- a/packages/pn-pa-webapp/src/utils/__test__/notification.utility.test.ts
+++ b/packages/pn-pa-webapp/src/utils/__test__/notification.utility.test.ts
@@ -1,4 +1,8 @@
-import { newNotification, newNotificationDTO } from '../../redux/newNotification/__test__/test-utils';
+import {
+  newNotification,
+  newNotificationDTO,
+  newNotificationDTOWithUndefinedAddress, newNotificationWithEmptyAddress
+} from '../../redux/newNotification/__test__/test-utils';
 import { newNotificationMapper } from '../notification.utility';
 
 describe('Test notification utility', () => {
@@ -6,5 +10,11 @@ describe('Test notification utility', () => {
     const result = newNotificationMapper(newNotification);
   
     expect(result).toEqual(newNotificationDTO);
+  });
+
+  test('Checks that if physical address has empty required fields, its value is set to undefined', () => {
+    const result = newNotificationMapper(newNotificationWithEmptyAddress);
+
+    expect(result).toEqual(newNotificationDTOWithUndefinedAddress);
   });
 });

--- a/packages/pn-pa-webapp/src/utils/__test__/notification.utility.test.ts
+++ b/packages/pn-pa-webapp/src/utils/__test__/notification.utility.test.ts
@@ -3,7 +3,16 @@ import {
   newNotificationDTO,
   newNotificationDTOWithUndefinedAddress, newNotificationWithEmptyAddress
 } from '../../redux/newNotification/__test__/test-utils';
-import { newNotificationMapper } from '../notification.utility';
+import {getDuplicateValuesByKeys, newNotificationMapper} from '../notification.utility';
+
+const mockArray = [
+  { 'key1': "value1", 'key2': "value2", 'key3': "value3" },
+  { 'key1': "valueX", 'key2': "valueY", 'key3': "valueZ" },
+  { 'key1': "value1", 'key2': "value2", 'key3': "value3" },
+  { 'key1': "value1", 'key2': "value2", 'key3': "value3" },
+  { 'key1': "valueX", 'key2': "valueY", 'key3': "valueZ" },
+  { 'key1': "value1", 'key2': "valueY", 'key3': "valueZ" }
+];
 
 describe('Test notification utility', () => {
   test('Map notification from presentation layer to api layer', () => {
@@ -16,5 +25,11 @@ describe('Test notification utility', () => {
     const result = newNotificationMapper(newNotificationWithEmptyAddress);
 
     expect(result).toEqual(newNotificationDTOWithUndefinedAddress);
+  });
+
+  test('Checks that getDuplicateValuesByKeys returns duplicate values', () => {
+    const result = getDuplicateValuesByKeys(mockArray,['key1', 'key2', 'key3']);
+
+    expect(result).toEqual(['value1value2value3', 'valueXvalueYvalueZ']);
   });
 });

--- a/packages/pn-pa-webapp/src/utils/notification.utility.ts
+++ b/packages/pn-pa-webapp/src/utils/notification.utility.ts
@@ -10,7 +10,7 @@ import {
   PaymentModel
 } from '../models/NewNotification';
 
-const checkFisicalAddress = (recipient: NewNotificationRecipient) => {
+const checkPhysicalAddress = (recipient: NewNotificationRecipient) => {
   if (
     recipient.address &&
     recipient.houseNumber &&
@@ -63,7 +63,7 @@ const newNotificationRecipientsMapper = (
         },
       },
       digitalDomicile,
-      physicalAddress: checkFisicalAddress(recipient),
+      physicalAddress: checkPhysicalAddress(recipient),
     };
   });
 

--- a/packages/pn-pa-webapp/src/utils/notification.utility.ts
+++ b/packages/pn-pa-webapp/src/utils/notification.utility.ts
@@ -1,3 +1,5 @@
+/* eslint-disable functional/no-let */
+
 import _ from 'lodash';
 import { NotificationDetailRecipient, NotificationDetailDocument, RecipientType } from '@pagopa-pn/pn-commons';
 
@@ -135,4 +137,19 @@ export function newNotificationMapper(newNotification: NewNotification): NewNoti
   }
   /* eslint-enable functional/immutable-data */
   return newNotificationParsed;
+}
+
+export function getDuplicateValuesByKeys<T>(objectsList: Array<T>, keys: Array<keyof T>): Array<string> {
+  const getValue = (item: T) => {
+    let valueByKeys = '';
+    for (let i = 0; i < keys.length; i++) {
+      valueByKeys += item[keys[i]] ?? '';
+    }
+    return valueByKeys;
+  };
+
+  return objectsList
+    .map((recipient) => getValue(recipient))
+    .filter((value, i, valueList) => valueList.indexOf(value) !== i)
+    .filter((value, i, valueList) => valueList.indexOf(value) === i);
 }


### PR DESCRIPTION
## Short description
In Recipient component, now if the user uses the same combination of creditorTaxId and 

## List of changes proposed in this pull request
- Adds check on same Notice Code and Creditor Tax Id for multiple recipients
- Refactor duplicate map and filter inside a function getDuplicateValuesByKeys
- Fixes tests for Recipient, now checks correctly that continue button is disabled if multiple recipients share the same Tax Id or Notice Code + Creditor Tax Id, and not because of other errors
- Changes some MockValues to ensure tests run correctly

## How to test
Send manual notification, in the recipients step, set the same combination of values in the "Codice fiscale ente creditore" and "Codice avviso" fields for 2 or more different recipients, an error should be displayed and the continue button should be disabled when all other fields are set correctly.