### PR TITLE
Pn 5214 fe invio codice otp anticipato prima dellaccettazione del disclamer

### DIFF
--- a/packages/pn-personafisica-webapp/src/component/Contacts/DigitalContactsCodeVerification.context.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Contacts/DigitalContactsCodeVerification.context.tsx
@@ -155,6 +155,8 @@ const DigitalContactsCodeVerificationProvider: FC<ReactNode> = ({ children }) =>
             })
           );
           handleClose('validated');
+        } else {
+          setOpen(true);
         }
       });
   };
@@ -209,7 +211,6 @@ const DigitalContactsCodeVerificationProvider: FC<ReactNode> = ({ children }) =>
     ) {
       // open verification code dialog
       handleCodeVerification();
-      setOpen(true);
     } else {
       // open disclaimer dialog
       setDisclaimerOpen(true);

--- a/packages/pn-personafisica-webapp/src/component/Contacts/DigitalContactsCodeVerification.context.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Contacts/DigitalContactsCodeVerification.context.tsx
@@ -97,7 +97,7 @@ const DigitalContactsCodeVerificationProvider: FC<ReactNode> = ({ children }) =>
 
   const handleConfirm = () => {
     setIsConfirmationModalVisible(false);
-    handleCodeVerification();
+    handleDisclaimerVisibilityFirst();
   };
 
   const handleDiscard = () => {
@@ -155,21 +155,6 @@ const DigitalContactsCodeVerificationProvider: FC<ReactNode> = ({ children }) =>
             })
           );
           handleClose('validated');
-        } else {
-          // if senderId !== 'default' they are a special contact => don't show disclaimer
-          // if modalProps.digitalDomicileType === LegalChannelType.PEC it's a legal contact => don't show disclaimer
-          // if modalProps.digitalDomicileType !== LegalChannelType.PEC and senderId === 'default' it's a
-          // courtesy contact => show disclaimer
-          if (
-            modalProps.digitalDomicileType === LegalChannelType.PEC ||
-            modalProps.senderId !== 'default'
-          ) {
-            // open verification code dialog
-            setOpen(true);
-          } else {
-            // open disclaimer dialog
-            setDisclaimerOpen(true);
-          }
         }
       });
   };
@@ -207,11 +192,29 @@ const DigitalContactsCodeVerificationProvider: FC<ReactNode> = ({ children }) =>
 
   useEffect(() => {
     if (!_.isEqual(modalProps, initialProps) && !contactAlreadyExists()) {
-      handleCodeVerification();
+      handleDisclaimerVisibilityFirst();
     } else if (contactAlreadyExists()) {
       setIsConfirmationModalVisible(true);
     }
   }, [modalProps]);
