### PR TITLE
Fix issue in ItemsTable where user was unable to navigate via keyboard

### DIFF
--- a/packages/pn-commons/src/components/Data/ItemsTable.tsx
+++ b/packages/pn-commons/src/components/Data/ItemsTable.tsx
@@ -115,6 +115,7 @@ function ItemsTable<ColumnId extends string>({
                   >
                     {column.onClick && (
                       <ButtonNaked
+                        tabIndex={column.disableAccessibility ? -1 : 0}
                         sx={buttonNakedInheritStyle}
                         onClick={() => column.onClick && column.onClick(row, column)}
                       >

--- a/packages/pn-commons/src/components/Data/ItemsTable.tsx
+++ b/packages/pn-commons/src/components/Data/ItemsTable.tsx
@@ -1,3 +1,4 @@
+import { ButtonNaked } from '@pagopa/mui-italia';
 import {
   Table,
   TableBody,
@@ -13,6 +14,7 @@ import { visuallyHidden } from '@mui/utils';
 
 import { Column, Item, Sort, Notification } from '../../types';
 import { getLocalizedOrDefaultLabel } from '../../services/localization.service';
+import { buttonNakedInheritStyle } from '../../utils';
 
 type Props<ColumnId> = {
   /** Table columns */
@@ -37,7 +39,7 @@ function ItemsTable<ColumnId extends string>({
       onChangeSorting({ order: isAsc ? 'desc' : 'asc', orderBy: property });
     }
   };
-  
+
   // Table style
   const Root = styled('div')(
     () => `
@@ -60,7 +62,11 @@ function ItemsTable<ColumnId extends string>({
   return (
     <Root>
       <TableContainer sx={{ marginBottom: '10px' }}>
-        <Table stickyHeader aria-label={getLocalizedOrDefaultLabel('common', 'table.aria-label', 'Tabella di item')} data-cy="table(notifications)">
+        <Table
+          stickyHeader
+          aria-label={getLocalizedOrDefaultLabel('common', 'table.aria-label', 'Tabella di item')}
+          data-cy="table(notifications)"
+        >
           <TableHead>
             <TableRow>
               {columns.map((column) => (
@@ -95,20 +101,32 @@ function ItemsTable<ColumnId extends string>({
             </TableRow>
           </TableHead>
           <TableBody sx={{ backgroundColor: 'background.paper' }}>
-              {rows.map((row) => (
-                <TableRow key={row.id} data-cy="table(notifications).row">
-                  {columns.map((column) => (
-                    <TableCell
-                      key={column.id}
-                      sx={{ width: column.width, borderBottom: 'none', cursor: column.onClick ? 'pointer': 'auto' }}
-                      align={column.align}
-                      onClick={() => column.onClick && column.onClick(row, column)}
-                    >
-                      {column.getCellLabel(row[column.id as keyof Notification], row)}
-                    </TableCell>
-                  ))}
-                </TableRow>
-              ))}
+            {rows.map((row) => (
+              <TableRow key={row.id} data-cy="table(notifications).row">
+                {columns.map((column) => (
+                  <TableCell
+                    key={column.id}
+                    sx={{
+                      width: column.width,
+                      borderBottom: 'none',
+                      cursor: column.onClick ? 'pointer' : 'auto',
+                    }}
+                    align={column.align}
+                  >
+                    {column.onClick && (
+                      <ButtonNaked
+                        sx={buttonNakedInheritStyle}
+                        onClick={() => column.onClick && column.onClick(row, column)}
+                      >
+                        {column.getCellLabel(row[column.id as keyof Notification], row)}
+                      </ButtonNaked>
+                    )}
+                    {!column.onClick &&
+                      column.getCellLabel(row[column.id as keyof Notification], row)}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
           </TableBody>
         </Table>
       </TableContainer>

--- a/packages/pn-commons/src/components/Data/__test__/ItemsTable.test.tsx
+++ b/packages/pn-commons/src/components/Data/__test__/ItemsTable.test.tsx
@@ -22,6 +22,7 @@ const columns: Array<Column> = [
     width: '50%',
     getCellLabel: (value: string) => value,
     onClick: handleColumnClick,
+    disableAccessibility: true
   },
 ];
 
@@ -99,5 +100,21 @@ describe('Notifications Table Component', () => {
     fireEvent.click(tableColumns[2].querySelectorAll('button')[0]);
     expect(handleColumnClick).toBeCalledTimes(1);
     expect(handleColumnClick).toBeCalledWith(rows[0], columns[2]);
+  });
+
+  it('disable accessibility navigation on a column', () => {
+    render(
+      <ItemsTable
+        columns={columns}
+        rows={rows}
+        sort={sort}
+      />
+    );
+    const table = screen.getByRole('table');
+    const tableBody = table.querySelector('tbody');
+    const firstRow = tableBody!.querySelector('tr');
+    const tableColumns = firstRow!.querySelectorAll('td');
+    const button = tableColumns[2].querySelectorAll('button')[0]
+    expect(button).toHaveAttribute('tabIndex', '-1');
   });
 });

--- a/packages/pn-commons/src/components/Data/__test__/ItemsTable.test.tsx
+++ b/packages/pn-commons/src/components/Data/__test__/ItemsTable.test.tsx
@@ -96,7 +96,7 @@ describe('Notifications Table Component', () => {
     const tableBody = table.querySelector('tbody');
     const firstRow = tableBody!.querySelector('tr');
     const tableColumns = firstRow!.querySelectorAll('td');
-    fireEvent.click(tableColumns[2]);
+    fireEvent.click(tableColumns[2].querySelectorAll('button')[0]);
     expect(handleColumnClick).toBeCalledTimes(1);
     expect(handleColumnClick).toBeCalledWith(rows[0], columns[2]);
   });

--- a/packages/pn-commons/src/types/ItemsTable.ts
+++ b/packages/pn-commons/src/types/ItemsTable.ts
@@ -15,6 +15,7 @@ export interface Column<ColumnId> {
   sortable?: boolean;
   getCellLabel(value: string | number | Array<string | ReactNode>, row?: Item): ReactNode;
   onClick?(row: Item, column: Column<ColumnId>): void;
+  disableAccessibility?: boolean;
 }
 
 export interface Item {

--- a/packages/pn-commons/src/utils/__test__/styles.utility.test.tsx
+++ b/packages/pn-commons/src/utils/__test__/styles.utility.test.tsx
@@ -1,0 +1,14 @@
+import { buttonNakedInheritStyle } from '../styles.utility';
+import { ButtonNaked } from '@pagopa/mui-italia';
+import { render } from '../../test-utils';
+import React from 'react';
+
+describe('Styles utilities test', () => {
+
+  it('buttonNakedInheritStyle test', () => {
+    const expetedResultStyle =
+      "color: 'inherit', border: 'none', font-size: 'inherit', font-family: 'inherit', background: 'inherit', margin: 0, padding: 0, font-weight: 'inherit'";
+    const result = render(<ButtonNaked sx={buttonNakedInheritStyle}>Mocked-button</ButtonNaked>);
+    expect(result.container).toHaveStyle(expetedResultStyle);
+  });
+});

--- a/packages/pn-commons/src/utils/index.ts
+++ b/packages/pn-commons/src/utils/index.ts
@@ -49,6 +49,7 @@ import {
 import { performThunkAction } from './redux.utility';
 import { ResponseEventDispatcher, AppResponsePublisher } from './AppResponse';
 import { AppError, AppErrorFactory, errorFactoryManager, UnknownAppError } from './AppError';
+import { buttonNakedInheritStyle } from './styles.utility';
 
 export {
   getNotificationAllowedStatus,
@@ -101,4 +102,5 @@ export {
   UnknownAppError,
   sanitizeString,
   compileOneTrustPath,
+  buttonNakedInheritStyle,
 };

--- a/packages/pn-commons/src/utils/styles.utility.ts
+++ b/packages/pn-commons/src/utils/styles.utility.ts
@@ -1,0 +1,13 @@
+import { CSSProperties } from "react";
+
+/** Used with ButtonNaked, it set CSS properties inherited from parent(s) */
+export const buttonNakedInheritStyle: CSSProperties = {
+  color: 'inherit',
+  border: 'none',
+  fontSize: 'inherit',
+  fontFamily: 'inherit',
+  background: 'inherit',
+  margin: 0,
+  padding: 0,
+  fontWeight: 'inherit'
+};

--- a/packages/pn-pa-webapp/src/pages/components/Notifications/DesktopNotifications.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/Notifications/DesktopNotifications.tsx
@@ -61,6 +61,7 @@ const DesktopNotifications = ({
       onClick(row: Item) {
         handleRowClick(row);
       },
+      disableAccessibility: true,
     },
     {
       id: 'recipients',
@@ -77,6 +78,7 @@ const DesktopNotifications = ({
       onClick(row: Item) {
         handleRowClick(row);
       },
+      disableAccessibility: true,
     },
     {
       id: 'subject',
@@ -88,6 +90,7 @@ const DesktopNotifications = ({
       onClick(row: Item) {
         handleRowClick(row);
       },
+      disableAccessibility: true,
     },
     {
       id: 'iun',
@@ -116,6 +119,7 @@ const DesktopNotifications = ({
       onClick(row: Item) {
         handleRowClick(row);
       },
+      disableAccessibility: true,
     },
     {
       id: 'notificationStatus',

--- a/packages/pn-pa-webapp/src/pages/components/Notifications/__test__/DesktopNotifications.test.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/Notifications/__test__/DesktopNotifications.test.tsx
@@ -60,7 +60,7 @@ describe('DesktopNotifications Component', () => {
       />
     );
     const notificationsTableCell = result.container.querySelector(
-      'table tr:first-child td:nth-child(2)'
+      'table tr:first-child td:nth-child(2) button'
     );
     fireEvent.click(notificationsTableCell!);
     await waitFor(() => {

--- a/packages/pn-personafisica-webapp/src/component/Notifications/DesktopNotifications.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Notifications/DesktopNotifications.tsx
@@ -58,6 +58,7 @@ const DesktopNotifications = ({
       onClick(row: Item) {
         handleRowClick(row);
       },
+      disableAccessibility: true,
     },
     {
       id: 'sentAt',
@@ -70,6 +71,7 @@ const DesktopNotifications = ({
       onClick(row: Item) {
         handleRowClick(row);
       },
+      disableAccessibility: true,
     },
     {
       id: 'sender',
@@ -82,6 +84,7 @@ const DesktopNotifications = ({
       onClick(row: Item) {
         handleRowClick(row);
       },
+      disableAccessibility: true,
     },
     {
       id: 'subject',
@@ -93,6 +96,7 @@ const DesktopNotifications = ({
       onClick(row: Item) {
         handleRowClick(row);
       },
+      disableAccessibility: true,
     },
     {
       id: 'iun',

--- a/packages/pn-personafisica-webapp/src/component/Notifications/__test__/DesktopNotifications.test.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Notifications/__test__/DesktopNotifications.test.tsx
@@ -57,7 +57,7 @@ describe('DesktopNotifications Component', () => {
       />
     );
     const notificationsTableCell = result?.container.querySelector(
-      'table tr:first-child td:nth-child(2)'
+      'table tr:first-child td:nth-child(2) button'
     );
     fireEvent.click(notificationsTableCell!);
     await waitFor(() => {

--- a/packages/pn-personagiuridica-webapp/src/component/Notifications/DesktopNotifications.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Notifications/DesktopNotifications.tsx
@@ -58,6 +58,7 @@ const DesktopNotifications = ({
       onClick(row: Item) {
         handleRowClick(row);
       },
+      disableAccessibility: true,
     },
     {
       id: 'sentAt',
@@ -70,6 +71,7 @@ const DesktopNotifications = ({
       onClick(row: Item) {
         handleRowClick(row);
       },
+      disableAccessibility: true,
     },
     {
       id: 'sender',
@@ -82,6 +84,7 @@ const DesktopNotifications = ({
       onClick(row: Item) {
         handleRowClick(row);
       },
+      disableAccessibility: true,
     },
     {
       id: 'subject',
@@ -93,6 +96,7 @@ const DesktopNotifications = ({
       onClick(row: Item) {
         handleRowClick(row);
       },
+      disableAccessibility: true,
     },
     {
       id: 'iun',

--- a/packages/pn-personagiuridica-webapp/src/component/Notifications/__test__/DesktopNotifications.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Notifications/__test__/DesktopNotifications.test.tsx
@@ -57,7 +57,7 @@ describe('DesktopNotifications Component', () => {
       />
     );
     const notificationsTableCell = result?.container.querySelector(
-      'table tr:first-child td:nth-child(2)'
+      'table tr:first-child td:nth-child(2) button'
     );
     fireEvent.click(notificationsTableCell!);
     await waitFor(() => {


### PR DESCRIPTION
## Short description
Fix issue in ItemsTable where user was unable to navigate via keyboard.

## Long description
Accessibility navigation with keyboard is possible by setting tabIndex={0} on HTML tags. However tabIndex alone is insufficient because any onClick event associated to tags like DIV, TABLE, TD or any of non-interaction HTML tags (example: BUTTON, INPUT, SELECT, etc.), won't trigger if you press space or enter. The natural solution is to wrap content with BUTTON tag where onClick event is present.

## List of changes proposed in this pull request
- Added new utility styles.utility.tsx to pn-commons. It contains a const with CSS properties for ButtonNaked compononent
- Wrapped any cell content with ButtonNaked component where onClick is defined.

## How to test
Open notifications table from any app and use keyboard. Now you should be able to navigate and also select a notification by pressing space or enter.