### PR TITLE
PN-5497 - eventCode renamed as deliveryDetailCode in digital timeline events

### DIFF
--- a/packages/pn-commons/src/types/NotificationDetail.ts
+++ b/packages/pn-commons/src/types/NotificationDetail.ts
@@ -160,16 +160,18 @@ export interface SendCourtesyMessageDetails extends BaseDetails {
 
 export interface SendDigitalDetails extends BaseDetails {
   digitalAddress?: DigitalAddress;
+  responseStatus?: 'OK' | 'KO';
+  deliveryDetailCode?: string;
+  // ---------------------------------------------------
+  // the following fields are present in some digital-flow-related events,
+  // but they currently have no influence in the behavior of PN frontend.
+  // I keep them just because they are included in several test notification structures
+  // ---------------------------------------------------
+  // Carlos Lombardi, 2023.04.18
+  // ---------------------------------------------------
   digitalAddressSource?: AddressSource;
   retryNumber?: number;
-  downstreamId?: {
-    systemId: string;
-    messageId: string;
-  };
-  responseStatus?: 'OK' | 'KO';
   notificationDate?: string;
-  errors?: Array<string>;
-  eventCode?: string;
 }
 
 export interface PaidDetails extends BaseDetails {

--- a/packages/pn-commons/src/utils/TimelineUtils/SendDigitalProgressStep.ts
+++ b/packages/pn-commons/src/utils/TimelineUtils/SendDigitalProgressStep.ts
@@ -3,8 +3,8 @@ import { TimelineStep, TimelineStepInfo, TimelineStepPayload } from './TimelineS
 
 export class SendDigitalProgressStep extends TimelineStep {
   getTimelineStepInfo(payload: TimelineStepPayload): TimelineStepInfo | null {
-    const eventCode = (payload.step.details as SendDigitalDetails).eventCode;
-    if (eventCode === 'C008' || eventCode === 'C010' || eventCode === 'DP10') {
+    const deliveryDetailCode = (payload.step.details as SendDigitalDetails).deliveryDetailCode;
+    if (deliveryDetailCode === 'C008' || deliveryDetailCode === 'C010' || deliveryDetailCode === 'DP10') {
       return {
         ...this.localizeTimelineStatus(
           'send-digital-progress-error',
@@ -19,7 +19,7 @@ export class SendDigitalProgressStep extends TimelineStep {
           }
         ),
       };
-    } else if (eventCode === 'C001' || eventCode === 'DP00') {
+    } else if (deliveryDetailCode === 'C001' || deliveryDetailCode === 'DP00') {
       return {
         ...this.localizeTimelineStatus(
           'send-digital-progress-success',

--- a/packages/pn-commons/src/utils/__test__/notification.utility.test.ts
+++ b/packages/pn-commons/src/utils/__test__/notification.utility.test.ts
@@ -516,7 +516,7 @@ describe('timeline event description', () => {
 
   it('return timeline status infos - SEND_DIGITAL_PROGRESS - failure - single recipient', () => {
     parsedNotificationCopy.timeline[0].category = TimelineCategory.SEND_DIGITAL_PROGRESS;
-    (parsedNotificationCopy.timeline[0].details as SendDigitalDetails).eventCode = 'C008';
+    (parsedNotificationCopy.timeline[0].details as SendDigitalDetails).deliveryDetailCode = 'C008';
     testTimelineStatusInfosFnSingle(
       'send-digital-progress-error',
       'send-digital-progress-error-description',
@@ -527,7 +527,7 @@ describe('timeline event description', () => {
   it('return timeline status infos - SEND_DIGITAL_PROGRESS - failure - multi recipient 1', () => {
     parsedNotificationTwoRecipientsCopy.timeline[0].category =
       TimelineCategory.SEND_DIGITAL_PROGRESS;
-    (parsedNotificationTwoRecipientsCopy.timeline[0].details as SendDigitalDetails).eventCode =
+    (parsedNotificationTwoRecipientsCopy.timeline[0].details as SendDigitalDetails).deliveryDetailCode =
       'C010';
     (parsedNotificationTwoRecipientsCopy.timeline[0].details as SendDigitalDetails).digitalAddress =
       {
@@ -543,7 +543,7 @@ describe('timeline event description', () => {
 
   it('return timeline status infos - SEND_DIGITAL_PROGRESS - success - single recipient', () => {
     parsedNotificationCopy.timeline[0].category = TimelineCategory.SEND_DIGITAL_PROGRESS;
-    (parsedNotificationCopy.timeline[0].details as SendDigitalDetails).eventCode = 'C001';
+    (parsedNotificationCopy.timeline[0].details as SendDigitalDetails).deliveryDetailCode = 'C001';
     (parsedNotificationCopy.timeline[0].details as SendDigitalDetails).digitalAddress = {
       address: 'titi35@other.org',
       type: DigitalDomicileType.PEC,
@@ -558,7 +558,7 @@ describe('timeline event description', () => {
   it('return timeline status infos - SEND_DIGITAL_PROGRESS - failure - multi recipient 0', () => {
     parsedNotificationTwoRecipientsCopy.timeline[0].category =
       TimelineCategory.SEND_DIGITAL_PROGRESS;
-    (parsedNotificationTwoRecipientsCopy.timeline[0].details as SendDigitalDetails).eventCode =
+    (parsedNotificationTwoRecipientsCopy.timeline[0].details as SendDigitalDetails).deliveryDetailCode =
       'DP00';
     testTimelineStatusInfosFnMulti0(
       'send-digital-progress-success',
@@ -1415,14 +1415,14 @@ describe('timeline legal fact link text', () => {
 
   it('return legalFact label - SEND_DIGITAL_PROGRESS (success) - PEC_RECEIPT', () => {
     parsedNotificationCopy.timeline[0].category = TimelineCategory.SEND_DIGITAL_PROGRESS;
-    (parsedNotificationCopy.timeline[0].details as SendDigitalDetails).eventCode = 'C001';
+    (parsedNotificationCopy.timeline[0].details as SendDigitalDetails).deliveryDetailCode = 'C001';
     const label = getLegalFactLabel(parsedNotificationCopy.timeline[0], LegalFactType.PEC_RECEIPT);
     expect(label).toBe('detail.receipt detail.timeline.legalfact.pec-receipt-accepted');
   });
 
   it('return legalFact label - SEND_DIGITAL_PROGRESS (failure) - PEC_RECEIPT', () => {
     parsedNotificationCopy.timeline[0].category = TimelineCategory.SEND_DIGITAL_PROGRESS;
-    (parsedNotificationCopy.timeline[0].details as SendDigitalDetails).eventCode = 'C008';
+    (parsedNotificationCopy.timeline[0].details as SendDigitalDetails).deliveryDetailCode = 'C008';
     const label = getLegalFactLabel(parsedNotificationCopy.timeline[0], LegalFactType.PEC_RECEIPT);
     expect(label).toBe('detail.receipt detail.timeline.legalfact.pec-receipt-not-accepted');
   });

--- a/packages/pn-commons/src/utils/__test__/parseNotificationDetail.multirecipient.test.ts
+++ b/packages/pn-commons/src/utils/__test__/parseNotificationDetail.multirecipient.test.ts
@@ -47,7 +47,7 @@ const multiTimeline = (digital1IsOK: boolean, sendDeliveredTo1 = false) => {
       "details": {
         "digitalAddress": { "type": "PEC", "address": "manudido99@gmail.com" },
         "recIndex": 0, "digitalAddressSource": "PLATFORM", "retryNumber": 0,
-        "eventCode": "C001",
+        "deliveryDetailCode": "C001",
         "notificationDate": "2023-01-26T13:56:06.224667703Z", "sendingReceipts": [{}],  "shouldRetry": false,
       }
     },
@@ -86,7 +86,7 @@ const multiTimeline = (digital1IsOK: boolean, sendDeliveredTo1 = false) => {
       "details": {
         "digitalAddress": { "type": "PEC", "address": "toto86@gmail.com" },
         "recIndex": 1, "digitalAddressSource": "PLATFORM", "retryNumber": 1,
-        "eventCode": "C001",
+        "deliveryDetailCode": "C001",
         "notificationDate": "2023-01-26T13:57:12.224667703Z", "sendingReceipts": [{}], "shouldRetry": false
       }
     },

--- a/packages/pn-commons/src/utils/__test__/parseNotificationDetail.test.ts
+++ b/packages/pn-commons/src/utils/__test__/parseNotificationDetail.test.ts
@@ -39,7 +39,7 @@ const eventsUpToSecondAttempt = [
     "details": {
       "digitalAddress": { "type": "PEC", "address": "manudido99@gmail.com" },
       "recIndex": 0, "digitalAddressSource": "PLATFORM", "retryNumber": 0,
-      "eventCode": "C001",
+      "deliveryDetailCode": "C001",
       "notificationDate": "2023-01-26T13:56:06.224667703Z", "sendingReceipts": [{}],  "shouldRetry": false,
     }
   },
@@ -87,7 +87,7 @@ const eventsUpToSecondAttempt = [
     "details": {
       "digitalAddress": { "type": "PEC", "address": "manudido86@gmail.com" },
       "recIndex": 0, "digitalAddressSource": "PLATFORM", "retryNumber": 1,
-      "eventCode": "C001",
+      "deliveryDetailCode": "C001",
       "notificationDate": "2023-01-26T13:57:41.224667703Z", "sendingReceipts": [{}], "shouldRetry": false
     }
   },

--- a/packages/pn-commons/src/utils/__test__/test-utils.ts
+++ b/packages/pn-commons/src/utils/__test__/test-utils.ts
@@ -241,7 +241,7 @@ export function acceptedDeliveringDeliveredTimeline(): Array<INotificationDetail
       category: TimelineCategory.SEND_DIGITAL_PROGRESS,
       details: {
         recIndex: 0,
-        eventCode: 'C001',
+        deliveryDetailCode: 'C001',
         digitalAddressSource: AddressSource.PLATFORM,
         digitalAddress: { type: DigitalDomicileType.PEC, address: 'some@mail.it' },
       } as NotificationDetailTimelineDetails,

--- a/packages/pn-commons/src/utils/notification.utility.ts
+++ b/packages/pn-commons/src/utils/notification.utility.ts
@@ -336,8 +336,8 @@ export function getLegalFactLabel(
     legalFactType === LegalFactType.PEC_RECEIPT
   ) {
     if (
-      (timelineStep.details as SendDigitalDetails).eventCode === 'C001' ||
-      (timelineStep.details as SendDigitalDetails).eventCode === 'DP00'
+      (timelineStep.details as SendDigitalDetails).deliveryDetailCode === 'C001' ||
+      (timelineStep.details as SendDigitalDetails).deliveryDetailCode === 'DP00'
     ) {
       return `${receiptLabel} ${getLocalizedOrDefaultLabel(
         'notifications',
@@ -345,9 +345,9 @@ export function getLegalFactLabel(
         'di accettazione PEC'
       )}`;
     } else if (
-      (timelineStep.details as SendDigitalDetails).eventCode === 'C008' ||
-      (timelineStep.details as SendDigitalDetails).eventCode === 'C010' ||
-      (timelineStep.details as SendDigitalDetails).eventCode === 'DP10'
+      (timelineStep.details as SendDigitalDetails).deliveryDetailCode === 'C008' ||
+      (timelineStep.details as SendDigitalDetails).deliveryDetailCode === 'C010' ||
+      (timelineStep.details as SendDigitalDetails).deliveryDetailCode === 'DP10'
     ) {
       return `${receiptLabel} ${getLocalizedOrDefaultLabel(
         'notifications',

--- a/packages/pn-pa-webapp/cypress/fixtures/notifications/effective_date.json
+++ b/packages/pn-pa-webapp/cypress/fixtures/notifications/effective_date.json
@@ -153,7 +153,6 @@
           "address": "CSRGGL44L13H501E@pnpagopa.postecert.local"
         },
         "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "retryNumber": 0
       }
     },
@@ -174,11 +173,10 @@
           "address": "CSRGGL44L13H501E@pnpagopa.postecert.local"
         },
         "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "retryNumber": 0,
         "notificationDate": "2022-11-17T14:13:26.240662Z",
         "sendingReceipts": [{}],
-        "eventCode": "C001",
+        "deliveryDetailCode": "C001",
         "shouldRetry": false
       }
     },
@@ -198,8 +196,6 @@
           "type": "PEC",
           "address": "CSRGGL44L13H501E@pnpagopa.postecert.local"
         },
-        "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "responseStatus": "OK",
         "notificationDate": "2022-11-17T14:13:35.000552Z",
         "sendingReceipts": [{}]

--- a/packages/pn-pa-webapp/cypress/fixtures/notifications/old/notification-1.json
+++ b/packages/pn-pa-webapp/cypress/fixtures/notifications/old/notification-1.json
@@ -222,7 +222,6 @@
           "address": "CLMCST42R12D969Z@pnpagopa.postecert.local"
         },
         "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "retryNumber": 0
       }
     },
@@ -251,7 +250,6 @@
           "address": "FRMTTR76M06B715E@pnpagopa.postecert.local"
         },
         "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "retryNumber": 0
       }
     },
@@ -272,11 +270,10 @@
           "address": "CLMCST42R12D969Z@pnpagopa.postecert.local"
         },
         "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "retryNumber": 0,
         "notificationDate": "2022-11-16T07:05:11.865793Z",
         "sendingReceipts": [{}],
-        "eventCode": "C001",
+        "deliveryDetailCode": "C001",
         "shouldRetry": false
       }
     },
@@ -301,7 +298,7 @@
         "retryNumber": 0,
         "notificationDate": "2022-11-16T07:05:11.823799Z",
         "sendingReceipts": [{}],
-        "eventCode": "C001",
+        "deliveryDetailCode": "C001",
         "shouldRetry": false
       }
     },
@@ -321,8 +318,6 @@
           "type": "PEC",
           "address": "CLMCST42R12D969Z@pnpagopa.postecert.local"
         },
-        "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "responseStatus": "OK",
         "notificationDate": "2022-11-16T07:05:20.32423Z",
         "sendingReceipts": [{}]
@@ -344,8 +339,6 @@
           "type": "PEC",
           "address": "FRMTTR76M06B715E@pnpagopa.postecert.local"
         },
-        "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "responseStatus": "OK",
         "notificationDate": "2022-11-16T07:05:20.451956Z",
         "sendingReceipts": [{}]

--- a/packages/pn-pa-webapp/cypress/fixtures/notifications/old/notification-2.json
+++ b/packages/pn-pa-webapp/cypress/fixtures/notifications/old/notification-2.json
@@ -181,7 +181,6 @@
           "address": "FRMTTR76M06B715E@pnpagopa.postecert.local"
         },
         "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "retryNumber": 0
       }
     },
@@ -223,7 +222,6 @@
           "address": "CLMCST42R12D969Z@pnpagopa.postecert.local"
         },
         "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "retryNumber": 0
       }
     },
@@ -244,11 +242,10 @@
           "address": "FRMTTR76M06B715E@pnpagopa.postecert.local"
         },
         "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "retryNumber": 0,
         "notificationDate": "2022-11-16T07:04:41.328644Z",
         "sendingReceipts": [{}],
-        "eventCode": "C001",
+        "deliveryDetailCode": "C001",
         "shouldRetry": false
       }
     },
@@ -269,11 +266,10 @@
           "address": "CLMCST42R12D969Z@pnpagopa.postecert.local"
         },
         "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "retryNumber": 0,
         "notificationDate": "2022-11-16T07:04:46.277011Z",
         "sendingReceipts": [{}],
-        "eventCode": "C001",
+        "deliveryDetailCode": "C001",
         "shouldRetry": false
       }
     },
@@ -293,8 +289,6 @@
           "type": "PEC",
           "address": "FRMTTR76M06B715E@pnpagopa.postecert.local"
         },
-        "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "responseStatus": "OK",
         "notificationDate": "2022-11-16T07:04:50.166343Z",
         "sendingReceipts": [{}]
@@ -342,8 +336,6 @@
           "type": "PEC",
           "address": "CLMCST42R12D969Z@pnpagopa.postecert.local"
         },
-        "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "responseStatus": "OK",
         "notificationDate": "2022-11-16T07:04:55.000564Z",
         "sendingReceipts": [{}]

--- a/packages/pn-pa-webapp/cypress/fixtures/notifications/old/notification-4.json
+++ b/packages/pn-pa-webapp/cypress/fixtures/notifications/old/notification-4.json
@@ -219,7 +219,6 @@
           "address": "FRMTTR76M06B715E@pnpagopa.postecert.local"
         },
         "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "retryNumber": 0
       }
     },
@@ -248,7 +247,6 @@
           "address": "CLMCST42R12D969Z@pnpagopa.postecert.local"
         },
         "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "retryNumber": 0
       }
     },
@@ -269,11 +267,10 @@
           "address": "CLMCST42R12D969Z@pnpagopa.postecert.local"
         },
         "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "retryNumber": 0,
         "notificationDate": "2022-11-15T19:09:41.208285Z",
         "sendingReceipts": [{}],
-        "eventCode": "C001",
+        "deliveryDetailCode": "C001",
         "shouldRetry": false
       }
     },
@@ -294,11 +291,10 @@
           "address": "FRMTTR76M06B715E@pnpagopa.postecert.local"
         },
         "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "retryNumber": 0,
         "notificationDate": "2022-11-15T19:09:41.377307Z",
         "sendingReceipts": [{}],
-        "eventCode": "C001",
+        "deliveryDetailCode": "C001",
         "shouldRetry": false
       }
     },
@@ -318,8 +314,6 @@
           "type": "PEC",
           "address": "CLMCST42R12D969Z@pnpagopa.postecert.local"
         },
-        "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "responseStatus": "OK",
         "notificationDate": "2022-11-15T19:09:50.001058Z",
         "sendingReceipts": [{}]
@@ -341,8 +335,6 @@
           "type": "PEC",
           "address": "FRMTTR76M06B715E@pnpagopa.postecert.local"
         },
-        "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "responseStatus": "OK",
         "notificationDate": "2022-11-15T19:09:50.149174Z",
         "sendingReceipts": [{}]

--- a/packages/pn-personafisica-webapp/cypress/fixtures/notifications/delegator/detail.json
+++ b/packages/pn-personafisica-webapp/cypress/fixtures/notifications/delegator/detail.json
@@ -151,7 +151,6 @@
           "address": "GRBGPP87L04L741X@pnpagopa.postecert.local"
         },
         "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "retryNumber": 0
       }
     },
@@ -172,11 +171,10 @@
           "address": "GRBGPP87L04L741X@pnpagopa.postecert.local"
         },
         "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "retryNumber": 0,
         "notificationDate": "2022-11-08T11:58:52.240662Z",
         "sendingReceipts": [{}],
-        "eventCode": "C001",
+        "deliveryDetailCode": "C001",
         "shouldRetry": false
       }
     },
@@ -196,8 +194,6 @@
           "type": "PEC",
           "address": "GRBGPP87L04L741X@pnpagopa.postecert.local"
         },
-        "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "responseStatus": "OK",
         "notificationDate": "2022-11-08T11:59:00.000552Z",
         "sendingReceipts": [{}]

--- a/packages/pn-personafisica-webapp/cypress/fixtures/notifications/effective_date.json
+++ b/packages/pn-personafisica-webapp/cypress/fixtures/notifications/effective_date.json
@@ -151,7 +151,6 @@
           "address": "CSRGGL44L13H501E@pnpagopa.postecert.local"
         },
         "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "retryNumber": 0
       }
     },
@@ -172,11 +171,10 @@
           "address": "CSRGGL44L13H501E@pnpagopa.postecert.local"
         },
         "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "retryNumber": 0,
         "notificationDate": "2022-11-17T13:50:09.240662Z",
         "sendingReceipts": [{}],
-        "eventCode": "C001",
+        "deliveryDetailCode": "C001",
         "shouldRetry": false
       }
     },
@@ -196,8 +194,6 @@
           "type": "PEC",
           "address": "CSRGGL44L13H501E@pnpagopa.postecert.local"
         },
-        "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "responseStatus": "OK",
         "notificationDate": "2022-11-17T13:50:17.000552Z",
         "sendingReceipts": [{}]

--- a/packages/pn-personafisica-webapp/cypress/fixtures/notifications/viewed.json
+++ b/packages/pn-personafisica-webapp/cypress/fixtures/notifications/viewed.json
@@ -166,7 +166,6 @@
           "address": "gcesare@test.pagopa.it"
         },
         "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "retryNumber": 0
       }
     },
@@ -187,11 +186,10 @@
           "address": "gcesare@test.pagopa.it"
         },
         "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "retryNumber": 0,
         "notificationDate": "2022-11-22T15:09:51.351501Z",
         "sendingReceipts": [{}],
-        "eventCode": "C001",
+        "deliveryDetailCode": "C001",
         "shouldRetry": false
       }
     },
@@ -211,8 +209,6 @@
           "type": "PEC",
           "address": "gcesare@test.pagopa.it"
         },
-        "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "responseStatus": "OK",
         "notificationDate": "2022-11-22T15:09:59.100689Z",
         "sendingReceipts": [{}]

--- a/packages/pn-personagiuridica-webapp/cypress/fixtures/notifications/delegator/detail.json
+++ b/packages/pn-personagiuridica-webapp/cypress/fixtures/notifications/delegator/detail.json
@@ -151,7 +151,6 @@
           "address": "GRBGPP87L04L741X@pnpagopa.postecert.local"
         },
         "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "retryNumber": 0
       }
     },
@@ -172,11 +171,10 @@
           "address": "GRBGPP87L04L741X@pnpagopa.postecert.local"
         },
         "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "retryNumber": 0,
         "notificationDate": "2022-11-08T11:58:52.240662Z",
         "sendingReceipts": [{}],
-        "eventCode": "C001",
+        "deliveryDetailCode": "C001",
         "shouldRetry": false
       }
     },
@@ -196,8 +194,6 @@
           "type": "PEC",
           "address": "GRBGPP87L04L741X@pnpagopa.postecert.local"
         },
-        "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "responseStatus": "OK",
         "notificationDate": "2022-11-08T11:59:00.000552Z",
         "sendingReceipts": [{}]

--- a/packages/pn-personagiuridica-webapp/cypress/fixtures/notifications/effective_date.json
+++ b/packages/pn-personagiuridica-webapp/cypress/fixtures/notifications/effective_date.json
@@ -151,7 +151,6 @@
           "address": "CSRGGL44L13H501E@pnpagopa.postecert.local"
         },
         "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "retryNumber": 0
       }
     },
@@ -172,11 +171,10 @@
           "address": "CSRGGL44L13H501E@pnpagopa.postecert.local"
         },
         "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "retryNumber": 0,
         "notificationDate": "2022-11-17T13:50:09.240662Z",
         "sendingReceipts": [{}],
-        "eventCode": "C001",
+        "deliveryDetailCode": "C001",
         "shouldRetry": false
       }
     },
@@ -196,8 +194,6 @@
           "type": "PEC",
           "address": "CSRGGL44L13H501E@pnpagopa.postecert.local"
         },
-        "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "responseStatus": "OK",
         "notificationDate": "2022-11-17T13:50:17.000552Z",
         "sendingReceipts": [{}]

--- a/packages/pn-personagiuridica-webapp/cypress/fixtures/notifications/viewed.json
+++ b/packages/pn-personagiuridica-webapp/cypress/fixtures/notifications/viewed.json
@@ -166,7 +166,6 @@
           "address": "gcesare@test.pagopa.it"
         },
         "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "retryNumber": 0
       }
     },
@@ -187,11 +186,10 @@
           "address": "gcesare@test.pagopa.it"
         },
         "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "retryNumber": 0,
         "notificationDate": "2022-11-22T15:09:51.351501Z",
         "sendingReceipts": [{}],
-        "eventCode": "C001",
+        "deliveryDetailCode": "C001",
         "shouldRetry": false
       }
     },
@@ -211,8 +209,6 @@
           "type": "PEC",
           "address": "gcesare@test.pagopa.it"
         },
-        "digitalAddressSource": "SPECIAL",
-        "errors": [],
         "responseStatus": "OK",
         "notificationDate": "2022-11-22T15:09:59.100689Z",
         "sendingReceipts": [{}]


### PR DESCRIPTION
## Short description
Adapts timeline data structures since the field `eventCode` present in the detail for timeline events of type `SEND_DIGITAL_DOMICILE` / `SEND_DIGITAL_PROGRESS` / `SEND_DIGITAL_FEEBACK` has been renamed to `deliveryDetailCode` in the response of the API request (included in `pn-delivery-push`) that yields the details of a single notification.

## List of changes proposed in this pull request
- Renamed `eventCode` as `deliveryDetailCode` in the `SendDigitalDetails`  interface, cfr. `packages\pn-commons/src/types/NotificationDetail.ts`. Also removed two attributes that are not currently included in the API response (`errors` and `downstreamId`).
- Changed the behavior of the timeline accordingly.
- Changed the notification details defined for several tests accordingly.

## How to test
Enter any notification sent through digital workflow, e.g. QVZN-GKGV-DEZR-202304-Y-1 (cleopatra / comune di palermo) or WQPY-KZTH-WPDQ-202304-Y-1 (marcopolo / comune di palermo). The timeline should include events having as title "Invio via PEC preso in carico", like the one in the following image.
![image](https://user-images.githubusercontent.com/5519535/232840616-1a5eaf0a-e938-43e2-920b-32f3bf43c5de.png)
