### PR TITLE
denomination regexp

### DIFF
--- a/packages/pn-commons/src/utils/string.utility.ts
+++ b/packages/pn-commons/src/utils/string.utility.ts
@@ -16,6 +16,8 @@ export const dataRegex = {
     /^([A-Z]{6}[0-9LMNPQRSTUV]{2}[ABCDEHLMPRST]{1}[0-9LMNPQRSTUV]{2}[A-Z]{1}[0-9LMNPQRSTUV]{3}[A-Z]{1})$/i,
   pIva: /^\d{11}$/,
   taxonomyCode: /^(\d{6}[A-Z]{1})$/,
+  denomination: /^([\x20-\xFF]{1,80})$/,
+  noticeCode: /^\d{18}$/
 };
 
 /**

--- a/packages/pn-pa-webapp/src/pages/components/NewNotification/Recipient.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/NewNotification/Recipient.tsx
@@ -87,16 +87,13 @@ const Recipient = ({ paymentMode, onConfirm, onPreviousStep, recipientsData }: P
         .test({
           name: 'denominationTotalLength',
           test(value) {
-            const maxLength = this.parent.recipientType === RecipientType.PG ? 80 : 79;
-            const isAcceptableLength =
-              (value || '').length + ((this.parent.lastName as string) || '').length <= maxLength;
-            if (isAcceptableLength) {
+            const denomination = (value || '') + ((this.parent.lastName as string) || '');
+            if (dataRegex.denomination.test(denomination)) {
               return true;
-            } else {
-              // il messaggio di "denominazione troppo lunga" è diverso a seconda che sia PF o PG
-              const messageKey = `too-long-denomination-error-${this.parent.recipientType || 'PF'}`;
-              return this.createError({ message: t(messageKey), path: this.path });
             }
+            // il messaggio di "denominazione troppo lunga" è diverso a seconda che sia PF o PG
+            const messageKey = `too-long-denomination-error-${this.parent.recipientType || 'PF'}`;
+            return this.createError({ message: t(messageKey), path: this.path });
           },
         }),
       // la validazione di lastName è condizionale perché per persone giuridiche questo attributo
@@ -164,7 +161,7 @@ const Recipient = ({ paymentMode, onConfirm, onPreviousStep, recipientsData }: P
           .matches(dataRegex.pIva, t('fiscal-code-error')),
         noticeCode: yup
           .string()
-          .matches(/^\d{18}$/, t('notice-code-error'))
+          .matches(dataRegex.noticeCode, t('notice-code-error'))
           .required(tc('required-field')),
       };
     }


### PR DESCRIPTION
## Short description
aligned front-end configuration with the back-end one for the validation of inputs during notification creation

## List of changes proposed in this pull request
- Mooved regexp to string utility file
- Aligned front-end regexps with back-end ones
- Modified Recipients.tsx file to accept new regexp

## How to test
Go to new notification page, go to recipient step and try to add D’Arco as recipient lastname. Check that the error is displayed