### PR TITLE
Removed email view from mobile delegates and delegators

### DIFF
--- a/packages/pn-personafisica-webapp/src/component/Deleghe/MobileDelegates.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Deleghe/MobileDelegates.tsx
@@ -66,13 +66,6 @@ const MobileDelegates = () => {
       },
     },
     {
-      id: 'email',
-      label: t('deleghe.table.email'),
-      getLabel(value: string) {
-        return value;
-      },
-    },
-    {
       id: 'startDate',
       label: t('deleghe.table.delegationStart'),
       getLabel(value: string) {

--- a/packages/pn-personafisica-webapp/src/component/Deleghe/MobileDelegators.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Deleghe/MobileDelegators.tsx
@@ -56,13 +56,6 @@ const MobileDelegators = () => {
       },
     },
     {
-      id: 'email',
-      label: t('deleghe.table.email'),
-      getLabel(value: string) {
-        return value;
-      },
-    },
-    {
       id: 'startDate',
       label: t('deleghe.table.delegationStart'),
       getLabel(value: string) {

--- a/packages/pn-personagiuridica-webapp/src/component/Deleghe/MobileDelegates.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Deleghe/MobileDelegates.tsx
@@ -66,13 +66,6 @@ const MobileDelegates = () => {
       },
     },
     {
-      id: 'email',
-      label: t('deleghe.table.email'),
-      getLabel(value: string) {
-        return value;
-      },
-    },
-    {
       id: 'startDate',
       label: t('deleghe.table.delegationStart'),
       getLabel(value: string) {

--- a/packages/pn-personagiuridica-webapp/src/component/Deleghe/MobileDelegators.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Deleghe/MobileDelegators.tsx
@@ -56,13 +56,6 @@ const MobileDelegators = () => {
       },
     },
     {
-      id: 'email',
-      label: t('deleghe.table.email'),
-      getLabel(value: string) {
-        return value;
-      },
-    },
-    {
       id: 'startDate',
       label: t('deleghe.table.delegationStart'),
       getLabel(value: string) {


### PR DESCRIPTION
## Short description
Removed email view from mobile delegates and delegators.

## List of changes proposed in this pull request
- Removed from mobile delegators
- Removed from mobile dleegates

## How to test
Find user with delegates or delegators (or create a new delegator) and switch on mobile. You shouldn't see email anymore.