### PR TITLE
work in progress flag fix

### DIFF
--- a/packages/pn-pa-webapp/src/navigation/RouteGuard.tsx
+++ b/packages/pn-pa-webapp/src/navigation/RouteGuard.tsx
@@ -1,11 +1,11 @@
-import { AccessDenied } from "@pagopa-pn/pn-commons";
-import { Outlet, useNavigate } from "react-router-dom";
+import { AccessDenied } from '@pagopa-pn/pn-commons';
+import { Outlet, useNavigate } from 'react-router-dom';
 
-import { PNRole } from "../models/user";
-import { useAppSelector } from "../redux/hooks";
-import { RootState } from "../redux/store";
-import { getHomePage } from "../utils/role.utility";
-import { goToSelfcareLogin } from "./navigation.utility";
+import { PNRole } from '../models/user';
+import { useAppSelector } from '../redux/hooks';
+import { RootState } from '../redux/store';
+import { getHomePage } from '../utils/role.utility';
+import { goToSelfcareLogin } from './navigation.utility';
 
 /**
  * The roles associated to the routes guarded by this Guard.
@@ -26,10 +26,11 @@ const RouteGuard = ({ roles }: Props) => {
     return (
       <AccessDenied
         isLogged={!!sessionToken}
-        goToHomePage={() => navigate(getHomePage(), {replace: true})}
+        goToHomePage={() => navigate(getHomePage(), { replace: true })}
         goToLogin={() => goToSelfcareLogin()}
       />
-    );}
+    );
+  }
 
   return <Outlet />;
 };

--- a/packages/pn-pa-webapp/src/navigation/SessionGuard.tsx
+++ b/packages/pn-pa-webapp/src/navigation/SessionGuard.tsx
@@ -149,7 +149,7 @@ const SessionGuard = () => {
    */
   useEffect(() => {
     const doInitalPageDetermination = () => {
-      if (isForbiddenUser || WORK_IN_PROGRESS) {
+      if (isForbiddenUser || (!sessionToken && WORK_IN_PROGRESS)) {
         // ----------------------
         // I'm not sure about this management of the redirects
         // Momentarily I have added the isForbiddenUser variable that is true if login returns 451 error code

--- a/packages/pn-personafisica-webapp/src/navigation/SessionGuard.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/SessionGuard.tsx
@@ -204,7 +204,7 @@ const SessionGuard = () => {
             { replace: true }
           );
         }
-      } else if (isForbiddenUser || WORK_IN_PROGRESS) {
+      } else if (isForbiddenUser || (!sessionToken && WORK_IN_PROGRESS)) {
         // ----------------------
         // I'm not sure about this management of the redirects
         // Momentarily I have added the isForbiddenUser variable that is true if login returns 451 error code

--- a/packages/pn-personagiuridica-webapp/src/navigation/SessionGuard.tsx
+++ b/packages/pn-personagiuridica-webapp/src/navigation/SessionGuard.tsx
@@ -214,7 +214,7 @@ const SessionGuard = () => {
             { replace: true }
           );
         }
-      } else if (isForbiddenUser || WORK_IN_PROGRESS) {
+      } else if (isForbiddenUser || (!sessionToken && WORK_IN_PROGRESS)) {
         // ----------------------
         // I'm not sure about this management of the redirects
         // Momentarily I have added the isForbiddenUser variable that is true if login returns 451 error code


### PR DESCRIPTION
## Short description
Now if work_in_progress is enabled, the user sees the maintenance page, but he can login and access the webapp as before

## List of changes proposed in this pull request
- Added an extra checks in SessionGuard (pa/pg/pf)
## How to test
Set work_in_progress flag to true -> check that the user sees the maintenance page -> login -> check that the user can access the webapp