### PR TITLE
manage permissions for operator with groups - pn-6007

### DIFF
--- a/packages/pn-personagiuridica-webapp/src/api/auth/Auth.api.ts
+++ b/packages/pn-personagiuridica-webapp/src/api/auth/Auth.api.ts
@@ -22,5 +22,10 @@ export const AuthApi = {
         jti: response.data.jti,
         organization: response.data.organization,
         desired_exp: response.data.desired_exp,
+        hasGroup: Boolean(
+          response.data.organization &&
+            response.data.organization.groups &&
+            response.data.organization.groups.length > 0
+        ),
       })),
 };

--- a/packages/pn-personagiuridica-webapp/src/api/auth/Auth.api.ts
+++ b/packages/pn-personagiuridica-webapp/src/api/auth/Auth.api.ts
@@ -1,4 +1,4 @@
-import { PNRole, User } from '../../redux/auth/types';
+import { User } from '../../redux/auth/types';
 import { authClient } from '../apiClients';
 import { AUTH_TOKEN_EXCHANGE } from './auth.routes';
 
@@ -22,11 +22,5 @@ export const AuthApi = {
         jti: response.data.jti,
         organization: response.data.organization,
         desired_exp: response.data.desired_exp,
-        isGroupAdmin: Boolean(
-          response.data.organization.roles &&
-            response.data.organization.roles[0].role === PNRole.ADMIN &&
-            response.data.organization.groups &&
-            response.data.organization.groups.length > 0
-        ),
       })),
 };

--- a/packages/pn-personagiuridica-webapp/src/component/DomicileBanner/DomicileBanner.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/DomicileBanner/DomicileBanner.tsx
@@ -2,16 +2,13 @@ import { Alert, Box, Link, Stack, Typography } from '@mui/material';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { useHasPermissions } from '@pagopa-pn/pn-commons';
 
 import * as routes from '../../navigation/routes.const';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import { closeDomicileBanner } from '../../redux/sidemenu/reducers';
 import { RootState } from '../../redux/store';
-import { rolesAndHasGroup } from '../../redux/auth/reducers';
 import { trackEventByType } from '../../utils/mixpanel';
 import { TrackEventType } from '../../utils/events';
-import { PNRole } from '../../redux/auth/types';
 
 const messageIndex = Math.floor(Math.random() * 3) + 1;
 // const messages = [
