### PR TITLE
fix: add localization for notification empty state in pf and pg

### DIFF
--- a/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
@@ -8,6 +8,11 @@
     "status": "Stato",
     "show-detail": "Vedi dettaglio"
   },
+  "empty-state": {
+    "first-message": "Non hai ricevuto nessuna notifica. Vai alla sezione",
+    "action": "I tuoi recapiti",
+    "second-message": "e inserisci uno più recapiti di cortesia: così, se riceverai una notifica, te lo comunicheremo."
+  },
   "filters": {
     "iun": "Inserisci il Codice IUN",
     "data_da": "Da",

--- a/packages/pn-personafisica-webapp/src/component/Notifications/DesktopNotifications.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Notifications/DesktopNotifications.tsx
@@ -134,19 +134,19 @@ const DesktopNotifications = ({
   const filtersApplied: boolean = filterNotificationsRef.current.filtersApplied;
 
   const EmptyStateProps = {
-    emptyActionLabel: filtersApplied ? undefined : 'I tuoi Recapiti',
+    emptyActionLabel: filtersApplied ? undefined : t('empty-state.action'),
     emptyActionCallback: filtersApplied
       ? filterNotificationsRef.current.cleanFilters
       : handleRouteContacts,
     emptyMessage: filtersApplied
       ? undefined
-      : 'Non hai ricevuto nessuna notifica. Vai alla sezione',
+      : t('empty-state.first-message'),
     sentimentIcon: filtersApplied ? KnownSentiment.DISSATISFIED : KnownSentiment.NONE,
     secondaryMessage: filtersApplied
       ? undefined
       : {
-          emptyMessage: 'e inserisci uno più recapiti di cortesia: così, se riceverai una notifica, te lo comunicheremo.',
-        },
+        emptyMessage: t('empty-state.second-message'),
+      },
   };
 
   const showFilters = notifications?.length > 0 || filtersApplied;

--- a/packages/pn-personafisica-webapp/src/component/Notifications/MobileNotifications.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Notifications/MobileNotifications.tsx
@@ -160,19 +160,19 @@ const MobileNotifications = ({ notifications, sort, onChangeSorting, currentDele
   const filtersApplied: boolean = filterNotificationsRef.current.filtersApplied;
 
   const EmptyStateProps = {
-    emptyActionLabel: filtersApplied ? undefined : 'I tuoi Recapiti',
+    emptyActionLabel: filtersApplied ? undefined : t('empty-state.action'),
     emptyActionCallback: filtersApplied
       ? filterNotificationsRef.current.cleanFilters
       : handleRouteContacts,
     emptyMessage: filtersApplied
       ? undefined
-      : 'Non hai ricevuto nessuna notifica. Vai alla sezione',
+      : t('empty-state.first-message'),
     sentimentIcon: filtersApplied ? KnownSentiment.DISSATISFIED : KnownSentiment.NONE,
     secondaryMessage: filtersApplied
       ? undefined
       : {
-          emptyMessage: 'e inserisci uno più recapiti di cortesia: così, se riceverai una notifica, te lo comunicheremo.',
-        },
+        emptyMessage: t('empty-state.second-message'),
+      },
   };
 
   // Navigation handlers

--- a/packages/pn-personafisica-webapp/src/component/Notifications/__test__/MobileNotifications.test.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Notifications/__test__/MobileNotifications.test.tsx
@@ -58,7 +58,7 @@ describe('MobileNotifications Component', () => {
     expect(result.container).not.toHaveTextContent(/Filters/i);
     expect(result.container).not.toHaveTextContent(/Sort/i);
     expect(result.container).toHaveTextContent(
-      /Non hai ricevuto nessuna notifica. Vai alla sezione I tuoi recapiti e inserisci uno più recapiti di cortesia: così, se riceverai una notifica, te lo comunicheremo./i
+      /empty-state.first-message empty-state.action empty-state.second-message/i
     );
   });
 

--- a/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
@@ -14,6 +14,11 @@
     "show-detail": "Vedi dettaglio",
     "group-selector-title": "Menu selezione gruppo"
   },
+  "empty-state": {
+    "first-message": "Non hai ricevuto nessuna notifica. Vai alla sezione",
+    "action": "I tuoi recapiti",
+    "second-message": "e inserisci uno più recapiti di cortesia: così, se riceverai una notifica, te lo comunicheremo."
+  },
   "filters": {
     "iun": "Inserisci il Codice IUN",
     "data_da": "Da",

--- a/packages/pn-personagiuridica-webapp/src/component/Notifications/DesktopNotifications.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Notifications/DesktopNotifications.tsx
@@ -159,19 +159,18 @@ const DesktopNotifications = ({
   const filtersApplied: boolean = filterNotificationsRef.current.filtersApplied;
 
   const EmptyStateProps = {
-    emptyActionLabel: filtersApplied ? undefined : 'I tuoi Recapiti',
+    emptyActionLabel: filtersApplied ? undefined : t('empty-state.action'),
     emptyActionCallback: filtersApplied
       ? filterNotificationsRef.current.cleanFilters
       : handleRouteContacts,
     emptyMessage: filtersApplied
       ? undefined
-      : 'Non hai ricevuto nessuna notifica. Vai alla sezione',
+      : t('empty-state.first-message'),
     sentimentIcon: filtersApplied ? KnownSentiment.DISSATISFIED : KnownSentiment.NONE,
     secondaryMessage: filtersApplied
       ? undefined
       : {
-          emptyMessage:
-            'e inserisci uno più recapiti di cortesia: così, se riceverai una notifica, te lo comunicheremo.',
+          emptyMessage: t('empty-state.second-message'),
         },
   };
 

--- a/packages/pn-personagiuridica-webapp/src/component/Notifications/MobileNotifications.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Notifications/MobileNotifications.tsx
@@ -183,20 +183,19 @@ const MobileNotifications = ({ notifications, sort, onChangeSorting, isDelegated
   const filtersApplied: boolean = filterNotificationsRef.current.filtersApplied;
 
   const EmptyStateProps = {
-    emptyActionLabel: filtersApplied ? undefined : 'I tuoi Recapiti',
+    emptyActionLabel: filtersApplied ? undefined : t('empty-state.action'),
     emptyActionCallback: filtersApplied
       ? filterNotificationsRef.current.cleanFilters
       : handleRouteContacts,
     emptyMessage: filtersApplied
       ? undefined
-      : 'Non hai ricevuto nessuna notifica. Vai alla sezione',
+      : t('empty-state.first-message'),
     sentimentIcon: filtersApplied ? KnownSentiment.DISSATISFIED : KnownSentiment.NONE,
     secondaryMessage: filtersApplied
       ? undefined
       : {
-          emptyMessage:
-            'e inserisci uno più recapiti di cortesia: così, se riceverai una notifica, te lo comunicheremo.',
-        },
+        emptyMessage: t('empty-state.second-message'),
+      },
   };
 
   // Navigation handlers

--- a/packages/pn-personagiuridica-webapp/src/component/Notifications/__test__/DesktopNotifications.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Notifications/__test__/DesktopNotifications.test.tsx
@@ -44,7 +44,7 @@ describe('DesktopNotifications Component', () => {
     );
     expect(result.container).not.toHaveTextContent(/Filters/i);
     expect(result.container).toHaveTextContent(
-      /Non hai ricevuto nessuna notifica. Vai alla sezione I tuoi recapiti e inserisci uno più recapiti di cortesia: così, se riceverai una notifica, te lo comunicheremo./i
+      /empty-state.first-message empty-state.action empty-state.second-message/i
     );
   });
 

--- a/packages/pn-personagiuridica-webapp/src/component/Notifications/__test__/MobileNotifications.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Notifications/__test__/MobileNotifications.test.tsx
@@ -58,7 +58,7 @@ describe('MobileNotifications Component', () => {
     expect(result.container).not.toHaveTextContent(/Filters/i);
     expect(result.container).not.toHaveTextContent(/Sort/i);
     expect(result.container).toHaveTextContent(
-      /Non hai ricevuto nessuna notifica. Vai alla sezione I tuoi recapiti e inserisci uno più recapiti di cortesia: così, se riceverai una notifica, te lo comunicheremo./i
+      /empty-state.first-message empty-state.action empty-state.second-message/i
     );
   });
 


### PR DESCRIPTION
## Short description
add localization for notification empty state both desktop and mobile in pf and pg webapps, remove capital R in the word Recapiti for notifications empty state

## List of changes proposed in this pull request
- add localization for notification empty state both desktop and mobile in pf and pg webapps
- remove capital R in the word Recapiti for notifications empty state

## How to test
Behavior should be the same, the word recapiti should be in lower case.