### PR TITLE
Pn 5840 fe portale mittente destinatario label degli stati non piu centrato

### DIFF
--- a/packages/pn-commons/src/utils/__test__/styles.utility.test.tsx
+++ b/packages/pn-commons/src/utils/__test__/styles.utility.test.tsx
@@ -7,7 +7,7 @@ describe('Styles utilities test', () => {
 
   it('buttonNakedInheritStyle test', () => {
     const expetedResultStyle =
-      "color: 'inherit', border: 'none', font-size: 'inherit', font-family: 'inherit', background: 'inherit', margin: 0, padding: 0, font-weight: 'inherit', text-align: 'inherit'";
+      "color: 'inherit', border: 'none', font-size: 'inherit', font-family: 'inherit', background: 'inherit', margin: 0, padding: 0, font-weight: 'inherit', text-align: 'inherit', display: 'initial'";
     const result = render(<ButtonNaked sx={buttonNakedInheritStyle}>Mocked-button</ButtonNaked>);
     expect(result.container).toHaveStyle(expetedResultStyle);
   });

--- a/packages/pn-commons/src/utils/styles.utility.ts
+++ b/packages/pn-commons/src/utils/styles.utility.ts
@@ -10,6 +10,6 @@ export const buttonNakedInheritStyle: CSSProperties = {
   margin: 0,
   padding: 0,
   fontWeight: 'inherit',
-  display: 'inherit',
+  display: 'initial',
   textAlign: 'inherit'
 };


### PR DESCRIPTION
## Short description
Fixed issue with misaligned elements in table.

## List of changes proposed in this pull request
- Changed display property in buttonNakedInheritStyle
- Extended test for buttonNakedInheritStyle

## How to test
Open any notifications table (PF, PA or PG). You should see status label properly aligned now.