### PR TITLE
Feature/pn 2585 cloudfront distribution protection

### DIFF
--- a/aws-cdn-templates/one-cdn.yaml
+++ b/aws-cdn-templates/one-cdn.yaml
@@ -402,22 +402,10 @@ Resources:
       Description: Web Application Firewall for AWS CloudFront
       Name: !Join ["-", [CloudFront-WAF, !Ref Name]]
       Rules: 
-        - Action: 
-            Block: {}
-          Name: "CloudFront_Rate_based_Rule"
-          Priority: 0
-          Statement: 
-            RateBasedStatement: 
-              Limit: !Ref Limit
-              AggregateKeyType: IP
-          VisibilityConfig: 
-            SampledRequestsEnabled: true
-            CloudWatchMetricsEnabled: true
-            MetricName: "CloudFront_Rate_based_Rule"
         - Name: AWSManagedRulesAmazonIpReputationList
           OverrideAction: 
             None: {}
-          Priority: 1
+          Priority: 0
           Statement: 
             ManagedRuleGroupStatement:
               VendorName: AWS
@@ -429,7 +417,7 @@ Resources:
         - Name: AWSManagedRulesAnonymousIpList
           OverrideAction: 
             None: {}
-          Priority: 2
+          Priority: 1
           Statement: 
             ManagedRuleGroupStatement:
               VendorName: AWS
@@ -438,6 +426,18 @@ Resources:
             CloudWatchMetricsEnabled: true
             MetricName: AWSManagedRulesAnonymousIpList
             SampledRequestsEnabled: true
+        - Action: 
+            Block: {}
+          Name: "CloudFront_Rate_based_Rule"
+          Priority: 2
+          Statement: 
+            RateBasedStatement: 
+              Limit: !Ref Limit
+              AggregateKeyType: IP
+          VisibilityConfig: 
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: "CloudFront_Rate_based_Rule"
       Scope: CLOUDFRONT
       VisibilityConfig: 
         CloudWatchMetricsEnabled: true

--- a/aws-cdn-templates/one-cdn.yaml
+++ b/aws-cdn-templates/one-cdn.yaml
@@ -26,7 +26,7 @@ Parameters:
   AlternateWebDomainReferenceToSite:
     Description: true if the website must be reachable using the AlternateWebDomain
     Type: String
-    Default: 'true'
+    Default: 'true' 
 
   AlternateHostedZoneId:
     Description: Hosted Zone Id in which you want to add alternate DNS
@@ -37,10 +37,14 @@ Parameters:
     Description: "ACM Web Certificate ARN"
     Type: String
 
-  
   WebApiUrl:
     Description: "The Url of web API: useful for content-security-policy"
     Type: String
+
+  Limit:
+    Type: Number
+    Description: The limit on requests per 5-minute period for a single originating IP address.
+    Default: 2000
 
 Conditions:
 
@@ -291,6 +295,7 @@ Resources:
           AcmCertificateArn: !Ref WebCertificateArn
           MinimumProtocolVersion: TLSv1.2_2021
           SslSupportMethod: sni-only
+        WebACLId: !GetAtt ApiWafWebAcl.Arn
 
   DefaultHeaderPolicy:
     Type: AWS::CloudFront::ResponseHeadersPolicy
@@ -387,6 +392,57 @@ Resources:
         Comment: 'Rewriting the request between a CloudFront Distribution and an origin'
         Runtime: cloudfront-js-1.0
       Name: !Sub "${AWS::StackName}-RewriteDefaultIndexRequest"
+
+  # AWS WAF Web ACLs for CloudFront
+  ApiWafWebAcl:
+    Type: AWS::WAFv2::WebACL
+    Properties: 
+      DefaultAction: 
+        Allow: {}
+      Description: Web Application Firewall for AWS CloudFront
+      Name: !Join ["-", [CloudFront-WAF, !Ref Name]]
+      Rules: 
+        - Action: 
+            Block: {}
+          Name: "CloudFront_Rate_based_Rule"
+          Priority: 0
+          Statement: 
+            RateBasedStatement: 
+              Limit: !Ref Limit
+              AggregateKeyType: IP
+          VisibilityConfig: 
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: "CloudFront_Rate_based_Rule"
+        - Name: AWSManagedRulesAmazonIpReputationList
+          OverrideAction: 
+            None: {}
+          Priority: 1
+          Statement: 
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesAmazonIpReputationList
+          VisibilityConfig: 
+            CloudWatchMetricsEnabled: true
+            MetricName: AWSManagedRulesAmazonIpReputationList
+            SampledRequestsEnabled: true
+        - Name: AWSManagedRulesAnonymousIpList
+          OverrideAction: 
+            None: {}
+          Priority: 2
+          Statement: 
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesAnonymousIpList
+          VisibilityConfig: 
+            CloudWatchMetricsEnabled: true
+            MetricName: AWSManagedRulesAnonymousIpList
+            SampledRequestsEnabled: true
+      Scope: CLOUDFRONT
+      VisibilityConfig: 
+        CloudWatchMetricsEnabled: true
+        MetricName: !Join ["-", [CloudFront-WAF, !Ref Name]]
+        SampledRequestsEnabled: true
 
 Outputs:
 

--- a/aws-cdn-templates/one-cdn.yaml
+++ b/aws-cdn-templates/one-cdn.yaml
@@ -44,7 +44,7 @@ Parameters:
   Limit:
     Type: Number
     Description: The limit on requests per 5-minute period for a single originating IP address.
-    Default: 2000
+    Default: 1000
 
 Conditions:
 


### PR DESCRIPTION
## Short description
Added a WAF for CloudFront distribution 

## List of changes proposed in this pull request
- Added a new AWS WAF resource in CloudFormation template
- Template to be deployed in us-east-1 for WAF on CloudFront

## How to test
Once deployed, simulate a HTTP flood to the domain which should trigger Rate-based rules to block incoming requests once limit is reached