### PR TITLE
chore: Added missing parameter to fix download error in delegate PF

### DIFF
--- a/packages/pn-personafisica-webapp/src/api/notifications/Notifications.api.ts
+++ b/packages/pn-personafisica-webapp/src/api/notifications/Notifications.api.ts
@@ -42,7 +42,7 @@ export const NotificationsApi = {
    * @param  {string} endDate
    * @returns Promise
    */
-  getReceivedNotifications: (params: GetNotificationsParams): Promise<GetNotificationsResponse> => 
+  getReceivedNotifications: (params: GetNotificationsParams): Promise<GetNotificationsResponse> =>
     apiClient.get<GetNotificationsResponse>(NOTIFICATIONS_LIST(params)).then((response) => {
       if (response.data && response.data.resultsPage) {
         const notifications = response.data.resultsPage.map((d) => ({
@@ -87,10 +87,11 @@ export const NotificationsApi = {
         return {} as NotificationDetailForRecipient;
       }
     }),
-  
-  exchangeNotificationQrCode: (qrCode: string): Promise<NotificationId> => 
-    apiClient.post<NotificationId>(NOTIFICATION_ID_FROM_QRCODE(), { aarQrCodeValue: qrCode })
-    .then((response) => response.data),
+
+  exchangeNotificationQrCode: (qrCode: string): Promise<NotificationId> =>
+    apiClient
+      .post<NotificationId>(NOTIFICATION_ID_FROM_QRCODE(), { aarQrCodeValue: qrCode })
+      .then((response) => response.data),
 
   /**
    * Gets current user notification document
@@ -109,16 +110,22 @@ export const NotificationsApi = {
       .then((response) => getDownloadUrl(response)),
 
   /**
-   * 
+   *
    * @param  {string} iun
-   * @param  {NotificationDetailOtherDocument} otherDocument 
+   * @param  {NotificationDetailOtherDocument} otherDocument
    * @returns Promise
    */
-  getReceivedNotificationOtherDocument: (iun: string, otherDocument: NotificationDetailOtherDocument): Promise<{ url: string }> =>
+  getReceivedNotificationOtherDocument: (
+    iun: string,
+    otherDocument: NotificationDetailOtherDocument,
+    mandateId?: string,
+  ): Promise<{ url: string }> =>
     apiClient
-      .get<{ url: string }>(NOTIFICATION_DETAIL_OTHER_DOCUMENTS(iun, otherDocument), {params: {documentId: otherDocument.documentId}})
+      .get<{ url: string }>(NOTIFICATION_DETAIL_OTHER_DOCUMENTS(iun, otherDocument), {
+        params: { documentId: otherDocument.documentId, mandateId },
+      })
       .then((response) => getDownloadUrl(response)),
-  
+
   /**
    * Gets current user notification legalfact
    * @param  {string} iun
@@ -170,11 +177,14 @@ export const NotificationsApi = {
    * @param  {string} taxId
    * @returns Promise
    */
-  getNotificationPaymentUrl: (paymentNotice: PaymentNotice, returnUrl: string): Promise<{ checkoutUrl: string }> =>
+  getNotificationPaymentUrl: (
+    paymentNotice: PaymentNotice,
+    returnUrl: string
+  ): Promise<{ checkoutUrl: string }> =>
     apiClient
       .post<{ checkoutUrl: string }>(NOTIFICATION_PAYMENT_URL(), {
         paymentNotice,
-        returnUrl
+        returnUrl,
       })
       .then((response) => response.data),
 };

--- a/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
@@ -136,7 +136,7 @@ const NotificationDetail = () => {
   ) => {
     if (_.isObject(document)) {
       const otherDocument = document as NotificationDetailOtherDocument;
-      void dispatch(getReceivedNotificationOtherDocument({ iun: notification.iun, otherDocument }));
+      void dispatch(getReceivedNotificationOtherDocument({ iun: notification.iun, otherDocument, mandateId }));
     } else {
       const documentIndex = document as string;
       void dispatch(

--- a/packages/pn-personafisica-webapp/src/redux/notification/actions.ts
+++ b/packages/pn-personafisica-webapp/src/redux/notification/actions.ts
@@ -91,11 +91,18 @@ export const getNotificationPaymentUrl = createAsyncThunk<
   )
 );
 
-export const getReceivedNotificationOtherDocument = createAsyncThunk<{url: string}, {iun: string; otherDocument: NotificationDetailOtherDocument}>(
+export const getReceivedNotificationOtherDocument = createAsyncThunk<{url: string}, {iun: string; otherDocument: NotificationDetailOtherDocument; mandateId?: string}>(
   'getReceivedNotificationOtherDocument',
-  async (params: {iun: string; otherDocument: { documentId: string; documentType: string }}, { rejectWithValue }) => {
+  async (params: {
+    iun: string;
+    mandateId?: string;
+    otherDocument: {
+      documentId: string;
+      documentType: string;
+    };
+  }, { rejectWithValue }) => {
     try {
-      return await NotificationsApi.getReceivedNotificationOtherDocument(params.iun, params.otherDocument);
+      return await NotificationsApi.getReceivedNotificationOtherDocument(params.iun, params.otherDocument, params.mandateId);
     } catch (e) {
       return rejectWithValue(e);
     }


### PR DESCRIPTION
## Short description
Hot fix for AAR documents download in delegate PF

## List of changes proposed in this pull request
- Adds a missing parameter mandateId used to download AAR documents for delegate PF

## How to test
Example: In PF login with user ada then list notifications of "Cristoforo Colombo" and search for iun EWJR-KEMD-NQKM-202301-K-1. You should be able to download AAR document now.