### PR TITLE
Modified css style to make contacts to be word wrapped if necessary

### DIFF
--- a/packages/pn-personafisica-webapp/src/component/Contacts/DigitalContactElem.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Contacts/DigitalContactElem.tsx
@@ -132,7 +132,15 @@ const DigitalContactElem = forwardRef(
       <Grid key={f.id} item lg={f.size === 'auto' ? true : 'auto'} xs={12}>
         {!f.isEditable && f.component}
         {f.isEditable && editMode && f.component}
-        {f.isEditable && !editMode && <Typography>{(f.component as any).props.value}</Typography>}
+        {f.isEditable && !editMode && (
+          <Typography
+            sx={{
+              wordBreak: 'break-word',
+            }}
+          >
+            {(f.component as any).props.value}
+          </Typography>
+        )}
       </Grid>
     ));
 

--- a/packages/pn-personagiuridica-webapp/src/component/Contacts/DigitalContactElem.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Contacts/DigitalContactElem.tsx
@@ -132,7 +132,15 @@ const DigitalContactElem = forwardRef(
       <Grid key={f.id} item lg={f.size === 'auto' ? true : 'auto'} xs={12}>
         {!f.isEditable && f.component}
         {f.isEditable && editMode && f.component}
-        {f.isEditable && !editMode && <Typography>{(f.component as any).props.value}</Typography>}
+        {f.isEditable && !editMode && (
+          <Typography
+            sx={{
+              wordBreak: 'break-word',
+            }}
+          >
+            {(f.component as any).props.value}
+          </Typography>
+        )}
       </Grid>
     ));
 


### PR DESCRIPTION
## Short description
Modified css style to make contacts to be word wrapped if necessary.

## List of changes proposed in this pull request
- Modified css style to make contacts to be word wrapped if necessary
- Both PF and PG

## How to test
Go in contacts page, set mobile resolution and add a long email. The email is word wrapped now.