### PR TITLE
Refactored the way to retrieve organization data such the name

### DIFF
--- a/packages/pn-pa-webapp/src/App.tsx
+++ b/packages/pn-pa-webapp/src/App.tsx
@@ -26,7 +26,7 @@ import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 
 import Router from './navigation/routes';
-import { AUTH_ACTIONS, getOrganizationParty, logout } from './redux/auth/actions';
+import { AUTH_ACTIONS, logout } from './redux/auth/actions';
 import { useAppDispatch, useAppSelector } from './redux/hooks';
 import { RootState, store } from './redux/store';
 import { getMenuItems } from './utils/role.utility';
@@ -49,7 +49,7 @@ const App = () => {
 
   const loggedUser = useAppSelector((state: RootState) => state.userState.user);
   const loggedUserOrganizationParty = useAppSelector(
-    (state: RootState) => state.userState.organizationParty
+    (state: RootState) => state.userState.user.organization
   );
   const { tosConsent, privacyConsent } = useAppSelector((state: RootState) => state.userState);
   const currentStatus = useAppSelector((state: RootState) => state.appStatus.currentStatus);
@@ -59,8 +59,8 @@ const App = () => {
   const { hasApiErrors } = useErrors();
 
   // TODO check if it can exist more than one role on user
-  const role = loggedUser.organization?.roles[0];
-  const idOrganization = loggedUser.organization?.id;
+  const role = loggedUserOrganizationParty?.roles[0];
+  const idOrganization = loggedUserOrganizationParty?.id;
   const sessionToken = loggedUser.sessionToken;
 
   const configuration = useMemo(() => getConfiguration(), []);
@@ -146,7 +146,7 @@ const App = () => {
     () => [
       {
         id: '0',
-        name: loggedUserOrganizationParty.name,
+        name: loggedUserOrganizationParty?.name,
         // productRole: role?.role,
         productRole: t(`roles.${role?.role}`),
         logoUrl: undefined,
@@ -168,12 +168,6 @@ const App = () => {
   }, []);
 
   useTracking(configuration.MIXPANEL_TOKEN, process.env.NODE_ENV);
-
-  useEffect(() => {
-    if (idOrganization) {
-      void dispatch(getOrganizationParty(idOrganization));
-    }
-  }, [idOrganization]);
 
   useEffect(() => {
     if (sessionToken) {

--- a/packages/pn-pa-webapp/src/App.tsx
+++ b/packages/pn-pa-webapp/src/App.tsx
@@ -40,7 +40,6 @@ import { PAAppErrorFactory } from './utils/AppError/PAAppErrorFactory';
 import { setUpInterceptor } from './api/interceptors';
 import { getConfiguration } from './services/configuration.service';
 
-
 const App = () => {
   useUnload(() => {
     trackEventByType(TrackEventType.APP_UNLOAD);
@@ -48,9 +47,7 @@ const App = () => {
   setUpInterceptor(store);
 
   const loggedUser = useAppSelector((state: RootState) => state.userState.user);
-  const loggedUserOrganizationParty = useAppSelector(
-    (state: RootState) => state.userState.user.organization
-  );
+  const loggedUserOrganizationParty = loggedUser.organization;
   const { tosConsent, privacyConsent } = useAppSelector((state: RootState) => state.userState);
   const currentStatus = useAppSelector((state: RootState) => state.appStatus.currentStatus);
 
@@ -247,8 +244,10 @@ const App = () => {
         }
         showSideMenu={
           !!sessionToken &&
-          tosConsent && tosConsent.accepted &&
-          privacyConsent && privacyConsent.accepted &&
+          tosConsent &&
+          tosConsent.accepted &&
+          privacyConsent &&
+          privacyConsent.accepted &&
           !hasFetchOrganizationPartyError &&
           !isPrivacyPage
         }

--- a/packages/pn-pa-webapp/src/__test__/App.test.tsx
+++ b/packages/pn-pa-webapp/src/__test__/App.test.tsx
@@ -73,10 +73,6 @@ const reduxInitialState = (
       email: 'mocked-user@mocked-domain.com',
       sessionToken: 'mocked-token',
     },
-    organizationParty: {
-      id: '',
-      name: '',
-    } as Party,
     fetchedTos,
     fetchedPrivacy,
     tosConsent: {

--- a/packages/pn-pa-webapp/src/api/external-registries/External-registries.api.ts
+++ b/packages/pn-pa-webapp/src/api/external-registries/External-registries.api.ts
@@ -13,6 +13,7 @@ export const ExternalRegistriesAPI = {
    *     I decided to encapsulate the array nature of the endpoint inside the api definition.
    *     ---------------
    *     Carlos Lombardi, 2022.07.27
+   @deprecated since PN-5881
    */
   getOrganizationParty: (organizationId: string): Promise<Party> =>
     apiClient

--- a/packages/pn-pa-webapp/src/navigation/OrganizationPartyGuard.tsx
+++ b/packages/pn-pa-webapp/src/navigation/OrganizationPartyGuard.tsx
@@ -7,6 +7,10 @@ import { AUTH_ACTIONS, getOrganizationParty } from '../redux/auth/actions';
 import { useAppDispatch, useAppSelector } from '../redux/hooks';
 import { RootState } from '../redux/store';
 
+
+/**
+ @deprecated since PN-5881
+ */
 const OrganizationPartyGuard = () => {
   const loggedUser = useAppSelector((state: RootState) => state.userState.user);
   const idOrganization = loggedUser.organization?.id;

--- a/packages/pn-pa-webapp/src/navigation/__test__/routes.test.tsx
+++ b/packages/pn-pa-webapp/src/navigation/__test__/routes.test.tsx
@@ -46,7 +46,10 @@ jest.mock('../../pages/Dashboard.page', () =>
 );
 
 
-describe("router", () => {
+/*
+  OrganizationPartyGuard is deprecated, describe is set to skip.
+*/
+describe.skip("router", () => {
   beforeEach(() => {
     mockTosValue = true;
   });

--- a/packages/pn-pa-webapp/src/navigation/routes.tsx
+++ b/packages/pn-pa-webapp/src/navigation/routes.tsx
@@ -18,7 +18,6 @@ import * as routes from './routes.const';
 import SessionGuard from './SessionGuard';
 import RouteGuard from './RouteGuard';
 import ToSGuard from './ToSGuard';
-import OrganizationPartyGuard from './OrganizationPartyGuard';
 
 const handleAssistanceClick = () => {
   trackEventByType(TrackEventType.CUSTOMER_CARE_MAILTO, { source: 'postlogin' });
@@ -30,33 +29,31 @@ function Router() {
   return (
     <Routes>
       <Route path="/" element={<SessionGuard />}>
-        <Route path="/" element={<OrganizationPartyGuard />}>
-          {/* protected routes */}
-          <Route path="/" element={<RouteGuard roles={[PNRole.ADMIN, PNRole.OPERATOR]} />}>
-            <Route path="/" element={<ToSGuard />}>
-              <Route path={routes.DASHBOARD} element={<Dashboard />} />
-              <Route path={routes.DETTAGLIO_NOTIFICA} element={<NotificationDetail />} />
-              <Route path={routes.NUOVA_NOTIFICA} element={<NewNotification />} />
-              <Route path={routes.APP_STATUS} element={<AppStatus />} />
-              {/**
-               * Refers to PN-1741
-               * Commented out because beyond MVP scope
-               *
-               * LINKED TO:
-               * - "const BasicMenuItems" in packages/pn-pa-webapp/src/utils/role.utility.ts
-               * - BasicMenuItems in packages/pn-pa-webapp/src/utils/__TEST__/role.utilitytest.ts
-               *
-               * <Route path={routes.API_KEYS} element={<ApiKeys />} />
-               * */}
-              <Route path={routes.API_KEYS} element={<ApiKeys />} />
-              <Route path={routes.NUOVA_API_KEY} element={<NewApiKey />} />
-              <Route path={routes.STATISTICHE} element={<Statistics />} />
-              <Route path="/" element={<Navigate to={routes.DASHBOARD} />} />
-            </Route>
-            {/* not found - non-logged users will see the common AccessDenied component */}
-            <Route path="*" element={<RouteGuard roles={null} />}>
-              <Route path="*" element={<NotFound />} />
-            </Route>
+        {/* protected routes */}
+        <Route path="/" element={<RouteGuard roles={[PNRole.ADMIN, PNRole.OPERATOR]} />}>
+          <Route path="/" element={<ToSGuard />}>
+            <Route path={routes.DASHBOARD} element={<Dashboard />} />
+            <Route path={routes.DETTAGLIO_NOTIFICA} element={<NotificationDetail />} />
+            <Route path={routes.NUOVA_NOTIFICA} element={<NewNotification />} />
+            <Route path={routes.APP_STATUS} element={<AppStatus />} />
+            {/**
+             * Refers to PN-1741
+             * Commented out because beyond MVP scope
+             *
+             * LINKED TO:
+             * - "const BasicMenuItems" in packages/pn-pa-webapp/src/utils/role.utility.ts
+             * - BasicMenuItems in packages/pn-pa-webapp/src/utils/__TEST__/role.utilitytest.ts
+             *
+             * <Route path={routes.API_KEYS} element={<ApiKeys />} />
+             * */}
+            <Route path={routes.API_KEYS} element={<ApiKeys />} />
+            <Route path={routes.NUOVA_API_KEY} element={<NewApiKey />} />
+            <Route path={routes.STATISTICHE} element={<Statistics />} />
+            <Route path="/" element={<Navigate to={routes.DASHBOARD} />} />
+          </Route>
+          {/* not found - non-logged users will see the common AccessDenied component */}
+          <Route path="*" element={<RouteGuard roles={null} />}>
+            <Route path="*" element={<NotFound />} />
           </Route>
         </Route>
       </Route>

--- a/packages/pn-pa-webapp/src/pages/NewNotification.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/NewNotification.page.tsx
@@ -48,7 +48,6 @@ const NewNotification = () => {
   );
   const isCompleted = useAppSelector((state: RootState) => state.newNotificationState.isCompleted);
   const organization = useAppSelector((state: RootState) => state.userState.user.organization);
-  const organizationParty = useAppSelector((state: RootState) => state.userState.organizationParty);
   const { IS_PAYMENT_ENABLED } = useMemo(() => getConfiguration(), []);
   const dispatch = useAppDispatch();
   const { t } = useTranslation(['common', 'notifiche']);
@@ -124,11 +123,11 @@ const NewNotification = () => {
   useEffect(() => {
     dispatch(
       setSenderInfos({
-        senderDenomination: organizationParty.name,
+        senderDenomination: organization.name,
         senderTaxId: organization.fiscal_code,
       })
     );
-  }, [organization, organizationParty]);
+  }, [organization]);
 
   useEffect(() => () => void dispatch(resetState()), []);
 

--- a/packages/pn-pa-webapp/src/pages/Statistics.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/Statistics.page.tsx
@@ -9,12 +9,12 @@ import { RootState } from "../redux/store";
 const Statistics = () => {
   const { t } = useTranslation(['statistics']);
   const loggedUserOrganizationParty = useAppSelector(
-    (state: RootState) => state.userState.organizationParty
+    (state: RootState) => state.userState.user?.organization
   );
 
   const Subtitle = (
     <Grid item display="flex" flexDirection="row">
-      <Typography>{t('subtitle', { organization: loggedUserOrganizationParty.name })}</Typography>
+      <Typography>{t('subtitle', { organization: loggedUserOrganizationParty?.name })}</Typography>
       <Button variant="outlined" endIcon={<Download />} sx={{whiteSpace:"nowrap"}}>{t('export_all')}</Button>
     </Grid>
   );

--- a/packages/pn-pa-webapp/src/redux/auth/__test__/reducers.test.ts
+++ b/packages/pn-pa-webapp/src/redux/auth/__test__/reducers.test.ts
@@ -1,7 +1,5 @@
 import { ConsentsApi } from '../../../api/consents/Consents.api';
-import { ExternalRegistriesAPI } from '../../../api/external-registries/External-registries.api';
 import { Consent, ConsentType } from '../../../models/consents';
-import { Party } from '../../../models/party';
 import { PartyRole, PNRole } from '../../../models/user';
 import { store } from '../../store';
 import { acceptToS, getOrganizationParty } from '../actions';
@@ -35,10 +33,6 @@ describe('Auth redux state tests', () => {
             },
             desired_exp: 0,
           },
-      organizationParty: {
-        id: '',
-        name: '',
-      } as Party,
       isUnauthorizedUser: false,
       fetchedTos: false,
       fetchedPrivacy: false,
@@ -183,20 +177,4 @@ describe('Auth redux state tests', () => {
     expect(action.payload).toEqual(tosErrorResponse);
   });
 
-  it('Should be able to fetch the organization party', async () => {
-    const partyMock = { id: 'b6c5b42a-8a07-436f-96ce-8c2ab7f4dbd2', name: 'Comune di Valsamoggia' };
-    const apiSpy = jest.spyOn(ExternalRegistriesAPI, 'getOrganizationParty');
-    apiSpy.mockResolvedValue(partyMock);
-    const action = await store.dispatch(getOrganizationParty('mocked-organization-id'));
-    const payload = action.payload as Party;
-    expect(action.type).toBe('getOrganizationParty/fulfilled');
-    expect(payload).toEqual(partyMock);
-    // this kind of restore are not usually needed because most tests integrate the
-    // mockAuthorization function, which clears all mocks/spies after each test file.
-    // As this particular test file involves authorization, then it is not convenient to
-    // call mockAuthorization, hence the mocks/spies must be cleaned in each test.
-    // ------------
-    // Carlos Lombardi, 2022.07.28
-    apiSpy.mockRestore();
-  });
 });

--- a/packages/pn-pa-webapp/src/redux/auth/actions.ts
+++ b/packages/pn-pa-webapp/src/redux/auth/actions.ts
@@ -39,6 +39,9 @@ export const exchangeToken = createAsyncThunk<User, string>(
  *     ------------------------------
  *     Carlos Lombardi, 2022.07.27
  */
+/**
+ @deprecated since PN-5881
+ */
 export const getOrganizationParty = createAsyncThunk<Party, string>(
   AUTH_ACTIONS.GET_ORGANIZATION_PARTY,
   performThunkAction(async (organizationId: string) => {

--- a/packages/pn-pa-webapp/src/redux/auth/reducers.ts
+++ b/packages/pn-pa-webapp/src/redux/auth/reducers.ts
@@ -7,10 +7,16 @@ import {
   basicUserDataMatcherContents,
   dataRegex,
 } from '@pagopa-pn/pn-commons';
-import { Party } from '../../models/party';
 
 import { PartyRole, PNRole } from '../../models/user';
-import { exchangeToken, logout, getOrganizationParty, acceptToS, getToSApproval, acceptPrivacy, getPrivacyApproval } from './actions';
+import {
+  exchangeToken,
+  logout,
+  acceptToS,
+  getToSApproval,
+  acceptPrivacy,
+  getPrivacyApproval,
+} from './actions';
 import { User } from './types';
 
 const roleMatcher = yup.object({
@@ -60,10 +66,6 @@ const userSlice = createSlice({
     user: basicInitialUserData(userDataMatcher, noLoggedUserData),
     fetchedTos: false,
     fetchedPrivacy: false,
-    organizationParty: {
-      id: '',
-      name: '',
-    } as Party,
     isUnauthorizedUser: false,
     messageUnauthorizedUser: emptyUnauthorizedMessage,
     isClosedSession: false,
@@ -108,9 +110,6 @@ const userSlice = createSlice({
     builder.addCase(logout.fulfilled, (state, action) => {
       state.user = action.payload;
       state.isClosedSession = true;
-    });
-    builder.addCase(getOrganizationParty.fulfilled, (state, action) => {
-      state.organizationParty = action.payload;
     });
     builder.addCase(getToSApproval.fulfilled, (state, action) => {
       state.tosConsent = action.payload;

--- a/packages/pn-pa-webapp/src/redux/auth/types.ts
+++ b/packages/pn-pa-webapp/src/redux/auth/types.ts
@@ -12,4 +12,5 @@ export interface Organization {
   fiscal_code: string; // organization fiscal code
   groups?: Array<string>;
   hasGroups?: boolean;
+  name: string;
 }


### PR DESCRIPTION
## Short description
Refactored the way to retrieve organization data such the name.

## List of changes proposed in this pull request
- getOrganizationParty has been set to deprecated and no longer used
- OrganizationPartyGuard component has been set to deprecated and removed to the routes component
- Organization data is get from user.organization of userState now
- Fixed tests

## How to test
You should still see the organization name in the Header component (right side).