### PR TITLE
side menu expanded when a sub menu voice is selected

### DIFF
--- a/packages/pn-commons/src/components/SideMenu/SideMenu.tsx
+++ b/packages/pn-commons/src/components/SideMenu/SideMenu.tsx
@@ -21,8 +21,9 @@ const SideMenu: FC<Props> = ({ menuItems, selfCareItems, eventTrackingCallback }
   const isMobile = useIsMobile();
 
   const findMenuItemSelectedRecursive = (
-    items: Array<SideMenuItem>
-  ): { index: number; label: string; route: string } | null => {
+    items: Array<SideMenuItem>,
+    parent?: string
+  ): { index: number; label: string; route: string; parent?: string } | null => {
     // find if there is a menu item that matches current route
     // notSelectable flag indicates that the menu item is selectable
     let menuItemIndex = items.findIndex((m) => m.route === location.pathname && !m.notSelectable);
@@ -31,6 +32,7 @@ const SideMenu: FC<Props> = ({ menuItems, selfCareItems, eventTrackingCallback }
         index: menuItemIndex,
         label: items[menuItemIndex].label,
         route: items[menuItemIndex].route || '',
+        parent
       };
     }
     // find if there is a menu item that has route as a part of current one
@@ -45,12 +47,13 @@ const SideMenu: FC<Props> = ({ menuItems, selfCareItems, eventTrackingCallback }
     });
     if (menuItemIndex > -1) {
       if (items[menuItemIndex].children && items[menuItemIndex].children?.length) {
-        return findMenuItemSelectedRecursive(items[menuItemIndex].children!);
+        return findMenuItemSelectedRecursive(items[menuItemIndex].children!, items[menuItemIndex].label);
       }
       return {
         index: menuItemIndex,
         label: items[menuItemIndex].label,
         route: items[menuItemIndex].route || '',
+        parent
       };
     }
     return null;

--- a/packages/pn-commons/src/components/SideMenu/SideMenuList.tsx
+++ b/packages/pn-commons/src/components/SideMenu/SideMenuList.tsx
@@ -19,7 +19,7 @@ type Props = {
   menuItems: Array<SideMenuItem>;
   selfCareItems?: Array<SideMenuItem>;
   handleLinkClick: (item: SideMenuItem, flag?: boolean) => void;
-  selectedItem: { index: number; label: string; route: string };
+  selectedItem: { index: number; label: string; route: string; parent?: string };
 };
 
 const useStyles = makeStyles(() => ({
@@ -54,6 +54,12 @@ const SideMenuList = ({ menuItems, selfCareItems, handleLinkClick, selectedItem 
 
   useEffect(() => {
     setSelectedIndex(selectedItem);
+    // open parent menù
+    setOpenId(selectedItem.parent || '');
+    setOpen(selectedItem.parent !== undefined);
+    /* eslint-disable functional/immutable-data */
+    prevOpenId.current = selectedItem.parent || '';
+    /* eslint-enalbe functional/immutable-data */
   }, [selectedItem]);
 
   return (

--- a/packages/pn-commons/src/components/SideMenu/SideMenuListItem.tsx
+++ b/packages/pn-commons/src/components/SideMenu/SideMenuListItem.tsx
@@ -48,7 +48,7 @@ const SideMenuListItem = ({
       onClick={() => {
         onSelect();
         if (goOutside) {
-          window.open(item.route as string);
+          window.open(item.route);
         } else {
           handleLinkClick(item);
         }

--- a/packages/pn-commons/src/components/SideMenu/__test__/test-utils.ts
+++ b/packages/pn-commons/src/components/SideMenu/__test__/test-utils.ts
@@ -11,25 +11,25 @@ export const sideMenuItems: Array<SideMenuItem> = [
   { 
     label: 'Item 2',
     icon: QuestionMarkIcon,
-    route: '',
+    route: 'mocked-route-2',
     children: [{
       label: 'Item 2-1',
       icon: QuestionMarkIcon,
-      route: ''
+      route: 'mocked-route-2/mocked-route-2-1'
     }]
   },
   { 
     label: 'Item 3',
     icon: QuestionMarkIcon,
-    route: '',
+    route: 'mocked-route-3',
     children: [{
       label: 'Item 3-1',
       icon: QuestionMarkIcon,
-      route: ''
+      route: 'mocked-route-3/mocked-route-3-1'
     }, {
       label: 'Item 3-2',
       icon: QuestionMarkIcon,
-      route: ''
+      route: 'mocked-route-3/mocked-route-3-2'
     }]
   }
 ];


### PR DESCRIPTION
## Short description
When an user has some delegations, the side menu of the dashboard has the voice "Notifiche" that is expandable.
Before the fix, the menu was collapsed and so the user couldn't see which notifications he was seeing.
Now this behavior is fixed.

## List of changes proposed in this pull request
- Added parent property for those selected menu item that are children of another menu item
- Expand the menu voice, when the parent property is set

## How to test
Pf -> log with an user with delegations and check that menù is opened and the voice "Le tue notifiche" is selected. Select on of the delegators, refresh and check that the menù is opened and the right menu voice is selected. Go to delegator notification detail, refresh and do the check explained above