### PR TITLE
PN-5911 - timeline - single-recipient descriptions in recipient access to multi-recipient notifications

### DIFF
--- a/packages/pn-commons/src/utils/notification.utility.ts
+++ b/packages/pn-commons/src/utils/notification.utility.ts
@@ -483,10 +483,21 @@ export function getNotificationTimelineStatusInfos(
     // but otherwise take all steps as related with the only recipient included in the API response.
     : recipients.length === 1 ? recipients[0] : recipients[step.details.recIndex];
 
+  // we show the multirecipient versions of the step descriptions
+  // only if the array of recipients include more than one "full" element
+  // (i.e. an element including the full data about the recipient, instead of being included
+  //  just to preserve the correlation with the recIndex in each step).
+  // We consider a recipient description to be "full" if it includes recipientType, taxId and denomination.
+  // -------------------------------------
+  // Carlos Lombardi, 2023.05.17
+  // cfr. PN-5911
+  // -------------------------------------
   return TimelineStepFactory.createTimelineStep(step).getTimelineStepInfo({
     step,
     recipient,
-    isMultiRecipient: recipients.length > 1,
+    isMultiRecipient: recipients
+      .filter(recDescription => recDescription.denomination && recDescription.taxId && recDescription.recipientType)
+      .length > 1,
     allStepsForThisStatus
   });
 }


### PR DESCRIPTION
## Short description
When a recipient (either PF or PG) accesses the detail of a multirecipient notification, the timeline steps will be shown using the single-recipient version of the copy, thus not including name and taxId of the recipient.  
The behavior for sender (PA) access to multirecipient notifications is not changed, i.e. timeline steps are shown including name and taxId of the recipient for each step. 

## List of changes proposed in this pull request
Just changed `notification.utility.ts` in pn-commons, so that the multirecipient version is used only if the recipient array includes more than one full (i.e. including all the description rather than just the recipientType) element.

## How to test
Access the detail of a multirecipient notification from both sender and receiver, appreciate the difference in the timeline step descriptions (specially for events inside the "invio in corso"=delivering status).  
Current examples in DEV at 2023.05.17 13:45
- WZMG-YVQE-NYHX-202305-H-1 - comune di Palermo - cristoforocolombo and fieramosca (both PF)
- PQNL-UDVJ-KGUZ-202305-Y-1 - comune di Palermo - Divina Commedia and Convivio (both PG accessible through the user DanteAlighieri).
