### PR TITLE
fix: adds z-index to tabs element in landing for dropdown element

### DIFF
--- a/packages/pn-landing-webapp/src/components/Tabs.tsx
+++ b/packages/pn-landing-webapp/src/components/Tabs.tsx
@@ -90,6 +90,7 @@ const Tabs = ({
             open={dropdownOpen}
             anchorEl={anchorRef.current}
             transition
+            sx={{ zIndex: 9}}
             disablePortal>
             {({
               TransitionProps,

--- a/packages/pn-landing-webapp/src/components/Tabs.tsx
+++ b/packages/pn-landing-webapp/src/components/Tabs.tsx
@@ -90,7 +90,7 @@ const Tabs = ({
             open={dropdownOpen}
             anchorEl={anchorRef.current}
             transition
-            sx={{ zIndex: 9}}
+            sx={{ zIndex: 4 }}
             disablePortal>
             {({
               TransitionProps,


### PR DESCRIPTION
## Short description
Adds z-index to tabs element in landing for dropdown element

## List of changes proposed in this pull request
- Adds z-index to tabs element in landing for dropdown element

## How to test
In landing website on route /perfezionamento, the dropdown should show over the image when overlapped