+
+  const handleDisclaimerVisibilityFirst = () => {
+    // if senderId !== 'default' they are a special contact => don't show disclaimer
+    // if modalProps.digitalDomicileType === LegalChannelType.PEC it's a legal contact => don't show disclaimer
+    // if modalProps.digitalDomicileType !== LegalChannelType.PEC and senderId === 'default' it's a
+    // courtesy contact => show disclaimer
+    if (
+      modalProps.digitalDomicileType === LegalChannelType.PEC ||
+      modalProps.senderId !== 'default'
+    ) {
+      // open verification code dialog
+      handleCodeVerification();
+      setOpen(true);
+    } else {
+      // open disclaimer dialog
+      setDisclaimerOpen(true);
+    }
+  };
 
   const handleAddressUpdateError = useCallback(
     (responseError: AppResponse) => {
@@ -255,6 +258,7 @@ const DigitalContactsCodeVerificationProvider: FC<ReactNode> = ({ children }) =>
         <DisclaimerModal
           onConfirm={() => {
             setDisclaimerOpen(false);
+            handleCodeVerification();
             setOpen(true);
           }}
           onCancel={() => setDisclaimerOpen(false)}

--- a/packages/pn-personafisica-webapp/src/component/Contacts/__test__/CourtesyContactItem.test.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Contacts/__test__/CourtesyContactItem.test.tsx
@@ -104,7 +104,13 @@ describe('CourtesyContactItem component', () => {
         fireEvent.change(input!, { target: { value: INPUT_VALID_PHONE } });
         await waitFor(() => expect(input!).toHaveValue(INPUT_VALID_PHONE));
         const button = result!.getByRole('button');
-        fireEvent.click(button!);
+        await waitFor(() => fireEvent.click(button!));
+        // Confirms the disclaimer dialog
+        const disclaimerCheckbox = screen.getByRole('checkbox', { name: 'button.capito' });
+        fireEvent.click(disclaimerCheckbox);
+        const disclaimerConfirmButton = screen.getByRole('button', { name: 'button.conferma' });
+        fireEvent.click(disclaimerConfirmButton);
+
         await waitFor(() => {
           expect(mockDispatchFn).toBeCalledTimes(1);
           expect(mockActionFn).toBeCalledTimes(1);
@@ -116,11 +122,6 @@ describe('CourtesyContactItem component', () => {
             code: undefined,
           });
         });
-
-        const disclaimerCheckbox = screen.getByRole('checkbox', { name: 'button.capito' });
-        fireEvent.click(disclaimerCheckbox);
-        const disclaimerConfirmButton = screen.getByRole('button', { name: 'button.conferma' });
-        fireEvent.click(disclaimerConfirmButton);
 
         const dialog = await waitFor(() => {
           const dialogEl = screen.queryByTestId('codeDialog');
@@ -226,6 +227,11 @@ describe('CourtesyContactItem component', () => {
           }))
         );
         fireEvent.click(saveButton);
+        // Confirms the disclaimer dialog
+        const disclaimerCheckbox = screen.getByRole('checkbox', { name: 'button.capito' });
+        fireEvent.click(disclaimerCheckbox);
+        const disclaimerConfirmButton = screen.getByRole('button', { name: 'button.conferma' });
+        fireEvent.click(disclaimerConfirmButton);
         await waitFor(() => screen.getByText(INPUT_VALID_PHONE_UPDATE));
       });
 
@@ -237,6 +243,11 @@ describe('CourtesyContactItem component', () => {
         await waitFor(() => expect(input!).toHaveValue(INPUT_VALID_PHONE_2_UPDATE));
         const saveButton = screen.getByRole('button', { name: 'button.salva' });
         fireEvent.click(saveButton);
+        // Confirms the disclaimer dialog
+        const disclaimerCheckbox = screen.getByRole('checkbox', { name: 'button.capito' });
+        fireEvent.click(disclaimerCheckbox);
+        const disclaimerConfirmButton = screen.getByRole('button', { name: 'button.conferma' });
+        fireEvent.click(disclaimerConfirmButton);
         await waitFor(() => {
           expect(mockDispatchFn).toBeCalledTimes(1);
           expect(mockActionFn).toBeCalledTimes(1);
@@ -248,11 +259,6 @@ describe('CourtesyContactItem component', () => {
             code: undefined,
           });
         });
-        // Confirms the disclaimer dialog
-        const disclaimerCheckbox = screen.getByRole('checkbox', { name: 'button.capito' });
-        fireEvent.click(disclaimerCheckbox);
-        const disclaimerConfirmButton = screen.getByRole('button', { name: 'button.conferma' });
-        fireEvent.click(disclaimerConfirmButton);
         const dialog = await waitFor(() => {
           const dialogEl = screen.queryByTestId('codeDialog');
           expect(dialogEl).toBeInTheDocument();
@@ -446,7 +452,13 @@ describe('CourtesyContactItem component', () => {
         fireEvent.change(input!, { target: { value: VALID_EMAIL } });
         await waitFor(() => expect(input!).toHaveValue(VALID_EMAIL));
         const button = result!.getByRole('button');
-        fireEvent.click(button!);
+        await waitFor(() => fireEvent.click(button!));
+        // Confirms the disclaimer dialog
+        const disclaimerCheckbox = screen.getByRole('checkbox', { name: 'button.capito' });
+        fireEvent.click(disclaimerCheckbox);
+        const disclaimerConfirmButton = screen.getByRole('button', { name: 'button.conferma' });
+        fireEvent.click(disclaimerConfirmButton);
+
         await waitFor(() => {
           expect(mockDispatchFn).toBeCalledTimes(1);
           expect(mockActionFn).toBeCalledTimes(1);
@@ -458,11 +470,6 @@ describe('CourtesyContactItem component', () => {
             code: undefined,
           });
         });
-        // Confirms the disclaimer dialog
-        const disclaimerCheckbox = screen.getByRole('checkbox', { name: 'button.capito' });
-        fireEvent.click(disclaimerCheckbox);
-        const disclaimerConfirmButton = screen.getByRole('button', { name: 'button.conferma' });
-        fireEvent.click(disclaimerConfirmButton);
 
         const dialog = await waitFor(() => {
           const dialogEl = screen.queryByTestId('codeDialog');
@@ -566,7 +573,13 @@ describe('CourtesyContactItem component', () => {
             unwrap: () => Promise.resolve({ code: VALID_CODE }),
           }))
         );
-        fireEvent.click(saveButton);
+        await waitFor(() => fireEvent.click(saveButton));
+        // Confirms the disclaimer dialog
+        const disclaimerCheckbox = screen.getByRole('checkbox', { name: 'button.capito' });
+        fireEvent.click(disclaimerCheckbox);
+        const disclaimerConfirmButton = screen.getByRole('button', { name: 'button.conferma' });
+        fireEvent.click(disclaimerConfirmButton);
+        
         await waitFor(() => screen.getByText(VALID_EMAIL));
       });
 
@@ -580,6 +593,12 @@ describe('CourtesyContactItem component', () => {
         await waitFor(() => expect(input!).toHaveValue(VALID_EMAIL_2));
         const saveButton = screen.getByRole('button', { name: 'button.salva' });
         fireEvent.click(saveButton!);
+        // Confirms the disclaimer dialog
+        const disclaimerCheckbox = screen.getByRole('checkbox', { name: 'button.capito' });
+        fireEvent.click(disclaimerCheckbox);
+        const disclaimerConfirmButton = screen.getByRole('button', { name: 'button.conferma' });
+        fireEvent.click(disclaimerConfirmButton);
+        
         await waitFor(() => {
           expect(mockDispatchFn).toBeCalledTimes(1);
           expect(mockActionFn).toBeCalledTimes(1);
@@ -591,11 +610,6 @@ describe('CourtesyContactItem component', () => {
             code: undefined,
           });
         });
-        // Confirms the disclaimer dialog
-        const disclaimerCheckbox = screen.getByRole('checkbox', { name: 'button.capito' });
-        fireEvent.click(disclaimerCheckbox);
-        const disclaimerConfirmButton = screen.getByRole('button', { name: 'button.conferma' });
-        fireEvent.click(disclaimerConfirmButton);
 
         const dialog = await waitFor(() => {
           const dialogEl = screen.queryByTestId('codeDialog');

--- a/packages/pn-personagiuridica-webapp/src/component/Contacts/DigitalContactsCodeVerification.context.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Contacts/DigitalContactsCodeVerification.context.tsx
@@ -155,6 +155,8 @@ const DigitalContactsCodeVerificationProvider: FC<ReactNode> = ({ children }) =>
             })
           );
           handleClose('validated');
+        } else {
+          setOpen(true);
         }
       });
   };
@@ -209,7 +211,6 @@ const DigitalContactsCodeVerificationProvider: FC<ReactNode> = ({ children }) =>
     ) {
       // open verification code dialog
       handleCodeVerification();
-      setOpen(true);
     } else {
       // open disclaimer dialog
       setDisclaimerOpen(true);

--- a/packages/pn-personagiuridica-webapp/src/component/Contacts/DigitalContactsCodeVerification.context.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Contacts/DigitalContactsCodeVerification.context.tsx
@@ -97,7 +97,7 @@ const DigitalContactsCodeVerificationProvider: FC<ReactNode> = ({ children }) =>
 
   const handleConfirm = () => {
     setIsConfirmationModalVisible(false);
-    handleCodeVerification();
+    handleDisclaimerVisibilityFirst();
   };
 
   const handleDiscard = () => {
@@ -155,21 +155,6 @@ const DigitalContactsCodeVerificationProvider: FC<ReactNode> = ({ children }) =>
             })
           );
           handleClose('validated');
-        } else {
-          // if senderId !== 'default' they are a special contact => don't show disclaimer
-          // if modalProps.digitalDomicileType === LegalChannelType.PEC it's a legal contact => don't show disclaimer
-          // if modalProps.digitalDomicileType !== LegalChannelType.PEC and senderId === 'default' it's a
-          // courtesy contact => show disclaimer
-          if (
-            modalProps.digitalDomicileType === LegalChannelType.PEC ||
-            modalProps.senderId !== 'default'
-          ) {
-            // open verification code dialog
-            setOpen(true);
-          } else {
-            // open disclaimer dialog
-            setDisclaimerOpen(true);
-          }
         }
       });
   };
