### PR TITLE
Pg login from selfcare portal - pn-5157

### DIFF
--- a/packages/pn-personafisica-login/src/pages/login/Login.tsx
+++ b/packages/pn-personafisica-login/src/pages/login/Login.tsx
@@ -61,7 +61,7 @@ const Login = () => {
 
   const handleAssistanceClick = () => {
     trackEventByType(TrackEventType.CUSTOMER_CARE_MAILTO, { source: 'postlogin' });
-    /* eslint-disable-next-line functional/immutable-data */
+    // eslint-disable-next-line functional/immutable-data
     window.location.href = `mailto:${PAGOPA_HELP_EMAIL}`;
   };
 

--- a/packages/pn-personafisica-login/src/pages/success/Success.tsx
+++ b/packages/pn-personafisica-login/src/pages/success/Success.tsx
@@ -80,7 +80,9 @@ const SuccessPage = () => {
   const isMobile = useIsMobile();
   const [typeSelected, setTypeSelected] = useState<AppRouteType | null>(null);
 
-  const typeUrl = useMemo(() => storageTypeOps.read(), []);
+  // momentarily changed for pn-5157
+  // const typeUrl = useMemo(() => storageTypeOps.read(), []);
+  const typeUrl = useMemo(() => AppRouteType.PF, []);
   const aar = useMemo(() => storageAarOps.read(), []);
   const token = useMemo(() => window.location.hash, []);
 
@@ -90,24 +92,26 @@ const SuccessPage = () => {
 
   const handleAssistanceClick = () => {
     trackEventByType(TrackEventType.CUSTOMER_CARE_MAILTO, { source: 'postlogin' });
-    /* eslint-disable-next-line functional/immutable-data */
+    // eslint-disable-next-line functional/immutable-data
     window.location.href = `mailto:${PAGOPA_HELP_EMAIL}`;
   };
 
   const calcRedirectUrl = useCallback(
     (type: AppRouteType): string => {
-      /* eslint-disable-next-line functional/no-let */
-      let redirectUrl = '';
+      // momentarily changed for pn-5157
+      // eslint-disable-next-line functional/no-let
+      let redirectUrl = PF_URL ? PF_URL : '';
+      // let redirectUrl = '';
       if ((PF_URL && type === AppRouteType.PF) || (PG_URL && type === AppRouteType.PG)) {
         storageTypeOps.delete();
-        /* eslint-disable-next-line functional/immutable-data */
+        // eslint-disable-next-line functional/immutable-data
         redirectUrl = `${type === AppRouteType.PF ? PF_URL : PG_URL}`;
       }
 
       // the includes check is needed to prevent xss attacks
       if (redirectUrl && [PF_URL, PG_URL].includes(redirectUrl) && aar) {
         storageAarOps.delete();
-        /* eslint-disable-next-line functional/immutable-data */
+        // eslint-disable-next-line functional/immutable-data
         redirectUrl += `?${AppRouteParams.AAR}=${sanitizeString(aar)}`;
       }
 

--- a/packages/pn-personafisica-login/src/pages/success/__tests__/Success.test.tsx
+++ b/packages/pn-personafisica-login/src/pages/success/__tests__/Success.test.tsx
@@ -50,7 +50,8 @@ describe('test login page', () => {
     expect(mockLocationAssign).toBeCalledWith(PG_URL + '#token=fake-token');
   });
 
-  test('test redirect - xss attack', () => {
+  // momentarily commented for pn-5157
+  test.skip('test redirect - xss attack', () => {
     storageTypeOps.write('<script>malicious code</script>not-safe-url' as AppRouteType.PF);
     render(
       <BrowserRouter>
@@ -87,7 +88,8 @@ describe('test login page', () => {
     expect(mockLocationAssign).toBeCalledWith(PF_URL + '?aar=aar-malicious-token#token=fake-token');
   });
 
-  test('test redirect - disambiguation page', () => {
+  // momentarily commented for pn-5157
+  test.skip('test redirect - disambiguation page', () => {
     storageTypeOps.write('' as AppRouteType.PF);
     const { queryByTestId } = render(
       <BrowserRouter>

--- a/packages/pn-personafisica-login/src/utils/constants.ts
+++ b/packages/pn-personafisica-login/src/utils/constants.ts
@@ -13,7 +13,9 @@ export const OT_DOMAIN_ID = ENV.COOKIE.OT_DOMAIN_ID;
 export const ONE_TRUST_DRAFT_MODE = process.env.REACT_APP_ONE_TRUST_DRAFT_MODE === 'true';
 export const ONE_TRUST_PP = process.env.REACT_APP_ONE_TRUST_PP || '';
 export const PF_URL = process.env.REACT_APP_PF_URL;
-export const PG_URL = process.env.REACT_APP_PG_URL;
+// momentarily commented for pn-5157
+// export const PG_URL = process.env.REACT_APP_PG_URL;
+export const PG_URL = PF_URL;
 
 export const MIXPANEL_TOKEN = process.env.REACT_APP_MIXPANEL_TOKEN || 'DUMMY';
 

--- a/packages/pn-personafisica-webapp/src/App.tsx
+++ b/packages/pn-personafisica-webapp/src/App.tsx
@@ -16,7 +16,8 @@ import { ProductSwitchItem } from '@pagopa/mui-italia';
 import {
   AppMessage,
   AppResponseMessage,
-  AppRouteType,
+  // momentarily commented for pn-5157
+  // AppRouteType,
   appStateActions,
   errorFactoryManager,
   initLocalization,
@@ -60,7 +61,9 @@ const App = () => {
   const dispatch = useAppDispatch();
   const { t, i18n } = useTranslation(['common', 'notifiche']);
   const loggedUser = useAppSelector((state: RootState) => state.userState.user);
-  const { tosConsent, fetchedTos, privacyConsent, fetchedPrivacy } = useAppSelector((state: RootState) => state.userState);
+  const { tosConsent, fetchedTos, privacyConsent, fetchedPrivacy } = useAppSelector(
+    (state: RootState) => state.userState
+  );
   const { pendingDelegators, delegators } = useAppSelector(
     (state: RootState) => state.generalInfoState
   );
@@ -233,8 +236,9 @@ const App = () => {
 
   const handleUserLogout = () => {
     void dispatch(logout());
-
-    goToLoginPortal(AppRouteType.PF);
+    // momentarily commented for pn-5157
+    // goToLoginPortal(AppRouteType.PF);
+    goToLoginPortal();
   };
 
   return (

--- a/packages/pn-personafisica-webapp/src/navigation/AARGuard.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/AARGuard.tsx
@@ -17,7 +17,6 @@ function notificationDetailPath(notificationId: NotificationId): string {
     : GET_DETTAGLIO_NOTIFICA_PATH(notificationId.iun);
 }
 
-/* eslint-disable-next-line arrow-body-style */
 const AARGuard = () => {
   const location = useLocation();
   const navigate = useNavigate();

--- a/packages/pn-personafisica-webapp/src/navigation/RouteGuard.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/RouteGuard.tsx
@@ -1,4 +1,6 @@
-import { AccessDenied, AppRouteParams, AppRouteType } from '@pagopa-pn/pn-commons';
+// momentarily commented for pn-5157
+// import { AccessDenied, AppRouteParams, AppRouteType } from '@pagopa-pn/pn-commons';
+import { AccessDenied, AppRouteParams } from '@pagopa-pn/pn-commons';
 import { Outlet, useNavigate, useSearchParams } from 'react-router-dom';
 
 import { useAppSelector } from '../redux/hooks';
@@ -16,7 +18,9 @@ const RouteGuard = () => {
       <AccessDenied
         isLogged={false}
         goToHomePage={() => navigate(routes.NOTIFICHE, { replace: true })}
-        goToLogin={() => goToLoginPortal(AppRouteType.PF, params.get(AppRouteParams.AAR))}
+        // momentarily commented for pn-5157
+        // goToLogin={() => goToLoginPortal(AppRouteType.PF, params.get(AppRouteParams.AAR))}
+        goToLogin={() => goToLoginPortal(params.get(AppRouteParams.AAR))}
       />
     );
   }

--- a/packages/pn-personafisica-webapp/src/navigation/SessionGuard.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/SessionGuard.tsx
@@ -1,5 +1,6 @@
 import {
-  AppRouteType,
+  // momentarily commented for pn-5157
+  // AppRouteType,
   appStateActions,
   InactivityHandler,
   SessionModal,
@@ -73,7 +74,9 @@ const SessionGuardRender = () => {
         open
         title={goodbyeMessage.title}
         message={goodbyeMessage.message}
-        handleClose={() => goToLoginPortal(AppRouteType.PF)}
+        // momentarily commented for pn-5157
+        // handleClose={() => goToLoginPortal(AppRouteType.PF)}
+        handleClose={() => goToLoginPortal()}
         initTimeout
       />
     ) : isAnonymousUser || DISABLE_INACTIVITY_HANDLER ? (

--- a/packages/pn-personafisica-webapp/src/navigation/__test__/navigation.utility.test.ts
+++ b/packages/pn-personafisica-webapp/src/navigation/__test__/navigation.utility.test.ts
@@ -1,4 +1,5 @@
-import { AppRouteType } from '@pagopa-pn/pn-commons';
+// momentarily commented for pn-5157
+// import { AppRouteType } from '@pagopa-pn/pn-commons';
 import { URL_FE_LOGOUT } from '../../utils/constants';
 import { goToLoginPortal } from '../navigation.utility';
 
@@ -26,20 +27,32 @@ describe('Tests navigation utility methods', () => {
   });
 
   it('goToLoginPortal', () => {
-    goToLoginPortal(AppRouteType.PF);
+    // momentarily commented for pn-5157
+    // goToLoginPortal(AppRouteType.PF);
+    goToLoginPortal();
     expect(replaceFn).toBeCalledTimes(1);
-    expect(replaceFn).toBeCalledWith(`${URL_FE_LOGOUT}?type=PF`);
+    // momentarily commented for pn-5157
+    // expect(replaceFn).toBeCalledWith(`${URL_FE_LOGOUT}?type=PF`);
+    expect(replaceFn).toBeCalledWith(`${URL_FE_LOGOUT}`);
   });
 
   it('goToLoginPortal - aar', () => {
-    goToLoginPortal(AppRouteType.PF, 'fake-aar-token');
+    // momentarily commented for pn-5157
+    // goToLoginPortal(AppRouteType.PF, 'fake-aar-token');
+    goToLoginPortal('fake-aar-token');
     expect(replaceFn).toBeCalledTimes(1);
-    expect(replaceFn).toBeCalledWith(`${URL_FE_LOGOUT}?type=PF&aar=fake-aar-token`);
+    // momentarily commented for pn-5157
+    // expect(replaceFn).toBeCalledWith(`${URL_FE_LOGOUT}?type=PF&aar=fake-aar-token`);
+    expect(replaceFn).toBeCalledWith(`${URL_FE_LOGOUT}?aar=fake-aar-token`);
   });
 
   it('goToLoginPortal - aar', () => {
-    goToLoginPortal(AppRouteType.PF, '<script>malicious code</script>malicious-aar-token');
+    // momentarily commented for pn-5157
+    // goToLoginPortal(AppRouteType.PF, '<script>malicious code</script>malicious-aar-token');
+    goToLoginPortal('<script>malicious code</script>malicious-aar-token');
     expect(replaceFn).toBeCalledTimes(1);
-    expect(replaceFn).toBeCalledWith(`${URL_FE_LOGOUT}?type=PF&aar=malicious-aar-token`);
+    // momentarily commented for pn-5157
+    // expect(replaceFn).toBeCalledWith(`${URL_FE_LOGOUT}?type=PF&aar=malicious-aar-token`);
+    expect(replaceFn).toBeCalledWith(`${URL_FE_LOGOUT}?aar=malicious-aar-token`);
   });
 });

--- a/packages/pn-personafisica-webapp/src/navigation/navigation.utility.ts
+++ b/packages/pn-personafisica-webapp/src/navigation/navigation.utility.ts
@@ -1,14 +1,32 @@
-import { AppRouteType, sanitizeString, AppRouteParams } from '@pagopa-pn/pn-commons';
+// momentarily commented for pn-5157
+// import { AppRouteType, sanitizeString, AppRouteParams } from '@pagopa-pn/pn-commons';
+import { sanitizeString, AppRouteParams } from '@pagopa-pn/pn-commons';
 
 import { URL_FE_LOGOUT } from '../utils/constants';
 
+// momentarily commented for pn-5157
+/*
 export function goToLoginPortal(type: AppRouteType.PF | AppRouteType.PG, aarToken?: string | null) {
-  /* eslint-disable functional/no-let */
-  /* eslint-disable functional/immutable-data */
+  // eslint-disable-next-line functional/no-let
   let urlToRiderect = `${URL_FE_LOGOUT}?${AppRouteParams.TYPE}=${type}`;
   // the startsWith check is to prevent xss attacks
   if (urlToRiderect.startsWith(URL_FE_LOGOUT) && aarToken) {
+    // eslint-disable-next-line functional/immutable-data
     urlToRiderect += `&${AppRouteParams.AAR}=${sanitizeString(aarToken)}`;
+  }
+  // the indexOf check is to prevent xss attacks
+  if (urlToRiderect.startsWith(URL_FE_LOGOUT)) {
+    window.location.replace(`${urlToRiderect}`);
+  }
+}
+*/
+export function goToLoginPortal(aarToken?: string | null) {
+  // eslint-disable-next-line functional/no-let
+  let urlToRiderect = `${URL_FE_LOGOUT}`;
+  // the startsWith check is to prevent xss attacks
+  if (urlToRiderect.startsWith(URL_FE_LOGOUT) && aarToken) {
+    // eslint-disable-next-line functional/immutable-data
+    urlToRiderect += `?${AppRouteParams.AAR}=${sanitizeString(aarToken)}`;
   }
   // the indexOf check is to prevent xss attacks
   if (urlToRiderect.startsWith(URL_FE_LOGOUT)) {

--- a/packages/pn-personagiuridica-webapp/buildspec.yaml
+++ b/packages/pn-personagiuridica-webapp/buildspec.yaml
@@ -7,7 +7,9 @@ batch:
         variables:
           BUILD_ID: dev
           # PN-2029 REACT_APP_PAYMENT_DISCLAIMER_URL: https://www.pagopa.it
-          REACT_APP_URL_FE_LOGIN: https://portale-login.dev.pn.pagopa.it/
+          # momentarily commented for pn-5157
+          # REACT_APP_URL_FE_LOGIN: https://portale-login.dev.pn.pagopa.it/
+          REACT_APP_URL_SELFCARE_LOGIN: https://pnpg.dev.selfcare.pagopa.it/auth/login
           REACT_APP_URL_SELFCARE_BASE: https://pnpg.dev.selfcare.pagopa.it
           REACT_APP_URL_API: https://webapi.dev.pn.pagopa.it/
           REACT_APP_PAGOPA_HELP_EMAIL: notifichedigitali@assistenza.pagopa.it
@@ -23,8 +25,10 @@ batch:
         variables:
           BUILD_ID: svil
           # PN-2029 REACT_APP_PAYMENT_DISCLAIMER_URL: https://www.pagopa.it
-          REACT_APP_URL_FE_LOGIN: https://portale-login.svil.pn.pagopa.it/
-          REACT_APP_URL_SELFCARE_BASE: https://pnpg.dev.selfcare.pagopa.it
+          # momentarily commented for pn-5157
+          # REACT_APP_URL_FE_LOGIN: https://portale-login.svil.pn.pagopa.it/
+          REACT_APP_URL_SELFCARE_LOGIN: https://pnpg.svil.selfcare.pagopa.it/auth/login
+          REACT_APP_URL_SELFCARE_BASE: https://pnpg.svil.selfcare.pagopa.it
           REACT_APP_URL_API: https://webapi.svil.pn.pagopa.it/
           REACT_APP_PAGOPA_HELP_EMAIL: notifichedigitali@assistenza.pagopa.it
           REACT_APP_DISABLE_INACTIVITY_HANDLER: true
@@ -39,8 +43,10 @@ batch:
         variables:
           BUILD_ID: coll
           #PN-2029 REACT_APP_PAYMENT_DISCLAIMER_URL: https://www.pagopa.it
-          REACT_APP_URL_FE_LOGIN: https://portale-login.coll.pn.pagopa.it/
-          REACT_APP_URL_SELFCARE_BASE: https://pnpg.dev.selfcare.pagopa.it
+          # momentarily commented for pn-5157
+          # REACT_APP_URL_FE_LOGIN: https://portale-login.coll.pn.pagopa.it/
+          REACT_APP_URL_SELFCARE_LOGIN: https://pnpg.coll.selfcare.pagopa.it/auth/login
+          REACT_APP_URL_SELFCARE_BASE: https://pnpg.coll.selfcare.pagopa.it
           REACT_APP_URL_API: https://webapi.coll.pn.pagopa.it/
           REACT_APP_PAGOPA_HELP_EMAIL: notifichedigitali@assistenza.pagopa.it
           REACT_APP_DISABLE_INACTIVITY_HANDLER: false
@@ -55,8 +61,10 @@ batch:
         variables:
           BUILD_ID: cert
           #PN-2029 REACT_APP_PAYMENT_DISCLAIMER_URL: https://www.pagopa.it
-          REACT_APP_URL_FE_LOGIN: https://portale-login.cert.pn.pagopa.it/
-          REACT_APP_URL_SELFCARE_BASE: https://pnpg.dev.selfcare.pagopa.it
+          # momentarily commented for pn-5157
+          # REACT_APP_URL_FE_LOGIN: https://portale-login.cert.pn.pagopa.it/
+          REACT_APP_URL_SELFCARE_LOGIN: https://pnpg.cert.selfcare.pagopa.it/auth/login
+          REACT_APP_URL_SELFCARE_BASE: https://pnpg.cert.selfcare.pagopa.it
           REACT_APP_URL_API: https://webapi.cert.pn.pagopa.it/
           REACT_APP_PAGOPA_HELP_EMAIL: notifichedigitali@assistenza.pagopa.it
           REACT_APP_DISABLE_INACTIVITY_HANDLER: false
@@ -71,8 +79,10 @@ batch:
         variables:
           BUILD_ID: hotfix
           #PN-2029 REACT_APP_PAYMENT_DISCLAIMER_URL: https://www.pagopa.it
-          REACT_APP_URL_FE_LOGIN: https://portale-login.hotfix.pn.pagopa.it/
-          REACT_APP_URL_SELFCARE_BASE: https://pnpg.dev.selfcare.pagopa.it
+          # momentarily commented for pn-5157
+          # REACT_APP_URL_FE_LOGIN: https://portale-login.hotfix.pn.pagopa.it/
+          REACT_APP_URL_SELFCARE_LOGIN: https://pnpg.hotfix.selfcare.pagopa.it/auth/login
+          REACT_APP_URL_SELFCARE_BASE: https://pnpg.hotfix.selfcare.pagopa.it
           REACT_APP_URL_API: https://webapi.hotfix.pn.pagopa.it/
           REACT_APP_PAGOPA_HELP_EMAIL: notifichedigitali@assistenza.pagopa.it
           REACT_APP_DISABLE_INACTIVITY_HANDLER: false

--- a/packages/pn-personagiuridica-webapp/buildspec.yaml
+++ b/packages/pn-personagiuridica-webapp/buildspec.yaml
@@ -7,9 +7,7 @@ batch:
         variables:
           BUILD_ID: dev
           # PN-2029 REACT_APP_PAYMENT_DISCLAIMER_URL: https://www.pagopa.it
-          # momentarily commented for pn-5157
-          # REACT_APP_URL_FE_LOGIN: https://portale-login.dev.pn.pagopa.it/
-          REACT_APP_URL_SELFCARE_LOGIN: https://pnpg.dev.selfcare.pagopa.it/auth/login
+          REACT_APP_URL_FE_LOGIN: https://pnpg.dev.selfcare.pagopa.it/auth/login
           REACT_APP_URL_SELFCARE_BASE: https://pnpg.dev.selfcare.pagopa.it
           REACT_APP_URL_API: https://webapi.dev.pn.pagopa.it/
           REACT_APP_PAGOPA_HELP_EMAIL: notifichedigitali@assistenza.pagopa.it
@@ -26,9 +24,8 @@ batch:
           BUILD_ID: svil
           # PN-2029 REACT_APP_PAYMENT_DISCLAIMER_URL: https://www.pagopa.it
           # momentarily commented for pn-5157
-          # REACT_APP_URL_FE_LOGIN: https://portale-login.svil.pn.pagopa.it/
-          REACT_APP_URL_SELFCARE_LOGIN: https://pnpg.svil.selfcare.pagopa.it/auth/login
-          REACT_APP_URL_SELFCARE_BASE: https://pnpg.svil.selfcare.pagopa.it
+          REACT_APP_URL_FE_LOGIN: https://pnpg.dev.selfcare.pagopa.it/auth/login
+          REACT_APP_URL_SELFCARE_BASE: https://pnpg.dev.selfcare.pagopa.it
           REACT_APP_URL_API: https://webapi.svil.pn.pagopa.it/
           REACT_APP_PAGOPA_HELP_EMAIL: notifichedigitali@assistenza.pagopa.it
           REACT_APP_DISABLE_INACTIVITY_HANDLER: true
@@ -43,10 +40,8 @@ batch:
         variables:
           BUILD_ID: coll
           #PN-2029 REACT_APP_PAYMENT_DISCLAIMER_URL: https://www.pagopa.it
-          # momentarily commented for pn-5157
-          # REACT_APP_URL_FE_LOGIN: https://portale-login.coll.pn.pagopa.it/
-          REACT_APP_URL_SELFCARE_LOGIN: https://pnpg.coll.selfcare.pagopa.it/auth/login
-          REACT_APP_URL_SELFCARE_BASE: https://pnpg.coll.selfcare.pagopa.it
+          REACT_APP_URL_FE_LOGIN: https://pnpg.dev.selfcare.pagopa.it/auth/login
+          REACT_APP_URL_SELFCARE_BASE: https://pnpg.dev.selfcare.pagopa.it
           REACT_APP_URL_API: https://webapi.coll.pn.pagopa.it/
           REACT_APP_PAGOPA_HELP_EMAIL: notifichedigitali@assistenza.pagopa.it
           REACT_APP_DISABLE_INACTIVITY_HANDLER: false
@@ -61,10 +56,8 @@ batch:
         variables:
           BUILD_ID: cert
           #PN-2029 REACT_APP_PAYMENT_DISCLAIMER_URL: https://www.pagopa.it
-          # momentarily commented for pn-5157
-          # REACT_APP_URL_FE_LOGIN: https://portale-login.cert.pn.pagopa.it/
-          REACT_APP_URL_SELFCARE_LOGIN: https://pnpg.cert.selfcare.pagopa.it/auth/login
-          REACT_APP_URL_SELFCARE_BASE: https://pnpg.cert.selfcare.pagopa.it
+          REACT_APP_URL_FE_LOGIN: https://pnpg.dev.selfcare.pagopa.it/auth/login
+          REACT_APP_URL_SELFCARE_BASE: https://pnpg.dev.selfcare.pagopa.it
           REACT_APP_URL_API: https://webapi.cert.pn.pagopa.it/
           REACT_APP_PAGOPA_HELP_EMAIL: notifichedigitali@assistenza.pagopa.it
           REACT_APP_DISABLE_INACTIVITY_HANDLER: false
@@ -79,10 +72,8 @@ batch:
         variables:
           BUILD_ID: hotfix
           #PN-2029 REACT_APP_PAYMENT_DISCLAIMER_URL: https://www.pagopa.it
-          # momentarily commented for pn-5157
-          # REACT_APP_URL_FE_LOGIN: https://portale-login.hotfix.pn.pagopa.it/
-          REACT_APP_URL_SELFCARE_LOGIN: https://pnpg.hotfix.selfcare.pagopa.it/auth/login
-          REACT_APP_URL_SELFCARE_BASE: https://pnpg.hotfix.selfcare.pagopa.it
+          REACT_APP_URL_FE_LOGIN: https://pnpg.dev.selfcare.pagopa.it/auth/login
+          REACT_APP_URL_SELFCARE_BASE: https://pnpg.dev.selfcare.pagopa.it
           REACT_APP_URL_API: https://webapi.hotfix.pn.pagopa.it/
           REACT_APP_PAGOPA_HELP_EMAIL: notifichedigitali@assistenza.pagopa.it
           REACT_APP_DISABLE_INACTIVITY_HANDLER: false
@@ -98,7 +89,7 @@ batch:
     #        BUILD_ID: prod
     #        REACT_APP_PAGOPA_HELP_EMAIL: notifichedigitali@assistenza.pagopa.it
     #        REACT_APP_PAYMENT_DISCLAIMER_URL: https://www.pagopa.it
-    #        REACT_APP_URL_FE_LOGIN: https://login.notifichedigitali.it
+    #        REACT_APP_URL_FE_LOGIN: https://pnpg.dev.selfcare.pagopa.it/auth/login
     #        REACT_APP_URL_SELFCARE_BASE: https://pnpg.prod.selfcare.pagopa.it
     #        REACT_APP_URL_API: https://webapi.pn.pagopa.it/
     #        REACT_APP_DISABLE_INACTIVITY_HANDLER: false

--- a/packages/pn-personagiuridica-webapp/src/App.tsx
+++ b/packages/pn-personagiuridica-webapp/src/App.tsx
@@ -14,7 +14,8 @@ import { PartyEntity, ProductSwitchItem } from '@pagopa/mui-italia';
 import {
   AppMessage,
   AppResponseMessage,
-  AppRouteType,
+  // momentarily commented for pn-5157
+  // AppRouteType,
   appStateActions,
   errorFactoryManager,
   initLocalization,
@@ -45,13 +46,14 @@ import { goToLoginPortal } from './navigation/navigation.utility';
 import { setUpInterceptor } from './api/interceptors';
 import { getCurrentAppStatus } from './redux/appStatus/actions';
 
-
 const App = () => {
   setUpInterceptor(store);
   const dispatch = useAppDispatch();
   const { t, i18n } = useTranslation(['common', 'notifiche']);
   const loggedUser = useAppSelector((state: RootState) => state.userState.user);
-  const { tosConsent, fetchedTos, privacyConsent, fetchedPrivacy } = useAppSelector((state: RootState) => state.userState);
+  const { tosConsent, fetchedTos, privacyConsent, fetchedPrivacy } = useAppSelector(
+    (state: RootState) => state.userState
+  );
   const currentStatus = useAppSelector((state: RootState) => state.appStatus.currentStatus);
   const { pathname } = useLocation();
   const path = pathname.split('/');
@@ -73,20 +75,23 @@ const App = () => {
   const role = loggedUser.organization?.roles[0];
 
   // TODO: get products list from be (?)
-  const productsList: Array<ProductSwitchItem> = useMemo(() => [
-    {
-      id: '1',
-      title: t('header.product.organization-dashboard'),
-      productUrl: `${SELFCARE_BASE_URL}/dashboard/${organization?.id}`,
-      linkType: 'external',
-    },
-    {
-      id: '0',
-      title: t('header.product.notification-platform'),
-      productUrl: '',
-      linkType: 'internal',
-    },
-  ], [t, organization?.id]);
+  const productsList: Array<ProductSwitchItem> = useMemo(
+    () => [
+      {
+        id: '1',
+        title: t('header.product.organization-dashboard'),
+        productUrl: `${SELFCARE_BASE_URL}/dashboard/${organization?.id}`,
+        linkType: 'external',
+      },
+      {
+        id: '0',
+        title: t('header.product.notification-platform'),
+        productUrl: '',
+        linkType: 'internal',
+      },
+    ],
+    [t, organization?.id]
+  );
 
   useUnload(() => {
     trackEventByType(TrackEventType.APP_UNLOAD);
@@ -203,8 +208,9 @@ const App = () => {
 
   const handleUserLogout = () => {
     void dispatch(logout());
-
-    goToLoginPortal(AppRouteType.PG);
+    // momentarily commented for pn-5157
+    // goToLoginPortal(AppRouteType.PG);
+    goToLoginPortal();
   };
 
   return (

--- a/packages/pn-personagiuridica-webapp/src/api/notifications/Notifications.api.ts
+++ b/packages/pn-personagiuridica-webapp/src/api/notifications/Notifications.api.ts
@@ -35,7 +35,6 @@ const getDownloadUrl = (response: AxiosResponse): { url: string } => {
   return { url: '' };
 };
 
-
 export const NotificationsApi = {
   /**
    * Gets current user notifications

--- a/packages/pn-personagiuridica-webapp/src/navigation/AARGuard.tsx
+++ b/packages/pn-personagiuridica-webapp/src/navigation/AARGuard.tsx
@@ -1,4 +1,4 @@
-import { AccessDenied, LoadingPage } from '@pagopa-pn/pn-commons';
+import { AccessDenied, LoadingPage, sanitizeString } from '@pagopa-pn/pn-commons';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useLocation, Outlet } from 'react-router-dom';
@@ -36,7 +36,7 @@ const AARGuard = () => {
     }
     // get from localstorage
     if (storedAar) {
-      return storedAar;
+      return sanitizeString(storedAar);
     }
     return null;
   }, [location.search, storedAar]);

--- a/packages/pn-personagiuridica-webapp/src/navigation/AARGuard.tsx
+++ b/packages/pn-personagiuridica-webapp/src/navigation/AARGuard.tsx
@@ -17,7 +17,6 @@ function notificationDetailPath(notificationId: NotificationId): string {
     : GET_DETTAGLIO_NOTIFICA_PATH(notificationId.iun);
 }
 
-/* eslint-disable-next-line arrow-body-style */
 const AARGuard = () => {
   const location = useLocation();
   const navigate = useNavigate();
@@ -25,10 +24,22 @@ const AARGuard = () => {
   const [fetchError, setFetchError] = useState(false);
   const [notificationId, setNotificationId] = useState<NotificationId | undefined>();
 
+  // momentarily added for pn-5157
+  const storedAar = localStorage.getItem(DETTAGLIO_NOTIFICA_QRCODE_QUERY_PARAM);
+
   const aar = useMemo(() => {
     const queryParams = new URLSearchParams(location.search);
-    return queryParams.get(DETTAGLIO_NOTIFICA_QRCODE_QUERY_PARAM);
-  }, [location]);
+    // momentarily updated for pn-5157
+    const queryAar = queryParams.get(DETTAGLIO_NOTIFICA_QRCODE_QUERY_PARAM);
+    if (queryAar) {
+      return queryAar;
+    }
+    // get from localstorage
+    if (storedAar) {
+      return storedAar;
+    }
+    return null;
+  }, [location.search, storedAar]);
 
   useEffect(() => {
     const fetchNotificationFromQrCode = async () => {
@@ -41,7 +52,10 @@ const AARGuard = () => {
         }
       }
     };
-    void fetchNotificationFromQrCode();
+    // momentarily updated for pn-5157
+    void fetchNotificationFromQrCode().then(() =>
+      localStorage.removeItem(DETTAGLIO_NOTIFICA_QRCODE_QUERY_PARAM)
+    );
   }, [aar]);
 
   useEffect(() => {

--- a/packages/pn-personagiuridica-webapp/src/navigation/RouteGuard.tsx
+++ b/packages/pn-personagiuridica-webapp/src/navigation/RouteGuard.tsx
@@ -1,4 +1,6 @@
-import { AccessDenied, AppRouteParams, AppRouteType } from '@pagopa-pn/pn-commons';
+// momentarily commented for pn-5157
+// import { AccessDenied, AppRouteParams, AppRouteType } from '@pagopa-pn/pn-commons';
+import { AccessDenied, AppRouteParams } from '@pagopa-pn/pn-commons';
 import { Outlet, useNavigate, useSearchParams } from 'react-router-dom';
 
 import { useAppSelector } from '../redux/hooks';
@@ -12,11 +14,19 @@ const RouteGuard = () => {
   const { sessionToken } = useAppSelector((state: RootState) => state.userState.user);
 
   if (!sessionToken) {
+    // momentarily added for pn-5157
+    const aar = params.get(AppRouteParams.AAR);
+    if (aar) {
+      // save to localstorage
+      localStorage.setItem(AppRouteParams.AAR, aar);
+    }
     return (
       <AccessDenied
         isLogged={false}
         goToHomePage={() => navigate(routes.NOTIFICHE, { replace: true })}
-        goToLogin={() => goToLoginPortal(AppRouteType.PG, params.get(AppRouteParams.AAR))}
+        // momentarily commented for pn-5157
+        // goToLogin={() => goToLoginPortal(AppRouteType.PG, params.get(AppRouteParams.AAR))}
+        goToLogin={() => goToLoginPortal()}
       />
     );
   }

--- a/packages/pn-personagiuridica-webapp/src/navigation/RouteGuard.tsx
+++ b/packages/pn-personagiuridica-webapp/src/navigation/RouteGuard.tsx
@@ -1,6 +1,6 @@
 // momentarily commented for pn-5157
 // import { AccessDenied, AppRouteParams, AppRouteType } from '@pagopa-pn/pn-commons';
-import { AccessDenied, AppRouteParams } from '@pagopa-pn/pn-commons';
+import { AccessDenied, AppRouteParams, sanitizeString } from '@pagopa-pn/pn-commons';
 import { Outlet, useNavigate, useSearchParams } from 'react-router-dom';
 
 import { useAppSelector } from '../redux/hooks';
@@ -18,7 +18,7 @@ const RouteGuard = () => {
     const aar = params.get(AppRouteParams.AAR);
     if (aar) {
       // save to localstorage
-      localStorage.setItem(AppRouteParams.AAR, aar);
+      localStorage.setItem(AppRouteParams.AAR, sanitizeString(aar));
     }
     return (
       <AccessDenied

--- a/packages/pn-personagiuridica-webapp/src/navigation/SessionGuard.tsx
+++ b/packages/pn-personagiuridica-webapp/src/navigation/SessionGuard.tsx
@@ -1,5 +1,6 @@
 import {
-  AppRouteType,
+  // momentarily commented for pn-5157
+  // AppRouteType,
   appStateActions,
   InactivityHandler,
   SessionModal,
@@ -73,7 +74,9 @@ const SessionGuardRender = () => {
         open
         title={goodbyeMessage.title}
         message={goodbyeMessage.message}
-        handleClose={() => goToLoginPortal(AppRouteType.PG)}
+        // momentarily commented for pn-5157
+        // handleClose={() => goToLoginPortal(AppRouteType.PG)}
+        handleClose={() => goToLoginPortal()}
         initTimeout
       />
     ) : isAnonymousUser || DISABLE_INACTIVITY_HANDLER ? (

--- a/packages/pn-personagiuridica-webapp/src/navigation/__test__/navigation.utility.test.ts
+++ b/packages/pn-personagiuridica-webapp/src/navigation/__test__/navigation.utility.test.ts
@@ -1,4 +1,5 @@
-import { AppRouteType } from '@pagopa-pn/pn-commons';
+// momentarily commented for pn-5157
+// import { AppRouteType } from '@pagopa-pn/pn-commons';
 import { URL_FE_LOGOUT } from '../../utils/constants';
 import { goToLoginPortal } from '../navigation.utility';
 
@@ -26,11 +27,17 @@ describe('Tests navigation utility methods', () => {
   });
 
   it('goToLoginPortal', () => {
-    goToLoginPortal(AppRouteType.PG);
+    // momentarily commented for pn-5157
+    // goToLoginPortal(AppRouteType.PG);
+    goToLoginPortal();
     expect(replaceFn).toBeCalledTimes(1);
-    expect(replaceFn).toBeCalledWith(`${URL_FE_LOGOUT}?type=PG`);
+    // momentarily commented for pn-5157
+    // expect(replaceFn).toBeCalledWith(`${URL_FE_LOGOUT}?type=PG`);
+    expect(replaceFn).toBeCalledWith(`${URL_FE_LOGOUT}`);
   });
 
+  // momentarily commented for pn-5157
+  /*
   it('goToLoginPortal - aar', () => {
     goToLoginPortal(AppRouteType.PG, 'fake-aar-token');
     expect(replaceFn).toBeCalledTimes(1);
@@ -42,4 +49,5 @@ describe('Tests navigation utility methods', () => {
     expect(replaceFn).toBeCalledTimes(1);
     expect(replaceFn).toBeCalledWith(`${URL_FE_LOGOUT}?type=PG&aar=malicious-aar-token`);
   });
+  */
 });

--- a/packages/pn-personagiuridica-webapp/src/navigation/navigation.utility.ts
+++ b/packages/pn-personagiuridica-webapp/src/navigation/navigation.utility.ts
@@ -1,15 +1,26 @@
-import { AppRouteParams, AppRouteType, sanitizeString } from '@pagopa-pn/pn-commons';
-
+// momentarily commented for pn-5157
+// import { AppRouteParams, AppRouteType, sanitizeString } from '@pagopa-pn/pn-commons';
 import { URL_FE_LOGOUT } from '../utils/constants';
 
+// momentarily commented for pn-5157
+/*
 export function goToLoginPortal(type: AppRouteType.PF | AppRouteType.PG, aarToken?: string | null) {
-  /* eslint-disable functional/no-let */
-  /* eslint-disable functional/immutable-data */
+  // eslint-disable-next-line functional/no-let
   let urlToRiderect = `${URL_FE_LOGOUT}?${AppRouteParams.TYPE}=${type}`;
   // the startsWith check is to prevent xss attacks
   if (urlToRiderect.startsWith(URL_FE_LOGOUT) && aarToken) {
+    // eslint-disable-next-line functional/immutable-data
     urlToRiderect += `&${AppRouteParams.AAR}=${sanitizeString(aarToken)}`;
   }
+  // the indexOf check is to prevent xss attacks
+  if (urlToRiderect.startsWith(URL_FE_LOGOUT)) {
+    window.location.replace(`${urlToRiderect}`);
+  }
+}
+*/
+
+export function goToLoginPortal() {
+  const urlToRiderect = `${URL_FE_LOGOUT}`;
   // the indexOf check is to prevent xss attacks
   if (urlToRiderect.startsWith(URL_FE_LOGOUT)) {
     window.location.replace(`${urlToRiderect}`);

--- a/packages/pn-personagiuridica-webapp/src/utils/constants.ts
+++ b/packages/pn-personagiuridica-webapp/src/utils/constants.ts
@@ -6,9 +6,7 @@ export const LOG_REDUX_ACTIONS = IS_DEVELOP;
 export const API_BASE_URL = process.env.REACT_APP_URL_API;
 export const SELFCARE_BASE_URL = process.env.REACT_APP_URL_SELFCARE_BASE;
 
-// momentarily commented for pn-5157
-// export const URL_FE_LOGIN = process.env.REACT_APP_URL_FE_LOGIN;
-export const URL_FE_LOGIN = process.env.REACT_APP_URL_SELFCARE_LOGIN;
+export const URL_FE_LOGIN = process.env.REACT_APP_URL_FE_LOGIN;
 export const URL_FE_LOGOUT = `${URL_FE_LOGIN}logout`;
 
 export const PAGOPA_HELP_EMAIL = process.env.REACT_APP_PAGOPA_HELP_EMAIL;

--- a/packages/pn-personagiuridica-webapp/src/utils/constants.ts
+++ b/packages/pn-personagiuridica-webapp/src/utils/constants.ts
@@ -6,7 +6,9 @@ export const LOG_REDUX_ACTIONS = IS_DEVELOP;
 export const API_BASE_URL = process.env.REACT_APP_URL_API;
 export const SELFCARE_BASE_URL = process.env.REACT_APP_URL_SELFCARE_BASE;
 
-export const URL_FE_LOGIN = process.env.REACT_APP_URL_FE_LOGIN;
+// momentarily commented for pn-5157
+// export const URL_FE_LOGIN = process.env.REACT_APP_URL_FE_LOGIN;
+export const URL_FE_LOGIN = process.env.REACT_APP_URL_SELFCARE_LOGIN;
 export const URL_FE_LOGOUT = `${URL_FE_LOGIN}logout`;
 
 export const PAGOPA_HELP_EMAIL = process.env.REACT_APP_PAGOPA_HELP_EMAIL;


### PR DESCRIPTION
## Short description
Now the login for pg is managed by selfcare portal and not by login webapp

## List of changes proposed in this pull request
- Disabled PG management in login webapp
- Removed type query param when pf webapp redirects to login webapp
- Managed new login and aar in pg webapp

## How to test
- PF -> login with pf and check that the login works correctly
- PF -> use an aar link and check that it works correctly both for not logged user and logged one
- Login -> check that disambiguation page is never shown
- PG -> login with pg and check that the login works correctly
- PG -> logout with pg and check that we are redirected to selfcare portal and not login webapp
- PG -> use an aar link and check that it works correctly both for not logged user and logged one