### PR TITLE
Login with different role - pn-4434

### DIFF
--- a/packages/pn-pa-webapp/src/api/auth/Auth.api.ts
+++ b/packages/pn-pa-webapp/src/api/auth/Auth.api.ts
@@ -1,18 +1,19 @@
-import { User } from "../../redux/auth/types";
-import { authClient } from "../apiClients";
-import { AUTH_TOKEN_EXCHANGE } from "./auth.routes";
+import { User } from '../../redux/auth/types';
+import { authClient } from '../apiClients';
+import { AUTH_TOKEN_EXCHANGE } from './auth.routes';
 
 export const AuthApi = {
-    exchangeToken: (selfCareToken: string): Promise<User> =>
-      authClient.post<User>(AUTH_TOKEN_EXCHANGE(), {authorizationToken: selfCareToken})
-        .then((response) => ({
-            desired_exp: response.data.desired_exp,
-            email: response.data.email,
-            name: response.data.name,
-            family_name: response.data.family_name,
-            fiscal_number: response.data.fiscal_number,
-            organization: response.data.organization,
-            sessionToken: response.data.sessionToken,
-            uid: response.data.uid,
-        }))
+  exchangeToken: (selfCareToken: string): Promise<User> =>
+    authClient
+      .post<User>(AUTH_TOKEN_EXCHANGE(), { authorizationToken: selfCareToken })
+      .then((response) => ({
+        desired_exp: response.data.desired_exp,
+        email: response.data.email,
+        name: response.data.name,
+        family_name: response.data.family_name,
+        fiscal_number: response.data.fiscal_number,
+        organization: response.data.organization,
+        sessionToken: response.data.sessionToken,
+        uid: response.data.uid,
+      })),
 };

--- a/packages/pn-pa-webapp/src/navigation/SessionGuard.tsx
+++ b/packages/pn-pa-webapp/src/navigation/SessionGuard.tsx
@@ -117,15 +117,21 @@ const SessionGuard = () => {
       // se i dati del utente sono stati presi da session storage,
       // si deve saltare la user determination e settare l'indicativo di session reload
       // che verrà usato nella initial page determination
-      if (!sessionToken) {
-        const spidToken = getTokenParam();
-        if (spidToken) {
-          await dispatch(exchangeToken(spidToken));
-        }
+      // ----------------------
+      // When user leaves the application without logging out (clicking on a external link) and after returns with another user,
+      // the sessionStorage contains the information of the previous user and this cause a serious bug.
+      // So if a token is present in the url, I clear the sessionStorage and I'll do the new tokenExchange.
+      // Again, I strongly recommend to rethink the guard structure and functionality
+      // ----------------------
+      // Andrea Cimini, 2023.03.07
+      // ----------------------
+      const spidToken = getTokenParam();
+      if (spidToken) {
+        await dispatch(exchangeToken(spidToken));
       }
     };
     void performStep(INITIALIZATION_STEPS.USER_DETERMINATION, doUserDetermination);
-  }, [performStep, getTokenParam, sessionToken]);
+  }, [performStep, getTokenParam]);
 
   /**
    * Step 2 - initial page determination

--- a/packages/pn-personafisica-webapp/src/navigation/SessionGuard.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/SessionGuard.tsx
@@ -124,11 +124,17 @@ const SessionGuard = () => {
       // se i dati del utente sono stati presi da session storage,
       // si deve saltare la user determination e settare l'indicativo di session reload
       // che verrà usato nella initial page determination
-      if (!sessionToken) {
-        const spidToken = getTokenParam();
-        if (spidToken) {
-          await dispatch(exchangeToken(spidToken));
-        }
+      // ----------------------
+      // When user leaves the application without logging out (clicking on a external link) and after returns with another user,
+      // the sessionStorage contains the information of the previous user and this cause a serious bug.
+      // So if a token is present in the url, I clear the sessionStorage and I'll do the new tokenExchange.
+      // Again, I strongly recommend to rethink the guard structure and functionality
+      // ----------------------
+      // Andrea Cimini, 2023.03.07
+      // ----------------------
+      const spidToken = getTokenParam();
+      if (spidToken) {
+        await dispatch(exchangeToken(spidToken));
       }
     };
     void performStep(INITIALIZATION_STEPS.USER_DETERMINATION, doUserDetermination);

--- a/packages/pn-personagiuridica-webapp/src/navigation/SessionGuard.tsx
+++ b/packages/pn-personagiuridica-webapp/src/navigation/SessionGuard.tsx
@@ -126,11 +126,17 @@ const SessionGuard = () => {
       // se i dati del utente sono stati presi da session storage,
       // si deve saltare la user determination e settare l'indicativo di session reload
       // che verrà usato nella initial page determination
-      if (!sessionToken) {
-        const spidToken = getTokenParam();
-        if (spidToken) {
-          await dispatch(exchangeToken(spidToken));
-        }
+      // ----------------------
+      // When user leaves the application without logging out (clicking on a external link) and after returns with another user,
+      // the sessionStorage contains the information of the previous user and this cause a serious bug.
+      // So if a token is present in the url, I clear the sessionStorage and I'll do the new tokenExchange.
+      // Again, I strongly recommend to rethink the guard structure and functionality
+      // ----------------------
+      // Andrea Cimini, 2023.03.07
+      // ----------------------
+      const spidToken = getTokenParam();
+      if (spidToken) {
+        await dispatch(exchangeToken(spidToken));
       }
     };
     void performStep(INITIALIZATION_STEPS.USER_DETERMINATION, doUserDetermination);


### PR DESCRIPTION
## Short description
Login with user that have a different role compared to the previous one

## List of changes proposed in this pull request
- Recall token exchange every time there is a selfcaretoken in the url (SessionGuard.tsx of each app)

## How to test
The test can be done with pa. For the other is not possible, but the code is the same
- Log in with an user that have admin role
- Go to external link and logout (groups for example)
- Log in with an user with a different role
- Check that the information of the users are not overlapped