@@ -207,11 +192,29 @@ const DigitalContactsCodeVerificationProvider: FC<ReactNode> = ({ children }) =>
 
   useEffect(() => {
     if (!_.isEqual(modalProps, initialProps) && !contactAlreadyExists()) {
-      handleCodeVerification();
+      handleDisclaimerVisibilityFirst();
     } else if (contactAlreadyExists()) {
       setIsConfirmationModalVisible(true);
     }
   }, [modalProps]);
+
+  const handleDisclaimerVisibilityFirst = () => {
+    // if senderId !== 'default' they are a special contact => don't show disclaimer
+    // if modalProps.digitalDomicileType === LegalChannelType.PEC it's a legal contact => don't show disclaimer
+    // if modalProps.digitalDomicileType !== LegalChannelType.PEC and senderId === 'default' it's a
+    // courtesy contact => show disclaimer
+    if (
+      modalProps.digitalDomicileType === LegalChannelType.PEC ||
+      modalProps.senderId !== 'default'
+    ) {
+      // open verification code dialog
+      handleCodeVerification();
+      setOpen(true);
+    } else {
+      // open disclaimer dialog
+      setDisclaimerOpen(true);
+    }
+  };
 
   const handleAddressUpdateError = useCallback(
     (responseError: AppResponse) => {
@@ -255,6 +258,7 @@ const DigitalContactsCodeVerificationProvider: FC<ReactNode> = ({ children }) =>
         <DisclaimerModal
           onConfirm={() => {
             setDisclaimerOpen(false);
+            handleCodeVerification();
             setOpen(true);
           }}
           onCancel={() => setDisclaimerOpen(false)}

--- a/packages/pn-personagiuridica-webapp/src/component/Contacts/__test__/CourtesyContactItem.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Contacts/__test__/CourtesyContactItem.test.tsx
@@ -104,7 +104,13 @@ describe('CourtesyContactItem component', () => {
         fireEvent.change(input!, { target: { value: INPUT_VALID_PHONE } });
         await waitFor(() => expect(input!).toHaveValue(INPUT_VALID_PHONE));
         const button = result!.getByRole('button');
-        fireEvent.click(button!);
+        await waitFor(() => fireEvent.click(button!));
+        // Confirms the disclaimer dialog
+        const disclaimerCheckbox = screen.getByRole('checkbox', { name: 'button.capito' });
+        fireEvent.click(disclaimerCheckbox);
+        const disclaimerConfirmButton = screen.getByRole('button', { name: 'button.conferma' });
+        fireEvent.click(disclaimerConfirmButton);
+
         await waitFor(() => {
           expect(mockDispatchFn).toBeCalledTimes(1);
           expect(mockActionFn).toBeCalledTimes(1);
@@ -116,11 +122,6 @@ describe('CourtesyContactItem component', () => {
             code: undefined,
           });
         });
-
-        const disclaimerCheckbox = screen.getByRole('checkbox', { name: 'button.capito' });
-        fireEvent.click(disclaimerCheckbox);
-        const disclaimerConfirmButton = screen.getByRole('button', { name: 'button.conferma' });
-        fireEvent.click(disclaimerConfirmButton);
 
         const dialog = await waitFor(() => {
           const dialogEl = screen.queryByTestId('codeDialog');
@@ -226,6 +227,11 @@ describe('CourtesyContactItem component', () => {
           }))
         );
         fireEvent.click(saveButton);
+        // Confirms the disclaimer dialog
+        const disclaimerCheckbox = screen.getByRole('checkbox', { name: 'button.capito' });
+        fireEvent.click(disclaimerCheckbox);
+        const disclaimerConfirmButton = screen.getByRole('button', { name: 'button.conferma' });
+        fireEvent.click(disclaimerConfirmButton);
         await waitFor(() => screen.getByText(INPUT_VALID_PHONE_UPDATE));
       });
 
@@ -237,6 +243,11 @@ describe('CourtesyContactItem component', () => {
         await waitFor(() => expect(input!).toHaveValue(INPUT_VALID_PHONE_2_UPDATE));
         const saveButton = screen.getByRole('button', { name: 'button.salva' });
         fireEvent.click(saveButton);
+        // Confirms the disclaimer dialog
+        const disclaimerCheckbox = screen.getByRole('checkbox', { name: 'button.capito' });
+        fireEvent.click(disclaimerCheckbox);
+        const disclaimerConfirmButton = screen.getByRole('button', { name: 'button.conferma' });
+        fireEvent.click(disclaimerConfirmButton);
         await waitFor(() => {
           expect(mockDispatchFn).toBeCalledTimes(1);
           expect(mockActionFn).toBeCalledTimes(1);
@@ -248,11 +259,6 @@ describe('CourtesyContactItem component', () => {
             code: undefined,
           });
         });
-        // Confirms the disclaimer dialog
-        const disclaimerCheckbox = screen.getByRole('checkbox', { name: 'button.capito' });
-        fireEvent.click(disclaimerCheckbox);
-        const disclaimerConfirmButton = screen.getByRole('button', { name: 'button.conferma' });
-        fireEvent.click(disclaimerConfirmButton);
         const dialog = await waitFor(() => {
           const dialogEl = screen.queryByTestId('codeDialog');
           expect(dialogEl).toBeInTheDocument();
@@ -446,7 +452,13 @@ describe('CourtesyContactItem component', () => {
         fireEvent.change(input!, { target: { value: VALID_EMAIL } });
         await waitFor(() => expect(input!).toHaveValue(VALID_EMAIL));
         const button = result!.getByRole('button');
-        fireEvent.click(button!);
+        await waitFor(() => fireEvent.click(button!));
+        // Confirms the disclaimer dialog
+        const disclaimerCheckbox = screen.getByRole('checkbox', { name: 'button.capito' });
+        fireEvent.click(disclaimerCheckbox);
+        const disclaimerConfirmButton = screen.getByRole('button', { name: 'button.conferma' });
+        fireEvent.click(disclaimerConfirmButton);
+
         await waitFor(() => {
           expect(mockDispatchFn).toBeCalledTimes(1);
           expect(mockActionFn).toBeCalledTimes(1);
@@ -458,11 +470,6 @@ describe('CourtesyContactItem component', () => {
             code: undefined,
           });
         });
-        // Confirms the disclaimer dialog
-        const disclaimerCheckbox = screen.getByRole('checkbox', { name: 'button.capito' });
-        fireEvent.click(disclaimerCheckbox);
-        const disclaimerConfirmButton = screen.getByRole('button', { name: 'button.conferma' });
-        fireEvent.click(disclaimerConfirmButton);
 
         const dialog = await waitFor(() => {
           const dialogEl = screen.queryByTestId('codeDialog');
@@ -566,7 +573,13 @@ describe('CourtesyContactItem component', () => {
             unwrap: () => Promise.resolve({ code: VALID_CODE }),
           }))
         );
-        fireEvent.click(saveButton);
+        await waitFor(() => fireEvent.click(saveButton));
+        // Confirms the disclaimer dialog
+        const disclaimerCheckbox = screen.getByRole('checkbox', { name: 'button.capito' });
+        fireEvent.click(disclaimerCheckbox);
+        const disclaimerConfirmButton = screen.getByRole('button', { name: 'button.conferma' });
+        fireEvent.click(disclaimerConfirmButton);
+        
         await waitFor(() => screen.getByText(VALID_EMAIL));
       });
 
@@ -580,6 +593,12 @@ describe('CourtesyContactItem component', () => {
         await waitFor(() => expect(input!).toHaveValue(VALID_EMAIL_2));
         const saveButton = screen.getByRole('button', { name: 'button.salva' });
         fireEvent.click(saveButton!);
+        // Confirms the disclaimer dialog
+        const disclaimerCheckbox = screen.getByRole('checkbox', { name: 'button.capito' });
+        fireEvent.click(disclaimerCheckbox);
+        const disclaimerConfirmButton = screen.getByRole('button', { name: 'button.conferma' });
+        fireEvent.click(disclaimerConfirmButton);
+        
         await waitFor(() => {
           expect(mockDispatchFn).toBeCalledTimes(1);
           expect(mockActionFn).toBeCalledTimes(1);
@@ -591,11 +610,6 @@ describe('CourtesyContactItem component', () => {
             code: undefined,
           });
         });
-        // Confirms the disclaimer dialog
-        const disclaimerCheckbox = screen.getByRole('checkbox', { name: 'button.capito' });
-        fireEvent.click(disclaimerCheckbox);
-        const disclaimerConfirmButton = screen.getByRole('button', { name: 'button.conferma' });
-        fireEvent.click(disclaimerConfirmButton);
 
         const dialog = await waitFor(() => {
           const dialogEl = screen.queryByTestId('codeDialog');


### PR DESCRIPTION
## Short description
Fixed contacts endpoint call before disclaimer acceptance.

## List of changes proposed in this pull request
- Disclaimer acceptance is before contacts endpoint call in DigitalContactsCodeVerification context
- Refactored some tests

## How to test
Add new contacs and watch network section in dev tools in your browser. Now the endpoit is called after disclaimer acceptance.