### PR TITLE
(no issue attached) notification data - if just one recipient arrives, timeline events are linked to that recipient

### DIFF
--- a/packages/pn-commons/src/utils/notification.utility.ts
+++ b/packages/pn-commons/src/utils/notification.utility.ts
@@ -473,7 +473,15 @@ export function getNotificationTimelineStatusInfos(
   recipients: Array<NotificationDetailRecipient>,
   allStepsForThisStatus?: Array<INotificationDetailTimeline>
 ): TimelineStepInfo | null {
-  const recipient = !_.isNil(step.details.recIndex) ? recipients[step.details.recIndex] : undefined;
+  const recipient = _.isNil(step.details.recIndex) 
+    ?  undefined
+    // For the accesses from recipient apps (cittadino / impresa)
+    // the API response will probably (in some future) include only the info about the requester recipient,
+    // i.e. recipients will be an array with exactly one element, disregarding how many recipients are included 
+    // in the notification being requested.
+    // In that case, we don't consider the recIndex indicated in each timeline step, 
+    // but otherwise take all steps as related with the only recipient included in the API response.
+    : recipients.length === 1 ? recipients[0] : recipients[step.details.recIndex];
 
   return TimelineStepFactory.createTimelineStep(step).getTimelineStepInfo({
     step,
@@ -794,7 +802,13 @@ const populatePaymentHistory = (
     for (const payment of paymentTimelineStep) {
       const recIndex = payment.details.recIndex;
       if (recIndex !== null && recIndex !== undefined) {
-        const recipient = recipients[recIndex];
+        // For the accesses from recipient apps (cittadino / impresa)
+        // the API response will probably (in some future) include only the info about the requester recipient,
+        // i.e. recipients will be an array with exactly one element, disregarding how many recipients are included 
+        // in the notification being requested.
+        // In that case, we don't consider the recIndex indicated in each timeline step, 
+        // but otherwise take all steps as related with the only recipient included in the API response.
+        const recipient = recipients.length === 1 ? recipients[0] : recipients[recIndex];
         /* eslint-disable-next-line functional/immutable-data */
         paymentHistory.push({
           ...(payment.details as PaidDetails),

--- a/packages/pn-personafisica-webapp/src/utils/notification.utility.ts
+++ b/packages/pn-personafisica-webapp/src/utils/notification.utility.ts
@@ -31,23 +31,8 @@ export function parseNotificationDetailForRecipient(
     candidateCurrentRecipientIndex > -1 ? candidateCurrentRecipientIndex : 0;
   const currentRecipient = notification.recipients[currentRecipientIndex];
 
-  // PN-1737 - epuration of the legalfacts pertaining to other recipients will be epurated here ...  ...
-  const cleanedTimeline = notification.timeline.map((timelineElement) => {
-    const mustCleanLegalFactsIds =
-      timelineElement.legalFactsIds != null &&
-      timelineElement.details?.recIndex != null &&
-      timelineElement.details.recIndex !== currentRecipientIndex;
-    return timelineElement.legalFactsIds
-      ? {
-          ...timelineElement,
-          legalFactsIds: mustCleanLegalFactsIds ? [] : timelineElement.legalFactsIds,
-        }
-      : timelineElement;
-  });
-  const notificationClone = { ...notification, timeline: cleanedTimeline };
-
   // do the changes common to the pa and pf
-  const commonNotificationDetailForFe = parseNotificationDetail(notificationClone);
+  const commonNotificationDetailForFe = parseNotificationDetail(notification);
 
   return {
     ...commonNotificationDetailForFe,

--- a/packages/pn-personagiuridica-webapp/src/utils/notification.utility.ts
+++ b/packages/pn-personagiuridica-webapp/src/utils/notification.utility.ts
@@ -31,23 +31,8 @@ export function parseNotificationDetailForRecipient(
     candidateCurrentRecipientIndex > -1 ? candidateCurrentRecipientIndex : 0;
   const currentRecipient = notification.recipients[currentRecipientIndex];
 
-  // PN-1737 - epuration of the legalfacts pertaining to other recipients will be epurated here ...  ...
-  const cleanedTimeline = notification.timeline.map((timelineElement) => {
-    const mustCleanLegalFactsIds =
-      timelineElement.legalFactsIds != null &&
-      timelineElement.details?.recIndex != null &&
-      timelineElement.details.recIndex !== currentRecipientIndex;
-    return timelineElement.legalFactsIds
-      ? {
-          ...timelineElement,
-          legalFactsIds: mustCleanLegalFactsIds ? [] : timelineElement.legalFactsIds,
-        }
-      : timelineElement;
-  });
-  const notificationClone = { ...notification, timeline: cleanedTimeline };
-
   // do the changes common to the pa and pf
-  const commonNotificationDetailForFe = parseNotificationDetail(notificationClone);
+  const commonNotificationDetailForFe = parseNotificationDetail(notification);
 
   return {
     ...commonNotificationDetailForFe,


### PR DESCRIPTION
## Short description
Considering an eventual modification in the BE where for multirecipient notifications, if one recipient (or a delegate) accesses it, then the `recipients` array will include just the element referring to the requester recipient, this PR suggests to slightly modify the way timeline events are processed. If the `recipients` array includes exactly one element, all obtained timeline events will be considered to refer to the given recipient, whatever the value of `recIndex` could be.

## List of changes proposed in this pull request
- Performed the needed changes in `notification.utility.ts` in pn-commons.
- Erased the code in the `notification.utility.ts` of PF / PG which cleaned the legal facts for the elements not pertaining to the current recipient. This code is no longer needed since the API response include only the timeline events, and therefore the legal fact references, pertaining to the requester recipient.

## How to test
Enter a multirecipient notification, the timeline and the payment info box should show as expected for both sender and recipient access, even if the API response is hacked in order to include just one recipient for PF / PG access.

This is the mock I implemented for PF, using the notification LAVW-YNYL-HXJP-202305-P-1 - comune di Palermo - colombo + fieramosca as example. This is OK to simulate access by fieramosca, to simulate access from colombo just change 1 into 0. 
```
  getReceivedNotification: (
    iun: string,
    currentUserTaxId: string,
    delegatorsFromStore: Array<Delegator>,
    mandateId?: string
  ): Promise<NotificationDetailForRecipient> =>
    apiClient.get<NotificationDetail>(NOTIFICATION_DETAIL(iun, mandateId)).then((response) => {
      if (response.data) {
        if (response.data.iun === "LAVW-YNYL-HXJP-202305-P-1") {
          // eslint-disable-next-line functional/immutable-data
          response.data.recipients = [response.data.recipients[1]];
          // eslint-disable-next-line functional/immutable-data
          response.data.timeline = ([...response.data.timeline, {
            "elementId": "NOTIFICATION_PAID.IUN_HRZA-UXYK-TDJQ-202305-H-1.CODE_PPA30201168372486878377777777777",
            "timestamp": "2023-05-10T15:24:46.712Z",
            "legalFactsIds": [],
            "category": "PAYMENT",
            "details": {
                "recIndex": 1,
                "recipientType": "PF",
                "amount": 100,
                "creditorTaxId": "77777777777",
                "noticeCode": "302011683724868783",
                "paymentSourceChannel": "PA",
                "uncertainPaymentDate": false
            }
          },] as any);
        }
        return parseNotificationDetailForRecipient(
          response.data,
          currentUserTaxId,
          delegatorsFromStore,
          mandateId
        );
      } else {
        return {} as NotificationDetailForRecipient;
      }
    }),
```
**NB** I added payment information since I couldn't obtain a multirecipient notification including payments.

For PA, I forced a payment from each recipient for the same notification
```
  getSentNotification: (iun: string): Promise<NotificationDetail> =>
    apiClient.get<NotificationDetail>(NOTIFICATION_DETAIL(iun)).then((response) => {
      if (response.data) {
        if (response.data.iun === "LAVW-YNYL-HXJP-202305-P-1") {
          // eslint-disable-next-line functional/immutable-data
          response.data.timeline = ([...response.data.timeline, {
            "elementId": "NOTIFICATION_PAID.IUN_HRZA-UXYK-TDJQ-202305-H-1.CODE_PPA30201168372486878377777777777",
            "timestamp": "2023-05-10T15:24:46.712Z",
            "legalFactsIds": [],
            "category": "PAYMENT",
            "details": {
                "recIndex": 0,
                "recipientType": "PF",
                "amount": 100,
                "creditorTaxId": "77777777777",
                "noticeCode": "302011683724868783",
                "paymentSourceChannel": "PA",
                "uncertainPaymentDate": false
            }
          },{
            "elementId": "NOTIFICATION_PAID.IUN_HRZA-UXYK-TDJQ-202305-H-1.CODE_PPA30201168372486878477777777777",
            "timestamp": "2023-05-10T15:24:46.712Z",
            "legalFactsIds": [],
            "category": "PAYMENT",
            "details": {
                "recIndex": 1,
                "recipientType": "PF",
                "amount": 200,
                "creditorTaxId": "77777777777",
                "noticeCode": "302011683724868784",
                "paymentSourceChannel": "PA",
                "uncertainPaymentDate": false
            }
          },] as any);
        }
        return parseNotificationDetail(response.data);
      }
      return {} as NotificationDetail;
    }),
```
