### PR TITLE
new notification - wrong tax id error - pn-4421

### DIFF
--- a/packages/pn-commons/src/types/AppResponse.ts
+++ b/packages/pn-commons/src/types/AppResponse.ts
@@ -19,6 +19,7 @@ export interface ServerResponseError {
    * other requests having many fields that need to be validated)
    */
   element?: string;
+  detail?: string;
 }
 
 export interface AppResponse {
@@ -32,6 +33,7 @@ export interface AppResponse {
 export interface AppResponseError {
   code: string;
   element?: string;
+  detail?: string;
   message: {
     title: string;
     content: string;

--- a/packages/pn-commons/src/utils/AppError/AppError.ts
+++ b/packages/pn-commons/src/utils/AppError/AppError.ts
@@ -1,21 +1,20 @@
-import {
-  ServerResponseError,
-  ErrorMessage,
-  AppResponseError } from '../../types/AppResponse';
+import { ServerResponseError, ErrorMessage, AppResponseError } from '../../types/AppResponse';
 
 abstract class AppError {
   protected code: string;
   protected element: string;
+  protected detail: string;
 
   constructor(error: ServerResponseError) {
     this.code = error.code;
-    this.element = error.element || "";
+    this.element = error.element || '';
+    this.detail = error.detail || '';
   }
 
   getErrorDetail(): ServerResponseError {
     return {
       code: this.code,
-      element: this.element
+      element: this.element,
     };
   }
 
@@ -25,8 +24,8 @@ abstract class AppError {
       element: this.element,
       message: {
         title: this.getMessage().title,
-        content: this.getMessage().content
-      }
+        content: this.getMessage().content,
+      },
     };
   }
 

--- a/packages/pn-pa-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/it/notifiche.json
@@ -85,7 +85,7 @@
       "send-digital-success-description": "L'invio della notifica all'indirizzo PEC {{address}} è riuscito.",
       "send-digital-success-description-multirecipient": "L'invio della notifica a {{name}} {{taxId}} all'indirizzo PEC {{address}} è riuscito.",
       "send-simple-registered-letter": "Invio via raccomandata semplice",
-      "send-simple-registered-letter-description": "È in corso l'invio della notifica all'indirizzo {{address}} tramite raccomandata semplice.",      
+      "send-simple-registered-letter-description": "È in corso l'invio della notifica all'indirizzo {{address}} tramite raccomandata semplice.",
       "send-simple-registered-letter-description-multirecipient": "È in corso l'invio della notifica a {{name}} {{taxId}} all'indirizzo {{address}} tramite raccomandata semplice.",
       "send-analog-domicile-890": "Invio via raccomandata 890",
       "send-analog-domicile-890-description": "È iniziato l'invio della notifica all'indirizzo {{address}} tramite raccomandata 890.",
@@ -275,6 +275,16 @@
         "title": "La notifica è stata correttamente creata",
         "message": "Trovi gli aggiornamenti sul suo stato nella sezione \"Notifiche\"",
         "go-to-notifications": "Vai alle Notifiche"
+      }
+    },
+    "errors": {
+      "fiscal_code": {
+        "title": "Codice fiscale non valido",
+        "message": "Il codice fiscale per uno o più destinatari non è valido"
+      },
+      "invalid_parameter": {
+        "title": "Dati non validi",
+        "message": "Uno o più dei dati inseriti non sono validi"
       }
     }
   }

