### PR TITLE
test: fix cy tests not working after changes on 'notifiche' menu item

### DIFF
--- a/packages/pn-personafisica-webapp/cypress/e2e/Delegate.cy.ts
+++ b/packages/pn-personafisica-webapp/cypress/e2e/Delegate.cy.ts
@@ -10,8 +10,6 @@ describe('Delegation', () => {
   beforeEach(() => {
     cy.viewport(1920, 1080);
 
-    // cy.intercept('GET', /delivery\/notifications\/sent/, {
-
     cy.intercept(`${NOTIFICATIONS_LIST({ startDate: '', endDate: '' })}**size=10`, {
       fixture: 'notifications/list-10/page-1',
     }).as('getNotifications');
@@ -42,7 +40,6 @@ describe('Delegation', () => {
         fixture: 'notifications/delegator/detail',
       }).as('notificationAsDelegate');
       
-      cy.get('[data-testid="ExpandMoreIcon"]').click();
       cy.get('[data-cy="collapsible-list"] > :nth-child(2)').click();
 
       cy.wait('@notificationsAsDelegate').then((interception) => {

--- a/packages/pn-personafisica-webapp/cypress/e2e/NotificationFilters.cy.ts
+++ b/packages/pn-personafisica-webapp/cypress/e2e/NotificationFilters.cy.ts
@@ -13,7 +13,6 @@ const filterButton = 'Filtra';
 const notificationMenuItem = '[data-cy="menu-item(notifiche)"]';
 const delegationMenuItem = '[data-cy="menu-item(deleghe)"]';
 const notificationListItem = '[data-cy="table(notifications)"] > :nth-child(2) > :first';
-const collapsibleNotificationMenu = '[data-cy="collapsible-menu"]';
 const notificationsByDelegateMenuItem = '[data-cy="collapsible-list"] > :nth-child(2)';
 
 const getDates = (endToday: boolean = false) => {
@@ -212,7 +211,7 @@ describe('Notification Filters (delegators)', () => {
     cy.intercept(`${NOTIFICATIONS_LIST({ startDate: '', endDate: '' })}*`, {
       fixture: 'notifications/delegator/list-10/page-1',
     }).as('getNotificationsByDelegate');
-    cy.get(collapsibleNotificationMenu).click();
+    
     cy.get(notificationsByDelegateMenuItem).click();
 
     cy.wait('@getNotificationsByDelegate');


### PR DESCRIPTION
changes made to default status of the 'notifiche' menu item from collapsed to expanded caused tests acting as delegate to stop working