### PR TITLE
analog workflow KO (pn-2985)

### DIFF
--- a/packages/pn-commons/src/types/NotificationDetail.ts
+++ b/packages/pn-commons/src/types/NotificationDetail.ts
@@ -70,7 +70,7 @@ export interface SendPaperDetails extends BaseDetails {
   errors?: Array<string>;
   productType?: string;
   analogCost?: number;
-  status?: ResponseStatus;
+  responseStatus?: ResponseStatus;
   sendingReceipts?: Array<{
     id: string;
     system: string;

--- a/packages/pn-commons/src/utils/TimelineUtils/SendAnalogFeedbackStep.ts
+++ b/packages/pn-commons/src/utils/TimelineUtils/SendAnalogFeedbackStep.ts
@@ -1,9 +1,10 @@
-import { SendPaperDetails } from './../../types';
+import { ResponseStatus } from '../../types/NotificationDetail';
+import { SendPaperDetails } from '../../types';
 import { TimelineStep, TimelineStepInfo, TimelineStepPayload } from './TimelineStep';
 
 export class SendAnalogFeedbackStep extends TimelineStep {
   getTimelineStepInfo(payload: TimelineStepPayload): TimelineStepInfo | null {
-    if ((payload.step.details as SendPaperDetails).status === 'KO') {
+    if ((payload.step.details as SendPaperDetails).responseStatus === ResponseStatus.KO) {
       return {
         ...this.localizeTimelineStatus(
           'send-analog-error',

--- a/packages/pn-commons/src/utils/__test__/notification.utility.test.ts
+++ b/packages/pn-commons/src/utils/__test__/notification.utility.test.ts
@@ -321,29 +321,31 @@ describe('timeline utility functions', () => {
 
   it('return timeline status infos - SEND_ANALOG_FEEDBACK (failure)', () => {
     parsedNotificationCopy.timeline[0].category = TimelineCategory.SEND_ANALOG_FEEDBACK;
-    (parsedNotificationCopy.timeline[0].details as SendPaperDetails).status = ResponseStatus.KO;
+    (parsedNotificationCopy.timeline[0].details as SendPaperDetails).responseStatus =
+      ResponseStatus.KO;
     (parsedNotificationCopy.timeline[0].details as SendPaperDetails).physicalAddress = {
       address: 'Indirizzo fisico',
       zip: 'zip',
-      municipality: 'municipality'
+      municipality: 'municipality',
     };
     testTimelineStatusInfosFn(
       'Invio per via cartacea non riuscito',
-      "Il tentativo di invio della notifica per via cartacea a Nome Cognome non è riuscito."
+      'Il tentativo di invio della notifica per via cartacea a Nome Cognome non è riuscito.'
     );
   });
 
   it('return timeline status infos - SEND_ANALOG_FEEDBACK (success)', () => {
     parsedNotificationCopy.timeline[0].category = TimelineCategory.SEND_ANALOG_FEEDBACK;
-    (parsedNotificationCopy.timeline[0].details as SendPaperDetails).status = ResponseStatus.OK;
+    (parsedNotificationCopy.timeline[0].details as SendPaperDetails).responseStatus =
+      ResponseStatus.OK;
     (parsedNotificationCopy.timeline[0].details as SendPaperDetails).physicalAddress = {
       address: 'Indirizzo fisico',
       zip: 'zip',
-      municipality: 'municipality'
+      municipality: 'municipality',
     };
     testTimelineStatusInfosFn(
       'Invio per via cartacea riuscito',
-      "Il tentativo di invio della notifica per via cartacea a Nome Cognome è riuscito."
+      'Il tentativo di invio della notifica per via cartacea a Nome Cognome è riuscito.'
     );
   });
 
@@ -378,14 +380,16 @@ describe('timeline utility functions', () => {
 
   it('return legalFact label - SEND_ANALOG_FEEDBACK (success)', () => {
     parsedNotificationCopy.timeline[0].category = TimelineCategory.SEND_ANALOG_FEEDBACK;
-    (parsedNotificationCopy.timeline[0].details as SendPaperDetails).status = ResponseStatus.OK;
+    (parsedNotificationCopy.timeline[0].details as SendPaperDetails).responseStatus =
+      ResponseStatus.OK;
     const label = getLegalFactLabel(parsedNotificationCopy.timeline[0]);
     expect(label).toBe('Ricevuta di consegna raccomandata');
   });
 
   it('return legalFact label - SEND_ANALOG_FEEDBACK (failure)', () => {
     parsedNotificationCopy.timeline[0].category = TimelineCategory.SEND_ANALOG_FEEDBACK;
-    (parsedNotificationCopy.timeline[0].details as SendPaperDetails).status = ResponseStatus.KO;
+    (parsedNotificationCopy.timeline[0].details as SendPaperDetails).responseStatus =
+      ResponseStatus.KO;
     const label = getLegalFactLabel(parsedNotificationCopy.timeline[0]);
     expect(label).toBe('Ricevuta di mancata consegna raccomandata');
   });

--- a/packages/pn-commons/src/utils/notification.utility.ts
+++ b/packages/pn-commons/src/utils/notification.utility.ts
@@ -19,6 +19,7 @@ import {
   SendDigitalDetails,
   ViewedDetails,
   SendPaperDetails,
+  ResponseStatus,
 } from '../types/NotificationDetail';
 import { TimelineStepInfo } from './TimelineUtils/TimelineStep';
 import { TimelineStepFactory } from './TimelineUtils/TimelineStepFactory';
@@ -251,13 +252,13 @@ export function getLegalFactLabel(
   const receiptLabel = getLocalizedOrDefaultLabel('notifications', `detail.receipt`, 'Ricevuta');
   // TODO: localize in pn_ga branch
   if (timelineStep.category === TimelineCategory.SEND_ANALOG_FEEDBACK) {
-    if ((timelineStep.details as SendPaperDetails).status === 'OK') {
+    if ((timelineStep.details as SendPaperDetails).responseStatus === ResponseStatus.OK) {
       return `${receiptLabel} ${getLocalizedOrDefaultLabel(
         'notifications',
         'detail.timeline.legalfact.paper-receipt-delivered',
         'di consegna raccomandata'
       )}`;
-    } else if ((timelineStep.details as SendPaperDetails).status === 'KO') {
+    } else if ((timelineStep.details as SendPaperDetails).responseStatus === ResponseStatus.KO) {
       return `${receiptLabel} ${getLocalizedOrDefaultLabel(
         'notifications',
         'detail.timeline.legalfact.paper-receipt-not-delivered',


### PR DESCRIPTION
## Short description
Analog workflow failure management

## List of changes proposed in this pull request
- Changed status property in responseStatus property in SendPaperDetail model
- Replaced all the usages of status

## How to test
- Login in with marcopolo -> search notification with iun XVZY-RUEM-MQVP-202301-N-1 -> check that in timeline there are the analog steps OK.
- Login in with marcopolo -> search notification with iun WKUT-RVDQ-XDXU-202302-Y-1 -> check that in timeline there are the analog steps KO.