### PR TITLE
PN-5818 - empty state delegate PF

### DIFF
--- a/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
@@ -20,6 +20,9 @@
       "iun": "Inserisci un codice IUN valido"
     }
   },
+  "empty-state": {
+    "delegate": "{{name}} non ha ricevuto nessuna notifica."
+  },
   "sort": {
     "title": "Ordina",
     "cancel": "Annulla ordinamento",

--- a/packages/pn-personafisica-webapp/src/component/Notifications/DesktopNotifications.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Notifications/DesktopNotifications.tsx
@@ -137,12 +137,14 @@ const DesktopNotifications = ({
     emptyActionLabel: filtersApplied ? undefined : 'I tuoi Recapiti',
     emptyActionCallback: filtersApplied
       ? filterNotificationsRef.current.cleanFilters
-      : handleRouteContacts,
+      : currentDelegator ? undefined : handleRouteContacts,
     emptyMessage: filtersApplied
       ? undefined
-      : 'Non hai ricevuto nessuna notifica. Vai alla sezione',
+      : currentDelegator 
+        ? t('empty-state.delegate', { name: currentDelegator.delegator?.displayName }) 
+        : 'Non hai ricevuto nessuna notifica. Vai alla sezione',
     sentimentIcon: filtersApplied ? KnownSentiment.DISSATISFIED : KnownSentiment.NONE,
-    secondaryMessage: filtersApplied
+    secondaryMessage: (filtersApplied || currentDelegator)
       ? undefined
       : {
           emptyMessage: 'e inserisci uno più recapiti di cortesia: così, se riceverai una notifica, te lo comunicheremo.',

--- a/packages/pn-personafisica-webapp/src/component/Notifications/MobileNotifications.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Notifications/MobileNotifications.tsx
@@ -163,12 +163,14 @@ const MobileNotifications = ({ notifications, sort, onChangeSorting, currentDele
     emptyActionLabel: filtersApplied ? undefined : 'I tuoi Recapiti',
     emptyActionCallback: filtersApplied
       ? filterNotificationsRef.current.cleanFilters
-      : handleRouteContacts,
+      : currentDelegator ? undefined : handleRouteContacts,
     emptyMessage: filtersApplied
       ? undefined
-      : 'Non hai ricevuto nessuna notifica. Vai alla sezione',
+      : currentDelegator 
+        ? t('empty-state.delegate', { name: currentDelegator.delegator?.displayName }) 
+        : 'Non hai ricevuto nessuna notifica. Vai alla sezione',
     sentimentIcon: filtersApplied ? KnownSentiment.DISSATISFIED : KnownSentiment.NONE,
-    secondaryMessage: filtersApplied
+    secondaryMessage: (filtersApplied || currentDelegator)
       ? undefined
       : {
           emptyMessage: 'e inserisci uno più recapiti di cortesia: così, se riceverai una notifica, te lo comunicheremo.',

--- a/packages/pn-personafisica-webapp/src/component/Notifications/__test__/DesktopNotifications.test.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Notifications/__test__/DesktopNotifications.test.tsx
@@ -34,7 +34,7 @@ jest.mock('../FilterNotifications', () => {
 });
 
 describe('DesktopNotifications Component', () => {
-  it('renders DesktopNotifications', () => {
+  it('renders DesktopNotifications - empty case - recipient access', () => {
     // render component
     const result = render(
       <DesktopNotifications notifications={[]} sort={{ orderBy: '', order: 'asc' }} />
@@ -42,6 +42,25 @@ describe('DesktopNotifications Component', () => {
     expect(result.container).not.toHaveTextContent(/Filters/i);
     expect(result.container).toHaveTextContent(
       /empty-state.first-message empty-state.action empty-state.second-message/i
+    );
+  });
+
+  it('renders DesktopNotifications - empty case - delegate access', () => {
+    // render component
+    const result = render(
+      <DesktopNotifications notifications={[]} sort={{ orderBy: '', order: 'asc' }} currentDelegator={{
+        mandateId: 'mandate-id-1', 
+        delegator: { displayName: 'mandate-display-name-1', fiscalCode: 'tax-id-1', person: true },
+        status: 'active',
+        visibilityIds: [],
+        datefrom: '2023-04-08',
+        dateto: '2028-04-07',
+        verificationCode: '33334'
+      }}/>
+    );
+    expect(result.container).not.toHaveTextContent(/Filters/i);
+    expect(result.container).toHaveTextContent(
+      /empty-state.delegate/i
     );
   });
 


### PR DESCRIPTION
## Short description
This PR regards the notification list page for PF, in particular empty (i.e. no notifications to show) case, when the logged user is acting as delegate of another PF or a PG. In such case, the content of the "empty state" banner changes, now it should just read "[delegator name] non ha ricevuto nessuna notifica." and the link to add contact information is not included. The contents of the "empty state" banner when the logged user accesses to its own notifications is unchanged.

## List of changes proposed in this pull request
Just changed the `EmptyStateProps` in both `DesktopNotifications` and `MobileNotifications` for the PF, modifying some of the attributes if no filters are set and the logged user accessas as a delegate.

## How to test
Enter PF (not PG) with some user that is a delegate of other users, so that these delegators aren't recipient of any registered notification.
At the moment of writing (2020.05.16 14:30), in DEV we have:
- ada, has notifications, delegate from Lucrezia Borgia and Divina Commedia Srl (no notifications) and also Giuseppe Maria Garibaldi (having notifications).
- lucrezia, no notifications, delegate from Louis Amstrong (no notifications).