### PR TITLE
fix: PN-2672 format payment amount from eurocents to euros

### DIFF
--- a/packages/pn-pa-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/NotificationDetail.page.tsx
@@ -30,7 +30,7 @@ import {
   NotificationDetailRecipient,
   NotificationStatus,
   useErrors,
-  ApiError,
+  ApiError, formatEurocentToCurrency,
 } from '@pagopa-pn/pn-commons';
 import { Tag, TagGroup } from '@pagopa/mui-italia';
 import { trackEventByType } from '../utils/mixpanel';
@@ -149,8 +149,8 @@ const NotificationDetail = () => {
     },
     {
       label: t('detail.amount', { ns: 'notifiche' }),
-      rawValue: notification.amount?.toFixed(2),
-      value: <Box fontWeight={600}>{notification.amount?.toFixed(2)}</Box>,
+      rawValue: notification.amount ? formatEurocentToCurrency(notification.amount).toString() : undefined,
+      value: <Box fontWeight={600}>{notification.amount && formatEurocentToCurrency(notification.amount)}</Box>,
     },
     {
       label: t('detail.iun', { ns: 'notifiche' }),

--- a/packages/pn-pa-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
+++ b/packages/pn-pa-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
@@ -101,7 +101,7 @@ describe('NotificationDetail Page (one recipient)', () => {
     expect(result.container.querySelector('h4')).toHaveTextContent(notificationToFe.subject);
     expect(result.container).toHaveTextContent('mocked-abstract');
     expect(result.container).toHaveTextContent(/Table/i);
-    expect(result.container).toHaveTextContent(/130.00/i);
+    expect(result.container).toHaveTextContent(/1,30 €/i);
     expect(result.container).toHaveTextContent(
       `${notificationToFe.recipients[0].payment?.creditorTaxId} - ${notificationToFe.recipients[0].payment?.noticeCode}`
     );
@@ -198,7 +198,7 @@ describe('NotificationDetail Page (multi recipient)', () => {
     expect(result.container.querySelector('h4')).toHaveTextContent(notificationToFeMultiRecipient.subject);
     expect(result.container).toHaveTextContent('mocked-abstract');
     expect(result.container).toHaveTextContent(/Table/i);
-    expect(result.container).toHaveTextContent(/200.00/i);
+    expect(result.container).toHaveTextContent(/2,00 €/i);
     for (const recipient of notificationToFeMultiRecipient.recipients) {
       expect(result.container).toHaveTextContent(
         `${recipient.taxId} - ${recipient.payment?.creditorTaxId} - ${recipient.payment?.noticeCode}`


### PR DESCRIPTION
## Short description
Fixes error in payment amount format in notification detail for pn-pa-webapp

## List of changes proposed in this pull request
- Fixes error in payment amount format in NotificationDetail.page.tsx
- Changes tests accordingly for NotificationDetail.page.test.tsx

## How to test
Check that payment amount is formatted from eurocents to euros (es. 1010 -> 10,10 €) for notification detail for pn-pa-webapp
Tested in SVIL env for notification [QKGT-RPXH-NJTY-202211-D-1](https://portale-pa.svil.pn.pagopa.it/dashboard/QKGT-RPXH-NJTY-202211-D-1/dettaglio)