### PR TITLE
Fix/PN 2576 clear recipient fields

### DIFF
--- a/packages/pn-pa-webapp/src/pages/components/NewNotification/Recipient.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/NewNotification/Recipient.tsx
@@ -150,6 +150,10 @@ const Recipient = ({ onConfirm, onPreviousStep, recipientsData }: Props) => {
             is: true,
             then: yup.string().required(tc('required-field')),
           }),
+          municipality: yup.string().when('showPhysicalAddress', {
+            is: true,
+            then: yup.string().required(tc('required-field')),
+          }),
           province: yup.string().when('showPhysicalAddress', {
             is: true,
             then: yup.string().required(tc('required-field')),
@@ -269,7 +273,7 @@ const Recipient = ({ onConfirm, onPreviousStep, recipientsData }: Props) => {
       validateOnBlur={false}
       validateOnMount
     >
-      {({ values, setFieldValue, touched, handleBlur, errors, isValid /* setValues */ }) => (
+      {({ values, setFieldValue, touched, setFieldTouched, handleBlur, errors, isValid /* setValues */ }) => (
         <Form>
           <NewNotificationCard noPaper isContinueDisabled={!isValid} previousStepLabel={t('back-to-preliminary-informations')}
               previousStepOnClick={() => handlePreviousStep(values)}>
@@ -292,9 +296,13 @@ const Recipient = ({ onConfirm, onPreviousStep, recipientsData }: Props) => {
                     <Delete
                       data-testid="DeleteRecipientIcon"
                       onClick={() => {
+                        if(errors && errors.recipients && errors.recipients[index]) {
+                          setFieldTouched(`recipients.${index}`, false, false);
+                        }
                         setFieldValue(
                           'recipients',
-                          values.recipients.filter((_, j) => index !== j)
+                          values.recipients.filter((_, j) => index !== j),
+                          true
                         );
                       }}
                     />

--- a/packages/pn-pa-webapp/src/pages/components/NewNotification/__test__/Recipient.test.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/NewNotification/__test__/Recipient.test.tsx
@@ -25,6 +25,7 @@ const populateForm = async (form: HTMLFormElement) => {
   fireEvent.click(checkbox!);
   await testInput(form, `recipients[0].address`, newNotification.recipients[0].address);
   await testInput(form, `recipients[0].houseNumber`, newNotification.recipients[0].houseNumber);
+  await testInput(form, `recipients[0].municipality`, newNotification.recipients[0].municipality);
   await testInput(form, `recipients[0].zip`, newNotification.recipients[0].zip);
   await testInput(form, `recipients[0].province`, newNotification.recipients[0].province);
   await testInput(form, `recipients[0].foreignState`, newNotification.recipients[0].foreignState);


### PR DESCRIPTION
## Short description
This pr solve the following bugs creating a new notification:
- mandatory fields show an error deleting a recipient and attempting to add a new one
- missing mandatory validation on "municipality" field of a recipient address to set it as mandatory

## List of changes proposed in this pull request
- add municipality to yup validation schema and set it to required for recipients on a new notification
- reset touched fields after deleting a recipient on a new notification
- test: fix Recipient.test.tsx not working after changes

## How to test
- remove a recipient and click on "Add a recipient". No errors should be displayed on mandatory fields
- add a recipient without filling in the "municipality" input field. The "Go to next step" button should be disabled as the field is mandatory.