### PR TITLE
manage error with response null - pn-5888

### DIFF
--- a/packages/pn-commons/src/utils/redux.utility.ts
+++ b/packages/pn-commons/src/utils/redux.utility.ts
@@ -17,7 +17,9 @@ function parseError(e: any) {
       },
     };
   }
-  return e;
+  // if the error doesn't have the response object, the user interface doesn't react to the failing api
+  // so we set a generic error without data
+  return { response: { status: 500 } };
 }
 
 /**

--- a/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
@@ -27,6 +27,11 @@
     "desc": "decrescente",
     "options": "Opzioni sort"
   },
+  "empty-state": {
+    "message": "Non hai ricevuto nessuna notifica. Vai alla sezione",
+    "secondary-message": "e inserisci uno più recapiti di cortesia: così, se riceverai una notifica, te lo comunicheremo.",
+    "secondary-action": "I tuoi Recapiti"
+  },
   "from-qrcode": {
     "not-found": "Link alla notifica non trovato"
   },
@@ -221,7 +226,8 @@
         "pec-receipt-not-delivered": "di mancata consegna PEC",
         "paper-receipt-delivered": "di consegna raccomandata",
         "paper-receipt-not-delivered": "di mancata consegna raccomandata",
-        "analog-failure-delivery": "Deposito di avvenuta ricezione"      },
+        "analog-failure-delivery": "Deposito di avvenuta ricezione"
+      },
       "registered-letter-kind": {
         "AR": "A/R",
         "890": "890",

--- a/packages/pn-personafisica-webapp/src/component/Notifications/DesktopNotifications.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Notifications/DesktopNotifications.tsx
@@ -113,9 +113,17 @@ const DesktopNotifications = ({
       sortable: false, // TODO: will be re-enabled in PN-1124
       getCellLabel(_: string, row: Item) {
         const { label, tooltip, color } = getNotificationStatusInfos(
-          row.notificationStatus as NotificationStatus, {recipients: row.recipients as Array<string>}
+          row.notificationStatus as NotificationStatus,
+          { recipients: row.recipients as Array<string> }
         );
-        return <StatusTooltip label={label} tooltip={tooltip} color={color} eventTrackingCallback={handleEventTrackingTooltip}></StatusTooltip>;
+        return (
+          <StatusTooltip
+            label={label}
+            tooltip={tooltip}
+            color={color}
+            eventTrackingCallback={handleEventTrackingTooltip}
+          ></StatusTooltip>
+        );
       },
       onClick(row: Item) {
         handleRowClick(row);
@@ -134,18 +142,16 @@ const DesktopNotifications = ({
   const filtersApplied: boolean = filterNotificationsRef.current.filtersApplied;
 
   const EmptyStateProps = {
-    emptyActionLabel: filtersApplied ? undefined : 'I tuoi Recapiti',
+    emptyActionLabel: filtersApplied ? undefined : t('empty-state.secondary-action'),
     emptyActionCallback: filtersApplied
       ? filterNotificationsRef.current.cleanFilters
       : handleRouteContacts,
-    emptyMessage: filtersApplied
-      ? undefined
-      : 'Non hai ricevuto nessuna notifica. Vai alla sezione',
+    emptyMessage: filtersApplied ? undefined : t('empty-state.message'),
     sentimentIcon: filtersApplied ? KnownSentiment.DISSATISFIED : KnownSentiment.NONE,
     secondaryMessage: filtersApplied
       ? undefined
       : {
-          emptyMessage: 'e inserisci uno più recapiti di cortesia: così, se riceverai una notifica, te lo comunicheremo.',
+          emptyMessage: t('empty-state.secondary-message'),
         },
   };
 
@@ -154,7 +160,9 @@ const DesktopNotifications = ({
   // Navigation handlers
   const handleRowClick = (row: Item) => {
     if (currentDelegator) {
-      navigate(routes.GET_DETTAGLIO_NOTIFICA_DELEGATO_PATH(row.iun as string, currentDelegator.mandateId));
+      navigate(
+        routes.GET_DETTAGLIO_NOTIFICA_DELEGATO_PATH(row.iun as string, currentDelegator.mandateId)
+      );
     } else {
       navigate(routes.GET_DETTAGLIO_NOTIFICA_PATH(row.iun as string));
     }

--- a/packages/pn-personafisica-webapp/src/component/Notifications/MobileNotifications.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Notifications/MobileNotifications.tsx
@@ -34,7 +34,7 @@ type Props = {
   /** Card sort */
   sort?: Sort<NotificationColumn>;
   /** The function to be invoked if the user change sorting */
