### PR TITLE
special chars sanitized during translation

### DIFF
--- a/packages/pn-commons/src/utils/__test__/string.utility.test.ts
+++ b/packages/pn-commons/src/utils/__test__/string.utility.test.ts
@@ -1,0 +1,24 @@
+import { formatFiscalCode, sanitizeString } from '../string.utility';
+
+describe('String utility', () => {
+  it('formatFiscalCode', () => {
+    const fiscalCode = 'abc';
+    const result = formatFiscalCode(fiscalCode);
+    expect(result).toStrictEqual('ABC');
+  });
+
+  it('unescape - no char to sanitize', () => {
+    const str = 'abc';
+    const result = sanitizeString(str);
+    expect(result).toStrictEqual(str);
+  });
+
+  it('unescape - char to sanitize', () => {
+    // Malicious third-party code
+    const thirdPartyString = `<img src=x onerror="alert('XSS Attack')">`;
+    const thirdPartyURL = `javascript:alert('Another XSS Attack')`;
+    const htmlStr = `<p>${thirdPartyString}</p><p><a href="${thirdPartyURL}">View My Profile</a></p>`;
+    const result = sanitizeString(htmlStr);
+    expect(result).toStrictEqual('<p><img src="x"></p><p><a>View My Profile</a></p>');
+  });
+});

