### PR TITLE
PN-2747 - changed subtitle of app status page for PA, keeps as before for PF

### DIFF
--- a/packages/pn-pa-webapp/public/locales/it/appStatus.json
+++ b/packages/pn-pa-webapp/public/locales/it/appStatus.json
@@ -1,7 +1,7 @@
 {
   "appStatus": {
     "title": "Stato della piattaforma",
-    "subtitle": "Verifica il funzionamento di Piattaforma Notifiche, visualizza lo storico dei disservizi e scarica le relative attestazioni opponibili a terzi. Ogni attestazione certifica un disservizio: potrebbe esserti utile nel caso in cui questo abbia coinvolto una notifica destinata a te.",
+    "subtitle": "Verifica il funzionamento di Piattaforma Notifiche, visualizza lo storico dei disservizi e scarica le relative attestazioni opponibili a terzi.",
     "statusDescription": {
       "ok": "Tutti i servizi di Piattaforma Notifiche sono operativi.",
       "not-ok": "C'è un disservizio in corso. Per maggiori dettagli, consulta la tabella qui sotto."


### PR DESCRIPTION
## Short description
I changed the subtitle of the app status ("Stato della piattaforma") for the recipient ("persona fisica") webapp, according with the indication given in https://pagopa.atlassian.net/browse/PN-2747 .

## List of changes proposed in this pull request
Just changed the text in the corresponding entry of the Italian i18n file.

## How to test
Enter both sender ("pubblica amministrazione") and recipient ("persona fisica") webapps, in each of them go to the "Stato della piattaforma" option, and check whether the subtitle (i.e. the text below the "Stato della piattaforma" title) coincides or not with the corresponding text specified in https://pagopa.atlassian.net/browse/PN-2747.