### PR TITLE
Added missing prop to notification detail page of PG

### DIFF
--- a/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
@@ -305,6 +305,7 @@ const NotificationDetail = () => {
                 {!isCancelled && currentRecipient?.payment && creditorTaxId && noticeCode && (
                   <NotificationPayment
                     iun={notification.iun}
+                    paymentHistory={notification.paymentHistory}
                     senderDenomination={notification.senderDenomination}
                     subject={notification.subject}
                     notificationPayment={currentRecipient.payment}


### PR DESCRIPTION
## Short description
Missing prop `paymentHistory` in `NotificationPayment` component in `NotificationDetail.page` compoent was causing wrong payment status output in PG.

## List of changes proposed in this pull request
- Added missing `paymentHistory`  prop to notification detail page of PG

## How to test
Login PG with user `DanteAlighieri` and entity `DivinaCommediaSrl`. Then find iun `TDXM-GPKQ-RVJZ-202305-H-1`. This notification was the failing one about payment status. Now it will correctly show as paid with summary data.