### PR TITLE
fix tests failed because of changes in basic error handling

### DIFF
--- a/packages/pn-pa-webapp/src/redux/auth/__test__/reducers.test.ts
+++ b/packages/pn-pa-webapp/src/redux/auth/__test__/reducers.test.ts
@@ -109,18 +109,12 @@ describe('Auth redux state tests', () => {
   });
 
   it('Should NOT be able to fetch the tos approval', async () => {
-    const tosMock = {
-      recipientId: 'mock-recipient-id',
-      consentType: ConsentType.TOS,
-      accepted: false,
-      isFirstAccept: true,
-    };
+    const tosErrorResponse = { response: { data: 'error-tos', status: 500 }};
     const apiSpy = jest.spyOn(ConsentsApi, 'getConsentByType');
-    apiSpy.mockRejectedValue(tosMock);
+    apiSpy.mockRejectedValue(tosErrorResponse);
     const action = await store.dispatch(getToSApproval());
-    const payload = action.payload as Consent;
     expect(action.type).toBe('getToSApproval/rejected');
-    expect(payload).toEqual(tosMock);
+    expect(action.payload).toEqual(tosErrorResponse);
     apiSpy.mockRestore();
   });
 
@@ -135,13 +129,12 @@ describe('Auth redux state tests', () => {
   });
 
   it('Should NOT be able to fetch tos acceptance', async () => {
-    const tosAcceptanceMock = 'error';
+    const tosErrorResponse = { response: { data: 'error-tos-acceptance', status: 500 }};
     const apiSpy = jest.spyOn(ConsentsApi, 'setConsentByType');
-    apiSpy.mockRejectedValue(tosAcceptanceMock);
+    apiSpy.mockRejectedValue(tosErrorResponse);
     const action = await store.dispatch(acceptToS('mock-version-1'));
-    const payload = action.payload as string;
     expect(action.type).toBe('acceptToS/rejected');
-    expect(payload).toEqual(tosAcceptanceMock);
+    expect(action.payload).toEqual(tosErrorResponse);
   });
 
   it('Should be able to fetch the privacy approval', async () => {
@@ -162,18 +155,12 @@ describe('Auth redux state tests', () => {
   });
 
   it('Should NOT be able to fetch the privacy approval', async () => {
-    const tosMock = {
-      recipientId: 'mock-recipient-id',
-      consentType: ConsentType.DATAPRIVACY,
-      accepted: false,
-      isFirstAccept: true,
-    };
+    const tosErrorResponse = { response: { data: 'error-privacy-approval', status: 500 }};
     const apiSpy = jest.spyOn(ConsentsApi, 'getConsentByType');
-    apiSpy.mockRejectedValue(tosMock);
+    apiSpy.mockRejectedValue(tosErrorResponse);
     const action = await store.dispatch(getToSApproval());
-    const payload = action.payload as Consent;
     expect(action.type).toBe('getToSApproval/rejected');
-    expect(payload).toEqual(tosMock);
+    expect(action.payload).toEqual(tosErrorResponse);
     apiSpy.mockRestore();
   });
 
@@ -188,13 +175,12 @@ describe('Auth redux state tests', () => {
   });
 
   it('Should NOT be able to fetch privacy acceptance', async () => {
-    const tosAcceptanceMock = 'error';
+    const tosErrorResponse = { response: { data: 'error-privacy-acceptance', status: 500 }};
     const apiSpy = jest.spyOn(ConsentsApi, 'setConsentByType');
-    apiSpy.mockRejectedValue(tosAcceptanceMock);
+    apiSpy.mockRejectedValue(tosErrorResponse);
     const action = await store.dispatch(acceptToS('mock-version-1'));
-    const payload = action.payload as string;
     expect(action.type).toBe('acceptToS/rejected');
-    expect(payload).toEqual(tosAcceptanceMock);
+    expect(action.payload).toEqual(tosErrorResponse);
   });
 
   it('Should be able to fetch the organization party', async () => {


### PR DESCRIPTION
## Short description
Changes introduced in #743 made a test in pn-pa-webapp to fail. I introduce this PR as a quick fix in order to restore the test stability.

## List of changes proposed in this pull request
- changed `redux/auth/__test__/reducers.test` in order to set adequate error response mocks.

## How to test
Just run the test suite of pn-pa-webapp.