### PR TITLE
fix: PN-2745 typo in appstatus page ora to ore

### DIFF
--- a/packages/pn-commons/src/components/AppStatus/MobileDowntimeLog.tsx
+++ b/packages/pn-commons/src/components/AppStatus/MobileDowntimeLog.tsx
@@ -19,10 +19,10 @@ const MobileDowntimeLog = ({ downtimeLog, getDowntimeLegalFactDocumentDetails }:
   ], [getStatusFieldSpec]);
 
   const cardBody: Array<CardElement> = useMemo(() => [
-    {...adaptFieldSpecToMobile(getDateFieldSpec('startDate', false)), notWrappedInTypography: true},
-    {...adaptFieldSpecToMobile(getDateFieldSpec('endDate', false)), notWrappedInTypography: true},
+    { ...adaptFieldSpecToMobile(getDateFieldSpec('startDate', false)), notWrappedInTypography: true },
+    { ...adaptFieldSpecToMobile(getDateFieldSpec('endDate', false)), notWrappedInTypography: true },
     adaptFieldSpecToMobile(getFunctionalityFieldSpec()),
-    {...adaptFieldSpecToMobile(getLegalFactIdFieldSpec()), notWrappedInTypography: true},
+    { ...adaptFieldSpecToMobile(getLegalFactIdFieldSpec()), notWrappedInTypography: true },
   ], [getDateFieldSpec, getFunctionalityFieldSpec, getLegalFactIdFieldSpec]);
 
   /* eslint-disable-next-line sonarjs/no-identical-functions */

--- a/packages/pn-pa-webapp/public/locales/it/common.json
+++ b/packages/pn-pa-webapp/public/locales/it/common.json
@@ -58,7 +58,7 @@
   },
   "date-time": {
     "today-uppercase-initial": "Oggi",
-    "hour-of-day": "ora"
+    "hour-of-day": "ore"
   },
   "error-boundary": {
     "title": "Qualcosa è andato storto",

--- a/packages/pn-pa-webapp/src/pages/AppStatus.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/AppStatus.page.tsx
@@ -10,8 +10,6 @@ import { useAppDispatch, useAppSelector } from '../redux/hooks';
 import { RootState } from '../redux/store';
 import { clearLegalFactDocumentData, clearPagination, setPagination } from '../redux/appStatus/reducers';
 
-
-/* eslint-disable-next-line arrow-body-style */
 const AppStatus = () => {
   const dispatch = useAppDispatch();
   const currentStatus = useAppSelector((state: RootState) => state.appStatus.currentStatus);


### PR DESCRIPTION
## Short description
Fixes typo in AppStatus page for pn-pa-webapp

## List of changes proposed in this pull request
- Fixes typo in AppStatus page for pn-pa-webapp

## How to test
AppStatus page should now display "ore" instead of "ora"