### PR TITLE
fix: fix tos and privacy links to redirect the user to the right cont…

### DIFF
--- a/packages/pn-pa-webapp/src/pages/ToSAcceptance.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/ToSAcceptance.page.tsx
@@ -67,7 +67,7 @@ const TermsOfService = () => {
             description={<Trans
               ns={'common'}
               i18nKey={'tos.switch-label'}
-              components={[<PrivacyLink key={'privacy-link'} />, <TosLink key={'tos-link'} />]}
+              components={[<TosLink key={'tos-link'} />, <PrivacyLink key={'privacy-link'} />]}
             >
               Accedendo, accetti i <TosLink>Termini e condizioni d’uso</TosLink> del servizio e
               confermi di aver letto l’<PrivacyLink>Informativa Privacy</PrivacyLink>.


### PR DESCRIPTION
## Short description
This PR fixes a bug that was causing the sender (pn-pa-webapp) to be redirected to the wrong content when clicking on the "ToS" and "Privacy" links on the ToS acceptance page.

## List of changes proposed in this pull request
- switch the order of the components passed to the Trans component in ToSAcceptance.page.tsx

## How to test
Login in pn-pa-webapp as a user who didn't accept ToS yet (u.neri) and verify the links work properly