### PR TITLE
Fixed copy about login button in PA

### DIFF
--- a/packages/pn-pa-webapp/public/locales/it/common.json
+++ b/packages/pn-pa-webapp/public/locales/it/common.json
@@ -9,7 +9,7 @@
     "continue": "Continua",
     "send": "Invia",
     "go-to-home": "Torna alla home page",
-    "go-to-login": "Procedi al login"
+    "go-to-login": "Accedi"
   },
   "menu": {
     "notifications": "Notifiche",


### PR DESCRIPTION
## Short description
Fixed copy about login button in PA.

## List of changes proposed in this pull request
- Modified common.json in PA

## How to test
The button shown in PA before login should be "Accedi" now instead of "Procedi al login"