### PR TITLE
Pn 4264 fe integration test su invio manuale senza pagamenti cypress

### DIFF
--- a/packages/pn-pa-webapp/cypress/e2e/All.cy.ts
+++ b/packages/pn-pa-webapp/cypress/e2e/All.cy.ts
@@ -2,5 +2,6 @@ import "./Auth.cy";
 import "./TosAgreement.cy";
 import "./FilterNotifications.cy";
 import "./NewNotification.cy";
+import "./NewNotification.without.payment.methods.cy";
 import "./NotificationDetail.cy";
 import "./Pagination.cy";

--- a/packages/pn-pa-webapp/cypress/e2e/NewNotification.without.payment.methods.cy.ts
+++ b/packages/pn-pa-webapp/cypress/e2e/NewNotification.without.payment.methods.cy.ts
@@ -3,13 +3,11 @@ import { cesare, garibaldi } from '../fixtures/recipients';
 import { CREATE_NOTIFICATION } from '../../src/api/notifications/notifications.routes';
 import { PNRole } from '../../src/models/user';
 
-if (Cypress.env('IS_PAYMENT_ENABLED')) {
+if (!Cypress.env('IS_PAYMENT_ENABLED')) {
 
-  describe('New Notification with payment methods', () => {
+  describe('New Notification without payment methods', () => {
     const pdfTest1 = './cypress/fixtures/attachments/pdf_test_1.pdf';
     const pdfTest2 = './cypress/fixtures/attachments/pdf_test_2.pdf';
-    const pdfTest3 = './cypress/fixtures/attachments/pdf_test_3.pdf';
-    const pdfTest4 = './cypress/fixtures/attachments/pdf_test_4.pdf';
 
     beforeEach(() => {
       Cypress.on('uncaught:exception', (err, runnable) => {
@@ -41,15 +39,14 @@ if (Cypress.env('IS_PAYMENT_ENABLED')) {
         cy.visit('/dashboard/nuova-notifica');
       });
 
-      it('Creates a single recipient notification with a payment document', () => {
+      it('Creates a single recipient notification', () => {
         // Fill step 1
         cy.fillPreliminaryInfo({
           paProtocolNumber: 'prot-123456789',
           subject: 'Cypress Test - Create new notification',
-          abstract: 'Testing single recipient with a payment document',
+          abstract: 'Testing single recipient',
           taxonomyCode: '012345X',
           communicationType: 'Model_890',
-          paymentMethod: 'pagoPA',
         });
 
         cy.get('button[type="submit"]').should('be.enabled').click();
@@ -58,7 +55,6 @@ if (Cypress.env('IS_PAYMENT_ENABLED')) {
           position: 0,
           data: {
             ...cesare,
-            creditorTaxId: '77777777777',
             noticeCode: '302001869076319100',
           },
         });
@@ -72,152 +68,17 @@ if (Cypress.env('IS_PAYMENT_ENABLED')) {
 
         cy.wait('@preloadAttachments').its('response.statusCode').should('eq', 200);
 
-        // Fill step 4
-        cy.get('input[type="file"]').eq(0).selectFile(pdfTest2, { force: true });
-        cy.get('button[type="submit"]').click();
-
         cy.wait('@saveNewNotification');
 
         cy.contains('La notifica è stata correttamente creata');
       });
 
-      it('Creates a single recipient notification without any payment document', () => {
+      it('Creates a multi recipients notification', () => {
         // Fill step 1
         cy.fillPreliminaryInfo({
           paProtocolNumber: 'prot-123456789',
           subject: 'Cypress Test - Create new notification',
-          abstract: 'Testing single recipient without payment document',
-          taxonomyCode: '012345X',
-          communicationType: 'Model_890',
-        });
-
-        cy.get('button[type="submit"]').should('be.enabled').click();
-
-        // Fill step 2
-        cy.fillRecipient({
-          position: 0,
-          data: cesare,
-        });
-
-        cy.get('button[type="submit"]').should('be.enabled').click();
-
-        // Fill step 3
-        cy.get('input[type="file"]').eq(0).selectFile(pdfTest1, { force: true });
-        cy.get('input[name="documents.0.name"]').type('pdf di Test 1');
-        cy.get('button[type="submit"]').should('be.enabled').click();
-
-        cy.wait('@preloadAttachments').its('response.statusCode').should('eq', 200);
-
-        // Fill step 4
-        cy.contains(/^Invia$/).click();
-
-        cy.wait('@saveNewNotification');
-
-        cy.contains('La notifica è stata correttamente creata');
-      });
-
-      it('Creates a single recipient notification with payment document selected but without uploading it', () => {
-        // Fill step 1
-        cy.fillPreliminaryInfo({
-          paProtocolNumber: 'prot-123456789',
-          subject: 'Cypress Test - Create new notification',
-          abstract: 'Testing single recipient without payment document',
-          taxonomyCode: '012345X',
-          communicationType: 'Model_890',
-          paymentMethod: 'pagoPA',
-        });
-
-        cy.get('button[type="submit"]').should('be.enabled').click();
-
-        // Fill step 2
-        cy.fillRecipient({
-          position: 0,
-          data: {
-            ...cesare,
-            creditorTaxId: '77777777777',
-            noticeCode: '302001869076319100',
-          },
-        });
-
-        cy.get('button[type="submit"]').should('be.enabled').click();
-
-        // Fill step 3
-        cy.get('input[type="file"]').eq(0).selectFile(pdfTest1, { force: true });
-        cy.get('input[name="documents.0.name"]').type('pdf di Test 1');
-        cy.get('button[type="submit"]').should('be.enabled').click();
-
-        cy.wait('@preloadAttachments').its('response.statusCode').should('eq', 200);
-
-        // Fill step 4
-        cy.contains(/^Invia$/).click();
-
-        cy.wait('@saveNewNotification');
-
-        cy.contains('La notifica è stata correttamente creata');
-      });
-
-      it('Creates a multi recipients notification with payment documents', () => {
-        // Fill step 1
-        cy.fillPreliminaryInfo({
-          paProtocolNumber: 'prot-123456789',
-          subject: 'Cypress Test - Create new notification',
-          abstract: 'Testing multi recipient with payment documents',
-          taxonomyCode: '012345X',
-          communicationType: 'Model_890',
-          paymentMethod: 'pagoPA',
-        });
-
-        cy.get('button[type="submit"]').should('be.enabled').click();
-
-        // Fill step 2
-
-        // Recipient 1
-        cy.fillRecipient({
-          position: 0,
-          data: {
-            ...cesare,
-            creditorTaxId: '77777777777',
-            noticeCode: '302001869076319100',
-          },
-        });
-
-        cy.contains(/^Aggiungi un destinatario$/).click();
-
-        // Recipient 2
-        cy.fillRecipient({
-          position: 1,
-          data: {
-            ...garibaldi,
-            creditorTaxId: '77777777777',
-            noticeCode: '302001869076319101',
-          },
-        });
-
-        cy.get('button[type="submit"]').should('be.enabled').click();
-
-        // Fill step 3
-        cy.get('input[type="file"]').eq(0).selectFile(pdfTest1, { force: true });
-        cy.get('input[name="documents.0.name"]').type('pdf di Test 1');
-        cy.get('button[type="submit"]').should('be.enabled').click();
-
-        cy.wait('@preloadAttachments').its('response.statusCode').should('eq', 200);
-
-        // Fill step 4
-        cy.get('input[type="file"]').eq(0).selectFile(pdfTest2, { force: true });
-        cy.get('input[type="file"]').eq(0).selectFile(pdfTest3, { force: true });
-        cy.get('button[type="submit"]').click();
-
-        cy.wait('@saveNewNotification');
-
-        cy.contains('La notifica è stata correttamente creata');
-      });
-
-      it('Creates a multi recipients notification without payment documents', () => {
-        // Fill step 1
-        cy.fillPreliminaryInfo({
-          paProtocolNumber: 'prot-123456789',
-          subject: 'Cypress Test - Create new notification',
-          abstract: 'Testing multi recipient without payment documents',
+          abstract: 'Testing multi recipient',
           taxonomyCode: '012345X',
           communicationType: 'Model_890',
         });
@@ -251,9 +112,6 @@ if (Cypress.env('IS_PAYMENT_ENABLED')) {
 
         cy.wait('@preloadAttachments').its('response.statusCode').should('eq', 200);
 
-        // Fill step 4
-        cy.contains(/^Invia$/).click();
-
         cy.wait('@saveNewNotification');
 
         cy.contains('La notifica è stata correttamente creata');
@@ -265,7 +123,6 @@ if (Cypress.env('IS_PAYMENT_ENABLED')) {
         cy.get('#subject').type('Nuova Notifica');
         cy.get('#taxonomyCode').type('012345X');
         cy.get('[data-testid="comunicationTypeRadio"]').eq(0).click();
-        cy.get('[data-testid="paymentMethodRadio"]').eq(1).click();
         cy.get('button[type="submit"]').should('be.enabled').click();
 
         // Fill step 2
@@ -284,30 +141,6 @@ if (Cypress.env('IS_PAYMENT_ENABLED')) {
         cy.log('validation text error for taxId disappears');
         cy.get('.css-1robk8y-MuiFormHelperText-root').should('not.exist');
 
-        cy.log('writing invalid creditor taxtId');
-        cy.get('input[name="recipients[0].creditorTaxId"]').type('1231232131').blur();
-
-        cy.log('validation text error for creditor taxId appears');
-        cy.get('.css-1robk8y-MuiFormHelperText-root').should('be.visible');
-
-        cy.log('writing valid creditor taxtId');
-        cy.get('input[name="recipients[0].creditorTaxId"]').clear().type('12312321315');
-
-        cy.log('validation text error for creditor taxId disappears');
-        cy.get('.css-1robk8y-MuiFormHelperText-root').should('not.exist');
-
-        cy.log('writing invalid notice code');
-        cy.get('input[name="recipients[0].noticeCode"]').type('12312312312312125').blur();
-
-        cy.log('validation text error for notice code');
-        cy.get('.css-1robk8y-MuiFormHelperText-root').should('be.visible');
-
-        cy.log('writing valid notice code');
-        cy.get('input[name="recipients[0].noticeCode"]').clear().type('123123123123123125');
-
-        cy.log('validation text error for notice code disappears');
-        cy.get('.css-1robk8y-MuiFormHelperText-root').should('not.exist');
-
         cy.get('[data-testid="PhysicalAddressCheckbox"]').click();
         cy.get('input[name="recipients[0].address"]').type('Indirizzo');
         cy.get('input[name="recipients[0].houseNumber"]').type('3');
@@ -324,12 +157,6 @@ if (Cypress.env('IS_PAYMENT_ENABLED')) {
         cy.get('input[name="documents.0.name"]').type('pdf di Test 1');
         cy.get('input[name="documents.1.name"]').type('pdf di Test 2');
         cy.get('button[type="submit"]').should('be.enabled').click();
-
-        // Fill step 4
-        cy.get('input[type="file"]').eq(0).selectFile(pdfTest3, { force: true });
-        cy.get('input[type="file"]').eq(0).selectFile(pdfTest4, { force: true });
-
-        cy.get('button[type="submit"]').click();
 
         cy.wait('@saveNewNotification');
 
@@ -354,7 +181,6 @@ if (Cypress.env('IS_PAYMENT_ENABLED')) {
           abstract: 'Testing as administrator and without user groups',
           taxonomyCode: '012345X',
           communicationType: 'Model_890',
-          paymentMethod: 'pagoPA',
         });
 
         cy.get('#group').should('be.disabled');
@@ -365,7 +191,6 @@ if (Cypress.env('IS_PAYMENT_ENABLED')) {
           position: 0,
           data: {
             ...cesare,
-            creditorTaxId: '77777777777',
             noticeCode: '302001869076319100',
           },
         });
@@ -378,10 +203,6 @@ if (Cypress.env('IS_PAYMENT_ENABLED')) {
         cy.get('button[type="submit"]').should('be.enabled').click();
 
         cy.wait('@preloadAttachments').its('response.statusCode').should('eq', 200);
-
-        // Fill step 4
-        cy.get('input[type="file"]').eq(0).selectFile(pdfTest2, { force: true });
-        cy.get('button[type="submit"]').click();
 
         cy.wait('@saveNewNotification');
 
@@ -398,7 +219,6 @@ if (Cypress.env('IS_PAYMENT_ENABLED')) {
           abstract: 'Testing as administrator and with user groups',
           taxonomyCode: '012345X',
           communicationType: 'Model_890',
-          paymentMethod: 'pagoPA',
         });
 
         // The following validation need to be resolved with PN-2198
@@ -413,7 +233,6 @@ if (Cypress.env('IS_PAYMENT_ENABLED')) {
           position: 0,
           data: {
             ...cesare,
-            creditorTaxId: '77777777777',
             noticeCode: '302001869076319100',
           },
         });
@@ -426,10 +245,6 @@ if (Cypress.env('IS_PAYMENT_ENABLED')) {
         cy.get('button[type="submit"]').should('be.enabled').click();
 
         cy.wait('@preloadAttachments').its('response.statusCode').should('eq', 200);
-
-        // Fill step 4
-        cy.get('input[type="file"]').eq(0).selectFile(pdfTest2, { force: true });
-        cy.get('button[type="submit"]').click();
 
         cy.wait('@saveNewNotification');
 
@@ -454,7 +269,6 @@ if (Cypress.env('IS_PAYMENT_ENABLED')) {
           abstract: 'Testing as operator and without user groups',
           taxonomyCode: '012345X',
           communicationType: 'Model_890',
-          paymentMethod: 'pagoPA',
         });
 
         cy.get('#group').should('be.disabled');
@@ -465,7 +279,6 @@ if (Cypress.env('IS_PAYMENT_ENABLED')) {
           position: 0,
           data: {
             ...cesare,
-            creditorTaxId: '77777777777',
             noticeCode: '302001869076319100',
           },
         });
@@ -478,10 +291,6 @@ if (Cypress.env('IS_PAYMENT_ENABLED')) {
         cy.get('button[type="submit"]').should('be.enabled').click();
 
         cy.wait('@preloadAttachments').its('response.statusCode').should('eq', 200);
-
-        // Fill step 4
-        cy.get('input[type="file"]').eq(0).selectFile(pdfTest2, { force: true });
-        cy.get('button[type="submit"]').click();
 
         cy.wait('@saveNewNotification');
 
@@ -498,7 +307,6 @@ if (Cypress.env('IS_PAYMENT_ENABLED')) {
           abstract: 'Testing as operator and with user groups',
           taxonomyCode: '012345X',
           communicationType: 'Model_890',
-          paymentMethod: 'pagoPA',
         });
 
         // The following validation need to be resolved with PN-2198
@@ -513,7 +321,6 @@ if (Cypress.env('IS_PAYMENT_ENABLED')) {
           position: 0,
           data: {
             ...cesare,
-            creditorTaxId: '77777777777',
             noticeCode: '302001869076319100',
           },
         });
@@ -526,10 +333,6 @@ if (Cypress.env('IS_PAYMENT_ENABLED')) {
         cy.get('button[type="submit"]').should('be.enabled').click();
 
         cy.wait('@preloadAttachments').its('response.statusCode').should('eq', 200);
-
-        // Fill step 4
-        cy.get('input[type="file"]').eq(0).selectFile(pdfTest2, { force: true });
-        cy.get('button[type="submit"]').click();
 
         cy.wait('@saveNewNotification');
 

--- a/packages/pn-pa-webapp/cypress/support/NewNotification/index.ts
+++ b/packages/pn-pa-webapp/cypress/support/NewNotification/index.ts
@@ -26,8 +26,10 @@ Cypress.Commands.add('fillPreliminaryInfo', (data: PreliminaryInfoFormData) => {
   const communicationType = data.communicationType === 'A/R' ? 1 : 0;
   cy.get('[data-testid="comunicationTypeRadio"]').eq(communicationType).click();
 
-  const paymentMethodIndex = getPaymentMethodIndex(data.paymentMethod);
-  cy.get('[data-testid="paymentMethodRadio"]').eq(paymentMethodIndex).click();
+  if(Cypress.env('IS_PAYMENT_ENABLED')) {
+    const paymentMethodIndex = getPaymentMethodIndex(data.paymentMethod);
+    cy.get('[data-testid="paymentMethodRadio"]').eq(paymentMethodIndex).click();
+  }
 });
 
 Cypress.Commands.add('fillRecipient', (recipient: RecipientFormData) => {
@@ -38,12 +40,12 @@ Cypress.Commands.add('fillRecipient', (recipient: RecipientFormData) => {
   cy.log('writing valid taxtId');
   cy.get(`input[name="recipients\[${recipient.position}\]\.taxId"]`).clear().type(recipient.data.taxId);
   
-  if(recipient.data.creditorTaxId) {
+  if(recipient.data.creditorTaxId && Cypress.env('IS_PAYMENT_ENABLED')) {
     cy.log('writing valid creditor taxtId');
     cy.get(`input[name="recipients\[${recipient.position}\]\.creditorTaxId"]`).clear().type(recipient.data.creditorTaxId);
   }
 
-  if(recipient.data.noticeCode) {
+  if(recipient.data.noticeCode && Cypress.env('IS_PAYMENT_ENABLED')) {
     cy.log('writing valid notice code');
     cy.get(`input[name="recipients\[${recipient.position}\]\.noticeCode"]`).clear().type(recipient.data.noticeCode);
   }


### PR DESCRIPTION
## Short description
Added Cypress ENV variable to switch between notification with / without payment methods.

## List of changes proposed in this pull request
- New boolean variable for cypress.env.json IS_PAYMENT_ENABLED. This variable must be set the same value as REACT_APP_IS_PAYMENT_ENABLED

## How to test
Two ways of testing available.
1. Set REACT_APP_IS_PAYMENT_ENABLED and IS_PAYMENT_ENABLED to true to enable notifications with payment methods
2. Set REACT_APP_IS_PAYMENT_ENABLED and IS_PAYMENT_ENABLED to false to disable notifications with payment methods

## Update Confluence configuration page
When PR is approved then update the Confluence configuration page, section Cypress for PA, by adding the new variable IS_PAYMENT_ENABLED in cypress.env.json 