### PR TITLE
Removed references to different amount payment

### DIFF
--- a/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
@@ -66,8 +66,6 @@
       "summary-succeeded": "Pagato",
       "summary-in-progress": "Pagamento in corso",
       "amount": "Importo",
-      "disclaimer": "Questo importo verrà aggiornato al momento del pagamento. Quindi potrebbe essere diverso.",
-      "disclaimer-link": "Come mai?",
       "submit": "Paga",
       "divider-text": "oppure",
       "download-pagopa-notification": "Scarica l'avviso pagoPA",

--- a/packages/pn-personafisica-webapp/src/component/Notifications/NotificationPayment.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Notifications/NotificationPayment.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import _ from 'lodash';
 import { LoadingButton } from '@mui/lab';
@@ -42,7 +42,6 @@ import {
   NOTIFICATION_ACTIONS,
 } from '../../redux/notification/actions';
 import { RootState } from '../../redux/store';
-import { FAQ_DIFFERENT_AMOUNTS_SUFFIX } from '../../navigation/externalRoutes.const';
 import { TrackEventType } from '../../utils/events';
 import { trackEventByType } from '../../utils/mixpanel';
 import { getConfiguration } from "../../services/configuration.service";
@@ -76,7 +75,6 @@ interface PaymentMessageData {
 interface PaymentData {
   title: string;
   amount?: string;
-  disclaimer?: JSX.Element;
   message?: PaymentMessageData;
   action?: PrimaryAction;
 }
@@ -117,7 +115,7 @@ const NotificationPayment: React.FC<Props> = ({
   subject,
 }) => {
   const { t } = useTranslation(['notifiche']);
-  const { PAGOPA_HELP_EMAIL, LANDING_SITE_URL } = getConfiguration();
+  const { PAGOPA_HELP_EMAIL } = getConfiguration();
   const isMobile = useIsMobile();
   const [loading, setLoading] = useState(true);
   const dispatch = useAppDispatch();
@@ -268,39 +266,16 @@ const NotificationPayment: React.FC<Props> = ({
       title = t('detail.payment.summary-in-progress', { ns: 'notifiche' });
     }
     const amount = paymentInfo.amount ? formatEurocentToCurrency(paymentInfo.amount) : '';
-    const disclaimer = amount ? getDisclaimer() : undefined;
     const message = getMessageData();
     const action = getActionData(amount);
 
     return {
       title,
       amount,
-      disclaimer,
       message,
       action,
     };
   };
-
-  const completeFaqDifferentAmountsUrl = useMemo(
-    () => LANDING_SITE_URL && FAQ_DIFFERENT_AMOUNTS_SUFFIX
-      ? `${LANDING_SITE_URL}${FAQ_DIFFERENT_AMOUNTS_SUFFIX}`
-      : undefined,
-    []
-  );
-
-  /** returns disclaimer JSX */
-  const getDisclaimer = useCallback((): JSX.Element | undefined => (
-    <>
-      {t('detail.payment.disclaimer', { ns: 'notifiche' })}
-      &nbsp;
-      {
-        completeFaqDifferentAmountsUrl &&
-        <Link href={completeFaqDifferentAmountsUrl} target="_blank">
-          {t('detail.payment.disclaimer-link', { ns: 'notifiche' })}
-        </Link>
-      }
-    </>
-  ), [completeFaqDifferentAmountsUrl]);
 
   /** returns message data to be passed into the alert */
   const getMessageData = (): PaymentMessageData | undefined => {
@@ -506,11 +481,6 @@ const NotificationPayment: React.FC<Props> = ({
               ) : (
                 data.amount
               )}
-            </Typography>
-          </Grid>
-          <Grid item xs={12} lg={12} sx={{ my: '1rem' }}>
-            <Typography variant="body2" display="inline">
-              {data.amount && data.disclaimer}
             </Typography>
           </Grid>
           <Stack spacing={2} width="100%">

--- a/packages/pn-personafisica-webapp/src/component/Notifications/__test__/NotificationPayment.test.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Notifications/__test__/NotificationPayment.test.tsx
@@ -167,9 +167,6 @@ describe('NotificationPayment component', () => {
     const amountLoader = screen.getByTestId('loading-skeleton');
     expect(amountLoader).toBeInTheDocument();
 
-    const disclaimer = screen.queryByText('detail.payment.disclaimer');
-    expect(disclaimer).not.toBeInTheDocument();
-
     const loadingButton = screen.getByRole('button', { name: 'detail.payment.submit' });
     expect(loadingButton.querySelector('svg')).toBeInTheDocument();
     expect(loadingButton).toBeInTheDocument();
@@ -208,9 +205,6 @@ describe('NotificationPayment component', () => {
     const amount = screen.getByRole('heading', { name: 'detail.payment.amount' });
     expect(amount).toBeInTheDocument();
     expect(amount).toHaveTextContent(/473,50\b/);
-
-    const disclaimer = screen.getByText('detail.payment.disclaimer');
-    expect(disclaimer).toBeInTheDocument();
 
     const loadingButton = screen.getByRole('button', { name: /detail.payment.submit 473,50\b/ });
     expect(loadingButton).toBeInTheDocument();
@@ -254,8 +248,6 @@ describe('NotificationPayment component', () => {
     const amount = screen.getByRole('heading', { name: 'detail.payment.amount' });
     expect(amount).toBeInTheDocument();
     expect(amount).toHaveTextContent(/473,50\b/);
-    const disclaimer = screen.queryByText('detail.payment.disclaimer');
-    expect(disclaimer).toBeInTheDocument();
     const loadingButton = screen.queryByRole('button', { name: /detail.payment.submit 473,50\b/ });
     expect(loadingButton).not.toBeInTheDocument();
     const alert = screen.getByTestId('InfoOutlinedIcon');
@@ -296,8 +288,6 @@ describe('NotificationPayment component', () => {
     const amount = screen.getByRole('heading', { name: 'detail.payment.amount' });
     expect(amount).toBeInTheDocument();
     expect(amount).toHaveTextContent('');
-    const disclaimer = screen.queryByText('detail.payment.disclaimer');
-    expect(disclaimer).not.toBeInTheDocument();
     const loadingButton = screen.queryByRole('button', { name: /detail.payment.submit 473,50\b/ });
     expect(loadingButton).not.toBeInTheDocument();
     const alert = screen.getByTestId('SuccessOutlinedIcon');
@@ -325,9 +315,6 @@ describe('NotificationPayment component', () => {
     const amountLoader = screen.getByTestId('loading-skeleton');
     expect(amountLoader).toBeInTheDocument();
 
-    const disclaimer_loading = screen.queryByText('detail.payment.disclaimer');
-    expect(disclaimer_loading).not.toBeInTheDocument();
-
     await waitFor(() => {
       expect(mock.history.get.length).toBe(1);
       expect(mock.history.get[0].url).toContain('mocked-creditorTaxId/mocked-noticeCode');
@@ -340,9 +327,6 @@ describe('NotificationPayment component', () => {
     const amount = screen.getByRole('heading', { name: 'detail.payment.amount' });
     expect(amount).toBeInTheDocument();
     expect(amount).toHaveTextContent('');
-
-    const disclaimer = screen.queryByText('detail.payment.disclaimer');
-    expect(disclaimer).not.toBeInTheDocument();
 
     const loadingButton = screen.queryByRole('button', { name: /detail.payment.submit\b/ });
     expect(loadingButton).not.toBeInTheDocument();
@@ -379,9 +363,6 @@ describe('NotificationPayment component', () => {
     const amountLoader = screen.getByTestId('loading-skeleton');
     expect(amountLoader).toBeInTheDocument();
 
-    const disclaimer_loading = screen.queryByText('detail.payment.disclaimer');
-    expect(disclaimer_loading).not.toBeInTheDocument();
-
     await waitFor(() => {
       expect(mock.history.get.length).toBe(1);
       expect(mock.history.get[0].url).toContain('mocked-creditorTaxId/mocked-noticeCode');
@@ -394,9 +375,6 @@ describe('NotificationPayment component', () => {
     const amount = screen.getByRole('heading', { name: 'detail.payment.amount' });
     expect(amount).toBeInTheDocument();
     expect(amount).toHaveTextContent('');
-
-    const disclaimer = screen.queryByText('detail.payment.disclaimer');
-    expect(disclaimer).not.toBeInTheDocument();
 
     const loadingButton = screen.queryByRole('button', { name: /detail.payment.submit\b/ });
     expect(loadingButton).not.toBeInTheDocument();
@@ -433,9 +411,6 @@ describe('NotificationPayment component', () => {
     const amountLoader = screen.getByTestId('loading-skeleton');
     expect(amountLoader).toBeInTheDocument();
 
-    const disclaimer_loading = screen.queryByText('detail.payment.disclaimer');
-    expect(disclaimer_loading).not.toBeInTheDocument();
-
     await waitFor(() => {
       expect(mock.history.get.length).toBe(1);
       expect(mock.history.get[0].url).toContain('mocked-creditorTaxId/mocked-noticeCode');
@@ -448,9 +423,6 @@ describe('NotificationPayment component', () => {
     const amount = screen.getByRole('heading', { name: 'detail.payment.amount' });
     expect(amount).toBeInTheDocument();
     expect(amount).toHaveTextContent('');
-
-    const disclaimer = screen.queryByText('detail.payment.disclaimer');
-    expect(disclaimer).not.toBeInTheDocument();
 
     const loadingButton = screen.queryByRole('button', { name: /detail.payment.submit\b/ });
     expect(loadingButton).not.toBeInTheDocument();
@@ -487,9 +459,6 @@ describe('NotificationPayment component', () => {
     const amountLoader = screen.getByTestId('loading-skeleton');
     expect(amountLoader).toBeInTheDocument();
 
-    const disclaimer_loading = screen.queryByText('detail.payment.disclaimer');
-    expect(disclaimer_loading).not.toBeInTheDocument();
-
     await waitFor(() => {
       expect(mock.history.get.length).toBe(1);
       expect(mock.history.get[0].url).toContain('mocked-creditorTaxId/mocked-noticeCode');
@@ -502,9 +471,6 @@ describe('NotificationPayment component', () => {
     const amount = screen.getByRole('heading', { name: 'detail.payment.amount' });
     expect(amount).toBeInTheDocument();
     expect(amount).toHaveTextContent('');
-
-    const disclaimer = screen.queryByText('detail.payment.disclaimer');
-    expect(disclaimer).not.toBeInTheDocument();
 
     const loadingButton = screen.queryByRole('button', { name: /detail.payment.submit\b/ });
     expect(loadingButton).not.toBeInTheDocument();
@@ -538,9 +504,6 @@ describe('NotificationPayment component', () => {
     const amountLoader = screen.getByTestId('loading-skeleton');
     expect(amountLoader).toBeInTheDocument();
 
-    const disclaimer_loading = screen.queryByText('detail.payment.disclaimer');
-    expect(disclaimer_loading).not.toBeInTheDocument();
-
     await waitFor(() => {
       expect(mock.history.get.length).toBe(1);
       expect(mock.history.get[0].url).toContain('mocked-creditorTaxId/mocked-noticeCode');
@@ -553,9 +516,6 @@ describe('NotificationPayment component', () => {
     const amount = screen.getByRole('heading', { name: 'detail.payment.amount' });
     expect(amount).toBeInTheDocument();
     expect(amount).toHaveTextContent('');
-
-    const disclaimer = screen.queryByText('detail.payment.disclaimer');
-    expect(disclaimer).not.toBeInTheDocument();
 
     const loadingButton = screen.queryByRole('button', { name: /detail.payment.submit\b/ });
     expect(loadingButton).not.toBeInTheDocument();
@@ -586,9 +546,6 @@ describe('NotificationPayment component', () => {
     const amountLoader = screen.getByTestId('loading-skeleton');
     expect(amountLoader).toBeInTheDocument();
 
-    const disclaimer_loading = screen.queryByText('detail.payment.disclaimer');
-    expect(disclaimer_loading).not.toBeInTheDocument();
-
     await waitFor(() => {
       expect(mock.history.get.length).toBe(1);
       expect(mock.history.get[0].url).toContain('mocked-creditorTaxId/mocked-noticeCode');
@@ -601,9 +558,6 @@ describe('NotificationPayment component', () => {
     const amount = screen.getByRole('heading', { name: 'detail.payment.amount' });
     expect(amount).toBeInTheDocument();
     expect(amount).toHaveTextContent('');
-
-    const disclaimer = screen.queryByText('detail.payment.disclaimer');
-    expect(disclaimer).not.toBeInTheDocument();
 
     const loadingButton = screen.queryByRole('button', { name: /detail.payment.submit\b/ });
     expect(loadingButton).not.toBeInTheDocument();

--- a/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
@@ -63,8 +63,6 @@
       "summary-succeeded": "Pagato",
       "summary-in-progress": "Pagamento in corso",
       "amount": "Importo",
-      "disclaimer": "Questo importo verrà aggiornato al momento del pagamento. Quindi potrebbe essere diverso.",
-      "disclaimer-link": "Come mai?",
       "submit": "Paga",
       "divider-text": "oppure",
       "download-pagopa-notification": "Scarica l'avviso pagoPA",

--- a/packages/pn-personagiuridica-webapp/src/component/Notifications/NotificationPayment.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Notifications/NotificationPayment.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import _ from 'lodash';
 import { LoadingButton } from '@mui/lab';
@@ -42,9 +42,6 @@ import {
   NOTIFICATION_ACTIONS,
 } from '../../redux/notification/actions';
 import { RootState } from '../../redux/store';
-import {
-  FAQ_DIFFERENT_AMOUNTS_SUFFIX,
-} from '../../navigation/externalRoutes.const';
 import { TrackEventType } from '../../utils/events';
 import { trackEventByType } from '../../utils/mixpanel';
 import { getConfiguration } from "../../services/configuration.service";
@@ -78,7 +75,6 @@ interface PaymentMessageData {
 interface PaymentData {
   title: string;
   amount?: string;
-  disclaimer?: JSX.Element;
   message?: PaymentMessageData;
   action?: PrimaryAction;
 }
@@ -118,7 +114,7 @@ const NotificationPayment: React.FC<Props> = ({
   senderDenomination,
   subject,
 }) => {
-  const { PAGOPA_HELP_EMAIL, LANDING_SITE_URL } = getConfiguration();
+  const { PAGOPA_HELP_EMAIL } = getConfiguration();
   const { t } = useTranslation(['notifiche']);
   const isMobile = useIsMobile();
   const [loading, setLoading] = useState(true);
@@ -270,40 +266,16 @@ const NotificationPayment: React.FC<Props> = ({
       title = t('detail.payment.summary-in-progress', { ns: 'notifiche' });
     }
     const amount = paymentInfo.amount ? formatEurocentToCurrency(paymentInfo.amount) : '';
-    const disclaimer = amount ? getDisclaimer() : undefined;
     const message = getMessageData();
     const action = getActionData(amount);
 
     return {
       title,
       amount,
-      disclaimer,
       message,
       action,
     };
   };
-
-  const completeFaqDifferentAmountsUrl = useMemo(
-    () => LANDING_SITE_URL && FAQ_DIFFERENT_AMOUNTS_SUFFIX
-      ? `${LANDING_SITE_URL}${FAQ_DIFFERENT_AMOUNTS_SUFFIX}`
-      : undefined,
-    []
-  );
-
-  /** returns disclaimer JSX */
-  const getDisclaimer = useCallback((): JSX.Element | undefined => (
-    <>
-      {t('detail.payment.disclaimer', { ns: 'notifiche' })}
-      &nbsp;
-      {
-        completeFaqDifferentAmountsUrl &&
-        <Link href={completeFaqDifferentAmountsUrl} target="_blank">
-          {t('detail.payment.disclaimer-link', { ns: 'notifiche' })}
-        </Link>
-      }
-    </>
-  ), [completeFaqDifferentAmountsUrl]);
-
 
   /** returns message data to be passed into the alert */
   const getMessageData = (): PaymentMessageData | undefined => {
@@ -509,11 +481,6 @@ const NotificationPayment: React.FC<Props> = ({
               ) : (
                 data.amount
               )}
-            </Typography>
-          </Grid>
-          <Grid item xs={12} lg={12} sx={{ my: '1rem' }}>
-            <Typography variant="body2" display="inline">
-              {data.amount && data.disclaimer}
             </Typography>
           </Grid>
           <Stack spacing={2} width="100%">

--- a/packages/pn-personagiuridica-webapp/src/component/Notifications/__test__/NotificationPayment.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Notifications/__test__/NotificationPayment.test.tsx
@@ -167,9 +167,6 @@ describe('NotificationPayment component', () => {
     const amountLoader = screen.getByTestId('loading-skeleton');
     expect(amountLoader).toBeInTheDocument();
 
-    const disclaimer = screen.queryByText('detail.payment.disclaimer');
-    expect(disclaimer).not.toBeInTheDocument();
-
     const loadingButton = screen.getByRole('button', { name: 'detail.payment.submit' });
     expect(loadingButton.querySelector('svg')).toBeInTheDocument();
     expect(loadingButton).toBeInTheDocument();
@@ -208,9 +205,6 @@ describe('NotificationPayment component', () => {
     const amount = screen.getByRole('heading', { name: 'detail.payment.amount' });
     expect(amount).toBeInTheDocument();
     expect(amount).toHaveTextContent(/473,50\b/);
-
-    const disclaimer = screen.getByText('detail.payment.disclaimer');
-    expect(disclaimer).toBeInTheDocument();
 
     const loadingButton = screen.getByRole('button', { name: /detail.payment.submit 473,50\b/ });
     expect(loadingButton).toBeInTheDocument();
@@ -254,8 +248,6 @@ describe('NotificationPayment component', () => {
     const amount = screen.getByRole('heading', { name: 'detail.payment.amount' });
     expect(amount).toBeInTheDocument();
     expect(amount).toHaveTextContent(/473,50\b/);
-    const disclaimer = screen.queryByText('detail.payment.disclaimer');
-    expect(disclaimer).toBeInTheDocument();
     const loadingButton = screen.queryByRole('button', { name: /detail.payment.submit 473,50\b/ });
     expect(loadingButton).not.toBeInTheDocument();
     const alert = screen.getByTestId('InfoOutlinedIcon');
@@ -296,8 +288,6 @@ describe('NotificationPayment component', () => {
     const amount = screen.getByRole('heading', { name: 'detail.payment.amount' });
     expect(amount).toBeInTheDocument();
     expect(amount).toHaveTextContent('');
-    const disclaimer = screen.queryByText('detail.payment.disclaimer');
-    expect(disclaimer).not.toBeInTheDocument();
     const loadingButton = screen.queryByRole('button', { name: /detail.payment.submit 473,50\b/ });
     expect(loadingButton).not.toBeInTheDocument();
     const alert = screen.getByTestId('SuccessOutlinedIcon');
@@ -325,9 +315,6 @@ describe('NotificationPayment component', () => {
     const amountLoader = screen.getByTestId('loading-skeleton');
     expect(amountLoader).toBeInTheDocument();
 
-    const disclaimer_loading = screen.queryByText('detail.payment.disclaimer');
-    expect(disclaimer_loading).not.toBeInTheDocument();
-
     await waitFor(() => {
       expect(mock.history.get.length).toBe(1);
       expect(mock.history.get[0].url).toContain('mocked-creditorTaxId/mocked-noticeCode');
@@ -340,9 +327,6 @@ describe('NotificationPayment component', () => {
     const amount = screen.getByRole('heading', { name: 'detail.payment.amount' });
     expect(amount).toBeInTheDocument();
     expect(amount).toHaveTextContent('');
-
-    const disclaimer = screen.queryByText('detail.payment.disclaimer');
-    expect(disclaimer).not.toBeInTheDocument();
 
     const loadingButton = screen.queryByRole('button', { name: /detail.payment.submit\b/ });
     expect(loadingButton).not.toBeInTheDocument();
@@ -379,9 +363,6 @@ describe('NotificationPayment component', () => {
     const amountLoader = screen.getByTestId('loading-skeleton');
     expect(amountLoader).toBeInTheDocument();
 
-    const disclaimer_loading = screen.queryByText('detail.payment.disclaimer');
-    expect(disclaimer_loading).not.toBeInTheDocument();
-
     await waitFor(() => {
       expect(mock.history.get.length).toBe(1);
       expect(mock.history.get[0].url).toContain('mocked-creditorTaxId/mocked-noticeCode');
@@ -394,9 +375,6 @@ describe('NotificationPayment component', () => {
     const amount = screen.getByRole('heading', { name: 'detail.payment.amount' });
     expect(amount).toBeInTheDocument();
     expect(amount).toHaveTextContent('');
-
-    const disclaimer = screen.queryByText('detail.payment.disclaimer');
-    expect(disclaimer).not.toBeInTheDocument();
 
     const loadingButton = screen.queryByRole('button', { name: /detail.payment.submit\b/ });
     expect(loadingButton).not.toBeInTheDocument();
@@ -433,9 +411,6 @@ describe('NotificationPayment component', () => {
     const amountLoader = screen.getByTestId('loading-skeleton');
     expect(amountLoader).toBeInTheDocument();
 
-    const disclaimer_loading = screen.queryByText('detail.payment.disclaimer');
-    expect(disclaimer_loading).not.toBeInTheDocument();
-
     await waitFor(() => {
       expect(mock.history.get.length).toBe(1);
       expect(mock.history.get[0].url).toContain('mocked-creditorTaxId/mocked-noticeCode');
@@ -448,9 +423,6 @@ describe('NotificationPayment component', () => {
     const amount = screen.getByRole('heading', { name: 'detail.payment.amount' });
     expect(amount).toBeInTheDocument();
     expect(amount).toHaveTextContent('');
-
-    const disclaimer = screen.queryByText('detail.payment.disclaimer');
-    expect(disclaimer).not.toBeInTheDocument();
 
     const loadingButton = screen.queryByRole('button', { name: /detail.payment.submit\b/ });
     expect(loadingButton).not.toBeInTheDocument();
@@ -487,9 +459,6 @@ describe('NotificationPayment component', () => {
     const amountLoader = screen.getByTestId('loading-skeleton');
     expect(amountLoader).toBeInTheDocument();
 
-    const disclaimer_loading = screen.queryByText('detail.payment.disclaimer');
-    expect(disclaimer_loading).not.toBeInTheDocument();
-
     await waitFor(() => {
       expect(mock.history.get.length).toBe(1);
       expect(mock.history.get[0].url).toContain('mocked-creditorTaxId/mocked-noticeCode');
@@ -502,9 +471,6 @@ describe('NotificationPayment component', () => {
     const amount = screen.getByRole('heading', { name: 'detail.payment.amount' });
     expect(amount).toBeInTheDocument();
     expect(amount).toHaveTextContent('');
-
-    const disclaimer = screen.queryByText('detail.payment.disclaimer');
-    expect(disclaimer).not.toBeInTheDocument();
 
     const loadingButton = screen.queryByRole('button', { name: /detail.payment.submit\b/ });
     expect(loadingButton).not.toBeInTheDocument();
@@ -538,9 +504,6 @@ describe('NotificationPayment component', () => {
     const amountLoader = screen.getByTestId('loading-skeleton');
     expect(amountLoader).toBeInTheDocument();
 
-    const disclaimer_loading = screen.queryByText('detail.payment.disclaimer');
-    expect(disclaimer_loading).not.toBeInTheDocument();
-
     await waitFor(() => {
       expect(mock.history.get.length).toBe(1);
       expect(mock.history.get[0].url).toContain('mocked-creditorTaxId/mocked-noticeCode');
@@ -553,9 +516,6 @@ describe('NotificationPayment component', () => {
     const amount = screen.getByRole('heading', { name: 'detail.payment.amount' });
     expect(amount).toBeInTheDocument();
     expect(amount).toHaveTextContent('');
-
-    const disclaimer = screen.queryByText('detail.payment.disclaimer');
-    expect(disclaimer).not.toBeInTheDocument();
 
     const loadingButton = screen.queryByRole('button', { name: /detail.payment.submit\b/ });
     expect(loadingButton).not.toBeInTheDocument();
@@ -586,9 +546,6 @@ describe('NotificationPayment component', () => {
     const amountLoader = screen.getByTestId('loading-skeleton');
     expect(amountLoader).toBeInTheDocument();
 
-    const disclaimer_loading = screen.queryByText('detail.payment.disclaimer');
-    expect(disclaimer_loading).not.toBeInTheDocument();
-
     await waitFor(() => {
       expect(mock.history.get.length).toBe(1);
       expect(mock.history.get[0].url).toContain('mocked-creditorTaxId/mocked-noticeCode');
@@ -601,9 +558,6 @@ describe('NotificationPayment component', () => {
     const amount = screen.getByRole('heading', { name: 'detail.payment.amount' });
     expect(amount).toBeInTheDocument();
     expect(amount).toHaveTextContent('');
-
-    const disclaimer = screen.queryByText('detail.payment.disclaimer');
-    expect(disclaimer).not.toBeInTheDocument();
 
     const loadingButton = screen.queryByRole('button', { name: /detail.payment.submit\b/ });
     expect(loadingButton).not.toBeInTheDocument();


### PR DESCRIPTION
## Short description
Removed references to different amount payment.

## List of changes proposed in this pull request
- Removed references to different amount payment from NotificationPayment component, both PF and PG
- Fixed tests, both PF and PG
- Removed unused strings from notifiche.json, both PF and PG

## How to test
Find a notification with payment enabled. You shuldn't see payment different amount disclaimer anymore.