### PR TITLE
Added tooltip on groups in api key list, created new component

### DIFF
--- a/packages/pn-commons/src/components/CustomTagGroup/CustomTagGroup.tsx
+++ b/packages/pn-commons/src/components/CustomTagGroup/CustomTagGroup.tsx
@@ -1,0 +1,35 @@
+import { Box, Chip } from '@mui/material';
+import React from 'react';
+import CustomTooltip from '../CustomTooltip';
+interface CustomTagGroupProps {
+  /** how many items will be visible */
+  visibleItems?: number;
+  /** callback function when tooltip is opened */
+  onOpen?: () => void;
+  children: JSX.Element | Array<JSX.Element>;
+}
+const CustomTagGroup = ({ visibleItems, onOpen, children }: CustomTagGroupProps) => {
+  const arrayChildren = React.Children.count(children)
+    ? (children as Array<JSX.Element>)
+    : [children as JSX.Element];
+  const isOverflow = visibleItems ? arrayChildren.length > visibleItems : false;
+  const maxCount = isOverflow ? visibleItems : arrayChildren.length;
+  return (
+    <>
+      {arrayChildren.slice(0, maxCount).map((c) => c)}
+      {isOverflow && (
+        <Box>
+          <CustomTooltip
+            openOnClick={false}
+            onOpen={onOpen}
+            tooltipContent={<>{arrayChildren.slice(visibleItems).map((c) => c)}</>}
+          >
+            <Chip label={`+${arrayChildren.length - (visibleItems as number)}`} />
+          </CustomTooltip>
+        </Box>
+      )}
+    </>
+  );
+};
+
+export default CustomTagGroup;

--- a/packages/pn-commons/src/components/CustomTagGroup/__test__/CustomTagGroup.test.tsx
+++ b/packages/pn-commons/src/components/CustomTagGroup/__test__/CustomTagGroup.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '../../../test-utils';
+import { Box } from '@mui/material';
+import CustomTagGroup from '../CustomTagGroup';
+
+describe('CustomTagGroup component', () => {
+  const tagsArray = ['mock-tag-1', 'mock-tag-2', 'mock-tag-3', 'mock-tag-4'];
+  const tags = tagsArray.map((v, i) => <Box key={i}>{v}</Box>);
+  const mockCallbackFn = jest.fn();
+
+  it('renders component with all tags', () => {
+    const result = render(<CustomTagGroup>{tags}</CustomTagGroup>);
+    expect(result.container).toHaveTextContent(/mock-tag-1mock-tag-2mock-tag-3mock-tag-4/);
+  });
+
+  it('renders component with limited 3 tags', () => {
+    const result = render(<CustomTagGroup visibleItems={3}>{tags}</CustomTagGroup>);
+    expect(result.container).toHaveTextContent(/mock-tag-1mock-tag-2mock-tag-3/);
+    expect(result.container).not.toHaveTextContent(/mock-tag-4/);
+    expect(result.container).toHaveTextContent(/\+1/);
+  });
+
+  it('renders component with limited 3 tags, trigger tooltip and callback', async () => {
+    const result = render(
+      <CustomTagGroup visibleItems={3} onOpen={mockCallbackFn}>
+        {tags}
+      </CustomTagGroup>
+    );
+    expect(result.container).toHaveTextContent(/mock-tag-1mock-tag-2mock-tag-3/);
+    expect(result.container).not.toHaveTextContent(/mock-tag-4/);
+    expect(result.container).toHaveTextContent(/\+1/);
+    const tooltip = screen.getByRole('button');
+    await waitFor(async () => fireEvent.mouseOver(tooltip));
+    await waitFor(async () => expect(screen.getAllByText(/mock-tag-4/)[0]).toBeInTheDocument());
+    expect(mockCallbackFn).toBeCalledTimes(1);
+  });
+});

--- a/packages/pn-commons/src/components/index.ts
+++ b/packages/pn-commons/src/components/index.ts
@@ -47,6 +47,7 @@ import SnackBar from './SnackBar/SnackBar';
 import { SpecialContactsProvider, useSpecialContactsContext } from "./SpecialContacts.context";
 import TimedMessage from './TimedMessage/TimedMessage';
 import AppNotAccessible from './AppNotAccessible';
+import CustomTagGroup from './CustomTagGroup/CustomTagGroup';
 
 export {
   LoadingOverlay,
@@ -95,7 +96,8 @@ export {
   SpecialContactsProvider,
   useSpecialContactsContext,
   TimedMessage,
-  AppNotAccessible
+  AppNotAccessible,
+  CustomTagGroup
 };
 
 export type { DowntimeLogColumn };

--- a/packages/pn-pa-webapp/src/pages/components/ApiKeys/DesktopApiKeys.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/ApiKeys/DesktopApiKeys.tsx
@@ -204,7 +204,7 @@ const DesktopApiKeys = ({ apiKeys, handleModalClick }: Props) => {
       width: '15%',
       getCellLabel(value: Array<string>) {
         return (
-          <CustomTagGroup visibleItems={2}>
+          <CustomTagGroup visibleItems={3}>
             {value.map((v, i) => (
               <Box key={i} sx={{ my: 1 }}>
                 <Tag value={v} />

--- a/packages/pn-pa-webapp/src/pages/components/ApiKeys/DesktopApiKeys.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/ApiKeys/DesktopApiKeys.tsx
@@ -1,7 +1,6 @@
 import { Fragment, useState, MouseEvent, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Box, IconButton, Menu, MenuItem, Typography } from '@mui/material';
-import { Tag, TagGroup } from '@pagopa/mui-italia';
 import { MoreVert } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
 
@@ -13,7 +12,9 @@ import {
   EmptyState,
   CopyToClipboard,
   formatDate,
+  CustomTagGroup,
 } from '@pagopa-pn/pn-commons';
+import { Tag } from '@pagopa/mui-italia';
 import {
   ApiKey,
   ApiKeyColumn,
@@ -45,7 +46,7 @@ const DesktopApiKeys = ({ apiKeys, handleModalClick }: Props) => {
    * @returns true if the api key history contains status ROTATED, otherwise false
    */
   const isApiKeyRotated = (apiKeyIdx: number): boolean => {
-    const currentApiKey = (rows[apiKeyIdx] as any) as ApiKey;
+    const currentApiKey = rows[apiKeyIdx] as any as ApiKey;
     return !!currentApiKey.statusHistory.find((status) => status.status === ApiKeyStatus.ROTATED);
   };
 
@@ -203,11 +204,13 @@ const DesktopApiKeys = ({ apiKeys, handleModalClick }: Props) => {
       width: '15%',
       getCellLabel(value: Array<string>) {
         return (
-          <TagGroup visibleItems={3}>
-            {value.map((v) => (
-              <Tag key={v} value={v} />
+          <CustomTagGroup visibleItems={2}>
+            {value.map((v, i) => (
+              <Box key={i} sx={{ my: 1 }}>
+                <Tag value={v} />
+              </Box>
             ))}
-          </TagGroup>
+          </CustomTagGroup>
         );
       },
     },


### PR DESCRIPTION
## Short description
Added a tooltip on +X in api key list, column groups.

## List of changes proposed in this pull request
- Created a new common component: CustomTagGroup and tests
- Used in api key list with groups length > X

## How to test
Find an api key with more than 3 user groups and do mouse hover. You should see tooltip with remaining groups.