### PR TITLE
Fixed non clickable dropdown arrow in notification filters PA

### DIFF
--- a/packages/pn-pa-webapp/src/pages/components/Notifications/FilterNotificationsFormBody.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/Notifications/FilterNotificationsFormBody.tsx
@@ -202,7 +202,6 @@ const FilterNotificationsFormBody = ({
         sx={{
           marginBottom: isMobile ? '20px' : '0',
           '& .MuiInputBase-root': {
-            pr: 4,
             overflow: 'hidden',
             textOverflow: 'ellipsis',
           },


### PR DESCRIPTION
## Short description
Fixed non clickable dropdown arrow in notification filters PA.

## List of changes proposed in this pull request
- Removed unnecessary padding right

## How to test
You shuld be able to click status dropdown arrow filter in PA notifications.