### PR TITLE
opt error copy when accepting a mandate - pn-5810

### DIFF
--- a/packages/pn-commons/src/components/AppMessage.tsx
+++ b/packages/pn-commons/src/components/AppMessage.tsx
@@ -37,15 +37,18 @@ const AppMessage = () => {
 
   const enqueueMessages = (messages: Array<IAppMessage>, type: 'success' | 'error') => {
     const newQueue: Array<EnqueuedMessage> = messages
-      .filter((message: IAppMessage) => 
-        // The messages keep in the appState Redux store slice until the same action is re-invoked.
-        // Hence, the messages already shown, being shown, or already in the about-to-show queue, 
-        // musn't be added to the queue again 
-        // (those already or currently shown have entered and then left the queue)
-        // ------------------------------
-        // Carlos Lombardi, 2022.12.16
-        // ------------------------------
-        !message.alreadyShown && message.id !== currentMessage?.message.id && !isMessageEnqueued(message)
+      .filter(
+        (message: IAppMessage) =>
+          // The messages keep in the appState Redux store slice until the same action is re-invoked.
+          // Hence, the messages already shown, being shown, or already in the about-to-show queue,
+          // musn't be added to the queue again
+          // (those already or currently shown have entered and then left the queue)
+          // ------------------------------
+          // Carlos Lombardi, 2022.12.16
+          // ------------------------------
+          !message.alreadyShown &&
+          message.id !== currentMessage?.message.id &&
+          !isMessageEnqueued(message)
       )
       .map((message: IAppMessage) => ({
         type,
@@ -74,6 +77,7 @@ const AppMessage = () => {
       {currentMessage && (
         <SnackBar
           key={currentMessage.message.id}
+          title={currentMessage.message.title}
           message={currentMessage.message.message}
           open
           type={currentMessage.type === MessageType.ERROR ? MessageType.ERROR : MessageType.SUCCESS}

--- a/packages/pn-commons/src/components/SnackBar/SnackBar.tsx
+++ b/packages/pn-commons/src/components/SnackBar/SnackBar.tsx
@@ -1,4 +1,4 @@
-import { Alert, Snackbar, IconButton } from '@mui/material';
+import { Alert, Snackbar, IconButton, AlertTitle } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import { useEffect, useState } from 'react';
 import { useIsMobile } from '../../hooks/useIsMobile';
@@ -9,6 +9,8 @@ type Props = {
   open: boolean;
   /** message type (error, success, info, warning) */
   type: MessageType;
+  /** title to be shown */
+  title?: React.ReactNode;
   /** message to be shown */
   message: React.ReactNode;
   /** A closing delay: if specified the sneakbar would close itself */
@@ -18,7 +20,15 @@ type Props = {
   variant?: 'outlined' | 'standard' | 'filled';
 };
 
-const SnackBar = ({ message, open, type, closingDelay, onClose, variant = 'outlined' }: Props) => {
+const SnackBar = ({
+  title,
+  message,
+  open,
+  type,
+  closingDelay,
+  onClose,
+  variant = 'outlined',
+}: Props) => {
   const [openStatus, setOpenStatus] = useState(open);
   const isMobile = useIsMobile();
 
@@ -29,7 +39,7 @@ const SnackBar = ({ message, open, type, closingDelay, onClose, variant = 'outli
     }
   };
 
-  //create timer for closing snackbar after *closingDelay* milliseconds
+  // create timer for closing snackbar after *closingDelay* milliseconds
   useEffect(() => {
     if (closingDelay && openStatus) {
       const timer = setTimeout(() => {
@@ -76,6 +86,7 @@ const SnackBar = ({ message, open, type, closingDelay, onClose, variant = 'outli
               }}
               variant={variant}
             >
+              {title && <AlertTitle>{title}</AlertTitle>}
               {message}
             </Alert>
           </Snackbar>

--- a/packages/pn-personafisica-webapp/public/locales/it/deleghe.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/deleghe.json
@@ -12,7 +12,6 @@
     "accept_title": "Inserisci il codice di verifica",
     "accept_description": "Per accettare la delega, inserisci il codice che {{name}} ha condiviso con te.",
     "add": "Aggiungi una delega",
-    "invalid_code": "Codice di verifica non valido",
     "revoke": "Revoca",
     "reject": "Rifiuta",
     "accept": "Accetta",
@@ -115,8 +114,8 @@
       "message": "Non è possibile delegare se stessi"
     },
     "invalid_verification_code": {
-      "title": "Codice non valido",
-      "message": "Codice di verifica non valido"
+      "title": "Il codice è sbagliato",
+      "message": "Controllalo e inseriscilo di nuovo"
     },
     "fiscal_code": {
       "title": "Codice fiscale non valido",

--- a/packages/pn-personafisica-webapp/src/pages/Deleghe.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/Deleghe.page.tsx
@@ -43,7 +43,10 @@ const Deleghe = () => {
   } = useAppSelector((state: RootState) => state.delegationsState.acceptModalState);
   const [pageReady, setPageReady] = useState(false);
 
-  const [errorText, setErrorText] = useState('');
+  const [errorMessage, setErrorMessage] = useState<{
+    title: string;
+    content: string;
+  }>();
 
   const dispatch = useAppDispatch();
 
@@ -85,7 +88,7 @@ const Deleghe = () => {
 
   const handleAcceptDelegationError = (errorResponse: AppResponse) => {
     const error = errorResponse.errors ? errorResponse.errors[0] : null;
-    setErrorText(error?.message.content || '');
+    setErrorMessage(error?.message);
   };
 
   useEffect(() => {
@@ -110,8 +113,8 @@ const Deleghe = () => {
           confirmLabel={t('deleghe.accept')}
           codeSectionTitle={t('deleghe.verification_code')}
           hasError={acceptError}
-          // errorMessage={t('deleghe.invalid_code')}
-          errorMessage={errorText}
+          errorTitle={errorMessage?.title}
+          errorMessage={errorMessage?.content}
         />
         <ConfirmationModal
           open={open}

--- a/packages/pn-personagiuridica-webapp/public/locales/it/deleghe.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/it/deleghe.json
@@ -140,8 +140,8 @@
       "message": "Non è possibile delegare se stessi"
     },
     "invalid_verification_code": {
-      "title": "Codice non valido",
-      "message": "Il codice che hai inserito è sbagliato. Riprova."
+      "title": "Il codice è sbagliato",
+      "message": "Controllalo e inseriscilo di nuovo"
     },
     "invalid_verification_code_ua": {
       "title": "Codice non valido",

--- a/packages/pn-personagiuridica-webapp/src/component/Deleghe/AcceptDelegationModal.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Deleghe/AcceptDelegationModal.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Autocomplete,
@@ -15,8 +15,9 @@ import {
   RadioGroup,
   TextField,
 } from '@mui/material';
-import { CodeModal, useIsMobile } from '@pagopa-pn/pn-commons';
+import { AppResponse, AppResponsePublisher, CodeModal, useIsMobile } from '@pagopa-pn/pn-commons';
 
+import { ServerResponseErrorCode } from '../../utils/AppError/types';
 import { useAppSelector } from '../../redux/hooks';
 import { RootState } from '../../redux/store';
 
@@ -49,6 +50,7 @@ const AcceptDelegationModal: React.FC<Props> = ({
   });
   const [groupInputValue, setGroupInputValue] = useState('');
   const [code, setCode] = useState<Array<string>>([]);
+  const [error, setError] = useState<{ title: string; content: string }>();
   const { t } = useTranslation(['deleghe']);
   const isMobile = useIsMobile();
   const textPosition = useMemo(() => (isMobile ? 'center' : 'left'), [isMobile]);
@@ -65,6 +67,7 @@ const AcceptDelegationModal: React.FC<Props> = ({
       setCode(code);
       return;
     }
+    setError(undefined);
     handleConfirm(code, []);
   };
 
@@ -92,6 +95,28 @@ const AcceptDelegationModal: React.FC<Props> = ({
     setStep(0);
   };
 
+  const handleAcceptanceError = useCallback((responseError: AppResponse) => {
+    // if code is invalid, pass the error to the AcceptModal and after to the CodeModal
+    const error = responseError.errors ? responseError.errors[0] : null;
+    if (error?.code === ServerResponseErrorCode.PN_MANDATE_INVALIDVERIFICATIONCODE) {
+      setError(error?.message);
+    }
+    return true;
+  }, []);
+
+  useEffect(() => {
+    // code validation is done only during acceptance and not during update
+    if (!isEditMode) {
+      AppResponsePublisher.error.subscribe('acceptDelegation', handleAcceptanceError);
+    }
+
+    return () => {
+      if (!isEditMode) {
+        AppResponsePublisher.error.unsubscribe('acceptDelegation', handleAcceptanceError);
+      }
+    };
+  }, [handleAcceptanceError]);
+
   if (step === 0) {
     return (
       <CodeModal
@@ -105,6 +130,9 @@ const AcceptDelegationModal: React.FC<Props> = ({
         confirmCallback={handleFirstStepConfirm}
         confirmLabel={t('deleghe.accept-delegation')}
         codeSectionTitle={t('deleghe.verification_code')}
+        errorTitle={error?.title}
+        errorMessage={error?.content}
+        hasError={Boolean(error)}
       ></CodeModal>
     );
   }


### PR DESCRIPTION
## Short description
Changed the copy of the error message that is shown when an user inserts the wrong code during the mandate's acceptance

## List of changes proposed in this pull request
- PF -> deleghe.page.tsx -> added error title
- PF/PG -> deleghe.json -> updated the copy
- PG -> AcceptanceModal.tsx -> show alert when code is wrong

## How to test
- Create mandate from PG to PF -> insert wrong otp and check the message
- Create mandate from PF to PG -> insert wrong otp and check the message