### PR TITLE
fix: change name in revocation modal from user name to organization name

### DIFF
--- a/packages/pn-personagiuridica-webapp/src/component/Deleghe/DelegationsElements.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Deleghe/DelegationsElements.tsx
@@ -73,7 +73,7 @@ export const Menu: React.FC<Props> = ({ menuType, id, userLogged, row, onAction 
       : t('deleghe.rejection_question', { delegator: row?.name });
   const subtitleModal =
     menuType === 'delegates'
-      ? t('deleghe.subtitle_revocation', { recipient: userLogged?.name })
+      ? t('deleghe.subtitle_revocation', { recipient: userLogged?.organization.name })
       : t('deleghe.subtitle_rejection', { delegator: row?.name });
   const confirmLabel =
     menuType === 'delegates' ? t('deleghe.confirm_revocation') : t('deleghe.confirm_rejection');


### PR DESCRIPTION
## Short description
Change name in revocation modal from user name to organization name

## How to test
Check that in the delegation revocate modal the organization name is shown instead of the user name