### PR TITLE
fix: add group-admin empty state message for notifications in pg

### DIFF
--- a/packages/pn-commons/src/components/EmptyState.tsx
+++ b/packages/pn-commons/src/components/EmptyState.tsx
@@ -54,7 +54,7 @@ function EmptyState({
       <Typography variant="body2" sx={{ display: 'inline' }}>
         {emptyMessage}
       </Typography>
-      {emptyActionCallback && (
+      {emptyActionCallback && emptyActionLabel && (
         <>
           &nbsp;
           <ButtonNaked

--- a/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
@@ -37,7 +37,8 @@
     "first-message": "Non hai ricevuto nessuna notifica. Vai alla sezione",
     "action": "Recapiti",
     "second-message": "e inserisci uno più recapiti di cortesia: così, se riceverai una notifica, te lo comunicheremo.",
-    "delegate": "Non ci sono notifiche in delega a {{name}} da leggere."
+    "delegate": "Non ci sono notifiche in delega a {{name}} da leggere.",
+    "group-admin": "Non hai ricevuto nessuna notifica."
   },
   "from-qrcode": {
     "not-found": "Link alla notifica non trovato"

--- a/packages/pn-personagiuridica-webapp/src/component/Notifications/DesktopNotifications.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Notifications/DesktopNotifications.tsx
@@ -42,7 +42,7 @@ const DesktopNotifications = ({
   const navigate = useNavigate();
   const { t } = useTranslation(['notifiche', 'common']);
   const filterNotificationsRef = useRef({ filtersApplied: false, cleanFilters: () => void 0 });
-
+  const { isGroupAdmin } = useAppSelector((state: RootState) => state.userState.user);
   const organization = useAppSelector((state: RootState) => state.userState.user.organization);
 
   const handleEventTrackingTooltip = () => {
@@ -162,16 +162,27 @@ const DesktopNotifications = ({
 
   const filtersApplied: boolean = filterNotificationsRef.current.filtersApplied;
 
+  const getEmptyStateFirstMessage = () => {
+    if (filtersApplied) {
+      return undefined;
+    }
+    if (isGroupAdmin) {
+      return t('empty-state.group-admin');
+    }
+    if (isDelegatedPage) {
+      return t('empty-state.delegate', { name: organization.name });
+    }
+    return t('empty-state.first-message');
+  };
+
   const EmptyStateProps = {
-    emptyActionLabel: filtersApplied ? undefined : t('empty-state.action'),
+    emptyActionLabel: filtersApplied || isGroupAdmin ? undefined : t('empty-state.action'),
     emptyActionCallback: filtersApplied
       ? filterNotificationsRef.current.cleanFilters
       : isDelegatedPage ? undefined : handleRouteContacts,
-    emptyMessage: filtersApplied 
-      ? undefined 
-      : isDelegatedPage ? t('empty-state.delegate', { name: organization.name }) : t('empty-state.first-message'),
+    emptyMessage: getEmptyStateFirstMessage(),
     sentimentIcon: filtersApplied ? KnownSentiment.DISSATISFIED : KnownSentiment.NONE,
-    secondaryMessage: (filtersApplied || isDelegatedPage)
+    secondaryMessage: (filtersApplied || isDelegatedPage || isGroupAdmin)
       ? undefined
       : {
           emptyMessage: t('empty-state.second-message'),

--- a/packages/pn-personagiuridica-webapp/src/component/Notifications/MobileNotifications.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Notifications/MobileNotifications.tsx
@@ -64,6 +64,7 @@ const MobileNotifications = ({
     filtersApplied: false,
     cleanFilters: () => void 0,
   });
+  const { isGroupAdmin } = useAppSelector((state: RootState) => state.userState.user);
 
   const organization = useAppSelector((state: RootState) => state.userState.user.organization);
 
@@ -191,16 +192,27 @@ const MobileNotifications = ({
 
   const filtersApplied: boolean = filterNotificationsRef.current.filtersApplied;
 
+  const getEmptyStateFirstMessage = () => {
+    if (filtersApplied) {
+      return undefined;
+    }
+    if (isGroupAdmin) {
+      return t('empty-state.group-admin');
+    }
+    if (isDelegatedPage) {
+      return t('empty-state.delegate', { name: organization.name });
+    }
+    return t('empty-state.first-message');
+  };
+
   const EmptyStateProps = {
-    emptyActionLabel: filtersApplied ? undefined : t('empty-state.action'),
+    emptyActionLabel: filtersApplied || isGroupAdmin ? undefined : t('empty-state.action'),
     emptyActionCallback: filtersApplied
       ? filterNotificationsRef.current.cleanFilters
       : isDelegatedPage ? undefined : handleRouteContacts,
-    emptyMessage: filtersApplied 
-      ? undefined 
-      : isDelegatedPage ? t('empty-state.delegate', { name: organization.name }) : t('empty-state.first-message'),
+    emptyMessage: getEmptyStateFirstMessage(),
     sentimentIcon: filtersApplied ? KnownSentiment.DISSATISFIED : KnownSentiment.NONE,
-    secondaryMessage: (filtersApplied || isDelegatedPage)
+    secondaryMessage: (filtersApplied || isDelegatedPage || isGroupAdmin)
       ? undefined
       : {
           emptyMessage: t('empty-state.second-message'),


### PR DESCRIPTION
## Short description
Change the message for the empty state in Notifications page in case the user is a group admin one, removes link to contacts page

## List of changes proposed in this pull request
- Adds function to get first message
- Adds new entry for group admin empty state message in notifiche.json

## How to test
Check that for a user with empty state the message doesn't show the link to recapiti page