### PR TITLE
PG - filter delegation by taxId - pn-5795

### DIFF
--- a/packages/pn-commons/src/components/Data/SmartFilter.tsx
+++ b/packages/pn-commons/src/components/Data/SmartFilter.tsx
@@ -51,7 +51,7 @@ const SmartFilter = <FormValues extends object>({
   const classes = useStyles();
   const currentFilters = useRef<FormValues>(formValues);
   const isPreviousSearch = _.isEqual(formValues, currentFilters.current);
-  const filtersCount = filtersApplied(initialValues, currentFilters.current);
+  const filtersCount = filtersApplied(currentFilters.current, initialValues);
 
   const submitHandler = (e?: FormEvent<HTMLFormElement> | undefined) => {
     // eslint-disable-next-line functional/immutable-data

--- a/packages/pn-personagiuridica-webapp/public/locales/it/deleghe.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/it/deleghe.json
@@ -52,8 +52,8 @@
       "groups": "Gruppi",
       "group": "Gruppo",
       "no-group-found": "Nessun gruppo trovato",
-      "no-name-found": "Nessun nome trovato",
-      "menu-aria-label": "Menù azioni"
+      "menu-aria-label": "Menù azioni",
+      "tax-id": "Codice Fiscale/P. Iva"
     },
     "accept-delegation": "Accetta la delega",
     "associate-groups-title": "Vuoi assegnare la delega ad un gruppo?",
@@ -69,7 +69,12 @@
     "revoke-successfully": "Delega Revocata.",
     "reject-successfully": "Delega Rifiutata.",
     "revoke-error": "Si è verificato un errore e la delega non è stata revocata. Riprova.",
-    "reject-error": "Si è verificato un errore e la delega non è stata rifiutata. Riprova."
+    "reject-error": "Si è verificato un errore e la delega non è stata rifiutata. Riprova.",
+    "validation": {
+      "pIvaAndFiscalCode": {
+        "wrong": "Il Codice Fiscale/P. Iva inserito non è corretto"
+      }
+    }
   },
   "nuovaDelega": {
     "breadcrumb": "Nuova delega",
@@ -114,6 +119,9 @@
       "expirationDate": {
         "required": "La data di termine delega è obbligatoria",
         "wrong": "Data errata"
+      },
+      "pIvaAndFiscalCode": {
+        "wrong": "Il Codice Fiscale inserito non è corretto"
       }
     }
   },

