### PR TITLE
PG - Group selector for delegated notifications - pn-385 

### DIFF
--- a/packages/pn-commons/src/components/TitleBox.tsx
+++ b/packages/pn-commons/src/components/TitleBox.tsx
@@ -1,10 +1,12 @@
 import { GridSize, Typography, Grid, SxProps, Theme } from '@mui/material';
 import { Variant } from '@mui/material/styles/createTypography';
-import { ReactFragment, ReactNode } from 'react';
+import { ReactNode } from 'react';
 
 type Props = {
   /** Title of the page to render */
   title: ReactNode;
+  /** Button near the title */
+  titleButton?: ReactNode;
   /** Subtitle (optional) of the page to render */
   subTitle?: string | JSX.Element;
   /** Gridsize for title on mobile devices */
@@ -18,8 +20,6 @@ type Props = {
   variantSubTitle?: Variant;
   /** style to apply */
   sx?: SxProps<Theme>;
-  /** Children */
-  children?: ReactFragment;
   /** a11y for component */
   ariaLabel?: string;
 };
@@ -27,8 +27,9 @@ type Props = {
 /**
  * TitleBox element. It renders a Title (default variant is h1) and a subtitle (default variant is h5)
  */
-export default function TitleBox({
+const TitleBox: React.FC<Props> = ({
   title,
+  titleButton,
   subTitle,
   mbTitle = 2,
   mtGrid,
@@ -38,43 +39,46 @@ export default function TitleBox({
   sx,
   ariaLabel,
   children,
-}: Props) {
-  return (
-    <Grid
-      id="page-header-container"
-      aria-orientation="horizontal"
-      tabIndex={0}
-      container
-      mt={mtGrid}
-      sx={sx}
-    >
-      {title && (
-        <Grid id="item" item xs={12} mb={mbTitle}>
-          <Typography
-            id="title-of-page"
-            role="heading"
-            aria-label={ariaLabel}
-            aria-selected="true"
-            variant={variantTitle}
-          >
-            {title}
-          </Typography>
-        </Grid>
-      )}
-      {subTitle && (
-        <Grid aria-orientation="horizontal" item xs={12} mb={mbSubTitle}>
-          <Typography
-            variant={variantSubTitle}
-            sx={{ fontSize: '18px' }}
-            component={typeof subTitle !== 'string' ? 'div' : 'p'}
-          >
-            {subTitle}
-          </Typography>
-        </Grid>
-      )}
-      <Grid aria-orientation="vertical" item xs={12}>
-        <Typography sx={{ fontSize: '18px' }}>{children}</Typography>
+}) => (
+  <Grid
+    id="page-header-container"
+    aria-orientation="horizontal"
+    tabIndex={0}
+    container
+    mt={mtGrid}
+    sx={sx}
+  >
+    {title && (
+      <Grid id="item" item xs={12} mb={mbTitle}>
+        <Typography
+          id="title-of-page"
+          role="heading"
+          aria-label={ariaLabel}
+          aria-selected="true"
+          variant={variantTitle}
+          display="inline-block"
+          sx={{ verticalAlign: 'middle' }}
+        >
+          {title}
+        </Typography>
+        {titleButton}
       </Grid>
+    )}
+    {subTitle && (
+      <Grid aria-orientation="horizontal" item xs={12} mb={mbSubTitle}>
+        <Typography
+          variant={variantSubTitle}
+          sx={{ fontSize: '18px' }}
+          component={typeof subTitle !== 'string' ? 'div' : 'p'}
+        >
+          {subTitle}
+        </Typography>
+      </Grid>
+    )}
+    <Grid aria-orientation="vertical" item xs={12}>
+      <Typography sx={{ fontSize: '18px' }}>{children}</Typography>
     </Grid>
-  );
-}
+  </Grid>
+);
+
+export default TitleBox;

--- a/packages/pn-commons/src/types/Notifications.ts
+++ b/packages/pn-commons/src/types/Notifications.ts
@@ -27,5 +27,5 @@ export interface GetNotificationsParams {
   size?: number;
   nextPagesKey?: string;
   iunMatch?: string;
-  groups?: Array<string>;
+  group?: string;
 }

--- a/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
@@ -12,11 +12,7 @@
     "iun": "Codice IUN",
     "status": "Stato",
     "show-detail": "Vedi dettaglio",
-    "view-group": "Visualizza gruppo associato",
-    "group-modal": {
-      "title": "Gruppo associato alle notifiche di {{recipient}}",
-      "body": "Se hai bisogno di modificarlo, puoi farlo tramite la funzione di modifica all’interno della sezione “Deleghe”."
-    }
+    "group-selector-title": "Menu selezione gruppo"
   },
   "filters": {
     "iun": "Inserisci il Codice IUN",

--- a/packages/pn-personagiuridica-webapp/src/api/notifications/notifications.routes.ts
+++ b/packages/pn-personagiuridica-webapp/src/api/notifications/notifications.routes.ts
@@ -46,7 +46,6 @@ const API_NOTIFICATIONS_TAX_ID_PARAMETER = 'taxId';
 const API_NOTIFICATIONS_NOTICE_CODE_PARAMETER = 'noticeCode';
 const API_NOTIFICATIONS_OTHER_DOCUMENT_TYPE = 'documentType';
 
-
 // Paths
 const API_NOTIFICATIONS_RECEIVED_PATH = `${API_NOTIFICATIONS_BASE}/${API_NOTIFICATIONS_RECEIVED}`;
 const API_NOTIFICATIONS_DELEGATOR_PATH = `${API_NOTIFICATIONS_BASE}/${API_NOTIFICATIONS_RECEIVED}/${API_NOTIFICATIONS_DELEGATED}`;
@@ -75,7 +74,7 @@ export function NOTIFICATIONS_LIST(params: GetNotificationsParams, delegated?: b
       [API_NOTIFICATIONS_NEXT_PAGES_KEY_PARAMETER]: params.nextPagesKey || '',
       [API_NOTIFICATIONS_IUN_MATCH_PARAMETER]: params.iunMatch || '',
       [API_NOTIFICATIONS_MANDATE_ID_PARAMETER]: params.mandateId || '',
-      [API_NOTIFICATIONS_GROUP_PARAMETER]: params.groups ? params.groups : '',
+      [API_NOTIFICATIONS_GROUP_PARAMETER]: params.group ? params.group : '',
     },
   });
 }
@@ -118,14 +117,17 @@ export function NOTIFICATION_DETAIL_DOCUMENTS(
   });
 }
 
