### PR TITLE
Replaced texts in payment label in notification details PA

### DIFF
--- a/packages/pn-pa-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/it/notifiche.json
@@ -19,8 +19,8 @@
   },
   "payment": {
     "title": "Pagamenti",
-    "subtitle-single": "I costi di notifica sono stati pagati dal destinatario",
-    "subtitle-multiple": "I costi di notifica sono stati pagati dai seguenti destinatari:",
+    "subtitle-single": "Il destinatario ha effettuato un pagamento. Ecco i dettagli:",
+    "subtitle-multiple": "Questi destinatari hanno effettuato un pagamento:",
     "show-more": "Mostra dettagli"
   },
   "table": {


### PR DESCRIPTION
## Short description
Replaced texts in payment label in notification details PA.

## List of changes proposed in this pull request
- Replaced text for payment.subtitle-single in notifiche.json
- Replaced text for payment.subtitle-multiple in notifiche.json

## How to test
With SVIL environment, use these iun codes

MONO - user baldassarremazza, Comune di Milano
YDUM-AEQX-KZNR-202303-Z-1 --> mono (Milano)
WMUQ-JUYJ-TLUN-202303-W-1 --> mono (Milano)

MULTI - user grossini, Comune di Palermo
GVYQ-WLPR-GPQE-202303-A-1 --> multi (Palermo)
RNRD-DPHU-VPRE-202303-H-1 --> multi (Palermo)