### PR TITLE
fix i18n texts for legal facts of analog flow events

### DIFF
--- a/packages/pn-pa-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/it/notifiche.json
@@ -227,7 +227,7 @@
       "registered-letter-kind": {
         "AR": "A/R",
         "890": "890",
-        "RIR": "internazionale A/R",
+        "RIR": "A/R internazionale",
         "RS": "semplice",
         "RIS": "internazionale semplice"
       },

--- a/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
@@ -250,15 +250,15 @@
       "registered-letter-kind": {
         "AR": "A/R",
         "890": "890",
-        "RIR": "internazionale A/R",
+        "RIR": "A/R internazionale",
         "RS": "semplice",
         "RIS": "internazionale semplice"
       },
       "analog-workflow-attachment-kind": {
+        "AR": "Ricevuta di consegna",
         "Plico": "Scansione del plico",
+        "23L": "Avviso di ricevimento",
         "Indagine": "Scansione dell'indagine",
-        "AR": "Ricevuta di ritorno",
-        "23L": "Ricevuta di consegna",
         "generic": "Documento allegato"
       },
       "analog-workflow-failure-cause": {

--- a/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
@@ -248,13 +248,15 @@
       "registered-letter-kind": {
         "AR": "A/R",
         "890": "890",
-        "RIR": "internazionale A/R"
+        "RIR": "A/R internazionale",
+        "RS": "semplice",
+        "RIS": "internazionale semplice"
       },
       "analog-workflow-attachment-kind": {
+        "AR": "Ricevuta di consegna",
         "Plico": "Scansione del plico",
-        "Indagine": "Scansione dell'analisi dell'indagine ",
-        "AR": "Ricevuta di ritorno",
-        "23L": "Ricevuta 23L",
+        "23L": "Avviso di ricevimento",
+        "Indagine": "Scansione dell'indagine",
         "generic": "Documento allegato"
       },
       "analog-workflow-failure-cause": {


### PR DESCRIPTION
## Short description
Just fixed some i18n texts related to analog flow legal facts (and also kinds of letters), now these facts should be homogeneous in PG / PF / PA.

## List of changes proposed in this pull request
Just fixed the corresponding entries in the various `notifiche.json` files.

## How to test
For each kind of analog-flow specific legal facts (plico / 23L / AR / Indagine), enter the details of a notification involving a legal fact of that kind, and check the link text.  
For each kind of letter (A/R, A/R internazionale, internazionale semplice, 890, semplice), enter the details of a notification involving a registered letter of that kind, and check the texts of the SEND_ANALOG_PROGRESS or SEND_SIMPLE_REGISTERED_LETTER_PROGRESS events.  