### PR TITLE
PN-5875 - notification subject controlled length in manual notification creation

### DIFF
--- a/packages/pn-pa-webapp/public/locales/it/common.json
+++ b/packages/pn-pa-webapp/public/locales/it/common.json
@@ -129,6 +129,7 @@
   "required-field": "Campo obbligatorio",
   "required": "obbligatorio",
   "too-long-field-error": "Scrivi massimo {{maxLength}} caratteri",
+  "too-short-field-error": "Scrivi al minimo {{minLength}} caratteri",
   "no-spaces-at-edges": "Spazi non validi all'inizio/fine",
   "invalid": "non valido",
   "upload-file": {

--- a/packages/pn-pa-webapp/src/pages/components/NewNotification/PreliminaryInformations.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/NewNotification/PreliminaryInformations.tsx
@@ -60,7 +60,7 @@ const PreliminaryInformations = ({ notification, onConfirm }: Props) => {
 
   const validationSchema = yup.object({
     paProtocolNumber: requiredStringFieldValidation(tc, 256),
-    subject: requiredStringFieldValidation(tc, 134),
+    subject: requiredStringFieldValidation(tc, 120).min(10, tc('too-short-field-error', { minLength: 10 })),
     abstract: yup.string().max(1024, tc('too-long-field-error', { maxLength: 1024 })).matches(dataRegex.noSpaceAtEdges, tc('no-spaces-at-edges')),
     physicalCommunicationType: yup.string().required(),
     paymentMode: yup.string().required(),

--- a/packages/pn-pa-webapp/src/pages/components/NewNotification/__test__/PreliminaryInformations.test.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/NewNotification/__test__/PreliminaryInformations.test.tsx
@@ -32,6 +32,22 @@ async function testRadio(form: HTMLFormElement, dataTestId: string, index: numbe
   });
 }
 
+const populateFormWithoutPayment = async (form: HTMLFormElement) => {
+  await testInput(form!, 'paProtocolNumber', 'mocked-NotificationId');
+  await testInput(form!, 'subject', 'mocked-Subject');
+  await testInput(form!, 'taxonomyCode', '012345N');
+  await testSelect(
+    form!,
+    'group',
+    [
+      { label: 'Group1', value: '1' },
+      { label: 'Group2', value: '2' },
+    ],
+    1
+  );
+  await testRadio(form!, 'comunicationTypeRadio', 1);
+};
+
 const mockIsPaymentEnabledGetter = jest.fn();
 jest.mock('../../../../services/configuration.service', () => {
   return {
@@ -187,6 +203,26 @@ describe('PreliminaryInformations Component with payment disabled', () => {
     const button = form?.querySelector('button');
     expect(button!).toBeDisabled();
   });
+
+  it('tests form validation (subject)', async () => {
+    const form = result.container.querySelector('form') as HTMLFormElement;
+    const submitButton = form.querySelector('button[type="submit"]');
+    expect(submitButton).toBeDisabled();
+    await populateFormWithoutPayment(form);
+    expect(submitButton).toBeEnabled();
+    await testInput(form, `subject`, 'five5');
+    expect(submitButton).toBeDisabled();
+    await testInput(form, `subject`, 'TwentyTwentyTwenty20');
+    expect(submitButton).toBeEnabled();
+    await testInput(form, 
+      `subject`, 
+      'oneHundredAndTwentyOneoneHundredAndTwentyOneoneHundredAndTwentyOneoneHundredAndTwentyOneoneHundredAndTwentyOne1234567890a'
+    );
+    expect(submitButton).toBeDisabled();
+    await testInput(form, `subject`, 'FifteenFifteenX');
+    expect(submitButton).toBeEnabled();
+  }, 20000);
+
 
   it.skip('changes form values and clicks on confirm', async () => {
     const form = result.container.querySelector('form');


### PR DESCRIPTION
**Beware**  
The issue should pass direct to "In Test"when both this PR and the parallel work on the backend have been merged. Please inform @clombardi when merging this PR, instead of passing the issue to "In review". Thanks a lot!!

## Short description
Changed the validation of the subject field in the first step (preliminary information) in manual notification creation, to enforce the length to be no less than 10 and no more than 120.  

## List of changes proposed in this pull request
Just changed the specification of the validation on `subject`, and added a test.

## How to test
Just enter any PA user, enter the manual notification creation procedure, and play with the length of the "Oggetto della notifica" field in the first step.