@@ -26,11 +23,6 @@ const DomicileBanner = () => {
   const dispatch = useAppDispatch();
   const open = useAppSelector((state: RootState) => state.generalInfoState.domicileBannerOpened);
   const legalDomicile = useAppSelector((state: RootState) => state.generalInfoState.legalDomicile);
-  const { hasGroup: userHasGroup, roles } = useAppSelector(rolesAndHasGroup);
-
-  const userHasAdminPermissions = useHasPermissions(roles[0] ? [roles[0].role] : [], [
-    PNRole.ADMIN,
-  ]);
   const path = pathname.split('/');
   const source = path[path.length - 1] === 'notifica' ? 'detail' : 'list';
 
@@ -44,10 +36,10 @@ const DomicileBanner = () => {
   };
 
   useEffect(() => {
-    if ((legalDomicile && legalDomicile.length > 0) || !userHasAdminPermissions || userHasGroup) {
+    if (legalDomicile && legalDomicile.length > 0) {
       dispatch(closeDomicileBanner());
     }
-  }, [legalDomicile, userHasGroup, userHasAdminPermissions]);
+  }, [legalDomicile]);
 
   return open ? (
     <Box mb={2.5}>

--- a/packages/pn-personagiuridica-webapp/src/component/DomicileBanner/__test__/DomicileBanner.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/DomicileBanner/__test__/DomicileBanner.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import { fireEvent, render } from '../../../__test__/test-utils';
-import { PNRole } from '../../../redux/auth/types';
 import DomicileBanner from '../DomicileBanner';
 
 jest.mock('react-i18next', () => ({
@@ -17,30 +16,7 @@ jest.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigateFn,
 }));
 
-const getReduxInitialState = (
-  hasGroup: boolean,
-  isAdmin: boolean = true,
-  domicileBannerOpened: boolean = true
-) => ({
-  userState: {
-    user: {
-      organization: {
-        groups: hasGroup
-          ? [
-              {
-                id: 'group-1',
-                name: 'Group 1',
-              },
-            ]
-          : [],
-        roles: [
-          {
-            role: isAdmin ? PNRole.ADMIN : PNRole.OPERATOR,
-          },
-        ],
-      },
-    },
-  },
+const getReduxInitialState = (domicileBannerOpened: boolean = true) => ({
   generalInfoState: {
     pendingDelegators: 0,
     legalDomicile: [],
@@ -52,7 +28,6 @@ describe('DomicileBanner component', () => {
   it('renders the component', () => {
     const result = render(<DomicileBanner />);
     const dialog = result.getByTestId('addDomicileBanner');
-
     expect(dialog).toBeInTheDocument();
     expect(result.container).toHaveTextContent(/detail.add_domicile/i);
   });
@@ -60,48 +35,21 @@ describe('DomicileBanner component', () => {
   it('clicks on the link to add a domicile', () => {
     const result = render(<DomicileBanner />);
     const link = result.getByRole('button', { name: /detail.add_domicile/ });
-
     fireEvent.click(link);
-
     expect(mockNavigateFn).toBeCalled();
   });
 
   it('clicks on the close button', () => {
     const result = render(<DomicileBanner />);
     const closeButton = result.getByTestId('CloseIcon');
-
     fireEvent.click(closeButton);
     const dialog = result.queryByTestId('addDomicileBanner');
     expect(dialog).toBeNull();
   });
 
-  it('banner is open if user has no groups and is admin', () => {
-    const result = render(<DomicileBanner />, { preloadedState: getReduxInitialState(false) });
-    expect(result.queryByTestId('CloseIcon')).toBeInTheDocument();
-  });
-
-  it('banner is closed if user has groups and is admin', () => {
-    const result = render(<DomicileBanner />, { preloadedState: getReduxInitialState(true) });
-    expect(result.queryByTestId('CloseIcon')).toBeNull();
-  });
-
-  it('banner is closed if user has no groups and is operator', () => {
-    const result = render(<DomicileBanner />, {
-      preloadedState: getReduxInitialState(false, false),
-    });
-    expect(result.queryByTestId('CloseIcon')).toBeNull();
-  });
-
-  it('banner is closed if user has groups and is operator', () => {
-    const result = render(<DomicileBanner />, {
-      preloadedState: getReduxInitialState(true, false),
-    });
-    expect(result.queryByTestId('CloseIcon')).toBeNull();
-  });
-
   it('banner is closed with domicileBannerOpened as false', () => {
     const result = render(<DomicileBanner />, {
-      preloadedState: getReduxInitialState(false, false),
+      preloadedState: getReduxInitialState(false),
     });
     expect(result.queryByTestId('CloseIcon')).toBeNull();
   });

--- a/packages/pn-personagiuridica-webapp/src/navigation/SessionGuard.tsx
+++ b/packages/pn-personagiuridica-webapp/src/navigation/SessionGuard.tsx
@@ -15,7 +15,6 @@ import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { AUTH_ACTIONS, exchangeToken, logout } from '../redux/auth/actions';
 import { useAppDispatch, useAppSelector } from '../redux/hooks';
 import { RootState } from '../redux/store';
-import { rolesAndHasGroup } from '../redux/auth/reducers';
 import { getConfiguration } from '../services/configuration.service';
 import { goToLoginPortal } from './navigation.utility';
 import * as routes from './routes.const';
@@ -110,13 +109,14 @@ const SessionGuardRender = () => {
 const SessionGuard = () => {
   const location = useLocation();
   const isInitialized = useAppSelector((state: RootState) => state.appState.isInitialized);
-  const { sessionToken, desired_exp: expDate } = useAppSelector(
-    (state: RootState) => state.userState.user
-  );
+  const {
+    sessionToken,
+    desired_exp: expDate,
+    hasGroup,
+  } = useAppSelector((state: RootState) => state.userState.user);
   const { isClosedSession, isForbiddenUser } = useAppSelector(
     (state: RootState) => state.userState
   );
-  const { hasGroup: userHasGroup } = useAppSelector(rolesAndHasGroup);
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
   const sessionCheck = useSessionCheck(200, () => dispatch(logout()));
@@ -186,7 +186,7 @@ const SessionGuard = () => {
           // ----------------------
           // Andrea Cimini, 2023.01.27
           // ----------------------
-          if (!userHasGroup) {
+          if (!hasGroup) {
             navigate({ pathname: routes.NOTIFICHE, search: location.search }, { replace: true });
           } else {
             navigate(

--- a/packages/pn-personagiuridica-webapp/src/navigation/SessionGuard.tsx
+++ b/packages/pn-personagiuridica-webapp/src/navigation/SessionGuard.tsx
@@ -15,6 +15,7 @@ import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { AUTH_ACTIONS, exchangeToken, logout } from '../redux/auth/actions';
 import { useAppDispatch, useAppSelector } from '../redux/hooks';
 import { RootState } from '../redux/store';
+import { rolesAndHasGroup } from '../redux/auth/reducers';
 import { getConfiguration } from '../services/configuration.service';
 import { goToLoginPortal } from './navigation.utility';
 import * as routes from './routes.const';
@@ -115,7 +116,7 @@ const SessionGuard = () => {
   const { isClosedSession, isForbiddenUser } = useAppSelector(
     (state: RootState) => state.userState
   );
-  const { isGroupAdmin } = useAppSelector((state: RootState) => state.userState.user);
+  const { hasGroup: userHasGroup } = useAppSelector(rolesAndHasGroup);
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
   const sessionCheck = useSessionCheck(200, () => dispatch(logout()));
@@ -185,7 +186,7 @@ const SessionGuard = () => {
           // ----------------------
           // Andrea Cimini, 2023.01.27
           // ----------------------
-          if (!isGroupAdmin) {
+          if (!userHasGroup) {
             navigate({ pathname: routes.NOTIFICHE, search: location.search }, { replace: true });
           } else {
             navigate(

--- a/packages/pn-personagiuridica-webapp/src/navigation/routes.tsx
+++ b/packages/pn-personagiuridica-webapp/src/navigation/routes.tsx
@@ -3,8 +3,8 @@ import { Routes, Route } from 'react-router-dom';
 import { AppNotAccessible, LoadingPage, NotFound, PrivateRoute } from '@pagopa-pn/pn-commons';
 
 import { useAppSelector } from '../redux/hooks';
-import { RootState } from '../redux/store';
 import { PNRole } from '../redux/auth/types';
+import { rolesAndHasGroup } from '../redux/auth/reducers';
 import { trackEventByType } from '../utils/mixpanel';
 import { TrackEventType } from '../utils/events';
 import { getConfiguration } from '../services/configuration.service';
@@ -31,9 +31,8 @@ const handleAssistanceClick = () => {
 };
 
 function Router() {
-  const { organization, isGroupAdmin } = useAppSelector((state: RootState) => state.userState.user);
-  const currentRoles =
-    organization && organization.roles ? organization.roles.map((role) => role.role) : [];
+  const { hasGroup: userHasGroup, roles } = useAppSelector(rolesAndHasGroup);
+  const currentRoles = roles.map((role) => role.role);
 
   return (
     <Suspense fallback={<LoadingPage />}>
@@ -49,7 +48,7 @@ function Router() {
                     <PrivateRoute
                       currentRoles={[]}
                       requiredRoles={[]}
-                      additionalCondition={!isGroupAdmin}
+                      additionalCondition={!userHasGroup}
                       redirectTo={<NotFound />}
                     >
                       <Notifiche />
@@ -63,7 +62,7 @@ function Router() {
                     <PrivateRoute
                       currentRoles={[]}
                       requiredRoles={[]}
-                      additionalCondition={!isGroupAdmin}
+                      additionalCondition={!userHasGroup}
                       redirectTo={<NotFound />}
                     >
                       <NotificationDetail />
@@ -90,7 +89,7 @@ function Router() {
                       currentRoles={currentRoles}
                       requiredRoles={[PNRole.ADMIN]}
                       redirectTo={<NotFound />}
-                      additionalCondition={!isGroupAdmin}
+                      additionalCondition={!userHasGroup}
                     >
                       <NuovaDelega />
                     </PrivateRoute>
@@ -102,7 +101,7 @@ function Router() {
                     <PrivateRoute
                       currentRoles={currentRoles}
                       requiredRoles={[PNRole.ADMIN]}
-                      additionalCondition={!isGroupAdmin}
+                      additionalCondition={!userHasGroup}
                       redirectTo={<NotFound />}
                     >
                       <Contacts />

--- a/packages/pn-personagiuridica-webapp/src/navigation/routes.tsx
+++ b/packages/pn-personagiuridica-webapp/src/navigation/routes.tsx
@@ -2,9 +2,9 @@ import React, { Suspense } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import { AppNotAccessible, LoadingPage, NotFound, PrivateRoute } from '@pagopa-pn/pn-commons';
 
+import { RootState } from '../redux/store';
 import { useAppSelector } from '../redux/hooks';
 import { PNRole } from '../redux/auth/types';
-import { rolesAndHasGroup } from '../redux/auth/reducers';
 import { trackEventByType } from '../utils/mixpanel';
 import { TrackEventType } from '../utils/events';
 import { getConfiguration } from '../services/configuration.service';
@@ -31,9 +31,9 @@ const handleAssistanceClick = () => {
 };
 
 function Router() {
-  const { hasGroup: userHasGroup, roles } = useAppSelector(rolesAndHasGroup);
-  const currentRoles = roles.map((role) => role.role);
-
+  const { organization, hasGroup } = useAppSelector((state: RootState) => state.userState.user);
+  const currentRoles =
+    organization && organization.roles ? organization.roles.map((role) => role.role) : [];
   return (
     <Suspense fallback={<LoadingPage />}>
       <Routes>
@@ -48,7 +48,7 @@ function Router() {
                     <PrivateRoute
                       currentRoles={[]}
                       requiredRoles={[]}
-                      additionalCondition={!userHasGroup}
+                      additionalCondition={!hasGroup}
                       redirectTo={<NotFound />}
                     >
                       <Notifiche />
@@ -62,7 +62,7 @@ function Router() {
                     <PrivateRoute
                       currentRoles={[]}
                       requiredRoles={[]}
-                      additionalCondition={!userHasGroup}
+                      additionalCondition={!hasGroup}
                       redirectTo={<NotFound />}
                     >
                       <NotificationDetail />
@@ -89,7 +89,7 @@ function Router() {
                       currentRoles={currentRoles}
                       requiredRoles={[PNRole.ADMIN]}
                       redirectTo={<NotFound />}
-                      additionalCondition={!userHasGroup}
+                      additionalCondition={!hasGroup}
                     >
                       <NuovaDelega />
                     </PrivateRoute>
@@ -101,7 +101,7 @@ function Router() {
                     <PrivateRoute
                       currentRoles={currentRoles}
                       requiredRoles={[PNRole.ADMIN]}
-                      additionalCondition={!userHasGroup}
+                      additionalCondition={!hasGroup}
                       redirectTo={<NotFound />}
                     >
                       <Contacts />

--- a/packages/pn-personagiuridica-webapp/src/pages/Deleghe.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/Deleghe.page.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Box, Tab, Tabs } from '@mui/material';
-
-import { TitleBox, TabPanel, useHasPermissions } from '@pagopa-pn/pn-commons';
 import { useTranslation } from 'react-i18next';
+import { Box, Tab, Tabs } from '@mui/material';
+import { TitleBox, TabPanel } from '@pagopa-pn/pn-commons';
+
 import { useAppDispatch, useAppSelector } from '../redux/hooks';
 import { resetState } from '../redux/delegation/reducers';
 import {
@@ -11,8 +11,7 @@ import {
   getDelegatesByCompany,
   getDelegatorsNames,
 } from '../redux/delegation/actions';
-import { rolesAndHasGroup } from '../redux/auth/reducers';
-import { PNRole } from '../redux/auth/types';
+import { RootState } from '../redux/store';
 import LoadingPageWrapper from '../component/LoadingPageWrapper/LoadingPageWrapper';
 import DelegatesByCompany from '../component/Deleghe/DelegatesByCompany';
 import DelegationsOfTheCompany from '../component/Deleghe/DelegationsOfTheCompany';
@@ -23,11 +22,7 @@ const Deleghe = () => {
   const [pageReady, setPageReady] = useState(false);
   const [value, setValue] = useState(0);
   const dispatch = useAppDispatch();
-  const { hasGroup: userHasGroup, roles } = useAppSelector(rolesAndHasGroup);
-
-  const userHasAdminPermissions = useHasPermissions(roles[0] ? [roles[0].role] : [], [
-    PNRole.ADMIN,
-  ]);
+  const { hasGroup } = useAppSelector((state: RootState) => state.userState.user);
   const { DELEGATIONS_TO_PG_ENABLED } = getConfiguration();
 
   const handleChange = (_event: React.SyntheticEvent, newValue: number) => {
@@ -35,8 +30,8 @@ const Deleghe = () => {
   };
 
   const retrieveData = useCallback(() => {
-    // operators and groups administrator cannot see the delegates by the company
-    if (userHasAdminPermissions && !userHasGroup) {
+    // groups administrator cannot see the delegates by the company
+    if (!hasGroup) {
       void dispatch(getDelegatesByCompany());
     }
     if (DELEGATIONS_TO_PG_ENABLED) {
@@ -67,7 +62,7 @@ const Deleghe = () => {
             {t('deleghe.description')}
           </TitleBox>
         </Box>
-        {userHasAdminPermissions && !userHasGroup && (
+        {!hasGroup && (
           <>
             <Box sx={{ borderBottom: 1, borderColor: 'divider', mx: 3 }}>
               <Tabs
@@ -89,7 +84,7 @@ const Deleghe = () => {
             </TabPanel>
           </>
         )}
-        {userHasAdminPermissions && userHasGroup && (
+        {hasGroup && (
           <Box sx={{ mx: 3 }}>
             <DelegationsOfTheCompany />
           </Box>

--- a/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
@@ -171,14 +171,18 @@ const NotificationDetail = () => {
     }
   };
 
-  // legalFact can be either a LegalFactId, or a NotificationDetailOtherDocument 
+  // legalFact can be either a LegalFactId, or a NotificationDetailOtherDocument
   // (generated from details.generatedAarUrl in ANALOG_FAILURE_WORKFLOW timeline elements).
   // Cfr. comment in the definition of INotificationDetailTimeline in pn-commons/src/types/NotificationDetail.ts.
   const legalFactDownloadHandler = (legalFact: LegalFactId | NotificationDetailOtherDocument) => {
     if ((legalFact as LegalFactId).key) {
       dispatch(resetLegalFactState());
       void dispatch(
-        getReceivedNotificationLegalfact({ iun: notification.iun, legalFact: legalFact as LegalFactId, mandateId })
+        getReceivedNotificationLegalfact({
+          iun: notification.iun,
+          legalFact: legalFact as LegalFactId,
+          mandateId,
+        })
       );
     } else if ((legalFact as NotificationDetailOtherDocument).documentId) {
       const otherDocument = legalFact as NotificationDetailOtherDocument;
@@ -312,7 +316,7 @@ const NotificationDetail = () => {
                     mandateId={mandateId}
                   />
                 )}
-                {userHasAdminPermissions && <DomicileBanner />}
+                {userHasAdminPermissions && !currentUser.hasGroup && <DomicileBanner />}
                 <Paper sx={{ p: 3 }} className="paperContainer">
                   <NotificationDetailDocuments
                     title={t('detail.acts', { ns: 'notifiche' })}

--- a/packages/pn-personagiuridica-webapp/src/pages/Notifiche.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/Notifiche.page.tsx
@@ -118,7 +118,7 @@ const Notifiche = ({ isDelegatedPage = false }: Props) => {
   return (
     <LoadingPageWrapper isInitialized={pageReady}>
       <Box p={3}>
-        {userHasAdminPermissions && <DomicileBanner />}
+        {userHasAdminPermissions && !organizationGroup && <DomicileBanner />}
         <TitleBox
           variantTitle="h4"
           title={pageTitle}

--- a/packages/pn-personagiuridica-webapp/src/redux/auth/__test__/reducers.test.ts
+++ b/packages/pn-personagiuridica-webapp/src/redux/auth/__test__/reducers.test.ts
@@ -48,6 +48,7 @@ describe('Auth redux state tests', () => {
         jti: '',
         aud: '',
         desired_exp: 0,
+        hasGroup: false,
         organization: {
           fiscal_code: '',
           id: '',

--- a/packages/pn-personagiuridica-webapp/src/redux/auth/__test__/reducers.test.ts
+++ b/packages/pn-personagiuridica-webapp/src/redux/auth/__test__/reducers.test.ts
@@ -48,7 +48,6 @@ describe('Auth redux state tests', () => {
         jti: '',
         aud: '',
         desired_exp: 0,
-        isGroupAdmin: false,
         organization: {
           fiscal_code: '',
           id: '',

--- a/packages/pn-personagiuridica-webapp/src/redux/auth/__test__/test-users.ts
+++ b/packages/pn-personagiuridica-webapp/src/redux/auth/__test__/test-users.ts
@@ -26,4 +26,5 @@ export const userResponse: User = {
     ],
     fiscal_code: '12345678910',
   },
+  hasGroup: false,
 };

--- a/packages/pn-personagiuridica-webapp/src/redux/auth/__test__/test-users.ts
+++ b/packages/pn-personagiuridica-webapp/src/redux/auth/__test__/test-users.ts
@@ -26,5 +26,4 @@ export const userResponse: User = {
     ],
     fiscal_code: '12345678910',
   },
-  isGroupAdmin: false,
 };

--- a/packages/pn-personagiuridica-webapp/src/redux/auth/reducers.ts
+++ b/packages/pn-personagiuridica-webapp/src/redux/auth/reducers.ts
@@ -8,7 +8,6 @@ import {
 import { createSlice } from '@reduxjs/toolkit';
 import * as yup from 'yup';
 
-import { RootState } from '../store';
 import {
   acceptToS,
   acceptPrivacy,
@@ -44,6 +43,7 @@ const userDataMatcher = yup
     jti: yup.string().matches(dataRegex.lettersNumbersAndDashs),
     organization: organizationMatcher,
     desired_exp: yup.number(),
+    hasGroup: yup.boolean(),
   })
   .noUnknown(true);
 
@@ -67,6 +67,7 @@ const noLoggedUserData = {
     fiscal_code: '',
   },
   desired_exp: 0,
+  hasGroup: false,
 } as User;
 
 const emptyUnauthorizedMessage = { title: '', message: '' };
@@ -157,20 +158,5 @@ const userSlice = createSlice({
     });
   },
 });
-
-const rolesAndHasGroup = (state: RootState) => ({
-  roles:
-    state.userState.user.organization &&
-    state.userState.user.organization.roles &&
-    state.userState.user.organization.roles.length
-      ? state.userState.user.organization.roles
-      : [],
-  hasGroup:
-    state.userState.user.organization &&
-    state.userState.user.organization.groups &&
-    state.userState.user.organization.groups.length > 0,
-});
-
-export { rolesAndHasGroup };
 
 export default userSlice;

--- a/packages/pn-personagiuridica-webapp/src/redux/auth/reducers.ts
+++ b/packages/pn-personagiuridica-webapp/src/redux/auth/reducers.ts
@@ -7,6 +7,8 @@ import {
 } from '@pagopa-pn/pn-commons';
 import { createSlice } from '@reduxjs/toolkit';
 import * as yup from 'yup';
+
+import { RootState } from '../store';
 import {
   acceptToS,
   acceptPrivacy,
@@ -42,7 +44,6 @@ const userDataMatcher = yup
     jti: yup.string().matches(dataRegex.lettersNumbersAndDashs),
     organization: organizationMatcher,
     desired_exp: yup.number(),
-    isGroupAdmin: yup.boolean(),
   })
   .noUnknown(true);
 
@@ -66,7 +67,6 @@ const noLoggedUserData = {
     fiscal_code: '',
   },
   desired_exp: 0,
-  isGroupAdmin: false,
 } as User;
 
 const emptyUnauthorizedMessage = { title: '', message: '' };
@@ -157,5 +157,20 @@ const userSlice = createSlice({
     });
   },
 });
+
+const rolesAndHasGroup = (state: RootState) => ({
+  roles:
+    state.userState.user.organization &&
+    state.userState.user.organization.roles &&
+    state.userState.user.organization.roles.length
+      ? state.userState.user.organization.roles
+      : [],
+  hasGroup:
+    state.userState.user.organization &&
+    state.userState.user.organization.groups &&
+    state.userState.user.organization.groups.length > 0,
+});
+
+export { rolesAndHasGroup };
 
 export default userSlice;

--- a/packages/pn-personagiuridica-webapp/src/redux/auth/types.ts
+++ b/packages/pn-personagiuridica-webapp/src/redux/auth/types.ts
@@ -35,4 +35,5 @@ export interface User extends BasicUser {
   jti: string;
   organization: Organization;
   desired_exp: number;
+  hasGroup?: boolean;
 }

--- a/packages/pn-personagiuridica-webapp/src/redux/auth/types.ts
+++ b/packages/pn-personagiuridica-webapp/src/redux/auth/types.ts
@@ -35,5 +35,4 @@ export interface User extends BasicUser {
   jti: string;
   organization: Organization;
   desired_exp: number;
-  isGroupAdmin?: boolean;
 }


### PR DESCRIPTION
## Short description
Now we manage the permissions also for the operator with groups.

## List of changes proposed in this pull request
- Changed isGroupAdmin flag with hasGroup
- Replaced isGroupAdmin flag with hasGroup in all components that used it
- Removed group check inside the DomicileBanner component

## How to test
- PG -> login with an admin -> check that you can view notifications (delegated and not), you can manage mandates (from the PG and to PG) and you can manage contacts
- PG -> login with a group admin -> check that you can only view delegated notifications, you can manage mandates (to PG and only associated to user group) and you cannot manage contacts
- PG -> login with operator -> check that you can view notifications (delegated and not), you cannot manage mandates and you cannot manage contacts
-  PG -> login with group operator -> check that you can only view delegated notifications, you cannot manage mandates and you cannot manage contacts