-export function NOTIFICATION_DETAIL_OTHER_DOCUMENTS(iun: string, otherDocument: NotificationDetailOtherDocument) {
+export function NOTIFICATION_DETAIL_OTHER_DOCUMENTS(
+  iun: string,
+  otherDocument: NotificationDetailOtherDocument
+) {
   return compileRoute({
     prefix: API_DELIVERY_PUSH_PREFIX,
     path: API_NOTIFICATION_DETAIL_OTHER_DOCUMENT_PATH,
     params: {
       [API_NOTIFICATIONS_IUN_PARAMETER]: iun,
-      [API_NOTIFICATIONS_OTHER_DOCUMENT_TYPE]: otherDocument.documentType
-    }
+      [API_NOTIFICATIONS_OTHER_DOCUMENT_TYPE]: otherDocument.documentType,
+    },
   });
 }
 

--- a/packages/pn-personagiuridica-webapp/src/component/Notifications/DesktopNotifications.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Notifications/DesktopNotifications.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useRef, useState } from 'react';
+import { Fragment, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
@@ -14,25 +14,12 @@ import {
   KnownSentiment,
 } from '@pagopa-pn/pn-commons';
 
-import {
-  Box,
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  Divider,
-  MenuItem,
-  Typography,
-} from '@mui/material';
-
 import * as routes from '../../navigation/routes.const';
 import { getNewNotificationBadge } from '../NewNotificationBadge/NewNotificationBadge';
 import { trackEventByType } from '../../utils/mixpanel';
 import { TrackEventType } from '../../utils/events';
 import { NotificationColumn } from '../../models/Notifications';
 import FilterNotifications from './FilterNotifications';
-import NotificationMenu from './NotificationMenu';
 
 type Props = {
   notifications: Array<Notification>;
@@ -44,11 +31,6 @@ type Props = {
   isDelegatedPage?: boolean;
 };
 
-type GroupModalProps = {
-  recipient: string;
-  group?: string;
-};
-
 const DesktopNotifications = ({
   notifications,
   sort,
@@ -58,18 +40,9 @@ const DesktopNotifications = ({
   const navigate = useNavigate();
   const { t } = useTranslation(['notifiche', 'common']);
   const filterNotificationsRef = useRef({ filtersApplied: false, cleanFilters: () => void 0 });
-  const [openGroupModal, setOpenGroupModal] = useState<undefined | GroupModalProps>(undefined);
 
   const handleEventTrackingTooltip = () => {
     trackEventByType(TrackEventType.NOTIFICATION_TABLE_ROW_TOOLTIP);
-  };
-
-  const handleModalClose = () => {
-    setOpenGroupModal(undefined);
-  };
-
-  const handleShowGroup = (row: Item) => {
-    setOpenGroupModal({ recipient: row.recipients as string, group: row.group as string });
   };
 
   const columns: Array<Column<NotificationColumn>> = [
@@ -170,25 +143,8 @@ const DesktopNotifications = ({
       },
       disableAccessibility: true,
     };
-    const menuField = {
-      id: 'menu' as NotificationColumn,
-      label: '',
-      width: '18%',
-      sortable: false,
-      getCellLabel(_: string, row: Item) {
-        return (
-          <NotificationMenu>
-            <MenuItem data-testid="buttonView" onClick={() => handleShowGroup(row)}>
-              {t('table.view-group')}
-            </MenuItem>
-          </NotificationMenu>
-        );
-      },
-    };
     // eslint-disable-next-line functional/immutable-data
     columns.splice(3, 0, recipientField);
-    // eslint-disable-next-line functional/immutable-data
-    columns.splice(7, 0, menuField);
   }
 
   const rows: Array<Item> = notifications.map((n, i) => ({
@@ -241,27 +197,6 @@ const DesktopNotifications = ({
         <ItemsTable columns={columns} rows={rows} sort={sort} onChangeSorting={onChangeSorting} />
       ) : (
         <EmptyState {...EmptyStateProps} />
-      )}
-      {openGroupModal !== undefined && (
-        <Dialog open onClick={handleModalClose}>
-          <Box p={3}>
-            <DialogTitle>
-              {t('table.group-modal.title', { recipient: openGroupModal.recipient })}
-            </DialogTitle>
-            <DialogContent>
-              <Typography my={2} mx={4} fontWeight="bold">
-                {openGroupModal.group}
-              </Typography>
-              <Divider />
-              <Typography my={3}>{t('table.group-modal.body')}</Typography>
-            </DialogContent>
-            <DialogActions>
-              <Button variant="outlined" onClick={handleModalClose} data-testid="codeCancelButton">
-                {t('button.close', { ns: 'common' })}
-              </Button>
-            </DialogActions>
-          </Box>
-        </Dialog>
       )}
     </Fragment>
   );

--- a/packages/pn-personagiuridica-webapp/src/component/Notifications/GroupSelector.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Notifications/GroupSelector.tsx
@@ -1,0 +1,68 @@
+import { MouseEvent, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Box, Button, Menu, MenuItem } from '@mui/material';
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+
+import { RootState } from '../../redux/store';
+import { useAppDispatch, useAppSelector } from '../../redux/hooks';
+import { getGroups } from '../../redux/delegation/actions';
+
+type Props = {
+  currentGroup: string;
+  onGroupSelection: (id: string) => void;
+};
+
+const GroupSelector: React.FC<Props> = ({ currentGroup, onGroupSelection }) => {
+  const { t } = useTranslation(['notifiche']);
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+  const dispatch = useAppDispatch();
+  const groups = useAppSelector((state: RootState) => state.delegationsState.groups);
+
+  const handleMenuClick = (event: MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleMenuClose = () => {
+    setAnchorEl(null);
+  };
+
+  useEffect(() => {
+    void dispatch(getGroups());
+  }, []);
+
+  return (
+    <Box data-testid="groupSelector" display="inline-block" sx={{ verticalAlign: 'middle', mx: 2 }}>
+      <Box>
+        <Button
+          onClick={handleMenuClick}
+          size="small"
+          variant="contained"
+          data-testid="groupSelectorButton"
+          aria-label={t('table.group-selector-title')}
+          aria-controls={open ? 'group-selector' : undefined}
+          aria-haspopup="true"
+          aria-expanded={open ? 'true' : undefined}
+          endIcon={<ArrowDropDownIcon />}
+        >
+          {currentGroup && groups.find((group) => group.id === currentGroup)?.name}
+        </Button>
+      </Box>
+      <Menu
+        open={open}
+        anchorEl={anchorEl}
+        onClose={handleMenuClose}
+        onClick={handleMenuClose}
+        id="group-selector"
+      >
+        {groups.map((group) => (
+          <MenuItem key={group.id} onClick={() => onGroupSelection(group.id)}>
+            {group.name}
+          </MenuItem>
+        ))}
+      </Menu>
+    </Box>
+  );
+};
+
+export default GroupSelector;

--- a/packages/pn-personagiuridica-webapp/src/component/Notifications/__test__/GroupSelector.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Notifications/__test__/GroupSelector.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+import { fireEvent, mockApi, within, render, screen, waitFor } from '../../../__test__/test-utils';
+import { apiClient } from '../../../api/apiClients';
+import { GET_GROUPS } from '../../../api/external-registries/external-registries-routes';
+import GroupSelector from '../GroupSelector';
+
+jest.mock('react-i18next', () => ({
+  // this mock makes sure any components using the translate hook can use it without a warning being shown
+  useTranslation: () => ({
+    t: (str: string) => str,
+  }),
+}));
+
+const onGroupSelectionCbk = jest.fn();
+
+describe('GroupSelector component', () => {
+  it('checks that it opens and renders the children correctly', async () => {
+    const mock = mockApi(apiClient, 'GET', GET_GROUPS(), 200, undefined, [
+      { id: 'group-1', name: 'Group 1' },
+      { id: 'group-2', name: 'Group 2' },
+    ]);
+    const result = render(
+      <GroupSelector currentGroup="group-1" onGroupSelection={onGroupSelectionCbk} />
+    );
+    await waitFor(() => {
+      expect(mock.history.get).toHaveLength(1);
+    });
+    const menuButton = result.getByTestId('groupSelectorButton');
+    expect(menuButton).toHaveTextContent('Group 1');
+    fireEvent.click(menuButton);
+    const dropdown = await waitFor(() => screen.getByRole('presentation'));
+    expect(dropdown).toBeInTheDocument();
+    const menuItems = within(dropdown).getAllByRole('menuitem');
+    expect(menuItems).toHaveLength(2);
+    expect(menuItems[0]).toHaveTextContent('Group 1');
+    expect(menuItems[1]).toHaveTextContent('Group 2');
+    fireEvent.click(menuItems[1]);
+    expect(onGroupSelectionCbk).toBeCalledTimes(1);
+    expect(onGroupSelectionCbk).toBeCalledWith('group-2');
+    await waitFor(() => {
+      expect(dropdown).not.toBeInTheDocument();
+    });
+    mock.reset();
+    mock.restore();
+  });
+});

--- a/packages/pn-personagiuridica-webapp/src/pages/__test__/Notifiche.page.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/__test__/Notifiche.page.test.tsx
@@ -56,7 +56,9 @@ describe('Notifiche Page - with notifications', () => {
 
   it('renders notifiche page', () => {
     expect(screen.getAllByRole('heading')[0]).toHaveTextContent(/title/i);
-    expect(screen.getAllByRole('heading')[0]).not.toHaveTextContent(/title-delegated-notifications/i);
+    expect(screen.getAllByRole('heading')[0]).not.toHaveTextContent(
+      /title-delegated-notifications/i
+    );
     const filterForm = result?.container.querySelector('form');
     expect(filterForm).toBeInTheDocument();
     const notificationsTable = result?.container.querySelector('table');
@@ -75,6 +77,8 @@ describe('Notifiche Page - with notifications', () => {
       status: '',
       subjectRegExp: '',
       size: 10,
+      group: undefined,
+      nextPagesKey: undefined,
     });
   });
 
@@ -198,6 +202,8 @@ describe('Notifiche Delegate Page - with delegated notifications', () => {
       status: '',
       subjectRegExp: '',
       size: 10,
+      group: undefined,
+      nextPagesKey: undefined,
     });
   });
 });

--- a/packages/pn-personagiuridica-webapp/src/redux/dashboard/reducers.ts
+++ b/packages/pn-personagiuridica-webapp/src/redux/dashboard/reducers.ts
@@ -5,7 +5,7 @@ import {
   today,
   Notification,
   formatToTimezoneString,
-  Sort
+  Sort,
 } from '@pagopa-pn/pn-commons';
 import { NotificationColumn } from '../../models/Notifications';
 
@@ -35,7 +35,7 @@ const dashboardSlice = createSlice({
     } as Sort<NotificationColumn>,
   },
   reducers: {
-    setPagination: (state, action: PayloadAction<{page: number; size: number}>) => {
+    setPagination: (state, action: PayloadAction<{ page: number; size: number }>) => {
       if (state.pagination.size !== action.payload.size) {
         // reset pagination
         state.pagination.nextPagesKey = [];


### PR DESCRIPTION
## Short description
When we login with a PG user that is a group administrator, we can only see notifications for one group at a time. For this reason, a group switch has been added near the section title

## List of changes proposed in this pull request
- Added group selector
- Removed context menu from notification list, because we don't have the information about the group linked to the notification

## How to test
Dev -> log with Dante Alighieri - VitaNova -> I see all the delegated notifications without group switch
Dev -> log with Giuseppe Ungaretti - VitaNova -> I see group switch