### PR TITLE
Replaced transition effect with Fade in Perfezionamento landing page, added padding to heading title

### DIFF
--- a/packages/pn-landing-webapp/pages/perfezionamento.tsx
+++ b/packages/pn-landing-webapp/pages/perfezionamento.tsx
@@ -1,7 +1,7 @@
 import { Infoblock } from "@pagopa/mui-italia";
 import { NextPage } from "next";
 import { useRef, useState } from "react";
-import { Box, Slide } from "@mui/material";
+import { Box, Fade } from "@mui/material";
 
 import {
   getCommonHeadingTitleData,
@@ -33,8 +33,7 @@ const Perfezionamento: NextPage = () => {
       <HeadingTitle {...headingTitleData} />
       <Tabs {...tabsData} onTabChange={handleTabChange} />
       <Box ref={containerRef}>
-        <Slide
-          direction="right"
+        <Fade
           in={currentTab.visible}
           timeout={transitionDuration}
         >
@@ -45,7 +44,7 @@ const Perfezionamento: NextPage = () => {
               )}
             />
           </Box>
-        </Slide>
+        </Fade>
       </Box>
     </>
   );

--- a/packages/pn-landing-webapp/src/components/HeadingTitle.tsx
+++ b/packages/pn-landing-webapp/src/components/HeadingTitle.tsx
@@ -7,7 +7,7 @@ const HeadingTitle = ({
   title?: string;
   subtitle?: string | JSX.Element;
 }) => (
-  <Box sx={{ textAlign: "center" }}>
+  <Box sx={{ textAlign: "center", px: 2 }}>
     <Typography variant="h4" sx={{ mb: 3 }}>
       {title}
     </Typography>


### PR DESCRIPTION
## Short description
Replaced transition effect with Fade in Perfezionamento landing page, added padding to heading title.

## List of changes proposed in this pull request
- Replaced Slide transition effect with Fade
- Fixed padding issue with HeadingTitle component in mobile.

## How to test
Run landing webapp and go to /perfezionamento
Fade effect is the new transition effect. Switch to mobile and you'll see padding fixed in HeadingTitle component.