### PR TITLE
PN-5877 - changed message for empty state for delegate access in PG

### DIFF
--- a/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
@@ -36,7 +36,8 @@
   "empty-state": {
     "first-message": "Non hai ricevuto nessuna notifica. Vai alla sezione",
     "action": "Recapiti",
-    "second-message": "e inserisci uno più recapiti di cortesia: così, se riceverai una notifica, te lo comunicheremo."
+    "second-message": "e inserisci uno più recapiti di cortesia: così, se riceverai una notifica, te lo comunicheremo.",
+    "delegate": "Non ci sono notifiche in delega a {{name}} da leggere."
   },
   "from-qrcode": {
     "not-found": "Link alla notifica non trovato"

--- a/packages/pn-personagiuridica-webapp/src/component/Notifications/DesktopNotifications.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Notifications/DesktopNotifications.tsx
@@ -14,6 +14,8 @@ import {
   KnownSentiment,
 } from '@pagopa-pn/pn-commons';
 
+import { useAppSelector } from '../../redux/hooks';
+import { RootState } from '../../redux/store';
 import * as routes from '../../navigation/routes.const';
 import { getNewNotificationBadge } from '../NewNotificationBadge/NewNotificationBadge';
 import { trackEventByType } from '../../utils/mixpanel';
@@ -40,6 +42,8 @@ const DesktopNotifications = ({
   const navigate = useNavigate();
   const { t } = useTranslation(['notifiche', 'common']);
   const filterNotificationsRef = useRef({ filtersApplied: false, cleanFilters: () => void 0 });
+
+  const organization = useAppSelector((state: RootState) => state.userState.user.organization);
 
   const handleEventTrackingTooltip = () => {
     trackEventByType(TrackEventType.NOTIFICATION_TABLE_ROW_TOOLTIP);
@@ -162,10 +166,12 @@ const DesktopNotifications = ({
     emptyActionLabel: filtersApplied ? undefined : t('empty-state.action'),
     emptyActionCallback: filtersApplied
       ? filterNotificationsRef.current.cleanFilters
-      : handleRouteContacts,
-    emptyMessage: filtersApplied ? undefined : t('empty-state.first-message'),
+      : isDelegatedPage ? undefined : handleRouteContacts,
+    emptyMessage: filtersApplied 
+      ? undefined 
+      : isDelegatedPage ? t('empty-state.delegate', { name: organization.name }) : t('empty-state.first-message'),
     sentimentIcon: filtersApplied ? KnownSentiment.DISSATISFIED : KnownSentiment.NONE,
-    secondaryMessage: filtersApplied
+    secondaryMessage: (filtersApplied || isDelegatedPage)
       ? undefined
       : {
           emptyMessage: t('empty-state.second-message'),

--- a/packages/pn-personagiuridica-webapp/src/component/Notifications/MobileNotifications.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Notifications/MobileNotifications.tsx
@@ -20,6 +20,8 @@ import {
 } from '@pagopa-pn/pn-commons';
 import { ButtonNaked, Tag } from '@pagopa/mui-italia';
 
+import { useAppSelector } from '../../redux/hooks';
+import { RootState } from '../../redux/store';
 import * as routes from '../../navigation/routes.const';
 import { getNewNotificationBadge } from '../NewNotificationBadge/NewNotificationBadge';
 import { trackEventByType } from '../../utils/mixpanel';
@@ -62,6 +64,8 @@ const MobileNotifications = ({
     filtersApplied: false,
     cleanFilters: () => void 0,
   });
+
+  const organization = useAppSelector((state: RootState) => state.userState.user.organization);
 
   const handleEventTrackingTooltip = () => {
     trackEventByType(TrackEventType.NOTIFICATION_TABLE_ROW_TOOLTIP);
@@ -191,10 +195,12 @@ const MobileNotifications = ({
     emptyActionLabel: filtersApplied ? undefined : t('empty-state.action'),
     emptyActionCallback: filtersApplied
       ? filterNotificationsRef.current.cleanFilters
-      : handleRouteContacts,
-    emptyMessage: filtersApplied ? undefined : t('empty-state.first-message'),
+      : isDelegatedPage ? undefined : handleRouteContacts,
+    emptyMessage: filtersApplied 
+      ? undefined 
+      : isDelegatedPage ? t('empty-state.delegate', { name: organization.name }) : t('empty-state.first-message'),
     sentimentIcon: filtersApplied ? KnownSentiment.DISSATISFIED : KnownSentiment.NONE,
-    secondaryMessage: filtersApplied
+    secondaryMessage: (filtersApplied || isDelegatedPage)
       ? undefined
       : {
           emptyMessage: t('empty-state.second-message'),

--- a/packages/pn-personagiuridica-webapp/src/component/Notifications/__test__/MobileNotifications.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Notifications/__test__/MobileNotifications.test.tsx
@@ -43,7 +43,7 @@ jest.mock('../FilterNotifications', () => {
 });
 
 describe('MobileNotifications Component', () => {
-  it('renders MobileNotifications', () => {
+  it('renders MobileNotifications - empty case - recipient access', () => {
     // render component
     const result = render(
       <MobileNotifications
@@ -56,6 +56,23 @@ describe('MobileNotifications Component', () => {
     expect(result.container).not.toHaveTextContent(/Sort/i);
     expect(result.container).toHaveTextContent(
       /empty-state.first-message empty-state.action empty-state.second-message/i
+    );
+  });
+
+  it('renders MobileNotifications - empty case - delegate access', () => {
+    // render component
+    const result = render(
+      <MobileNotifications
+        notifications={[]}
+        sort={{ orderBy: 'sentAt', order: 'asc' }}
+        onChangeSorting={() => {}}
+        isDelegatedPage
+      />
+    );
+    expect(result.container).not.toHaveTextContent(/Filters/i);
+    expect(result.container).not.toHaveTextContent(/Sort/i);
+    expect(result.container).toHaveTextContent(
+      /empty-state.delegate/i
     );
   });
 


### PR DESCRIPTION
## Short description
This PR regards the notification list page for PG, in particular empty (i.e. no notifications to show) case, when the logged user is acting as delegate of another PF or a PG. In such case, the content of the "empty state" banner changes, now it should just read "Non ci sono notifiche in delega a {{PG name}} da leggere." and the link to add contact information is not included. The contents of the "empty state" banner when the logged user accesses to its own notifications is unchanged.

## List of changes proposed in this pull request
Just changed the `EmptyStateProps` in both `DesktopNotifications` and `MobileNotifications` for the PG, modifying some of the attributes if no filters are set and the logged user accesses as a delegate.

## How to test
Enter PG (not PF) with some user that is a delegate of other users, so that these delegators aren't recipient of any registered notification.
At the moment of writing (2020.05.16 18:30), in DEV we have Convivio Spa, one of the organizations related to the user DanteAlighieri.