### PR TITLE
Pn 5281 fe sezione notifiche allineamento campi

### DIFF
--- a/packages/pn-commons/src/utils/__test__/styles.utility.test.tsx
+++ b/packages/pn-commons/src/utils/__test__/styles.utility.test.tsx
@@ -7,7 +7,7 @@ describe('Styles utilities test', () => {
 
   it('buttonNakedInheritStyle test', () => {
     const expetedResultStyle =
-      "color: 'inherit', border: 'none', font-size: 'inherit', font-family: 'inherit', background: 'inherit', margin: 0, padding: 0, font-weight: 'inherit'";
+      "color: 'inherit', border: 'none', font-size: 'inherit', font-family: 'inherit', background: 'inherit', margin: 0, padding: 0, font-weight: 'inherit', text-align: 'inherit'";
     const result = render(<ButtonNaked sx={buttonNakedInheritStyle}>Mocked-button</ButtonNaked>);
     expect(result.container).toHaveStyle(expetedResultStyle);
   });

--- a/packages/pn-commons/src/utils/styles.utility.ts
+++ b/packages/pn-commons/src/utils/styles.utility.ts
@@ -11,4 +11,5 @@ export const buttonNakedInheritStyle: CSSProperties = {
   padding: 0,
   fontWeight: 'inherit',
   display: 'inherit',
+  textAlign: 'inherit'
 };


### PR DESCRIPTION
## Short description
Fixed issue which cause misalignment with ItemsTable component.

## List of changes proposed in this pull request
- Added textAlign: inherit to buttonNakedInheritStyle
- Set proper test for buttonNakedInheritStyle

## How to test
You should not have the bug shown in [PN-5281](https://pagopa.atlassian.net/browse/PN-5281) images anymore.

[PN-5281]: https://pagopa.atlassian.net/browse/PN-5281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