--- a/packages/pn-personagiuridica-webapp/src/api/delegations/Delegations.api.ts
+++ b/packages/pn-personagiuridica-webapp/src/api/delegations/Delegations.api.ts
@@ -61,7 +61,7 @@ export const DelegationsApi = {
     apiClient
       .post<GetDelegatorsResponse>(
         DELEGATIONS_BY_DELEGATE({ size: params.size, nextPageKey: params.nextPageKey }),
-        { mandateIds: params.mandateIds, groups: params.groups, status: params.status }
+        { taxId: params.taxId, groups: params.groups, status: params.status }
       )
       .then((response: AxiosResponse<GetDelegatorsResponse>) => ({
         ...response.data,
@@ -146,6 +146,7 @@ export const DelegationsApi = {
    * Get all the delegators names for the authenticated user
    * @param {GetDelegatorsFilters} params
    * @return {Promise<GetDelegatorsResponse>}
+   * @deprecated since pn-5795
    */
   getDelegatorsNames: (): Promise<Array<DelegatorsNames>> =>
     apiClient

--- a/packages/pn-personagiuridica-webapp/src/component/Deleghe/DelegationsOfTheCompany.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Deleghe/DelegationsOfTheCompany.tsx
@@ -320,7 +320,7 @@ const DelegationsOfTheCompany = () => {
     const delegatorsFilters = {
       size: filters.size,
       nextPageKey: filters.page ? pagination.nextPagesKey[filters.page - 1] : undefined,
-      taxId: filters.taxId,
+      taxId: filters.taxId || undefined,
       groups: filters.groups,
       status: filters.status,
     } as GetDelegatorsFilters;

--- a/packages/pn-personagiuridica-webapp/src/component/Deleghe/DelegationsOfTheCompany.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Deleghe/DelegationsOfTheCompany.tsx
@@ -28,6 +28,7 @@ import {
   SmartFilter,
   SmartTable,
   SmartTableData,
+  dataRegex,
   useIsMobile,
 } from '@pagopa-pn/pn-commons';
 import { Tag } from '@pagopa/mui-italia';
@@ -42,19 +43,18 @@ import {
   DelegationStatus,
   DelegatorsColumn,
   DelegatorsFormFilters,
-  DelegatorsNames,
   GetDelegatorsFilters,
 } from '../../models/Deleghe';
 import { AcceptButton, Menu, OrganizationsList } from './DelegationsElements';
 
 const initialEmptyValues: {
-  mandateIds: Array<DelegatorsNames>;
+  taxId: string;
   groups: Array<{ id: string; name: string }>;
   status: Array<DelegationStatus>;
 } = {
-  mandateIds: [],
   groups: [],
   status: [],
+  taxId: '',
 };
 
 const DelegationsOfTheCompany = () => {
@@ -70,11 +70,9 @@ const DelegationsOfTheCompany = () => {
   );
   const pagination = useAppSelector((state: RootState) => state.delegationsState.pagination);
   const groups = useAppSelector((state: RootState) => state.delegationsState.groups);
-  const names = useAppSelector((state: RootState) => state.delegationsState.delegatorsNames);
   const statuses = (Object.keys(DelegationStatus) as Array<keyof typeof DelegationStatus>).map(
     (key) => ({ id: DelegationStatus[key], label: t(`deleghe.table.${DelegationStatus[key]}`) })
   );
-  const [nameInputValue, setNameInputValue] = useState('');
   const [groupInputValue, setGroupInputValue] = useState('');
   const rows: Array<Item> = delegationToItem(delegators);
   // back end return at most the next three pages
@@ -227,23 +225,19 @@ const DelegationsOfTheCompany = () => {
   );
 
   const initialValues: {
-    mandateIds: Array<DelegatorsNames>;
+    taxId: string;
     groups: Array<{ id: string; name: string }>;
     status: Array<DelegationStatus>;
   } = {
-    mandateIds: filters.mandateIds
-      ? names.filter(
-          (name) =>
-            filters.mandateIds &&
-            filters.mandateIds.findIndex((id) => name.mandateIds.includes(id)) > -1
-        )
-      : [],
+    taxId: filters.taxId || '',
     groups: filters.groups ? groups.filter((group) => filters.groups?.includes(group.id)) : [],
     status: filters.status || [],
   };
 
   const validationSchema = yup.object({
-    mandateIds: yup.array(),
+    taxId: yup
+      .string()
+      .matches(dataRegex.pIvaAndFiscalCode, t('deleghe.validation.pIvaAndFiscalCode.wrong')),
     groups: yup.array(),
     status: yup.array(),
   });
@@ -257,10 +251,7 @@ const DelegationsOfTheCompany = () => {
         size: filters.size,
         page: 0,
         status: values.status,
-        mandateIds: values.mandateIds.reduce(
-          (arr, d) => arr.concat(d.mandateIds),
-          [] as Array<string>
-        ),
+        taxId: values.taxId,
         groups: values.groups.map((d) => d.id),
       } as DelegatorsFormFilters;
       dispatch(setFilters(params));
@@ -329,7 +320,7 @@ const DelegationsOfTheCompany = () => {
     const delegatorsFilters = {
       size: filters.size,
       nextPageKey: filters.page ? pagination.nextPagesKey[filters.page - 1] : undefined,
-      mandateIds: filters.mandateIds,
+      taxId: filters.taxId,
       groups: filters.groups,
       status: filters.status,
     } as GetDelegatorsFilters;
@@ -383,38 +374,17 @@ const DelegationsOfTheCompany = () => {
               initialValues={initialEmptyValues}
             >
               <Grid item xs={12} lg>
-                <Autocomplete
-                  id="mandateIds"
+                <TextField
+                  id="taxId"
+                  value={formik.values.taxId}
+                  onChange={handleChangeTouched}
+                  label={t('deleghe.table.tax-id')}
+                  name="taxId"
+                  error={formik.touched.taxId && Boolean(formik.errors.taxId)}
+                  helperText={formik.touched.taxId && formik.errors.taxId}
                   size="small"
                   fullWidth
-                  options={names}
-                  disableCloseOnSelect
-                  multiple
-                  noOptionsText={t('deleghe.table.no-name-found')}
-                  getOptionLabel={getOptionLabel}
-                  isOptionEqualToValue={(option, value) => option.id === value.id}
-                  popupIcon={<SearchIcon />}
-                  sx={{
-                    [`& .MuiAutocomplete-popupIndicator`]: {
-                      transform: 'none',
-                    },
-                    marginBottom: isMobile ? '20px' : '0',
-                  }}
-                  renderOption={renderOption}
-                  renderInput={(params) => (
-                    <TextField
-                      {...params}
-                      label={t('deleghe.table.name')}
-                      placeholder={t('deleghe.table.name')}
-                      name="mandateIds"
-                    />
-                  )}
-                  value={formik.values.mandateIds}
-                  onChange={(_event: any, newValue: Array<{ id: string; name: string }>) =>
-                    handleChangeTouchedAutocomplete('mandateIds', newValue)
-                  }
-                  onInputChange={(_event, newInputValue) => setNameInputValue(newInputValue)}
-                  inputValue={nameInputValue}
+                  sx={{ marginBottom: isMobile ? '20px' : '0' }}
                 />
               </Grid>
               <Grid item xs={12} lg={3}>

--- a/packages/pn-personagiuridica-webapp/src/component/Deleghe/__test__/DelegationsOfTheCompany.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Deleghe/__test__/DelegationsOfTheCompany.test.tsx
@@ -113,7 +113,7 @@ describe('DelegationsOfTheCompany Component - assuming API works properly', () =
       {
         groups: ['group-2'],
         status: [DelegationStatus.ACTIVE, DelegationStatus.REJECTED],
-        mandateIds: [],
+        taxId: '',
       },
       {
         resultsPage: [arrayOfDelegators[1]],
@@ -166,7 +166,7 @@ describe('DelegationsOfTheCompany Component - assuming API works properly', () =
       expect(JSON.parse(mock.history.post[0].data)).toStrictEqual({
         groups: ['group-2'],
         status: [DelegationStatus.ACTIVE, DelegationStatus.REJECTED],
-        mandateIds: [],
+        taxId: '',
       });
       expect(result.container).not.toHaveTextContent(/marco verdi/i);
       expect(result.container).toHaveTextContent(/davide legato/i);

--- a/packages/pn-personagiuridica-webapp/src/component/Deleghe/__test__/DelegationsOfTheCompany.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Deleghe/__test__/DelegationsOfTheCompany.test.tsx
@@ -113,7 +113,6 @@ describe('DelegationsOfTheCompany Component - assuming API works properly', () =
       {
         groups: ['group-2'],
         status: [DelegationStatus.ACTIVE, DelegationStatus.REJECTED],
-        taxId: '',
       },
       {
         resultsPage: [arrayOfDelegators[1]],
@@ -166,7 +165,6 @@ describe('DelegationsOfTheCompany Component - assuming API works properly', () =
       expect(JSON.parse(mock.history.post[0].data)).toStrictEqual({
         groups: ['group-2'],
         status: [DelegationStatus.ACTIVE, DelegationStatus.REJECTED],
-        taxId: '',
       });
       expect(result.container).not.toHaveTextContent(/marco verdi/i);
       expect(result.container).toHaveTextContent(/davide legato/i);

--- a/packages/pn-personagiuridica-webapp/src/models/Deleghe.ts
+++ b/packages/pn-personagiuridica-webapp/src/models/Deleghe.ts
@@ -114,7 +114,7 @@ export interface GetDelegatorsParams {
 }
 
 export interface GetDelegatorsRequest {
-  mandateIds?: Array<string>;
+  taxId?: string;
   groups?: Array<string>;
   status?: Array<DelegationStatus>;
 }
@@ -129,6 +129,9 @@ export type GetDelegatorsFilters = GetDelegatorsParams & GetDelegatorsRequest;
 
 export type DelegatorsFormFilters = Exclude<GetDelegatorsFilters, 'nextPageKey'> & { page: number };
 
+/**
+ * @deprecated since pn-5795
+ */
 export interface DelegatorsNames {
   id: string;
   name: string;

--- a/packages/pn-personagiuridica-webapp/src/pages/Deleghe.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/Deleghe.page.tsx
@@ -5,12 +5,7 @@ import { TitleBox, TabPanel } from '@pagopa-pn/pn-commons';
 import { useTranslation } from 'react-i18next';
 import { useAppDispatch, useAppSelector } from '../redux/hooks';
 import { resetState } from '../redux/delegation/reducers';
-import {
-  getDelegators,
-  getGroups,
-  getDelegatesByCompany,
-  getDelegatorsNames,
-} from '../redux/delegation/actions';
+import { getDelegators, getGroups, getDelegatesByCompany } from '../redux/delegation/actions';
 import { RootState } from '../redux/store';
 import LoadingPageWrapper from '../component/LoadingPageWrapper/LoadingPageWrapper';
 import DelegatesByCompany from '../component/Deleghe/DelegatesByCompany';
@@ -37,7 +32,6 @@ const Deleghe = () => {
     if (DELEGATIONS_TO_PG_ENABLED) {
       void dispatch(getDelegators({ size: 10 }));
       void dispatch(getGroups());
-      void dispatch(getDelegatorsNames());
     }
     setPageReady(true);
   }, []);

--- a/packages/pn-personagiuridica-webapp/src/pages/__test__/Deleghe.page.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/__test__/Deleghe.page.test.tsx
@@ -36,7 +36,6 @@ describe('Deleghe page', () => {
       moreResult: false,
     });
     mockApi(mock, 'GET', GET_GROUPS(), 200, undefined, []);
-    mockApi(mock, 'GET', DELEGATIONS_NAME_BY_DELEGATE(), 200, undefined, []);
     const result = render(<Deleghe />);
     expect(result.container).toHaveTextContent(/deleghe.title/i);
     expect(result.container).toHaveTextContent(/deleghe.description/i);
@@ -56,7 +55,6 @@ describe('Deleghe page', () => {
       moreResult: false,
     });
     mockApi(mock, 'GET', GET_GROUPS(), 200, undefined, []);
-    mockApi(mock, 'GET', DELEGATIONS_NAME_BY_DELEGATE(), 200, undefined, []);
     const result = render(<Deleghe />);
     const tab2 = result.getByTestId('tab2');
     fireEvent.click(tab2);

--- a/packages/pn-personagiuridica-webapp/src/redux/delegation/__test__/reducers.test.ts
+++ b/packages/pn-personagiuridica-webapp/src/redux/delegation/__test__/reducers.test.ts
@@ -4,7 +4,6 @@ import {
   ACCEPT_DELEGATION,
   DELEGATIONS_BY_DELEGATE,
   DELEGATIONS_BY_DELEGATOR,
-  DELEGATIONS_NAME_BY_DELEGATE,
   REJECT_DELEGATION,
   REVOKE_DELEGATION,
   UPDATE_DELEGATION,
@@ -18,7 +17,6 @@ import {
   acceptDelegation,
   getDelegatesByCompany,
   getDelegators,
-  getDelegatorsNames,
   getGroups,
   rejectDelegation,
   revokeDelegation,
@@ -148,29 +146,6 @@ describe('delegation redux state tests', () => {
         status: GroupStatus.ACTIVE,
       },
     ]);
-    mock.reset();
-    mock.restore();
-  });
-
-  it('should get delegators names', async () => {
-    const mock = mockApi(
-      apiClient,
-      'GET',
-      DELEGATIONS_NAME_BY_DELEGATE(),
-      200,
-      undefined,
-      arrayOfDelegators
-    );
-    const action = await store.dispatch(getDelegatorsNames());
-    const payload = action.payload as any;
-    expect(action.type).toBe('getDelegatorsNames/fulfilled');
-    expect(payload).toEqual(
-      arrayOfDelegators.map((delegator) => ({
-        id: delegator.delegator.fiscalCode,
-        name: delegator.delegator.displayName,
-        mandateIds: [delegator.mandateId],
-      }))
-    );
     mock.reset();
     mock.restore();
   });

--- a/packages/pn-personagiuridica-webapp/src/redux/delegation/__test__/test.utils.ts
+++ b/packages/pn-personagiuridica-webapp/src/redux/delegation/__test__/test.utils.ts
@@ -127,7 +127,6 @@ export const initialState = {
     nextPagesKey: [],
   },
   groups: [],
-  delegatorsNames: [],
   filters: {
     size: 10,
     page: 0,

--- a/packages/pn-personagiuridica-webapp/src/redux/delegation/actions.ts
+++ b/packages/pn-personagiuridica-webapp/src/redux/delegation/actions.ts
@@ -5,7 +5,6 @@ import { ExternalRegistriesAPI } from '../../api/external-registries/External-re
 import {
   AcceptDelegationResponse,
   Delegation,
-  DelegatorsNames,
   GetDelegatorsFilters,
   GetDelegatorsResponse,
 } from '../../models/Deleghe';
@@ -14,7 +13,6 @@ import { Groups } from '../../models/groups';
 export enum DELEGATION_ACTIONS {
   GET_DELEGATES_BY_COMPANY = 'getDelegatesByCompany',
   GET_DELEGATORS = 'getDelegators',
-  GET_DELEGATORS_NAMES = 'getDelegatorsNames',
 }
 
 export const getDelegatesByCompany = createAsyncThunk<Array<Delegation>>(
@@ -54,11 +52,6 @@ export const acceptDelegation = createAsyncThunk<
 export const getGroups = createAsyncThunk<Array<Groups>>(
   'getGroups',
   performThunkAction(() => ExternalRegistriesAPI.getGroups())
-);
-
-export const getDelegatorsNames = createAsyncThunk<Array<DelegatorsNames>>(
-  DELEGATION_ACTIONS.GET_DELEGATORS_NAMES,
-  performThunkAction(() => DelegationsApi.getDelegatorsNames())
 );
 
 export const updateDelegation = createAsyncThunk<

--- a/packages/pn-personagiuridica-webapp/src/redux/delegation/reducers.ts
+++ b/packages/pn-personagiuridica-webapp/src/redux/delegation/reducers.ts
@@ -1,11 +1,6 @@
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
-import {
-  Delegation,
-  DelegationStatus,
-  DelegatorsFormFilters,
-  DelegatorsNames,
-} from '../../models/Deleghe';
+import { Delegation, DelegationStatus, DelegatorsFormFilters } from '../../models/Deleghe';
 import { Groups } from '../../models/groups';
 import {
   getDelegatesByCompany,
@@ -14,7 +9,6 @@ import {
   rejectDelegation,
   revokeDelegation,
   getGroups,
-  getDelegatorsNames,
   updateDelegation,
 } from './actions';
 
@@ -28,7 +22,6 @@ const initialState = {
     moreResult: false,
   },
   groups: [] as Array<Groups>,
-  delegatorsNames: [] as Array<DelegatorsNames>,
   filters: {
     size: 10,
     page: 0,
@@ -77,9 +70,6 @@ const delegationsSlice = createSlice({
     });
     builder.addCase(getGroups.fulfilled, (state, action) => {
       state.groups = action.payload;
-    });
-    builder.addCase(getDelegatorsNames.fulfilled, (state, action) => {
-      state.delegatorsNames = action.payload;
     });
     builder.addCase(updateDelegation.fulfilled, (state, action) => {
       state.delegations.delegators = state.delegations.delegators.map((delegator: Delegation) =>


### PR DESCRIPTION
## Short description
In PG, delegation are now filterable by taxId

## List of changes proposed in this pull request
- Deprecated api that returns all the names of the delegators
- Replaced filter by name with filter by taxId

## How to test
PG -> login with DanteAlighieri - DivinaCommedia -> go to "Deleghe a carico" -> filter by taxId and check that delegations are filtered correctly