### PR TITLE
prevent code modal closing on accidental click - pn-5891

### DIFF
--- a/packages/pn-commons/src/components/CodeModal/CodeModal.tsx
+++ b/packages/pn-commons/src/components/CodeModal/CodeModal.tsx
@@ -21,7 +21,6 @@ type Props = {
   subtitle: ReactNode;
   open: boolean;
   initialValues: Array<string>;
-  handleClose: () => void;
   codeSectionTitle: string;
   codeSectionAdditional?: ReactNode;
   confirmLabel?: string;
@@ -40,7 +39,6 @@ type Props = {
  * @param subtitle subtitle to show
  * @param open flag to hide/show modal
  * @param initialValues initial code
- * @param handleClose function that is called when modal is closed
  * @param codeSectionTitle title of the section where is the code
  * @param codeSectionAdditional additional elments under the code
  * @param confirmLabel label of the confirm button
@@ -56,7 +54,6 @@ const CodeModal = memo(
     subtitle,
     open,
     initialValues,
-    handleClose,
     codeSectionTitle,
     codeSectionAdditional,
     confirmLabel,
@@ -87,10 +84,11 @@ const CodeModal = memo(
     return (
       <Dialog
         open={open}
-        onClose={handleClose}
+        // onClose={handleClose}
         aria-labelledby="dialog-title"
         aria-describedby="dialog-description"
         data-testid="codeDialog"
+        disableEscapeKeyDown
       >
         <DialogTitle id="dialog-title" sx={{ textAlign: textPosition }}>
           {title}

--- a/packages/pn-commons/src/components/CodeModal/__test__/CodeModal.test.tsx
+++ b/packages/pn-commons/src/components/CodeModal/__test__/CodeModal.test.tsx
@@ -1,9 +1,9 @@
+import React from 'react';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 
 import { render } from '../../../test-utils';
 import CodeModal from '../CodeModal';
 
-const handleCloseMock = jest.fn();
 const cancelButtonMock = jest.fn();
 const confirmButtonMock = jest.fn();
 
@@ -14,13 +14,12 @@ const openedModalComponent = (open: boolean, hasError: boolean = false) => (
     open={open}
     initialValues={new Array(5).fill('')}
     codeSectionTitle="mocked-section-title"
-    handleClose={handleCloseMock}
     cancelLabel="mocked-cancel"
     cancelCallback={cancelButtonMock}
     confirmLabel="mocked-confirm"
     confirmCallback={confirmButtonMock}
     hasError={hasError}
-    errorMessage='mocked-errorMessage'
+    errorMessage="mocked-errorMessage"
   />
 );
 

--- a/packages/pn-personafisica-webapp/src/component/Contacts/DigitalContactsCodeVerification.context.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Contacts/DigitalContactsCodeVerification.context.tsx
@@ -293,7 +293,6 @@ const DigitalContactsCodeVerificationProvider: FC<ReactNode> = ({ children }) =>
           }
           open={open}
           initialValues={new Array(5).fill('')}
-          handleClose={() => handleClose()}
           codeSectionTitle={t(`${modalProps.labelRoot}.insert-code`, { ns: 'recapiti' })}
           codeSectionAdditional={
             <Box>

--- a/packages/pn-personafisica-webapp/src/component/Deleghe/Delegates.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Deleghe/Delegates.tsx
@@ -3,7 +3,15 @@ import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Box, Button, Chip, Stack, Typography } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
-import { Column, ItemsTable as Table, Item, CodeModal, Sort, EmptyState, ApiErrorWrapper } from '@pagopa-pn/pn-commons';
+import {
+  Column,
+  ItemsTable as Table,
+  Item,
+  CodeModal,
+  Sort,
+  EmptyState,
+  ApiErrorWrapper,
+} from '@pagopa-pn/pn-commons';
 
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import { RootState } from '../../redux/store';
@@ -12,8 +20,8 @@ import delegationToItem from '../../utils/delegation.utility';
 import { DelegationStatus, getDelegationStatusLabelAndColor } from '../../utils/status.utility';
 import { DELEGATION_ACTIONS, getDelegates } from '../../redux/delegation/actions';
 import { setDelegatesSorting } from '../../redux/delegation/reducers';
-import { trackEventByType } from "../../utils/mixpanel";
-import { TrackEventType } from "../../utils/events";
+import { trackEventByType } from '../../utils/mixpanel';
+import { TrackEventType } from '../../utils/events';
 import { DelegatesColumn } from '../../models/Deleghe';
 
 import { Menu, OrganizationsList } from './DelegationsElements';
@@ -95,7 +103,7 @@ const Delegates = () => {
 
   const handleAddDelegationClick = (source: string) => {
     navigate(routes.NUOVA_DELEGA);
-    trackEventByType(TrackEventType.DELEGATION_DELEGATE_ADD_CTA, {source});
+    trackEventByType(TrackEventType.DELEGATION_DELEGATE_ADD_CTA, { source });
   };
 
   const handleCloseShowCodeModal = () => {
@@ -113,7 +121,6 @@ const Delegates = () => {
         subtitle={t('deleghe.show_code_subtitle')}
         open={showCodeModal.open}
         initialValues={showCodeModal.code.split('')}
-        handleClose={handleCloseShowCodeModal}
         cancelCallback={handleCloseShowCodeModal}
         cancelLabel={t('deleghe.close')}
         codeSectionTitle={t('deleghe.verification_code')}

--- a/packages/pn-personafisica-webapp/src/component/Deleghe/MobileDelegates.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Deleghe/MobileDelegates.tsx
@@ -3,15 +3,22 @@ import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Box, Button, Chip, Typography } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
-import { CardElement, ItemsCard, Item, CodeModal, EmptyState, ApiErrorWrapper } from '@pagopa-pn/pn-commons';
+import {
+  CardElement,
+  ItemsCard,
+  Item,
+  CodeModal,
+  EmptyState,
+  ApiErrorWrapper,
+} from '@pagopa-pn/pn-commons';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import { RootState } from '../../redux/store';
 import * as routes from '../../navigation/routes.const';
 import delegationToItem from '../../utils/delegation.utility';
 import { DelegationStatus, getDelegationStatusLabelAndColor } from '../../utils/status.utility';
 import { DELEGATION_ACTIONS, getDelegates } from '../../redux/delegation/actions';
-import { trackEventByType } from "../../utils/mixpanel";
-import { TrackEventType } from "../../utils/events";
+import { trackEventByType } from '../../utils/mixpanel';
+import { TrackEventType } from '../../utils/events';
 import { Menu, OrganizationsList } from './DelegationsElements';
 
 const MobileDelegates = () => {
@@ -34,8 +41,8 @@ const MobileDelegates = () => {
         return <Chip label={label} color={color} />;
       },
       gridProps: {
-        xs: 8
-      }
+        xs: 8,
+      },
     },
     {
       id: 'id',
@@ -52,8 +59,8 @@ const MobileDelegates = () => {
         );
       },
       gridProps: {
-        xs: 4
-      }
+        xs: 4,
+      },
     },
   ];
 
@@ -91,7 +98,7 @@ const MobileDelegates = () => {
 
   const handleAddDelegationClick = (source: string) => {
     navigate(routes.NUOVA_DELEGA);
-    trackEventByType(TrackEventType.DELEGATION_DELEGATE_ADD_CTA, {source});
+    trackEventByType(TrackEventType.DELEGATION_DELEGATE_ADD_CTA, { source });
   };
 
   const handleCloseShowCodeModal = () => {
@@ -105,7 +112,6 @@ const MobileDelegates = () => {
         subtitle={t('deleghe.show_code_subtitle')}
         open={showCodeModal.open}
         initialValues={showCodeModal.code.split('')}
-        handleClose={handleCloseShowCodeModal}
         cancelCallback={handleCloseShowCodeModal}
         cancelLabel={t('deleghe.close')}
         codeSectionTitle={t('deleghe.verification_code')}
@@ -116,17 +122,24 @@ const MobileDelegates = () => {
           {t('deleghe.delegatesTitle')}
         </Typography>
         <Box mb={2}>
-          <Button variant="outlined" onClick={(_e, source='default') => handleAddDelegationClick(source)} sx={{mb: 1}}>
+          <Button
+            variant="outlined"
+            onClick={(_e, source = 'default') => handleAddDelegationClick(source)}
+            sx={{ mb: 1 }}
+          >
             <AddIcon fontSize={'small'} sx={{ marginRight: 1 }} />
             {t('deleghe.add')}
           </Button>
         </Box>
-        <ApiErrorWrapper apiId={DELEGATION_ACTIONS.GET_DELEGATES} reloadAction={() => dispatch(getDelegates())}>
+        <ApiErrorWrapper
+          apiId={DELEGATION_ACTIONS.GET_DELEGATES}
+          reloadAction={() => dispatch(getDelegates())}
+        >
           {cardData.length ? (
             <ItemsCard cardHeader={cardHeader} cardBody={cardBody} cardData={cardData} />
           ) : (
             <EmptyState
-              emptyActionCallback={(_e, source='empty_state') => handleAddDelegationClick(source)}
+              emptyActionCallback={(_e, source = 'empty_state') => handleAddDelegationClick(source)}
               emptyMessage={t('deleghe.no_delegates')}
               emptyActionLabel={t('deleghe.add')}
             />

--- a/packages/pn-personafisica-webapp/src/pages/Deleghe.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/Deleghe.page.tsx
@@ -103,7 +103,6 @@ const Deleghe = () => {
           subtitle={t('deleghe.accept_description', { name: acceptName })}
           open={acceptOpen}
           initialValues={new Array(5).fill('')}
-          handleClose={handleCloseAcceptModal}
           cancelCallback={handleCloseAcceptModal}
           cancelLabel={t('button.indietro', { ns: 'common' })}
           confirmCallback={handleAccept}

--- a/packages/pn-personagiuridica-webapp/src/component/Contacts/DigitalContactsCodeVerification.context.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Contacts/DigitalContactsCodeVerification.context.tsx
@@ -293,7 +293,6 @@ const DigitalContactsCodeVerificationProvider: FC<ReactNode> = ({ children }) =>
           }
           open={open}
           initialValues={new Array(5).fill('')}
-          handleClose={() => handleClose()}
           codeSectionTitle={t(`${modalProps.labelRoot}.insert-code`, { ns: 'recapiti' })}
           codeSectionAdditional={
             <Box>

--- a/packages/pn-personagiuridica-webapp/src/component/Deleghe/AcceptDelegationModal.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Deleghe/AcceptDelegationModal.tsx
@@ -99,7 +99,6 @@ const AcceptDelegationModal: React.FC<Props> = ({
         subtitle={t('deleghe.accept_description', { name })}
         open={open}
         initialValues={code.length ? code : new Array(5).fill('')}
-        handleClose={handleClose}
         cancelCallback={handleClose}
         cancelLabel={t('button.annulla', { ns: 'common' })}
         confirmCallback={handleFirstStepConfirm}

--- a/packages/pn-personagiuridica-webapp/src/component/Deleghe/DelegationsElements.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Deleghe/DelegationsElements.tsx
@@ -240,7 +240,6 @@ export const Menu: React.FC<Props> = ({ menuType, id, userLogged, row, onAction 
           subtitle={t('deleghe.show_code_subtitle')}
           open={showCodeModal}
           initialValues={(row?.verificationCode as string).split('')}
-          handleClose={handleCloseShowCodeModal}
           cancelCallback={handleCloseShowCodeModal}
           cancelLabel={t('deleghe.close')}
           codeSectionTitle={t('deleghe.verification_code')}


### PR DESCRIPTION
## Short description
Code modal can't bee closed by clicking on backdrop or pressing esc key

## List of changes proposed in this pull request
- Updated CodeModal component

## How to test
- Login with PG or PF -> go to contacts -> add new contact -> check that code modal can't be closed by clicking on backdrop or pressing esc key
- Do the same test for the "Visualizza codice" and "Accetta" for the mandates