### PR TITLE
PN-2411-fe-abilitare-invio-manuale-per-persona-giuridica

### DIFF
--- a/packages/pn-pa-webapp/src/pages/components/NewNotification/Recipient.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/NewNotification/Recipient.tsx
@@ -452,7 +452,7 @@ const Recipient = ({
                               control={<Radio />}
                               name={`recipients[${index}].recipientType`}
                               label={t('legal-person')}
-                              disabled
+                              // disabled
                             />
                           </Grid>
                           {values.recipients[index].recipientType === RecipientType.PG && (


### PR DESCRIPTION
## Short description
Enable the option "Persona Giuridica" in the recipient ("Destinatario") step in the manual procedure for notification creation. Verified that the FE behaves as expected if such option is selected. I tried also with a notification with two recipients, one "Persona Giuridica" and one "Persona Fisica", seems to work OK.

## List of changes proposed in this pull request
Just enabled the radio button and checked that all is OK FE side. We also verified that the API call for the registration of the new notification does add it, and that the saved notification is available in the pa-webapp dashboard. Matteo Turra indicates that there are still some problems to be solved BE side.

## How to test
Enter the manual procedure for notification creation, arrive to the second step, the "Persona Giuridica" radio button should be enabled. Play changing the selection between "Persona Fisica" and "Persona Giuridica", go back and forth in the navigation. 