### PR TITLE
Links in API Key page has been set to target blank

### DIFF
--- a/packages/pn-pa-webapp/src/pages/ApiKeys.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/ApiKeys.page.tsx
@@ -33,11 +33,17 @@ const SubTitle = () => {
   return (
     <Fragment>
       {t('subtitle.text1')}
-      <Link href="https://petstore.swagger.io/?url=https://raw.githubusercontent.com/pagopa/pn-delivery/develop/docs/openapi/api-external-b2b-pa-v1.yaml#/NewNotification/sendNewNotification">
+      <Link
+        target="_blank"
+        href="https://petstore.swagger.io/?url=https://raw.githubusercontent.com/pagopa/pn-delivery/develop/docs/openapi/api-external-b2b-pa-v1.yaml#/NewNotification/sendNewNotification"
+      >
         {t('subtitle.text2')}
       </Link>
       {t('subtitle.text3')}
-      <Link href="https://petstore.swagger.io/?url=https://raw.githubusercontent.com/pagopa/pn-delivery/develop/docs/openapi/api-external-b2b-pa-v1.yaml#/SenderReadB2B/getNotificationRequestStatus">
+      <Link
+        target="_blank"
+        href="https://petstore.swagger.io/?url=https://raw.githubusercontent.com/pagopa/pn-delivery/develop/docs/openapi/api-external-b2b-pa-v1.yaml#/SenderReadB2B/getNotificationRequestStatus"
+      >
         {t('subtitle.text4')}
       </Link>
       {t('subtitle.text5')}


### PR DESCRIPTION
## Short description
Links in API Key page has been set to target blank.

## List of changes proposed in this pull request
- Subtitle links target set to '_blank'

## How to test
Enter PA and open API Keys page. The links in subtitle should opens in a new tab now.