### PR TITLE
Fixed issue SPID selectors view in tiny viewports

### DIFF
--- a/packages/pn-personafisica-login/src/pages/login/SpidSelect.tsx
+++ b/packages/pn-personafisica-login/src/pages/login/SpidSelect.tsx
@@ -29,7 +29,7 @@ const SpidSelect = ({ onBack }: { onBack: () => void }) => {
   };
 
   return (
-    <Grid container direction="column" sx={{ backgroundColor: '#FFF', height: '100vh' }}>
+    <Grid container direction="column" sx={{ backgroundColor: '#FFF', 'minHeight': '100vh' }}>
       <Grid container direction="row" justifyContent="space-around" mt={3}>
         <Grid item xs={1}>
           <img src={SpidBig} />


### PR DESCRIPTION
## Short description
Fixed issue where SPID selectors page is not correctly viewed with browser viewport which have height less than SPID selectors itself, including mobile.

## List of changes proposed in this pull request
- Replaced CSS property

## How to test
Make height of browser less than SPID selectors or use mobile. SPID selectors are now correctly visible.