-  onChangeSorting?: (s: Sort<NotificationColumn>  ) => void;
+  onChangeSorting?: (s: Sort<NotificationColumn>) => void;
   /** Delegator */
   currentDelegator?: Delegator;
 };
@@ -45,7 +45,7 @@ type Props = {
  * the MobileNotificationsSort component to be displayed, as commenting
  * out the relative code would have caused many "variable/prop declared
  * but never used" warnings to arise.
- * 
+ *
  * To enable the sort functionality again remove the line below and any
  * reference to IS_SORT_ENABLED
  */
@@ -90,9 +90,17 @@ const MobileNotifications = ({ notifications, sort, onChangeSorting, currentDele
       label: t('table.status'),
       getLabel(_, row: Item) {
         const { label, tooltip, color } = getNotificationStatusInfos(
-          row.notificationStatus as NotificationStatus, {recipients: row.recipients as Array<string>}
+          row.notificationStatus as NotificationStatus,
+          { recipients: row.recipients as Array<string> }
         );
-        return <StatusTooltip label={label} tooltip={tooltip} color={color} eventTrackingCallback={handleEventTrackingTooltip}></StatusTooltip>;
+        return (
+          <StatusTooltip
+            label={label}
+            tooltip={tooltip}
+            color={color}
+            eventTrackingCallback={handleEventTrackingTooltip}
+          ></StatusTooltip>
+        );
       },
       gridProps: {
         xs: 12,
@@ -160,25 +168,25 @@ const MobileNotifications = ({ notifications, sort, onChangeSorting, currentDele
   const filtersApplied: boolean = filterNotificationsRef.current.filtersApplied;
 
   const EmptyStateProps = {
-    emptyActionLabel: filtersApplied ? undefined : 'I tuoi Recapiti',
+    emptyActionLabel: filtersApplied ? undefined : t('empty-state.secondary-action'),
     emptyActionCallback: filtersApplied
       ? filterNotificationsRef.current.cleanFilters
       : handleRouteContacts,
-    emptyMessage: filtersApplied
-      ? undefined
-      : 'Non hai ricevuto nessuna notifica. Vai alla sezione',
+    emptyMessage: filtersApplied ? undefined : t('empty-state.message'),
     sentimentIcon: filtersApplied ? KnownSentiment.DISSATISFIED : KnownSentiment.NONE,
     secondaryMessage: filtersApplied
       ? undefined
       : {
-          emptyMessage: 'e inserisci uno più recapiti di cortesia: così, se riceverai una notifica, te lo comunicheremo.',
+          emptyMessage: t('empty-state.secondary-message'),
         },
   };
 
   // Navigation handlers
   const handleRowClick = (row: Item) => {
     if (currentDelegator) {
-      navigate(routes.GET_DETTAGLIO_NOTIFICA_DELEGATO_PATH(row.iun as string, currentDelegator.mandateId));
+      navigate(
+        routes.GET_DETTAGLIO_NOTIFICA_DELEGATO_PATH(row.iun as string, currentDelegator.mandateId)
+      );
     } else {
       navigate(routes.GET_DETTAGLIO_NOTIFICA_PATH(row.iun as string));
     }
@@ -212,9 +220,9 @@ const MobileNotifications = ({ notifications, sort, onChangeSorting, currentDele
         </Grid>
         <Grid item xs={6} textAlign="right">
           {/**
-            * Refers to PN-1741 
-            * See the comment above, where IS_SORT_ENABLE is declared!
-            * */}
+           * Refers to PN-1741
+           * See the comment above, where IS_SORT_ENABLE is declared!
+           * */}
           {IS_SORT_ENABLED && sort && showFilters && onChangeSorting && (
             <MobileNotificationsSort
               title={t('sort.title')}

--- a/packages/pn-personafisica-webapp/src/component/Notifications/__test__/DesktopNotifications.test.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Notifications/__test__/DesktopNotifications.test.tsx
@@ -1,7 +1,7 @@
-import { fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
 
+import { render, fireEvent, waitFor } from '../../../__test__/test-utils';
 import { notificationsToFe } from '../../../redux/dashboard/__test__/test-utils';
-import { render } from '../../../__test__/test-utils';
 import * as routes from '../../../navigation/routes.const';
 import DesktopNotifications from '../DesktopNotifications';
 
@@ -24,7 +24,7 @@ jest.mock('../FilterNotifications', () => {
   const { forwardRef, useImperativeHandle } = jest.requireActual('react');
   return forwardRef(({ showFilters }: { showFilters: boolean }, ref: any) => {
     useImperativeHandle(ref, () => ({
-      filtersApplied: false
+      filtersApplied: false,
     }));
     if (!showFilters) {
       return <></>;
@@ -37,14 +37,11 @@ describe('DesktopNotifications Component', () => {
   it('renders DesktopNotifications', () => {
     // render component
     const result = render(
-      <DesktopNotifications
-        notifications={[]}
-        sort={{ orderBy: '', order: 'asc' }}
-      />
+      <DesktopNotifications notifications={[]} sort={{ orderBy: '', order: 'asc' }} />
     );
     expect(result.container).not.toHaveTextContent(/Filters/i);
     expect(result.container).toHaveTextContent(
-      /Non hai ricevuto nessuna notifica. Vai alla sezione I tuoi recapiti e inserisci uno più recapiti di cortesia: così, se riceverai una notifica, te lo comunicheremo./i
+      /empty-state.message empty-state.secondary-action empty-state.secondary-message/i
     );
   });
 

--- a/packages/pn-personafisica-webapp/src/component/Notifications/__test__/MobileNotifications.test.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Notifications/__test__/MobileNotifications.test.tsx
@@ -1,7 +1,7 @@
-import { fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
 
+import { render, fireEvent, waitFor } from '../../../__test__/test-utils';
 import { notificationsToFe } from '../../../redux/dashboard/__test__/test-utils';
-import { render } from '../../../__test__/test-utils';
 import * as routes from '../../../navigation/routes.const';
 import MobileNotifications from '../MobileNotifications';
 
@@ -18,24 +18,22 @@ jest.mock('@pagopa-pn/pn-commons', () => {
   return {
     ...original,
     NotificationsCard: () => <div>Cards</div>,
-    MobileNotificationsSort: () => <div>Sort</div>
+    MobileNotificationsSort: () => <div>Sort</div>,
   };
 });
 
 jest.mock('react-i18next', () => ({
   // this mock makes sure any components using the translate hook can use it without a warning being shown
-  useTranslation: () => (
-    {
-      t: (str: string) => str,
-    }
-  ),
+  useTranslation: () => ({
+    t: (str: string) => str,
+  }),
 }));
 
 jest.mock('../FilterNotifications', () => {
   const { forwardRef, useImperativeHandle } = jest.requireActual('react');
   return forwardRef(({ showFilters }: { showFilters: boolean }, ref: any) => {
     useImperativeHandle(ref, () => ({
-      filtersApplied: false
+      filtersApplied: false,
     }));
     if (!showFilters) {
       return <></>;
@@ -45,7 +43,6 @@ jest.mock('../FilterNotifications', () => {
 });
 
 describe('MobileNotifications Component', () => {
-
   it('renders MobileNotifications', () => {
     // render component
     const result = render(
@@ -58,7 +55,7 @@ describe('MobileNotifications Component', () => {
     expect(result.container).not.toHaveTextContent(/Filters/i);
     expect(result.container).not.toHaveTextContent(/Sort/i);
     expect(result.container).toHaveTextContent(
-      /Non hai ricevuto nessuna notifica. Vai alla sezione I tuoi recapiti e inserisci uno più recapiti di cortesia: così, se riceverai una notifica, te lo comunicheremo./i
+      /empty-state.message empty-state.secondary-action empty-state.secondary-message/i
     );
   });
 

--- a/packages/pn-personafisica-webapp/src/redux/delegation/__test__/reducers.test.ts
+++ b/packages/pn-personafisica-webapp/src/redux/delegation/__test__/reducers.test.ts
@@ -63,7 +63,7 @@ describe('delegation redux state tests', () => {
     const payload = action.payload;
 
     expect(action.type).toBe('acceptDelegation/rejected');
-    expect(payload).toEqual('error');
+    expect(payload).toStrictEqual({ response: { status: 500 } });
     const acceptModalState = store.getState().delegationsState.acceptModalState;
     expect(acceptModalState.error).toEqual(true);
   });
@@ -85,7 +85,7 @@ describe('delegation redux state tests', () => {
     const payload = action.payload;
 
     expect(action.type).toBe('rejectDelegation/rejected');
-    expect(payload).toEqual('error');
+    expect(payload).toStrictEqual({ response: { status: 500 } });
   });
 
   it('should revoke a delegation for a delegate', async () => {
@@ -105,7 +105,7 @@ describe('delegation redux state tests', () => {
     const payload = action.payload;
 
     expect(action.type).toBe('revokeDelegation/rejected');
-    expect(payload).toEqual('error');
+    expect(payload).toStrictEqual({ response: { status: 500 } });
   });
 
   it('sets the confirmation modal state to open and then to close', async () => {

--- a/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
@@ -33,6 +33,11 @@
     "desc": "decrescente",
     "options": "Opzioni sort"
   },
+  "empty-state": {
+    "message": "Non hai ricevuto nessuna notifica. Vai alla sezione",
+    "secondary-message": "e inserisci uno più recapiti di cortesia: così, se riceverai una notifica, te lo comunicheremo.",
+    "secondary-action": "I tuoi Recapiti"
+  },
   "from-qrcode": {
     "not-found": "Link alla notifica non trovato"
   },

--- a/packages/pn-personagiuridica-webapp/src/component/Notifications/DesktopNotifications.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Notifications/DesktopNotifications.tsx
@@ -159,19 +159,16 @@ const DesktopNotifications = ({
   const filtersApplied: boolean = filterNotificationsRef.current.filtersApplied;
 
   const EmptyStateProps = {
-    emptyActionLabel: filtersApplied ? undefined : 'I tuoi Recapiti',
+    emptyActionLabel: filtersApplied ? undefined : t('empty-state.secondary-action'),
     emptyActionCallback: filtersApplied
       ? filterNotificationsRef.current.cleanFilters
       : handleRouteContacts,
-    emptyMessage: filtersApplied
-      ? undefined
-      : 'Non hai ricevuto nessuna notifica. Vai alla sezione',
+    emptyMessage: filtersApplied ? undefined : t('empty-state.message'),
     sentimentIcon: filtersApplied ? KnownSentiment.DISSATISFIED : KnownSentiment.NONE,
     secondaryMessage: filtersApplied
       ? undefined
       : {
-          emptyMessage:
-            'e inserisci uno più recapiti di cortesia: così, se riceverai una notifica, te lo comunicheremo.',
+          emptyMessage: t('empty-state.secondary-message'),
         },
   };
 

--- a/packages/pn-personagiuridica-webapp/src/component/Notifications/MobileNotifications.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Notifications/MobileNotifications.tsx
@@ -18,7 +18,7 @@ import {
   MobileNotificationsSort,
   KnownSentiment,
 } from '@pagopa-pn/pn-commons';
-import {ButtonNaked, Tag} from '@pagopa/mui-italia';
+import { ButtonNaked, Tag } from '@pagopa/mui-italia';
 
 import * as routes from '../../navigation/routes.const';
 import { getNewNotificationBadge } from '../NewNotificationBadge/NewNotificationBadge';
@@ -50,12 +50,17 @@ type Props = {
  */
 const IS_SORT_ENABLED = false;
 
-const MobileNotifications = ({ notifications, sort, onChangeSorting, isDelegatedPage = false }: Props) => {
+const MobileNotifications = ({
+  notifications,
+  sort,
+  onChangeSorting,
+  isDelegatedPage = false,
+}: Props) => {
   const navigate = useNavigate();
   const { t } = useTranslation('notifiche');
   const filterNotificationsRef = useRef({
     filtersApplied: false,
-    cleanFilters: () => void 0
+    cleanFilters: () => void 0,
   });
 
   const handleEventTrackingTooltip = () => {
@@ -137,12 +142,12 @@ const MobileNotifications = ({ notifications, sort, onChangeSorting, isDelegated
 
   if (isDelegatedPage) {
     const recipientField = {
-        id: 'group',
-        label: t('table.gruppi'),
-        getLabel(value: string) {
-          return <Tag value={value} data-testid={`groupChip-${value}`} />;
-        },
-      };
+      id: 'group',
+      label: t('table.gruppi'),
+      getLabel(value: string) {
+        return <Tag value={value} data-testid={`groupChip-${value}`} />;
+      },
+    };
 
     // eslint-disable-next-line functional/immutable-data
     cardBody.splice(3, 0, recipientField);
@@ -183,19 +188,16 @@ const MobileNotifications = ({ notifications, sort, onChangeSorting, isDelegated
   const filtersApplied: boolean = filterNotificationsRef.current.filtersApplied;
 
   const EmptyStateProps = {
-    emptyActionLabel: filtersApplied ? undefined : 'I tuoi Recapiti',
+    emptyActionLabel: filtersApplied ? undefined : t('empty-state.secondary-action'),
     emptyActionCallback: filtersApplied
       ? filterNotificationsRef.current.cleanFilters
       : handleRouteContacts,
-    emptyMessage: filtersApplied
-      ? undefined
-      : 'Non hai ricevuto nessuna notifica. Vai alla sezione',
+    emptyMessage: filtersApplied ? undefined : t('empty-state.message'),
     sentimentIcon: filtersApplied ? KnownSentiment.DISSATISFIED : KnownSentiment.NONE,
     secondaryMessage: filtersApplied
       ? undefined
       : {
-          emptyMessage:
-            'e inserisci uno più recapiti di cortesia: così, se riceverai una notifica, te lo comunicheremo.',
+          emptyMessage: t('empty-state.secondary-message'),
         },
   };
 
@@ -230,10 +232,7 @@ const MobileNotifications = ({ notifications, sort, onChangeSorting, isDelegated
     <Fragment>
       <Grid container direction="row" sx={{ marginBottom: '16px' }}>
         <Grid item xs={6}>
-          <FilterNotifications
-            ref={filterNotificationsRef}
-            showFilters={showFilters}
-          />
+          <FilterNotifications ref={filterNotificationsRef} showFilters={showFilters} />
         </Grid>
         <Grid item xs={6} textAlign="right">
           {/**

--- a/packages/pn-personagiuridica-webapp/src/component/Notifications/__test__/DesktopNotifications.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Notifications/__test__/DesktopNotifications.test.tsx
@@ -1,7 +1,7 @@
-import { fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
 
+import { render, fireEvent, waitFor } from '../../../__test__/test-utils';
 import { notificationsToFe } from '../../../redux/dashboard/__test__/test-utils';
-import { render } from '../../../__test__/test-utils';
 import * as routes from '../../../navigation/routes.const';
 import DesktopNotifications from '../DesktopNotifications';
 
@@ -24,7 +24,7 @@ jest.mock('../FilterNotifications', () => {
   const { forwardRef, useImperativeHandle } = jest.requireActual('react');
   return forwardRef(({ showFilters }: { showFilters: boolean }, ref: any) => {
     useImperativeHandle(ref, () => ({
-      filtersApplied: false
+      filtersApplied: false,
     }));
     if (!showFilters) {
       return <></>;
@@ -37,14 +37,11 @@ describe('DesktopNotifications Component', () => {
   it('renders DesktopNotifications', () => {
     // render component
     const result = render(
-      <DesktopNotifications
-        notifications={[]}
-        sort={{ orderBy: '', order: 'asc' }}
-      />
+      <DesktopNotifications notifications={[]} sort={{ orderBy: '', order: 'asc' }} />
     );
     expect(result.container).not.toHaveTextContent(/Filters/i);
     expect(result.container).toHaveTextContent(
-      /Non hai ricevuto nessuna notifica. Vai alla sezione I tuoi recapiti e inserisci uno più recapiti di cortesia: così, se riceverai una notifica, te lo comunicheremo./i
+      /empty-state.message empty-state.secondary-action empty-state.secondary-message/i
     );
   });
 

--- a/packages/pn-personagiuridica-webapp/src/component/Notifications/__test__/MobileNotifications.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Notifications/__test__/MobileNotifications.test.tsx
@@ -1,7 +1,7 @@
-import { fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
 
+import { render, fireEvent, waitFor } from '../../../__test__/test-utils';
 import { notificationsToFe } from '../../../redux/dashboard/__test__/test-utils';
-import { render } from '../../../__test__/test-utils';
 import * as routes from '../../../navigation/routes.const';
 import MobileNotifications from '../MobileNotifications';
 
@@ -18,24 +18,22 @@ jest.mock('@pagopa-pn/pn-commons', () => {
   return {
     ...original,
     NotificationsCard: () => <div>Cards</div>,
-    MobileNotificationsSort: () => <div>Sort</div>
+    MobileNotificationsSort: () => <div>Sort</div>,
   };
 });
 
 jest.mock('react-i18next', () => ({
   // this mock makes sure any components using the translate hook can use it without a warning being shown
-  useTranslation: () => (
-    {
-      t: (str: string) => str,
-    }
-  ),
+  useTranslation: () => ({
+    t: (str: string) => str,
+  }),
 }));
 
 jest.mock('../FilterNotifications', () => {
   const { forwardRef, useImperativeHandle } = jest.requireActual('react');
   return forwardRef(({ showFilters }: { showFilters: boolean }, ref: any) => {
     useImperativeHandle(ref, () => ({
-      filtersApplied: false
+      filtersApplied: false,
     }));
     if (!showFilters) {
       return <></>;
@@ -45,7 +43,6 @@ jest.mock('../FilterNotifications', () => {
 });
 
 describe('MobileNotifications Component', () => {
-
   it('renders MobileNotifications', () => {
     // render component
     const result = render(
@@ -58,7 +55,7 @@ describe('MobileNotifications Component', () => {
     expect(result.container).not.toHaveTextContent(/Filters/i);
     expect(result.container).not.toHaveTextContent(/Sort/i);
     expect(result.container).toHaveTextContent(
-      /Non hai ricevuto nessuna notifica. Vai alla sezione I tuoi recapiti e inserisci uno più recapiti di cortesia: così, se riceverai una notifica, te lo comunicheremo./i
+      /empty-state.message empty-state.secondary-action empty-state.secondary-message/i
     );
   });
 


### PR DESCRIPTION
## Short description
Errors that has response null weren't managed and so the interface didn't react as expected. Now these errors are managed as generic (500) errors.

## List of changes proposed in this pull request
- updated redux.utility.ts
- localized empty states in PF and PG

## How to test
- log with PG, PF or PA -> go to notification list -> change the path of the notification list api -> check that toast and empty state are shown