### PR TITLE
Feat/pn 2676 limit other attachments to 10

### DIFF
--- a/packages/pn-pa-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/it/notifiche.json
@@ -204,6 +204,7 @@
       },
       "attachments": {
         "title": "Allegati",
+        "max-attachments": "E' possibile inserire fino a un massimo di 10 allegati oltre l'atto.",
         "attach-for-recipients": "Allegati per tutti i destinatari",
         "act-attachment": "Allega l'atto",
         "doc-attachment": "Allega un altro documento",

--- a/packages/pn-pa-webapp/src/pages/components/NewNotification/Attachments.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/NewNotification/Attachments.tsx
@@ -301,14 +301,16 @@ const Attachments = ({ onConfirm, onPreviousStep, attachmentsData }: Props) => {
             sx={{ marginTop: i > 0 ? '30px' : '10px' }}
           />
         ))}
-        <ButtonNaked
-          onClick={addDocumentHandler}
-          color="primary"
-          startIcon={<AddIcon />}
-          sx={{ marginTop: '30px' }}
-        >
-          {formik.values.documents.length === 1 ? t('add-doc') : t('add-another-doc')}
-        </ButtonNaked>
+        {formik.values.documents.length <= 11 &&
+          <ButtonNaked
+            onClick={addDocumentHandler}
+            color="primary"
+            startIcon={<AddIcon/>}
+            sx={{marginTop: '30px'}}
+          >
+            {formik.values.documents.length === 1 ? t('add-doc') : t('add-another-doc')}
+          </ButtonNaked>
+        }
       </NewNotificationCard>
     </form>
   );

--- a/packages/pn-pa-webapp/src/pages/components/NewNotification/Attachments.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/NewNotification/Attachments.tsx
@@ -301,7 +301,7 @@ const Attachments = ({ onConfirm, onPreviousStep, attachmentsData }: Props) => {
             sx={{ marginTop: i > 0 ? '30px' : '10px' }}
           />
         ))}
-        {formik.values.documents.length <= 11 &&
+        {formik.values.documents.length < 11 &&
           <ButtonNaked
             onClick={addDocumentHandler}
             color="primary"

--- a/packages/pn-pa-webapp/src/pages/components/NewNotification/Attachments.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/NewNotification/Attachments.tsx
@@ -36,6 +36,8 @@ type AttachmentBoxProps = {
   fileUploaded?: NewNotificationDocument;
 };
 
+const MAX_NUMBER_OF_ATTACHMENTS = 10;
+
 const AttachmentBox = ({
   id,
   title,
@@ -272,6 +274,7 @@ const Attachments = ({ onConfirm, onPreviousStep, attachmentsData }: Props) => {
       <NewNotificationCard
         isContinueDisabled={!formik.isValid}
         title={t('attach-for-recipients')}
+        subtitle={t('max-attachments', { maxNumber: MAX_NUMBER_OF_ATTACHMENTS })}
         previousStepLabel={t('back-to-recipient')}
         previousStepOnClick={() => handlePreviousStep()}
       >
@@ -301,7 +304,7 @@ const Attachments = ({ onConfirm, onPreviousStep, attachmentsData }: Props) => {
             sx={{ marginTop: i > 0 ? '30px' : '10px' }}
           />
         ))}
-        {formik.values.documents.length < 11 &&
+        {formik.values.documents.length <= MAX_NUMBER_OF_ATTACHMENTS &&
           <ButtonNaked
             onClick={addDocumentHandler}
             color="primary"

--- a/packages/pn-pa-webapp/src/pages/components/NewNotification/NewNotificationCard.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/NewNotification/NewNotificationCard.tsx
@@ -6,6 +6,7 @@ type Props = {
   children: ReactNode;
   isContinueDisabled: boolean;
   title?: string;
+  subtitle?: string;
   noPaper?: boolean;
   submitLabel?: string;
   previousStepLabel?: string;
@@ -16,6 +17,7 @@ const NewNotificationCard = ({
   children,
   isContinueDisabled,
   title,
+  subtitle,
   noPaper = false,
   submitLabel,
   previousStepLabel,
@@ -28,6 +30,7 @@ const NewNotificationCard = ({
       {!noPaper && (
         <Paper sx={{ padding: '24px', marginTop: '40px' }} className="paperContainer">
           {title && <Typography variant="h6">{title}</Typography>}
+          {subtitle && <Typography variant="body1">{subtitle}</Typography>}
           <Box sx={{ marginTop: '20px' }}>{children}</Box>
         </Paper>
       )}

--- a/packages/pn-pa-webapp/src/pages/components/NewNotification/__test__/Attachments.test.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/NewNotification/__test__/Attachments.test.tsx
@@ -171,7 +171,7 @@ describe('Attachments Component', () => {
   it('Adds ten documents placeholders and checks that is not possible to add more', async () => {
     const form = result.container.querySelector('form');
     let buttons = await waitFor(() => form?.querySelectorAll('button'));
-    for (let i=0; i<11; i++) {
+    for (let i=0; i<10; i++) {
       fireEvent.click(buttons![0]);
     }
     buttons = await waitFor(() => form?.querySelectorAll('button'));

--- a/packages/pn-pa-webapp/src/pages/components/NewNotification/__test__/Attachments.test.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/NewNotification/__test__/Attachments.test.tsx
@@ -167,4 +167,15 @@ describe('Attachments Component', () => {
       },
     ]);
   });
+
+  it('Adds ten documents placeholders and checks that is not possible to add more', async () => {
+    const form = result.container.querySelector('form');
+    let buttons = await waitFor(() => form?.querySelectorAll('button'));
+    for (let i=0; i<11; i++) {
+      fireEvent.click(buttons![0]);
+    }
+    buttons = await waitFor(() => form?.querySelectorAll('button'));
+    expect(buttons![0]).not.toHaveTextContent(/add-another-doc/i);
+    expect(buttons![0]).toHaveTextContent(/button.continue/i);
+  });
 });


### PR DESCRIPTION
## Short description
Limits the number of other attachments to 10.

## List of changes proposed in this pull request
- The button is not visible when there are 11 attachment boxes (1 act + 10 other attachments)
- Adds a test to check that the button is not visible when there are 11 boxes

## How to test
In pn-pa-webapp send a new notification, in the attachments section add 10 attachments, the button to add another attachment should not be visible.