### PR TITLE
pn-2855 - reset document ref data when it is uploaded by drag

### DIFF
--- a/packages/pn-pa-webapp/src/pages/components/NewNotification/Attachments.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/NewNotification/Attachments.tsx
@@ -201,7 +201,6 @@ const Attachments = ({ onConfirm, onPreviousStep, attachmentsData }: Props) => {
     name?: string,
     size?: number
   ) => {
-    await formik.setFieldTouched(`${id}.file`, true, false);
     await formik.setFieldValue(id, {
       ...formik.values.documents[index],
       file: {
@@ -214,7 +213,8 @@ const Attachments = ({ onConfirm, onPreviousStep, attachmentsData }: Props) => {
         key: '',
         versionToken: '',
       },
-    });
+    }, false);
+    await formik.setFieldTouched(`${id}.file`, true, true);
   };
 
   const removeFileHandler = async (id: string, index: number) => {

--- a/packages/pn-pa-webapp/src/pages/components/NewNotification/PaymentMethods.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/NewNotification/PaymentMethods.tsx
@@ -44,7 +44,7 @@ const PaymentBox = ({ id, title, onFileUploaded, onRemoveFile, fileUploaded }: P
         uploadText={t('new-notification.drag-doc')}
         accept="application/pdf"
         onFileUploaded={(file, sha256, name, size) =>
-          onFileUploaded(`${id}.file`, file as Uint8Array, sha256, name, size)
+          onFileUploaded(id, file as Uint8Array, sha256, name, size)
         }
         onRemoveFile={() => onRemoveFile(id)}
         sx={{ marginTop: '10px' }}
@@ -265,18 +265,22 @@ const PaymentMethods = ({ notification, onConfirm, isCompleted, onPreviousStep }
   });
 
   const fileUploadedHandler = async (
+    taxId: string,
+    paymentType: 'pagoPaForm' | 'f24flatRate' | 'f24standard',
     id: string,
     file?: Uint8Array,
     sha256?: { hashBase64: string; hashHex: string },
     name?: string,
     size?: number
   ) => {
-    await formik.setFieldTouched(id, true, false);
+    await formik.setFieldTouched(`${id}.file`, true, false);
     await formik.setFieldValue(id, {
-      size,
-      uint8Array: file,
-      sha256,
-      name,
+      ...formik.values[taxId][paymentType],
+      file: { size, uint8Array: file, sha256, name },
+      ref: {
+        key: '',
+        versionToken: '',
+      },
     });
   };
 
@@ -317,7 +321,8 @@ const PaymentMethods = ({ notification, onConfirm, isCompleted, onPreviousStep }
               <PaymentBox
                 id={`${recipient.taxId}.pagoPaForm`}
                 title={`${t('attach-pagopa-notice')}*`}
-                onFileUploaded={fileUploadedHandler}
+                onFileUploaded={(id, file, sha256, name, size) =>
+                  fileUploadedHandler(recipient.taxId, 'pagoPaForm', id, file, sha256, name, size)}
                 onRemoveFile={(id) => removeFileHandler(id, recipient.taxId, 'pagoPaForm')}
                 fileUploaded={formik.values[recipient.taxId].pagoPaForm}
               />
@@ -325,7 +330,8 @@ const PaymentMethods = ({ notification, onConfirm, isCompleted, onPreviousStep }
                 <PaymentBox
                   id={`${recipient.taxId}.f24flatRate`}
                   title={`${t('attach-f24-flatrate')}*`}
-                  onFileUploaded={fileUploadedHandler}
+                  onFileUploaded={(id, file, sha256, name, size) =>
+                    fileUploadedHandler(recipient.taxId, 'f24flatRate', id, file, sha256, name, size)}
                   onRemoveFile={(id) => removeFileHandler(id, recipient.taxId, 'f24flatRate')}
                   fileUploaded={formik.values[recipient.taxId].f24flatRate}
                 />
@@ -334,7 +340,8 @@ const PaymentMethods = ({ notification, onConfirm, isCompleted, onPreviousStep }
                 <PaymentBox
                   id={`${recipient.taxId}.f24standard`}
                   title={`${t('attach-f24')}*`}
-                  onFileUploaded={fileUploadedHandler}
+                  onFileUploaded={(id, file, sha256, name, size) =>
+                    fileUploadedHandler(recipient.taxId, 'f24standard', id, file, sha256, name, size)}
                   onRemoveFile={(id) => removeFileHandler(id, recipient.taxId, 'f24standard')}
                   fileUploaded={formik.values[recipient.taxId].f24standard}
                 />

--- a/packages/pn-pa-webapp/src/pages/components/NewNotification/PaymentMethods.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/NewNotification/PaymentMethods.tsx
@@ -14,8 +14,7 @@ import {
 } from '../../../models/NewNotification';
 import { useAppDispatch } from '../../../redux/hooks';
 import { uploadNotificationPaymentDocument } from '../../../redux/newNotification/actions';
-import { setIsCompleted } from '../../../redux/newNotification/reducers';
-import { setPaymentDocuments } from '../../../redux/newNotification/reducers';
+import { setIsCompleted, setPaymentDocuments } from '../../../redux/newNotification/reducers';
 import NewNotificationCard from './NewNotificationCard';
 
 type PaymentBoxProps = {

--- a/packages/pn-pa-webapp/src/pages/components/NewNotification/PaymentMethods.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/NewNotification/PaymentMethods.tsx
@@ -272,7 +272,6 @@ const PaymentMethods = ({ notification, onConfirm, isCompleted, onPreviousStep }
     name?: string,
     size?: number
   ) => {
-    await formik.setFieldTouched(`${id}.file`, true, false);
     await formik.setFieldValue(id, {
       ...formik.values[taxId][paymentType],
       file: { size, uint8Array: file, sha256, name },
@@ -280,7 +279,8 @@ const PaymentMethods = ({ notification, onConfirm, isCompleted, onPreviousStep }
         key: '',
         versionToken: '',
       },
-    });
+    }, false);
+    await formik.setFieldTouched(`${id}.file`, true, true);
   };
 
   const removeFileHandler = async (

--- a/packages/pn-pa-webapp/src/pages/components/NewNotification/__test__/Attachments.test.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/NewNotification/__test__/Attachments.test.tsx
@@ -25,11 +25,11 @@ describe('Attachments Component', () => {
   (file as any).name = 'Mocked file';
 
   function uploadDocument(elem: ParentNode, index: number) {
+    const nameInput = elem.querySelector(`[id="documents.${index}.name"]`);
+    fireEvent.change(nameInput!, { target: { value: `Doc${index}` } });
     const fileInput = elem.querySelector('[data-testid="fileInput"]');
     const input = fileInput?.querySelector('input');
     fireEvent.change(input!, { target: { files: [file] } });
-    const nameInput = elem.querySelector(`[id="documents.${index}.name"]`);
-    fireEvent.change(nameInput!, { target: { value: `Doc${index}` } });
   }
 
   async function testConfirm(button: HTMLButtonElement, documents: Array<UploadDocumentParams>) {


### PR DESCRIPTION
## Short description
New notification - reset document ref data when it is uploaded and after is changed by drag

## List of changes proposed in this pull request
- Changed part that manage file upload in Attachments.tsx and PaymentMethods.tsx files

## How to test
Go to new notification, go to step 3 or 4, upload document and confirm. the file is uploaded (ref data is filled). Change the file by dragging new one without removing the old one. Reconfirm and check that the new file is uploaded and ref is filled with new data