### PR TITLE
PN-4862 - take config from json - tooling

### DIFF
--- a/packages/pn-commons/src/services/__test__/configuration.service.test.ts
+++ b/packages/pn-commons/src/services/__test__/configuration.service.test.ts
@@ -1,0 +1,73 @@
+import { Validator } from '@pagopa-pn/pn-validator';
+import { clearConfig, getConfiguration, loadConfiguration } from '../configuration.service';
+
+let mockFetchConfigurationResult: any;
+
+jest.mock('../fetch.configuration.service', () => {
+  const originalModule = jest.requireActual('../fetch.configuration.service');
+
+  //Mock the default export and named export 'foo'
+  return {
+    ...originalModule,
+    fetchConfiguration: async () => {
+      if (mockFetchConfigurationResult) {
+        return Promise.resolve(mockFetchConfigurationResult);
+      } else {
+        throw new Error('fetch.error');  
+      }
+    },
+  };
+});
+
+interface TestConfiguration {
+  a: number;
+}
+
+class TestConfigurationValidator extends Validator<TestConfiguration> {
+  constructor() {
+    super();
+    this.ruleFor('a').isNumber().not().isNull().not().isUndefined();
+  }
+}
+
+function getTestConfiguration(): TestConfiguration {
+  return getConfiguration<TestConfiguration>();
+}
+
+describe('configuration service', () => {
+  beforeEach(() => clearConfig());
+  
+  it('fetchConfiguration lauches error', async () => {
+    mockFetchConfigurationResult = undefined;
+    await expect(loadConfiguration(new TestConfigurationValidator())).rejects.toThrow('fetch.error');
+  });
+
+  it('wrong config contents - does not match the validator rules', async () => {
+    mockFetchConfigurationResult = {b: 42};
+    await expect(loadConfiguration(new TestConfigurationValidator())).rejects.toThrow(
+      JSON.stringify({ a: `Value mustn't be undefined`})
+    );
+  });
+
+  it('loadConfiguration called more than once', async () => {
+    mockFetchConfigurationResult = {a: 42};
+    await expect(loadConfiguration(new TestConfigurationValidator())).resolves;
+    await expect(loadConfiguration(new TestConfigurationValidator())).rejects.toThrow(
+      'config should be loaded just once'
+    );
+  });
+
+  it('getConfiguration called without having called loadConfiguration before', async () => {
+    mockFetchConfigurationResult = {a: 42};
+    expect(() => getTestConfiguration()).toThrow(
+      'loadConfiguration must be called before any call to getConfiguration'
+    );
+  });
+
+  it('happy path', async () => {
+    mockFetchConfigurationResult = {a: 42};
+    await loadConfiguration(new TestConfigurationValidator());
+    const config = getTestConfiguration();
+    expect(config.a).toBe(42);
+  });
+});

--- a/packages/pn-commons/src/services/__test__/configuration.service.test.ts
+++ b/packages/pn-commons/src/services/__test__/configuration.service.test.ts
@@ -1,5 +1,5 @@
 import { Validator } from '@pagopa-pn/pn-validator';
-import { clearConfig, getConfiguration, loadConfiguration } from '../configuration.service';
+import { Configuration } from '../configuration.service';
 
 let mockFetchConfigurationResult: any;
 
@@ -13,7 +13,7 @@ jest.mock('../fetch.configuration.service', () => {
       if (mockFetchConfigurationResult) {
         return Promise.resolve(mockFetchConfigurationResult);
       } else {
-        throw new Error('fetch.error');  
+        throw new Error('fetch.error');
       }
     },
   };
