### PR TITLE
PN-5133 - notification table - tab navigation stops only in IUN column

### DIFF
--- a/packages/pn-pa-webapp/src/pages/components/Notifications/DesktopNotifications.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/Notifications/DesktopNotifications.tsx
@@ -61,6 +61,7 @@ const DesktopNotifications = ({
       onClick(row: Item) {
         handleRowClick(row);
       },
+      disableAccessibility: true,
     },
     {
       id: 'recipients',
@@ -77,6 +78,7 @@ const DesktopNotifications = ({
       onClick(row: Item) {
         handleRowClick(row);
       },
+      disableAccessibility: true,
     },
     {
       id: 'subject',
@@ -88,6 +90,7 @@ const DesktopNotifications = ({
       onClick(row: Item) {
         handleRowClick(row);
       },
+      disableAccessibility: true,
     },
     {
       id: 'iun',
@@ -116,6 +119,7 @@ const DesktopNotifications = ({
       onClick(row: Item) {
         handleRowClick(row);
       },
+      disableAccessibility: true,
     },
     {
       id: 'notificationStatus',
@@ -129,6 +133,7 @@ const DesktopNotifications = ({
         );
         return <StatusTooltip label={label} tooltip={tooltip} color={color} eventTrackingCallback={handleEventTrackingTooltip}></StatusTooltip>;
       },
+      disableAccessibility: true,
     },
   ];
 

--- a/packages/pn-pa-webapp/src/pages/components/Notifications/__test__/DesktopNotifications.test.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/Notifications/__test__/DesktopNotifications.test.tsx
@@ -71,4 +71,31 @@ describe('DesktopNotifications Component', () => {
     });
   });
 
+  it('cells with/without tabindex', async () => {
+    const result = render(
+      <DesktopNotifications
+        notifications={notificationsToFe.resultsPage}
+        sort={{ orderBy: '', order: 'asc' }}
+        onManualSend={() => {}}
+        onApiKeys={() => {}}
+      />
+    );
+    const notificationsTableBody = result.container.querySelector(
+      'table tbody'
+    );
+    const notificationsTableRow = result.container.querySelector(
+      'table tbody tr:first-child'
+    );
+    const recipientCellButton = result.container.querySelector(
+      'table tbody tr:first-child td:nth-child(2) button'
+    );
+    const iunCellButton = result.container.querySelector(
+      'table tbody tr:first-child td:nth-child(4) button'
+    );
+    expect(notificationsTableBody?.children).toHaveLength(1);
+    expect(notificationsTableRow?.children).toHaveLength(6);
+    expect(recipientCellButton?.getAttribute("tabindex")).toEqual("-1");
+    expect(iunCellButton?.getAttribute("tabindex")).toEqual("0");
+  });
+
 });

--- a/packages/pn-personafisica-webapp/src/component/Notifications/DesktopNotifications.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Notifications/DesktopNotifications.tsx
@@ -121,6 +121,7 @@ const DesktopNotifications = ({
         );
         return <StatusTooltip label={label} tooltip={tooltip} color={color} eventTrackingCallback={handleEventTrackingTooltip}></StatusTooltip>;
       },
+      disableAccessibility: true,
     },
   ];
   const rows: Array<Item> = notifications.map((n, i) => ({

--- a/packages/pn-personagiuridica-webapp/src/component/Notifications/DesktopNotifications.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Notifications/DesktopNotifications.tsx
@@ -129,6 +129,7 @@ const DesktopNotifications = ({
           ></StatusTooltip>
         );
       },
+      disableAccessibility: true,
     },
   ];
   const rows: Array<Item> = notifications.map((n, i) => ({


### PR DESCRIPTION
## Short description
Modified the behavior of the notification tables, desktop version, so that the tab navigation stops in the IUN column only. This ease the navigation for visually impaired people.

## List of changes proposed in this pull request
Just added the needed `disableAccessibility` attributes in all columns except for IUN. I also added a test (which regards the value of tabindex) for PA.

## How to test
Just enter the dashboard / notification list for any of PA / PF / PG, and navigate it using tab until you reach the notification table. The tab navigation should stop in the IUN column and status description only.