### PR TITLE
fix: height of input in API key success page

### DIFF
--- a/packages/pn-pa-webapp/src/pages/components/NewApiKey/SyncFeedbackApiKey.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/NewApiKey/SyncFeedbackApiKey.tsx
@@ -22,7 +22,6 @@ const SyncFeedbackApiKey = ({ newApiKeyId = '' }) => {
         </Typography>
         <Box sx={{ mt: 3, mb: 5 }}>
           <TextField
-            size="small"
             id="apiKeyId"
             value={newApiKeyId}
             name="apiKeyId"
@@ -55,7 +54,7 @@ const SyncFeedbackApiKey = ({ newApiKeyId = '' }) => {
           sx={{ marginTop: '30px' }}
           onClick={() => navigate(routes.API_KEYS)}
         >
-          { t('go-to-api-keys') }
+          {t('go-to-api-keys')}
         </Button>
       </Box>
     </Box>


### PR DESCRIPTION
## Short description
Fix height of input in API key success page

## List of changes proposed in this pull request
- height of input in API key success page

## How to test
Generate a new API key and will see the input with right height