### PR TITLE
Feature/pn 2675 limit max 5 recipients

### DIFF
--- a/packages/pn-pa-webapp/src/pages/components/NewNotification/Recipient.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/NewNotification/Recipient.tsx
@@ -578,7 +578,7 @@ const Recipient = ({ paymentMode, onConfirm, onPreviousStep, recipientsData }: P
                         />
                       )}
                     </Grid>
-                    {values.recipients.length - 1 === index && (
+                    {values.recipients.length < 5 && values.recipients.length - 1 === index && (
                       <Stack mt={4} display="flex" direction="row" justifyContent="space-between">
                         <ButtonNaked
                           startIcon={<Add />}

--- a/packages/pn-pa-webapp/src/pages/components/NewNotification/Recipient.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/NewNotification/Recipient.tsx
@@ -587,6 +587,7 @@ const Recipient = ({ paymentMode, onConfirm, onPreviousStep, recipientsData }: P
                           }}
                           color="primary"
                           size="large"
+                          disabled={values.recipients.length >= 5}
                         >
                           {t('add-recipient')}
                         </ButtonNaked>

--- a/packages/pn-pa-webapp/src/pages/components/NewNotification/__test__/Recipient.test.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/NewNotification/__test__/Recipient.test.tsx
@@ -95,6 +95,23 @@ describe('Recipient Component', () => {
     await waitFor(() => expect(result?.container).not.toHaveTextContent(/title 2/i));
   });
 
+  it('renders the 5 cards, then add recipient should be disabled', async () => {
+    expect(result.container).not.toHaveTextContent(/title 1/i);
+    expect(result.container).not.toHaveTextContent(/title 2/i);
+    const addButton1 = result.queryByText('add-recipient');
+    fireEvent.click(addButton1!);
+    const addButton2 = result.queryByText('add-recipient');
+    fireEvent.click(addButton2!);
+    const addButton3 = result.queryByText('add-recipient');
+    fireEvent.click(addButton3!);
+    const addButton4 = result.queryByText('add-recipient');
+    fireEvent.click(addButton4!);
+    expect(result.container).toHaveTextContent(/title 1/i);
+    expect(result.container).toHaveTextContent(/title 5/i);
+    const addButton5 = result.queryByText('add-recipient');
+    expect(addButton5).toBeNull();
+  });
+
   it('shows the digital domicile form and the physical address form', async () => {
     const digitalDomicileCheckbox = result.getByTestId('DigitalDomicileCheckbox');
     const physicalAddressCheckbox = result.getByTestId('PhysicalAddressCheckbox');


### PR DESCRIPTION
## Short description
Removes 'Add recipient' button during manual notification sending when there are already 5 recipients.

## List of changes proposed in this pull request
- Removes 'Add recipient' button during manual notification sending when there are already 5 recipients.
- Adds test

## How to test
Go to new notification page in pn-pa-webapp, in the recipients section add 4 recipients, the add button should not be visible.