### PR TITLE
Modified texts for empty state in PG

### DIFF
--- a/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
@@ -34,10 +34,7 @@
     "options": "Opzioni sort"
   },
   "empty-state": {
-    "first-message-continuing": "Non hai ricevuto nessuna notifica. Vai alla sezione",
-    "first-message-alone": "Non hai ricevuto nessuna notifica.",
-    "action": "Recapiti",
-    "second-message": "e inserisci uno più recapiti di cortesia: così, se riceverai una notifica, te lo comunicheremo.",
+    "message": "Non ci sono notifiche per {{name}}.",
     "delegate": "Non ci sono notifiche in delega a {{name}} da leggere."
   },
   "from-qrcode": {

--- a/packages/pn-personagiuridica-webapp/src/component/Notifications/DesktopNotifications.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Notifications/DesktopNotifications.tsx
@@ -17,7 +17,7 @@ import {
 import { Typography } from '@mui/material';
 import { useAppSelector } from '../../redux/hooks';
 import { RootState } from '../../redux/store';
-import { Organization, PNRole } from '../../redux/auth/types';
+import { Organization } from '../../redux/auth/types';
 import * as routes from '../../navigation/routes.const';
 import { getNewNotificationBadge } from '../NewNotificationBadge/NewNotificationBadge';
 import { trackEventByType } from '../../utils/mixpanel';
@@ -36,14 +36,12 @@ type Props = {
 };
 
 // to avoid cognitive complexity warning - PN-5323
-function mainEmptyMessage(filtersApplied: boolean, isDelegatedPage: boolean, organization: Organization, role: PNRole, t: any) {
+function mainEmptyMessage(filtersApplied: boolean, isDelegatedPage: boolean, organization: Organization, t: any) {
   return filtersApplied
     ? undefined
     : isDelegatedPage
     ? t('empty-state.delegate', { name: organization.name })
-    : role !== PNRole.ADMIN 
-    ? t('empty-state.first-message-alone') 
-    : t('empty-state.first-message-continuing');
+    : t('empty-state.message', { name: organization.name });
 }
 
 const DesktopNotifications = ({
@@ -57,7 +55,6 @@ const DesktopNotifications = ({
   const filterNotificationsRef = useRef({ filtersApplied: false, cleanFilters: () => void 0 });
 
   const organization = useAppSelector((state: RootState) => state.userState.user.organization);
-  const role = organization.roles[0].role;
 
   const handleEventTrackingTooltip = () => {
     trackEventByType(TrackEventType.NOTIFICATION_TABLE_ROW_TOOLTIP);
@@ -174,27 +171,11 @@ const DesktopNotifications = ({
     id: n.paProtocolNumber + i.toString(),
   }));
 
-  const handleRouteContacts = () => {
-    navigate(routes.RECAPITI);
-  };
-
   const filtersApplied: boolean = filterNotificationsRef.current.filtersApplied;
 
   const EmptyStateProps = {
-    emptyActionLabel: filtersApplied ? undefined : t('empty-state.action'),
-    emptyActionCallback: filtersApplied
-      ? filterNotificationsRef.current.cleanFilters
-      : isDelegatedPage || role !== PNRole.ADMIN
-      ? undefined
-      : handleRouteContacts,
-    emptyMessage: mainEmptyMessage(filtersApplied, isDelegatedPage, organization, role, t),
+    emptyMessage: mainEmptyMessage(filtersApplied, isDelegatedPage, organization, t),
     sentimentIcon: filtersApplied ? KnownSentiment.DISSATISFIED : KnownSentiment.NONE,
-    secondaryMessage:
-      filtersApplied || isDelegatedPage || role !== PNRole.ADMIN
-        ? undefined
-        : {
-            emptyMessage: t('empty-state.second-message'),
-          },
   };
 
   const showFilters = notifications?.length > 0 || filtersApplied;

--- a/packages/pn-personagiuridica-webapp/src/component/Notifications/MobileNotifications.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Notifications/MobileNotifications.tsx
@@ -22,7 +22,7 @@ import { ButtonNaked } from '@pagopa/mui-italia';
 
 import { useAppSelector } from '../../redux/hooks';
 import { RootState } from '../../redux/store';
-import { Organization, PNRole } from '../../redux/auth/types';
+import { Organization } from '../../redux/auth/types';
 import * as routes from '../../navigation/routes.const';
 import { getNewNotificationBadge } from '../NewNotificationBadge/NewNotificationBadge';
 import { trackEventByType } from '../../utils/mixpanel';
@@ -54,20 +54,12 @@ type Props = {
 const IS_SORT_ENABLED = false;
 
 // to avoid cognitive complexity warning - PN-5323
-function mainEmptyMessage(
-  filtersApplied: boolean,
-  isDelegatedPage: boolean,
-  organization: Organization,
-  role: PNRole,
-  t: any
-) {
+function mainEmptyMessage(filtersApplied: boolean, isDelegatedPage: boolean, organization: Organization, t: any) {
   return filtersApplied
     ? undefined
     : isDelegatedPage
     ? t('empty-state.delegate', { name: organization.name })
-    : role !== PNRole.ADMIN
-    ? t('empty-state.first-message-alone')
-    : t('empty-state.first-message-continuing');
+    : t('empty-state.message', { name: organization.name });
 }
 
 const MobileNotifications = ({
@@ -84,7 +76,6 @@ const MobileNotifications = ({
   });
 
   const organization = useAppSelector((state: RootState) => state.userState.user.organization);
-  const role = organization.roles[0].role;
 
   const handleEventTrackingTooltip = () => {
     trackEventByType(TrackEventType.NOTIFICATION_TABLE_ROW_TOOLTIP);
@@ -208,27 +199,11 @@ const MobileNotifications = ({
     return arr;
   }, [] as Array<CardSort<NotificationColumn>>);
 
-  const handleRouteContacts = () => {
-    navigate(routes.RECAPITI);
-  };
-
   const filtersApplied: boolean = filterNotificationsRef.current.filtersApplied;
 
   const EmptyStateProps = {
-    emptyActionLabel: filtersApplied ? undefined : t('empty-state.action'),
-    emptyActionCallback: filtersApplied
-      ? filterNotificationsRef.current.cleanFilters
-      : isDelegatedPage || role !== PNRole.ADMIN
-      ? undefined
-      : handleRouteContacts,
-    emptyMessage: mainEmptyMessage(filtersApplied, isDelegatedPage, organization, role, t),
+    emptyMessage: mainEmptyMessage(filtersApplied, isDelegatedPage, organization, t),
     sentimentIcon: filtersApplied ? KnownSentiment.DISSATISFIED : KnownSentiment.NONE,
-    secondaryMessage:
-      filtersApplied || isDelegatedPage || role !== PNRole.ADMIN
-        ? undefined
-        : {
-            emptyMessage: t('empty-state.second-message'),
-          },
   };
 
   // Navigation handlers


### PR DESCRIPTION
## Short description
Modified texts for empty state in PG.

## List of changes proposed in this pull request
- Empty state edited for DesktopNotifications
- Empty state edited for MobileNotifications
- Removed unused strings in notifiche.json

## How to test
Find a PG user with no notifications (both self and delegate) and look for empty state message.