### PR TITLE
Modified chip color for viewed status

### DIFF
--- a/packages/pn-commons/src/utils/__test__/notification.utility.test.ts
+++ b/packages/pn-commons/src/utils/__test__/notification.utility.test.ts
@@ -375,7 +375,7 @@ describe('notification status texts', () => {
       },
       ['single-recipient'],
       'status.viewed',
-      'info',
+      'success',
       'status.viewed-tooltip',
       'status.viewed-description',
       { subject: 'status.recipient' }
@@ -392,7 +392,7 @@ describe('notification status texts', () => {
       },
       ['single-recipient'],
       'status.viewed',
-      'info',
+      'success',
       'status.viewed-tooltip',
       'status.viewed-description',
       { subject: 'status.delegate.Mario Rossi' }
@@ -408,7 +408,7 @@ describe('notification status texts', () => {
       },
       ['recipient-1', 'recipient-2'],
       'status.viewed-multirecipient',
-      'info',
+      'success',
       'status.viewed-tooltip-multirecipient',
       'status.viewed-description-multirecipient',
       { subject: 'status.recipient' }

--- a/packages/pn-commons/src/utils/notification.utility.ts
+++ b/packages/pn-commons/src/utils/notification.utility.ts
@@ -204,7 +204,7 @@ export function getNotificationStatusInfos(
         );
       }
       return {
-        color: 'info',
+        color: 'success',
         ...localizeStatus(
           'viewed',
           'Avvenuto accesso',


### PR DESCRIPTION
## Short description
Modified chip color for viewed status.

## List of changes proposed in this pull request
- Use "success" color (green) for viewed notification
- Fixed tests

## How to test
Open a PA user and look for viewed notification in list. The chip color is now green.