### PR TITLE
Added IN PROGRESS status in NotificationPayment components

### DIFF
--- a/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
@@ -74,7 +74,7 @@
       "download-f24": "Scarica il modello F24",
       "message-error-fetch-payment": "Non siamo riusciti a recuperare i dati di pagamento per questa notifica.",
       "message-completed": "Il pagamento è stato effettuato con successo.",
-      "message-in-progress": "Il pagamento è già in corso, puoi controllarne lo stato ricaricando la pagina o cliccando <0>Ricarica</0>. Se è passato troppo tempo senza aggiornamenti, segnalacelo!",
+      "message-in-progress": "Il pagamento è in corso: <0>ricarica la pagina</0> tra qualche ora per verificarne lo stato. Se risulta ancora in corso, <1>contatta l’assistenza</1>.",
       "message-failed": "Il pagamento non è andato a buon fine. Premi \"Paga\" per riprovare.",
       "message-network-error": "Si è verificato un errore nel recupero delle informazioni di pagamento. Ricarica la pagina.",
       "message-missing-parameter": "Codice notifica e/o codice fiscale ente non presenti!",

--- a/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
@@ -64,6 +64,7 @@
     "payment": {
       "summary-pending": "Da pagare",
       "summary-succeeded": "Pagato",
+      "summary-in-progress": "Pagamento in corso",
       "amount": "Importo",
       "disclaimer": "Questo importo verrà aggiornato al momento del pagamento. Quindi potrebbe essere diverso.",
       "disclaimer-link": "Come mai?",
@@ -73,7 +74,7 @@
       "download-f24": "Scarica il modello F24",
       "message-error-fetch-payment": "Non siamo riusciti a recuperare i dati di pagamento per questa notifica.",
       "message-completed": "Il pagamento è stato effettuato con successo.",
-      "message-in-progress": "Il pagamento è già in corso, riprova tra qualche minuto. Se è passato troppo tempo, segnalacelo!",
+      "message-in-progress": "Il pagamento è già in corso, puoi controllarne lo stato ricaricando la pagina o cliccando <0>Ricarica</0>. Se è passato troppo tempo senza aggiornamenti, segnalacelo!",
       "message-failed": "Il pagamento non è andato a buon fine. Premi \"Paga\" per riprovare.",
       "message-network-error": "Si è verificato un errore nel recupero delle informazioni di pagamento. Ricarica la pagina.",
       "message-missing-parameter": "Codice notifica e/o codice fiscale ente non presenti!",

--- a/packages/pn-personafisica-webapp/src/component/Notifications/NotificationPayment.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Notifications/NotificationPayment.tsx
@@ -275,6 +275,16 @@ const NotificationPayment: React.FC<Props> = ({
     </Link>
   );
 
+  const SupportButton = ({ children }: { children?: ReactNode }) => (
+    <Link
+      key="support-button"
+      sx={{ textDecoration: 'none', fontWeight: 'bold', cursor: 'pointer' }}
+      onClick={contactSupportClick}
+    >
+      {children}
+    </Link>
+  );
+
   /** returns message data to be passed into the alert */
   const getMessageData = (): PaymentMessageData | undefined => {
     if (!(notificationPayment.noticeCode && notificationPayment.creditorTaxId)) {
@@ -298,14 +308,15 @@ const NotificationPayment: React.FC<Props> = ({
               <Trans
                 ns={'notifiche'}
                 i18nKey={'detail.payment.message-in-progress'}
-                components={[<ReloadPaymentInfoButton key={'reload-payment-button'}>Ricarica</ReloadPaymentInfoButton>]}
+                components={[
+                  <ReloadPaymentInfoButton key={'reload-payment-button'} />,
+                  <SupportButton key={'support-button'} />,
+                ]}
               >
-                Il pagamento è già in corso, puoi controllarne lo stato ricaricando la pagina o
-                cliccando <ReloadPaymentInfoButton>Ricarica</ReloadPaymentInfoButton>. Se è passato
-                troppo tempo senza aggiornamenti, segnalacelo!
+                Il pagamento è in corso: <ReloadPaymentInfoButton>ricarica la pagina</ReloadPaymentInfoButton> tra qualche
+                ora per verificarne lo stato. Se risulta ancora in corso, <SupportButton>contatta l’assistenza</SupportButton>.
               </Trans>
             ),
-            action: MessageActionType.CONTACT_SUPPORT,
           };
         case PaymentStatus.FAILED:
           return getFailedMessageData();

--- a/packages/pn-personafisica-webapp/src/component/Notifications/NotificationPayment.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Notifications/NotificationPayment.tsx
@@ -23,14 +23,15 @@ import {
   formatEurocentToCurrency,
   NotificationDetailPayment,
   NotificationPaidDetail,
-  PaymentAttachmentSName, PaymentHistory,
+  PaymentAttachmentSName,
+  PaymentHistory,
   PaymentInfoDetail,
   PaymentStatus,
   useDownloadDocument,
   useIsMobile,
 } from '@pagopa-pn/pn-commons';
-import { useEffect, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { ReactNode, useEffect, useState } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
 
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import {
@@ -227,9 +228,11 @@ const NotificationPayment: React.FC<Props> = ({
   /** composes Payment Data to be rendered */
   const composePaymentData = (): PaymentData => {
     const title =
-      paymentInfo?.status !== PaymentStatus.SUCCEEDED
-        ? t('detail.payment.summary-pending', { ns: 'notifiche' })
-        : t('detail.payment.summary-succeeded', { ns: 'notifiche' });
+      paymentInfo?.status === PaymentStatus.SUCCEEDED
+        ? t('detail.payment.summary-succeeded', { ns: 'notifiche' })
+        : paymentInfo?.status === PaymentStatus.INPROGRESS
+        ? t('detail.payment.summary-in-progress', { ns: 'notifiche' })
+        : t('detail.payment.summary-pending', { ns: 'notifiche' });
 
     const amount = paymentInfo?.amount ? formatEurocentToCurrency(paymentInfo.amount) : '';
 
@@ -261,6 +264,17 @@ const NotificationPayment: React.FC<Props> = ({
     </>
   );
 
+  const ReloadPaymentInfoButton = ({ children }: { children?: ReactNode }) => (
+    <Link
+      key="reload-payment-button"
+      sx={{ textDecoration: 'none', fontWeight: 'bold', cursor: 'pointer' }}
+      color="primary"
+      onClick={fetchPaymentInfo}
+    >
+      {children}
+    </Link>
+  );
+
   /** returns message data to be passed into the alert */
   const getMessageData = (): PaymentMessageData | undefined => {
     if (!(notificationPayment.noticeCode && notificationPayment.creditorTaxId)) {
@@ -280,7 +294,17 @@ const NotificationPayment: React.FC<Props> = ({
         case PaymentStatus.INPROGRESS:
           return {
             type: 'info',
-            body: t('detail.payment.message-in-progress', { ns: 'notifiche' }),
+            body: (
+              <Trans
+                ns={'notifiche'}
+                i18nKey={'detail.payment.message-in-progress'}
+                components={[<ReloadPaymentInfoButton key={'reload-payment-button'}>Ricarica</ReloadPaymentInfoButton>]}
+              >
+                Il pagamento è già in corso, puoi controllarne lo stato ricaricando la pagina o
+                cliccando <ReloadPaymentInfoButton>Ricarica</ReloadPaymentInfoButton>. Se è passato
+                troppo tempo senza aggiornamenti, segnalacelo!
+              </Trans>
+            ),
             action: MessageActionType.CONTACT_SUPPORT,
           };
         case PaymentStatus.FAILED:
@@ -502,12 +526,12 @@ const NotificationPayment: React.FC<Props> = ({
                 </Stack>
               </>
             )}
-            {!loading
-              && paymentInfo.status === PaymentStatus.SUCCEEDED
-              && paymentHistory
-              && paymentHistory.length > 0
-              && <NotificationPaidDetail paymentDetailsList={paymentHistory} />
-            }
+            {!loading &&
+              paymentInfo.status === PaymentStatus.SUCCEEDED &&
+              paymentHistory &&
+              paymentHistory.length > 0 && (
+                <NotificationPaidDetail paymentDetailsList={paymentHistory} />
+              )}
           </Stack>
         </Grid>
       </Paper>

--- a/packages/pn-personafisica-webapp/src/component/Notifications/__test__/NotificationPayment.test.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Notifications/__test__/NotificationPayment.test.tsx
@@ -8,7 +8,7 @@ import {
   PaymentInfoDetail,
   RecipientType,
 } from '@pagopa-pn/pn-commons';
-import { act, prettyDOM, waitFor } from '@testing-library/react';
+import { act, waitFor } from '@testing-library/react';
 
 import { render, screen } from '../../../__test__/test-utils';
 import * as actions from '../../../redux/notification/actions';
@@ -227,7 +227,7 @@ describe('NotificationPayment component', () => {
   });
 
   it('renders properly if getPaymentInfo returns a "in progress" status', async () => {
-    render(
+    const result = render(
       <NotificationPayment
         iun="mocked-iun"
         notificationPayment={mockedNotificationDetailPayment}
@@ -250,7 +250,7 @@ describe('NotificationPayment component', () => {
       expect(amountLoader).not.toBeInTheDocument();
     });
 
-    const title = screen.getByRole('heading', { name: 'detail.payment.summary-pending' });
+    const title = screen.getByRole('heading', { name: 'detail.payment.summary-in-progress' });
     expect(title).toBeInTheDocument();
 
     const amount = screen.getByRole('heading', { name: 'detail.payment.amount' });
@@ -266,8 +266,7 @@ describe('NotificationPayment component', () => {
     const alert = screen.getByTestId('InfoOutlinedIcon');
     expect(alert).toBeInTheDocument();
 
-    const alertMessage = screen.getByText('detail.payment.message-in-progress');
-    expect(alertMessage).toBeInTheDocument();
+    expect(result.container).toHaveTextContent('detail.payment.summary-in-progress');
   });
 
   it('renders properly if getPaymentInfo returns a "succeeded" status', async () => {

--- a/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
@@ -73,7 +73,7 @@
       "download-f24": "Scarica il modello F24",
       "message-error-fetch-payment": "Non siamo riusciti a recuperare i dati di pagamento per questa notifica.",
       "message-completed": "Il pagamento è stato effettuato con successo.",
-      "message-in-progress": "Il pagamento è già in corso, puoi controllarne lo stato ricaricando la pagina o cliccando <0>Ricarica</0>. Se è passato troppo tempo senza aggiornamenti, segnalacelo!",
+      "message-in-progress": "Il pagamento è in corso: <0>ricarica la pagina</0> tra qualche ora per verificarne lo stato. Se risulta ancora in corso, <1>contatta l’assistenza</1>.",
       "message-failed": "Il pagamento non è andato a buon fine. Premi \"Paga\" per riprovare.",
       "message-network-error": "Si è verificato un errore nel recupero delle informazioni di pagamento. Ricarica la pagina.",
       "message-missing-parameter": "Codice notifica e/o codice fiscale ente non presenti!",

--- a/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
@@ -63,6 +63,7 @@
     "payment": {
       "summary-pending": "Da pagare",
       "summary-succeeded": "Pagato",
+      "summary-in-progress": "Pagamento in corso",
       "amount": "Importo",
       "disclaimer": "Questo importo verrà aggiornato al momento del pagamento. Quindi potrebbe essere diverso.",
       "disclaimer-link": "Come mai?",
@@ -72,7 +73,7 @@
       "download-f24": "Scarica il modello F24",
       "message-error-fetch-payment": "Non siamo riusciti a recuperare i dati di pagamento per questa notifica.",
       "message-completed": "Il pagamento è stato effettuato con successo.",
-      "message-in-progress": "Il pagamento è già in corso, riprova tra qualche minuto. Se è passato troppo tempo, segnalacelo!",
+      "message-in-progress": "Il pagamento è già in corso, puoi controllarne lo stato ricaricando la pagina o cliccando <0>Ricarica</0>. Se è passato troppo tempo senza aggiornamenti, segnalacelo!",
       "message-failed": "Il pagamento non è andato a buon fine. Premi \"Paga\" per riprovare.",
       "message-network-error": "Si è verificato un errore nel recupero delle informazioni di pagamento. Ricarica la pagina.",
       "message-missing-parameter": "Codice notifica e/o codice fiscale ente non presenti!",

--- a/packages/pn-personagiuridica-webapp/src/component/Notifications/NotificationPayment.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Notifications/NotificationPayment.tsx
@@ -279,6 +279,14 @@ const NotificationPayment: React.FC<Props> = ({
     </Link>
   );
   
+  const SupportButton = ({children}: {children?: ReactNode}) => (
+    <Link
+      key="support-button"
+      sx={{ textDecoration: 'none', fontWeight: 'bold', cursor: 'pointer' }}
+      onClick={contactSupportClick}
+    >{children}</Link>
+  );
+
   /** returns message data to be passed into the alert */
   const getMessageData = (): PaymentMessageData | undefined => {
     if (!(notificationPayment.noticeCode && notificationPayment.creditorTaxId)) {
@@ -302,14 +310,15 @@ const NotificationPayment: React.FC<Props> = ({
               <Trans
                 ns={'notifiche'}
                 i18nKey={'detail.payment.message-in-progress'}
-                components={[<ReloadPaymentInfoButton key={'reload-payment-button'}>Ricarica</ReloadPaymentInfoButton>]}
+                components={[
+                  <ReloadPaymentInfoButton key={'reload-payment-button'} />,
+                  <SupportButton key={'support-button'} />,
+                ]}
               >
-                Il pagamento è già in corso, puoi controllarne lo stato ricaricando la pagina o
-                cliccando <ReloadPaymentInfoButton>Ricarica</ReloadPaymentInfoButton>. Se è passato troppo
-                tempo senza aggiornamenti, segnalacelo!
+                Il pagamento è in corso: <ReloadPaymentInfoButton>ricarica la pagina</ReloadPaymentInfoButton> tra qualche
+                ora per verificarne lo stato. Se risulta ancora in corso, <SupportButton>contatta l’assistenza</SupportButton>.
               </Trans>
             ),
-            action: MessageActionType.CONTACT_SUPPORT,
           };
         case PaymentStatus.FAILED:
           return getFailedMessageData();

--- a/packages/pn-personagiuridica-webapp/src/component/Notifications/__test__/NotificationPayment.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Notifications/__test__/NotificationPayment.test.tsx
@@ -227,7 +227,7 @@ describe('NotificationPayment component', () => {
   });
 
   it('renders properly if getPaymentInfo returns a "in progress" status', async () => {
-    render(
+    const result = render(
       <NotificationPayment
         iun="mocked-iun"
         notificationPayment={mockedNotificationDetailPayment}
@@ -250,7 +250,7 @@ describe('NotificationPayment component', () => {
       expect(amountLoader).not.toBeInTheDocument();
     });
 
-    const title = screen.getByRole('heading', { name: 'detail.payment.summary-pending' });
+    const title = screen.getByRole('heading', { name: 'detail.payment.summary-in-progress' });
     expect(title).toBeInTheDocument();
 
     const amount = screen.getByRole('heading', { name: 'detail.payment.amount' });
@@ -266,8 +266,7 @@ describe('NotificationPayment component', () => {
     const alert = screen.getByTestId('InfoOutlinedIcon');
     expect(alert).toBeInTheDocument();
 
-    const alertMessage = screen.getByText('detail.payment.message-in-progress');
-    expect(alertMessage).toBeInTheDocument();
+    expect(result.container).toHaveTextContent('detail.payment.summary-in-progress');
   });
 
   it('renders properly if getPaymentInfo returns a "succeeded" status', async () => {


### PR DESCRIPTION
## Short description
Added IN PROGRESS status in NotificationPayment components.

## List of changes proposed in this pull request
- Added IN PROGRESS status in NotificationPayment components both PF and PG
- Added a new button which reloads payment status info
- Fixed both tests of the components above
- Modified translations

## How to test
Open any notification where it have to pay so pay it. The new payment status should shows IN PROGRESS label and in the description there is a link button which reloads payment status info.