### PR TITLE
fix: change copy 'Referente amministrativo' to 'Amministratore'

### DIFF
--- a/packages/pn-pa-webapp/public/locales/it/common.json
+++ b/packages/pn-pa-webapp/public/locales/it/common.json
@@ -144,6 +144,6 @@
   },
   "roles": {
     "operator": "Referente operativo",
-    "admin": "Referente amministrativo"
+    "admin": "Amministratore"
   }
 }

--- a/packages/pn-personagiuridica-webapp/public/locales/it/common.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/it/common.json
@@ -179,7 +179,7 @@
   },
   "roles": {
     "pg-operator": "Referente operativo",
-    "pg-admin": "Referente amministrativo"
+    "pg-admin": "Amministratore"
   },
   "required-field": "Campo obbligatorio"
 }


### PR DESCRIPTION
## Short description
Changes copy 'Referente amministrativo' to 'Amministratore'

## How to test
Check that in the partyswitch component (top-right) the role label shows 'Amministratore' instead of 'Referente amministrativo' for mittente and persona giuridica apps