### PR TITLE
PN-2798-[FE]-fuso-orario-sbagliato-sulle-attestazioni-opponibili-della-pagina-di-malfunzionamento

### DIFF
--- a/packages/pn-pa-webapp/src/pages/AppStatus.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/AppStatus.page.tsx
@@ -54,6 +54,7 @@ const AppStatus = () => {
   const fetchDowntimeLog = useCallback(() => {
     const fetchParams: GetDowntimeHistoryParams = {
       startDate: '1900-01-01T00:00:00Z',
+      endDate: new Date().toISOString(),
       functionality: [
         KnownFunctionality.NotificationCreate,
         KnownFunctionality.NotificationVisualization,

--- a/packages/pn-personafisica-webapp/src/pages/AppStatus.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/AppStatus.page.tsx
@@ -33,6 +33,7 @@ const AppStatus = () => {
   const fetchDowntimeLog = useCallback(() => {
     const fetchParams: GetDowntimeHistoryParams = { 
       startDate: "1900-01-01T00:00:00Z",
+      endDate: new Date().toISOString(),
       functionality: [KnownFunctionality.NotificationCreate, KnownFunctionality.NotificationVisualization, KnownFunctionality.NotificationWorkflow],
       size: String(paginationData.size),
       page: paginationData.resultPages[paginationData.page],


### PR DESCRIPTION
## Short description
I verified that the problems previously present regarding the timezone of the downtime records and the corresponding certificates (attestazioni opponibili a terzi) now are solved BE side, so their start/end times are shown correctly in the FE page about status/downtimes.  
On FE side, I limited the requests up to the present timestamp, to avoid getting eventual planned-for-the-future downtime records.

## List of changes proposed in this pull request
Just added a value to the `endTime` attribute in the API request query param.  
**Please note** I did this _separately_ for the status/downtime page in pa-webapp and pf-webapp, since the implementation is cloned for each app.

## How to test
Just enter the "Stato della piattaforma" option, check the last donwtime records (from 01/12/2022 on). You can also add new downtime records through the help desk web app.  
**Please** don't forget to check _both_ pa-webapp and pf-webapp.