### PR TITLE
fix: sidebar colors and remove selectability from selfcare items

### DIFF
--- a/packages/pn-commons/src/components/SideMenu/SideMenuList.tsx
+++ b/packages/pn-commons/src/components/SideMenu/SideMenuList.tsx
@@ -164,7 +164,7 @@ const SideMenuList = ({ menuItems, selfCareItems, handleLinkClick, selectedItem 
           )}
           className={classes.root}
         >
-          {selfCareItems?.map((selfcareItem: SideMenuItem, sIndex: number) => (
+          {selfCareItems?.map((selfcareItem: SideMenuItem) => (
             <SideMenuListItem
               key={selfcareItem.label}
               item={selfcareItem}

--- a/packages/pn-commons/src/components/SideMenu/SideMenuListItem.tsx
+++ b/packages/pn-commons/src/components/SideMenu/SideMenuListItem.tsx
@@ -1,5 +1,5 @@
 import { ExitToApp } from '@mui/icons-material';
-import { ListItemButton, ListItemIcon, ListItemText, useTheme } from '@mui/material';
+import { ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
 import Badge from '@mui/material/Badge';
 
 import { SideMenuItem } from '../../types';
@@ -42,9 +42,7 @@ const SideMenuListItem = ({
   goOutside = false,
   handleLinkClick,
   onSelect,
-}: Props) => {
-  const theme = useTheme();
-  return (
+}: Props) => (
     <ListItemButton
       selected={selected}
       onClick={() => {
@@ -59,27 +57,22 @@ const SideMenuListItem = ({
       data-testid={`sideMenuItem-${item.label}`}
     >
       {item.icon && (
-        <ListItemIcon sx={{ color: selected ? `${theme.palette.primary.dark} !important` : '' }}>
+        <ListItemIcon>
           {item.dotBadge ? (
             <Badge color="primary" variant="dot">
-              <item.icon sx={{ color: selected ? `${theme.palette.primary.dark} !important` : '' }} />
+              <item.icon />
             </Badge>
           ) : (
             renderIcon(item.icon)
           )}
         </ListItemIcon>
       )}
-      <ListItemText
-        primary={item.label}
-        sx={{ color: selected ? `${theme.palette.primary.dark} !important` : '' }}
-        data-testid={`menu-item(${item.label.toLowerCase()})`}
-      />
+      <ListItemText primary={item.label} data-testid={`menu-item(${item.label.toLowerCase()})`} />
       {item.rightBadgeNotification && (
-        <NotificationBadge numberOfNotification={item.rightBadgeNotification}/>
+        <NotificationBadge numberOfNotification={item.rightBadgeNotification} />
       )}
-      {goOutside && <ExitToApp color="action"/>}
+      {goOutside && <ExitToApp color="action" />}
     </ListItemButton>
   );
-};
 
 export default SideMenuListItem;


### PR DESCRIPTION
## Short description
Change sidemenu color for text and icons from primary main to primary dark and remove selectability from selfcare items

## List of changes proposed in this pull request
- Change sidemenu color for text and icons from primary main to primary dark for selected item
- Change onSelect function for selfcare items to a void function

## How to test
- Check that color for sidemenu items text and icon is #0062C3 while selected
- Check that when clicking on a selfcare item, it doesn't get selected while showing the page in which the app was on click