@@ -31,42 +31,42 @@ class TestConfigurationValidator extends Validator<TestConfiguration> {
 }
 
 function getTestConfiguration(): TestConfiguration {
-  return getConfiguration<TestConfiguration>();
+  return Configuration.get<TestConfiguration>();
 }
 
 describe('configuration service', () => {
-  beforeEach(() => clearConfig());
-  
+  beforeEach(() => Configuration.clear());
+
   it('fetchConfiguration lauches error', async () => {
     mockFetchConfigurationResult = undefined;
-    await expect(loadConfiguration(new TestConfigurationValidator())).rejects.toThrow('fetch.error');
+    await expect(Configuration.load(new TestConfigurationValidator())).rejects.toThrow('fetch.error');
   });
 
   it('wrong config contents - does not match the validator rules', async () => {
-    mockFetchConfigurationResult = {b: 42};
-    await expect(loadConfiguration(new TestConfigurationValidator())).rejects.toThrow(
-      JSON.stringify({ a: `Value mustn't be undefined`})
+    mockFetchConfigurationResult = { b: 42 };
+    await expect(Configuration.load(new TestConfigurationValidator())).rejects.toThrow(
+      JSON.stringify({ a: `Value mustn't be undefined` })
     );
   });
 
   it('loadConfiguration called more than once', async () => {
-    mockFetchConfigurationResult = {a: 42};
-    await expect(loadConfiguration(new TestConfigurationValidator())).resolves;
-    await expect(loadConfiguration(new TestConfigurationValidator())).rejects.toThrow(
-      'config should be loaded just once'
+    mockFetchConfigurationResult = { a: 42 };
+    await expect(Configuration.load(new TestConfigurationValidator())).resolves;
+    await expect(Configuration.load(new TestConfigurationValidator())).rejects.toThrow(
+      'Configuration should be loaded just once'
     );
   });
 
   it('getConfiguration called without having called loadConfiguration before', async () => {
-    mockFetchConfigurationResult = {a: 42};
+    mockFetchConfigurationResult = { a: 42 };
     expect(() => getTestConfiguration()).toThrow(
       'loadConfiguration must be called before any call to getConfiguration'
     );
   });
 
   it('happy path', async () => {
-    mockFetchConfigurationResult = {a: 42};
-    await loadConfiguration(new TestConfigurationValidator());
+    mockFetchConfigurationResult = { a: 42 };
+    await Configuration.load(new TestConfigurationValidator());
     const config = getTestConfiguration();
     expect(config.a).toBe(42);
   });

--- a/packages/pn-commons/src/services/configuration.service.ts
+++ b/packages/pn-commons/src/services/configuration.service.ts
@@ -12,6 +12,10 @@ export class Configuration {
     this.configurationLoadingExecuted = false;
   }
 
+  /**
+   * Get current configuration of type <T> if loading has been already made, otherwise it throws a ConfigurationError
+   * @returns Configuration of type T
+   */
   static get<T>(): T {
     if (!this.configurationLoadingExecuted) {
       throw new ConfigurationError('loadConfiguration must be called before any call to getConfiguration');
@@ -21,6 +25,10 @@ export class Configuration {
     return this.storedConfiguration;
   }
 
+  /**
+   * This method loads and validates a Configuration of type T 
+   * @param validator for T, you should provide your validator based on your config object
+   */
   static async load<T>(validator: Validator<T>): Promise<void> {
     if (this.configurationLoadingExecuted) {
       throw new ConfigurationError('Configuration should be loaded just once');

--- a/packages/pn-commons/src/services/configuration.service.ts
+++ b/packages/pn-commons/src/services/configuration.service.ts
@@ -1,0 +1,43 @@
+import { Validator } from "@pagopa-pn/pn-validator"
+import { fetchConfiguration } from "./fetch.configuration.service";
+
+// eslint-disable-next-line functional/no-let
+let storedConfiguration: any = null;
+
+// eslint-disable-next-line functional/no-let
+let configurationLoadingExecuted = false;
+
+export class ConfigurationError extends Error { }
+
+// for test purposes only!!
+export function clearConfig() {
+  storedConfiguration = null;
+  configurationLoadingExecuted = false;
+}
+
+export function validateConfiguration<T>(readConfiguration: T, validator: Validator<T>): T {
+  const validationResult = validator.validate(readConfiguration);
+  if (validationResult == null) {
+    return readConfiguration;
+  } else {
+    throw new ConfigurationError(JSON.stringify(validationResult));
+  }
+}
+
+export async function loadConfiguration<T>(validator: Validator<T>): Promise<void> {
+  if (configurationLoadingExecuted) {
+    throw new ConfigurationError('config should be loaded just once');
+  }
+  configurationLoadingExecuted = true;
+  const readValue: T = (await fetchConfiguration()) as T;
+  storedConfiguration = validateConfiguration(readValue, validator);
+}
+
+export function getConfiguration<T>(): T {
+  if (!configurationLoadingExecuted) {
+    throw new ConfigurationError('loadConfiguration must be called before any call to getConfiguration');
+  } else if (storedConfiguration == null) {
+    throw new ConfigurationError('error detected when loading configuration');
+  }
+  return storedConfiguration;
+}

--- a/packages/pn-commons/src/services/fetch.configuration.service.ts
+++ b/packages/pn-commons/src/services/fetch.configuration.service.ts
@@ -1,0 +1,19 @@
+/*
+ * this function is defined in a file separate from configuration.service.ts
+ * just to ease its mocking when testing loadConfiguration and getConfiguration.
+ */
+
+export async function fetchConfiguration(): Promise<any> {
+  try { 
+    const res = await fetch('conf/config.json', {
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+    });
+    return await res.json();
+  } catch (e) {
+    console.error(e);
+    throw e;
+  }  
+}

--- a/packages/pn-commons/src/services/index.ts
+++ b/packages/pn-commons/src/services/index.ts
@@ -1,5 +1,5 @@
 import { initLocalization } from './localization.service';
 import { trackEvent, interceptDispatch } from './tracking.service';
-import { loadConfiguration, getConfiguration } from './configuration.service';
+import { Configuration } from './configuration.service';
 
-export { initLocalization, trackEvent, interceptDispatch, loadConfiguration, getConfiguration };
+export { initLocalization, trackEvent, interceptDispatch, Configuration };

--- a/packages/pn-commons/src/services/index.ts
+++ b/packages/pn-commons/src/services/index.ts
@@ -1,4 +1,5 @@
 import { initLocalization } from './localization.service';
 import { trackEvent, interceptDispatch } from './tracking.service';
+import { loadConfiguration, getConfiguration } from './configuration.service';
 
-export { initLocalization, trackEvent, interceptDispatch };
+export { initLocalization, trackEvent, interceptDispatch, loadConfiguration, getConfiguration };


### PR DESCRIPTION
## Short description
Implement the tools needed to get the configuration from the file `public/conf/config.json` instead of env variables, so that we can move to a "build once - deploy many" scenario.

## List of changes proposed in this pull request
Created the `configuration.services.ts` file, which includes:
- a global (but not exported) variable to hold the read config
- a function `loadConfiguration<T>(validator)` (to be parametrized upon the type of the config for each PN app), which fetches the file, verifies the contents using the given validator (a validator created using `pn-validator` is expected), and stores it in the variable just mentioned. If the fetching fails, or the contents fail to pass the validation, then this function raises an exception.
- a function `getConfiguration<T>` which verifies that `loadConfiguration` have been called, and return just the stored value.

These functions are to be used in each PN app according to the instructions described in https://pagopa.atlassian.net/browse/PN-4426 and https://pagopa.atlassian.net/browse/PN-4864.

**NB**  
The actual file contents fetching is defined in a separate file for testing purposes, the same reason behind the `clearConfig` function added to the main file. 

## How to test
The only way provided in this PR alone to verify the implementation is to execute the `configuration.services.test.ts` test file. Several scenarios regarding initalization are described there.