--- a/packages/pn-pa-webapp/src/App.tsx
+++ b/packages/pn-pa-webapp/src/App.tsx
@@ -8,6 +8,7 @@ import {
   AppMessage,
   AppResponseMessage,
   appStateActions,
+  errorFactoryManager,
   initLocalization,
   Layout,
   LoadingOverlay,
@@ -17,7 +18,7 @@ import {
   useErrors,
   useMultiEvent,
   useTracking,
-  useUnload
+  useUnload,
 } from '@pagopa-pn/pn-commons';
 import { PartyEntity, ProductSwitchItem } from '@pagopa/mui-italia';
 import { ErrorInfo, useEffect, useMemo } from 'react';
@@ -36,7 +37,8 @@ import { PAGOPA_HELP_EMAIL, SELFCARE_BASE_URL, VERSION, MIXPANEL_TOKEN } from '.
 import { TrackEventType } from './utils/events';
 import { trackEventByType } from './utils/mixpanel';
 import './utils/onetrust';
-import { setUpInterceptor } from "./api/interceptors";
+import { PAAppErrorFactory } from './utils/AppError/PAAppErrorFactory';
+import { setUpInterceptor } from './api/interceptors';
 
 const App = () => {
   useUnload(() => {
@@ -66,22 +68,26 @@ const App = () => {
       /**
        * Refers to PN-1741
        * Commented out because beyond MVP scope
-       * 
+       *
        * LINKED TO:
        * - "<Route path={routes.API_KEYS}.../>" in packages/pn-pa-webapp/src/navigation/routes.tsx
        * - BasicMenuItems in packages/pn-pa-webapp/src/utils/__TEST__/role.utilitytest.ts
        */
       { label: 'menu.api-key', icon: VpnKey, route: routes.API_KEYS },
-      { 
-        label: 'menu.app-status', 
+      {
+        label: 'menu.app-status',
         // ATTENTION - a similar logic to choose the icon and its color is implemented in AppStatusBar (in pn-commons)
-        icon: () => currentStatus 
-          ? (currentStatus.appIsFullyOperative
-            ? <CheckCircleIcon sx={{ color: 'success.main' }} />
-            : <ErrorIcon sx={{ color: 'error.main' }} />)
-          : <HelpIcon />
-        , 
-        route: routes.APP_STATUS 
+        icon: () =>
+          currentStatus ? (
+            currentStatus.appIsFullyOperative ? (
+              <CheckCircleIcon sx={{ color: 'success.main' }} />
+            ) : (
+              <ErrorIcon sx={{ color: 'error.main' }} />
+            )
+          ) : (
+            <HelpIcon />
+          ),
+        route: routes.APP_STATUS,
       },
     ];
 
@@ -154,6 +160,8 @@ const App = () => {
   useEffect(() => {
     // init localization
     initLocalization((namespace, path, data) => t(path, { ns: namespace, ...data }));
+    // eslint-disable-next-line functional/immutable-data
+    errorFactoryManager.factory = new PAAppErrorFactory((path, ns) => t(path, { ns }));
   }, []);
 
   useTracking(MIXPANEL_TOKEN, process.env.NODE_ENV);

--- a/packages/pn-pa-webapp/src/utils/AppError/GenericInvalidParameterAppError.ts
+++ b/packages/pn-pa-webapp/src/utils/AppError/GenericInvalidParameterAppError.ts
@@ -1,0 +1,30 @@
+import { AppError, ServerResponseError } from '@pagopa-pn/pn-commons';
+
+enum InvalidParameter {
+  FISCAL_CODE = 'Invalid taxId for recipient',
+}
+
+export class GenericInvalidParameterAppError extends AppError {
+  private translateFunction: (path: string, ns: string) => string = (path: string) => path;
+
+  constructor(error: ServerResponseError, translateFunction: (path: string, ns: string) => string) {
+    super(error);
+    this.translateFunction = translateFunction;
+  }
+
+  getMessage() {
+    if (this.detail.startsWith(InvalidParameter.FISCAL_CODE)) {
+      return {
+        title: this.translateFunction('new-notification.errors.fiscal_code.title', 'notifiche'),
+        content: this.translateFunction('new-notification.errors.fiscal_code.message', 'notifiche'),
+      };
+    }
+    return {
+      title: this.translateFunction('new-notification.errors.invalid_parameter.title', 'notifiche'),
+      content: this.translateFunction(
+        'new-notification.errors.invalid_parameter.message',
+        'notifiche'
+      ),
+    };
+  }
+}

--- a/packages/pn-pa-webapp/src/utils/AppError/PAAppErrorFactory.ts
+++ b/packages/pn-pa-webapp/src/utils/AppError/PAAppErrorFactory.ts
@@ -1,0 +1,29 @@
+import {
+  AppError,
+  AppErrorFactory,
+  ServerResponseError,
+  UnknownAppError,
+} from '@pagopa-pn/pn-commons';
+
+import { GenericInvalidParameterAppError } from './GenericInvalidParameterAppError';
+import { ServerResponseErrorCode } from './types';
+
+export class PAAppErrorFactory extends AppErrorFactory {
+  private translateFunction: (path: string, ns: string) => string = (path: string) => path;
+
+  constructor(translateFunction: (path: string, ns: string) => string) {
+    super();
+    this.translateFunction = translateFunction;
+  }
+
+  protected getCustomError: (error: ServerResponseError) => AppError = (
+    error: ServerResponseError
+  ) => {
+    switch (error.code) {
+      case ServerResponseErrorCode.PN_GENERIC_INVALIDPARAMETER:
+        return new GenericInvalidParameterAppError(error, this.translateFunction);
+      default:
+        return new UnknownAppError(error);
+    }
+  };
+}

--- a/packages/pn-pa-webapp/src/utils/AppError/__test__/GenericInvalidParameterAppError.test.ts
+++ b/packages/pn-pa-webapp/src/utils/AppError/__test__/GenericInvalidParameterAppError.test.ts
@@ -1,0 +1,24 @@
+import { ServerResponseError } from '@pagopa-pn/pn-commons';
+
+import { GenericInvalidParameterAppError } from '../GenericInvalidParameterAppError';
+
+describe('Test GenericInvalidParameterAppError', () => {
+  const translateFn = (path: string, ns: string) => `${path} ${ns}`;
+
+  it('Should return invalid parameter message', () => {
+    const appError = new GenericInvalidParameterAppError({} as ServerResponseError, translateFn);
+    const messege = appError.getMessage();
+    expect(messege.title).toBe('new-notification.errors.invalid_parameter.title notifiche');
+    expect(messege.content).toBe('new-notification.errors.invalid_parameter.message notifiche');
+  });
+
+  it('Should return invalid fiscal code message', () => {
+    const appError = new GenericInvalidParameterAppError(
+      { detail: 'Invalid taxId for recipient' } as ServerResponseError,
+      translateFn
+    );
+    const messege = appError.getMessage();
+    expect(messege.title).toBe('new-notification.errors.fiscal_code.title notifiche');
+    expect(messege.content).toBe('new-notification.errors.fiscal_code.message notifiche');
+  });
+});

--- a/packages/pn-pa-webapp/src/utils/AppError/__test__/PAAppErrorFactory.test.ts
+++ b/packages/pn-pa-webapp/src/utils/AppError/__test__/PAAppErrorFactory.test.ts
@@ -1,0 +1,27 @@
+import { AppError, ServerResponseError } from '@pagopa-pn/pn-commons';
+
+import { PAAppErrorFactory } from '../PAAppErrorFactory';
+import { ServerResponseErrorCode } from '../types';
+import { GenericInvalidParameterAppError } from '../GenericInvalidParameterAppError';
+
+class PAAppErrorFactoryForTest extends PAAppErrorFactory {
+  constructor(translateFunction: (path: string, ns: string) => string) {
+    super(translateFunction);
+  }
+
+  public getCustomErrorForTest: (error: ServerResponseError) => AppError = (
+    error: ServerResponseError
+  ) => this.getCustomError(error);
+}
+
+describe('Test PFAppErrorFactory', () => {
+  const translateFn = (path: string, ns: string) => `${path} ${ns}`;
+  const errorFactory = new PAAppErrorFactoryForTest(translateFn);
+
+  it('Should return MandateNotFoundAppError', () => {
+    const errorClass = errorFactory.getCustomErrorForTest({
+      code: ServerResponseErrorCode.PN_GENERIC_INVALIDPARAMETER,
+    });
+    expect(errorClass).toBeInstanceOf(GenericInvalidParameterAppError);
+  });
+});

--- a/packages/pn-pa-webapp/src/utils/AppError/types.ts
+++ b/packages/pn-pa-webapp/src/utils/AppError/types.ts
@@ -1,0 +1,11 @@
+/**
+ * These codes have been retrived accessing the source code available
+ * inside the exception package of every BE project on github.
+ * Currently there's no centralized documentation that explains how
+ * and under which circumstances a particular error is thrown.
+ * Andrea Cimini 01.03.2023
+ */
+export enum ServerResponseErrorCode {
+    PN_GENERIC_INVALIDPARAMETER = 'PN_GENERIC_INVALIDPARAMETER',
+  }
+  

--- a/packages/pn-personafisica-webapp/src/utils/AppError/__test__/PFAppErrorFactory.test.ts
+++ b/packages/pn-personafisica-webapp/src/utils/AppError/__test__/PFAppErrorFactory.test.ts
@@ -38,35 +38,35 @@ describe('Test PFAppErrorFactory', () => {
     expect(errorClass).toBeInstanceOf(MandateAlreadyExistsAppError);
   });
 
-  it('Should return MandateNotFoundAppError', () => {
+  it('Should return MandateNotAcceptableAppError', () => {
     const errorClass = errorFactory.getCustomErrorForTest({
       code: ServerResponseErrorCode.PN_MANDATE_NOTACCEPTABLE,
     });
     expect(errorClass).toBeInstanceOf(MandateNotAcceptableAppError);
   });
 
-  it('Should return MandateNotFoundAppError', () => {
+  it('Should return MandateDelegateHimselfAppError', () => {
     const errorClass = errorFactory.getCustomErrorForTest({
       code: ServerResponseErrorCode.PN_MANDATE_DELEGATEHIMSELF,
     });
     expect(errorClass).toBeInstanceOf(MandateDelegateHimselfAppError);
   });
 
-  it('Should return MandateNotFoundAppError', () => {
+  it('Should return MandateInvalidVerificationCodeAppError', () => {
     const errorClass = errorFactory.getCustomErrorForTest({
       code: ServerResponseErrorCode.PN_MANDATE_INVALIDVERIFICATIONCODE,
     });
     expect(errorClass).toBeInstanceOf(MandateInvalidVerificationCodeAppError);
   });
 
-  it('Should return MandateNotFoundAppError', () => {
+  it('Should return UserAttributesInvalidVerificationCodeAppError', () => {
     const errorClass = errorFactory.getCustomErrorForTest({
       code: ServerResponseErrorCode.PN_USERATTRIBUTES_INVALIDVERIFICATIONCODE,
     });
     expect(errorClass).toBeInstanceOf(UserAttributesInvalidVerificationCodeAppError);
   });
 
-  it('Should return MandateNotFoundAppError', () => {
+  it('Should return GenericInvalidParameterPatternAppError', () => {
     const errorClass = errorFactory.getCustomErrorForTest({
       code: ServerResponseErrorCode.PN_GENERIC_INVALIDPARAMETER_PATTERN,
     });


### PR DESCRIPTION
## Short description
Changed error message when an user send a new notification request with worng tax id

## List of changes proposed in this pull request
- Added error factory
- Added a class to manage invalid parameter error
- Added localization for invalid parameter error
- Added tests

## How to test
Go to new notification -> add a recipient with TMOCHR95S51H501H or any wrong tax id -> check that right error message is shown