### PR TITLE
Feat/pn 2823

### DIFF
--- a/packages/pn-landing-webapp/.env
+++ b/packages/pn-landing-webapp/.env
@@ -4,4 +4,4 @@ NEXT_PUBLIC_PAGOPA_HELP_EMAIL = notifichedigitali@assistenza.pagopa.it
 NEXT_PUBLIC_PAGOPA_HOME = https://www.pagopa.it
 NEXT_PUBLIC_PRIVACY_DOCUMENT_PATH = /static/documents/informativa-privacy.pdf
 NEXT_PUBLIC_PA_PRIVACY_DOCUMENT_PATH = /static/documents/informativa-privacy-enti.pdf
-NEXT_PUBLIC_ONE_TRUST_PORTAL_CDN = https://privacyportalde-cdn.onetrust.com/77f17844-04c3-4969-a11d-462ee77acbe1/privacy-notices/draft/b5c8e1dc-89df-4ec2-a02d-1c0f55fac052.json
+NEXT_PUBLIC_ONE_TRUST_PORTAL_CDN = https://privacyportalde-cdn.onetrust.com/77f17844-04c3-4969-a11d-462ee77acbe1/privacy-notices/b5c8e1dc-89df-4ec2-a02d-1c0f55fac052.json

--- a/packages/pn-landing-webapp/buildspec.yaml
+++ b/packages/pn-landing-webapp/buildspec.yaml
@@ -6,7 +6,7 @@ batch:
         variables:
           BUILD_ID: dev
           NEXT_PUBLIC_PIATTAFORMA_NOTIFICHE_URL: "https://portale-login.dev.pn.pagopa.it/"
-          NEXT_PUBLIC_ONE_TRUST_PORTAL_CDN: "https://privacyportalde-cdn.onetrust.com/77f17844-04c3-4969-a11d-462ee77acbe1/privacy-notices/draft/b5c8e1dc-89df-4ec2-a02d-1c0f55fac052.json"
+          NEXT_PUBLIC_ONE_TRUST_PORTAL_CDN: "https://privacyportalde-cdn.onetrust.com/77f17844-04c3-4969-a11d-462ee77acbe1/privacy-notices/b5c8e1dc-89df-4ec2-a02d-1c0f55fac052.json"
     - identifier: pn_landing_svil_build
       env:
         variables:


### PR DESCRIPTION
## Short description
Landing -> public version of privacy page

## List of changes proposed in this pull request
- Updated NEXT_PUBLIC_ONE_TRUST_PORTAL_CDN const with new value

## How to test
Go to landing webapp, go to informativa-privacy page and check that public version is displayed