### PR TITLE
PN-4622 fixed silly bug in the DELIVERED status copy for PA

### DIFF
--- a/packages/pn-pa-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/it/notifiche.json
@@ -156,7 +156,7 @@
     "delivered-tooltip": "L'invio della notifica è terminato",
     "delivered-tooltip-multirecipient": "L'invio della notifica è terminato",
     "delivered-description": "L'invio della notifica è terminato.",
-    "delivered-description-with-delivery-mode": "La notifica è stata consegnata in quanto almeno un recapito {{deliveryMode}} è valido.",
+    "delivered-description-with-delivery-mode": "L'invio della notifica è terminato in quanto almeno un recapito {{deliveryMode}} è valido.",
     "delivered-description-multirecipient": "L'invio della notifica è terminato in quanto un recapito di almeno un destinatario è valido.",
     "delivering": "Invio in corso",
     "delivering-tooltip": "L'invio della notifica è in corso",


### PR DESCRIPTION
## Short description
Fixed the copy of the DELIVERED state in the timeline for PA (in PF/PG the right copy was already set).

## How to test
Enter e.g. the details for the notification ARDY-UNGJ-KYRN-202303-N-1 (Comune di Palermo / Marco Polo). For both PA and PF, the copy of the DELIVERED state should be as in the image.
![image](https://user-images.githubusercontent.com/5519535/226378444-9af5949d-90d8-49cb-aeff-05c87fbc22ba.png)