--- a/packages/pn-commons/src/utils/index.ts
+++ b/packages/pn-commons/src/utils/index.ts
@@ -1,4 +1,4 @@
-import { dataRegex, formatFiscalCode } from './string.utility';
+import { dataRegex, formatFiscalCode, sanitizeString } from './string.utility';
 import { calculatePages } from './pagination.utility';
 import {
     getNotificationStatusInfos,
@@ -63,4 +63,5 @@ export {
     apiOutcomeTestHelper,
     simpleMockForApiErrorWrapper,
     performThunkAction,
+    sanitizeString
 };

--- a/packages/pn-commons/src/utils/string.utility.ts
+++ b/packages/pn-commons/src/utils/string.utility.ts
@@ -1,6 +1,6 @@
 /**
  * Initial proposal of regex for different kinds of info expressed as strings,
- * the current aim is just to avoid security issues and/or 
+ * the current aim is just to avoid security issues and/or
  * security warnings in the static analysis of the source code.
  * In particular, the one for the phone number could be done *a lot* better.
  * ------------------------
@@ -33,12 +33,14 @@ export function formatFiscalCode(fiscalCode: string): string {
  * @param  {String}  value The attribute value
  * @return {Boolean}       If true, the attribute is potentially dangerous
  */
- function isPossiblyDangerous (name: string, value: string): boolean {
-	let val = value.replace(/\s+/g, '').toLowerCase();
-	if (['src', 'href', 'xlink:href'].includes(name)) {
-		if (val.includes('javascript:') || val.includes('data:text/html')) return true;
-	}
-	if (name.startsWith('on')) return true;
+function isPossiblyDangerous(name: string, value: string): boolean {
+  const val = value.replace(/\s+/g, '').toLowerCase();
+  if (['src', 'href', 'xlink:href'].includes(name)) {
+    if (val.includes('javascript:') || val.includes('data:text/html')) return true;
+  }
+  if (name.startsWith('on')) {
+	return true;
+  }
   return false;
 }
 
@@ -46,37 +48,37 @@ export function formatFiscalCode(fiscalCode: string): string {
  * Remove potentially dangerous attributes from an element
  * @param  {Element} elem The element
  */
- function removeAttributes (elem: Element) {
-	// Loop through each attribute
-	// If it's dangerous, remove it
-	let atts = elem.attributes;
-	for (let {name, value} of atts) {
-		if (!isPossiblyDangerous(name, value)) continue;
-		elem.removeAttribute(name);
-	}
+function removeAttributes(elem: Element) {
+  // Loop through each attribute
+  // If it's dangerous, remove it
+  const atts = elem.attributes;
+  for (const { name, value } of atts) {
+    if (!isPossiblyDangerous(name, value)) continue;
+    elem.removeAttribute(name);
+  }
 }
 
 /**
  * Remove <script> elements
  * @param  {Document} html The HTML
  */
- function removeScripts (html: Document) {
-	let scripts = html.querySelectorAll('script');
-	for (let script of scripts) {
-		script.remove();
-	}
+function removeScripts(html: Document) {
+  const scripts = html.querySelectorAll('script');
+  for (const script of scripts) {
+    script.remove();
+  }
 }
 
 /**
  * Remove dangerous stuff from the HTML document's nodes
  * @param  {Document | Element} html The HTML document
  */
- function clean (html: Document | Element) {
-	let nodes = html.children;
-	for (let node of nodes) {
-		removeAttributes(node);
-		clean(node);
-	}
+function clean(html: Document | Element) {
+  const nodes = html.children;
+  for (const node of nodes) {
+    removeAttributes(node);
+    clean(node);
+  }
 }
 
 /**
@@ -95,4 +97,3 @@ export function sanitizeString(srt: string): string {
   // return sanitized string
   return html.body.innerHTML;
 }
-

--- a/packages/pn-commons/tsconfig.json
+++ b/packages/pn-commons/tsconfig.json
@@ -3,6 +3,8 @@
     "target": "esnext",
     "module": "esnext",
     "lib": [
+      "DOM",
+      "DOM.Iterable",
       "es6",
       "dom",
       "es2019"

--- a/packages/pn-pa-webapp/src/i18n.ts
+++ b/packages/pn-pa-webapp/src/i18n.ts
@@ -1,6 +1,7 @@
 import i18next from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import HttpApi from 'i18next-http-backend';
+import { sanitizeString } from '@pagopa-pn/pn-commons';
 
 void i18next
   .use(initReactI18next)
@@ -10,6 +11,9 @@ void i18next
     fallbackLng: 'it',
     debug: process.env.NODE_ENV === 'development',
     ns: ['common'],
+    interpolation: {
+      escape: (srt: string): string => sanitizeString(srt)
+    }
   });
 
 export default i18next;

--- a/packages/pn-pa-webapp/tsconfig.json
+++ b/packages/pn-pa-webapp/tsconfig.json
@@ -5,7 +5,9 @@
     "lib": [
       "es6",
       "dom",
-      "es2019"
+      "es2019",
+      "DOM",
+      "DOM.Iterable",
     ],
     "jsx": "react-jsx",
     "noEmit": true,

--- a/packages/pn-personafisica-webapp/src/i18n.ts
+++ b/packages/pn-personafisica-webapp/src/i18n.ts
@@ -1,6 +1,7 @@
 import i18next from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import HttpApi from 'i18next-http-backend';
+import { sanitizeString } from '@pagopa-pn/pn-commons';
 
 void i18next
   .use(initReactI18next)
@@ -10,6 +11,9 @@ void i18next
     fallbackLng: 'it',
     debug: process.env.NODE_ENV === 'development',
     ns: ['common'],
+    interpolation: {
+      escape: (srt: string): string => sanitizeString(srt)
+    }
   });
 
 export default i18next;

--- a/packages/pn-personafisica-webapp/tsconfig.json
+++ b/packages/pn-personafisica-webapp/tsconfig.json
@@ -5,7 +5,9 @@
     "lib": [
       "es6",
       "dom",
-      "es2019"
+      "es2019",
+      "DOM",
+      "DOM.Iterable",
     ],
     "jsx": "react-jsx",
     "noEmit": true,


### PR DESCRIPTION
## Short description
Special character are escaped during translation (in our case char ' is translated to html code)
Introduced custom escape function to sanitize string when translating 

## List of changes proposed in this pull request
- Added a sanitize function into string.utility.ts in pn-commons package
- Configured i18next instance to accept the sanitize function in pa and pf packages

## How to test
Run pf package and point to coll environment. Login with Giovanna D'Arco and search notification with iun ZNGK-GRAD-KYDE-202211-A-1. Go to the notification detail and check that in timeline Giovanna D'Arco is printed correctly