### PR TITLE
Used recIndex to get proper index of recipient data

### DIFF
--- a/packages/pn-commons/src/utils/notification.utility.ts
+++ b/packages/pn-commons/src/utils/notification.utility.ts
@@ -784,10 +784,11 @@ const populateOtherDocuments = (
   );
   if (timelineFiltered.length > 0) {
     const isMultiRecipient = timelineFiltered.length > 1;
-    return timelineFiltered.map((t, index) => {
+    return timelineFiltered.map((t) => {
+      const recIndex = t.details.recIndex;
       const recipients = notificationDetail.recipients;
-      const recipientData = isMultiRecipient
-        ? ` - ${recipients[index].denomination} (${recipients[index].taxId})`
+      const recipientData = (isMultiRecipient && recIndex != null)
+        ? ` - ${recipients[recIndex].denomination} (${recipients[recIndex].taxId})`
         : '';
       const title = `${getLocalizedOrDefaultLabel(
         'notifications',


### PR DESCRIPTION
## Short description
There was case where array order of recipients was different from AAR array order. Fix is made by using recIndex instead of map index.

## List of changes proposed in this pull request
- Replaced map index with recIndex property to get recipient data

## How to test
Recipient denomination and tax IDs of AAR documents name should be fine, now.