### PR TITLE
fix: deleted groups handling

### DIFF
--- a/packages/pn-pa-webapp/src/pages/NewApiKey.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/NewApiKey.page.tsx
@@ -27,7 +27,7 @@ import * as routes from '../navigation/routes.const';
 import { RootState } from '../redux/store';
 import { useAppDispatch, useAppSelector } from '../redux/hooks';
 import { getApiKeyUserGroups, saveNewApiKey } from '../redux/NewApiKey/actions';
-import { UserGroup } from '../models/user';
+import { GroupStatus, UserGroup } from '../models/user';
 import SyncFeedbackApiKey from './components/NewApiKey/SyncFeedbackApiKey';
 
 const useStyles = makeStyles(() => ({
@@ -70,9 +70,7 @@ const NewApiKey = () => {
   });
 
   useEffect(() => {
-    if (groups.length === 0) {
-      void dispatch(getApiKeyUserGroups());
-    }
+    void dispatch(getApiKeyUserGroups(GroupStatus.ACTIVE));
   }, []);
 
   const formik = useFormik({

--- a/packages/pn-personagiuridica-webapp/src/component/Deleghe/AcceptDelegationModal.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Deleghe/AcceptDelegationModal.tsx
@@ -25,6 +25,7 @@ import {
 import { ServerResponseErrorCode } from '../../utils/AppError/types';
 import { useAppSelector } from '../../redux/hooks';
 import { RootState } from '../../redux/store';
+import { GroupStatus } from '../../models/groups';
 
 type Props = {
   isEditMode: boolean;
@@ -180,7 +181,7 @@ const AcceptDelegationModal: React.FC<Props> = ({
             id="groups"
             size="small"
             fullWidth
-            options={groups}
+            options={groups.filter((group) => group.status !== GroupStatus.DELETED)}
             disableCloseOnSelect
             multiple
             noOptionsText={t('deleghe.table.no-group-found')}

--- a/packages/pn-personagiuridica-webapp/src/component/Deleghe/DelegationsOfTheCompany.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Deleghe/DelegationsOfTheCompany.tsx
@@ -35,6 +35,7 @@ import { Tag } from '@pagopa/mui-italia';
 
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import { RootState } from '../../redux/store';
+import { GroupStatus } from '../../models/groups';
 import { DELEGATION_ACTIONS, getDelegators } from '../../redux/delegation/actions';
 import { setFilters } from '../../redux/delegation/reducers';
 import delegationToItem from '../../utils/delegation.utility';
@@ -392,7 +393,7 @@ const DelegationsOfTheCompany = () => {
                   id="groups"
                   size="small"
                   fullWidth
-                  options={groups}
+                  options={groups.filter((group) => group.status !== GroupStatus.DELETED)}
                   disableCloseOnSelect
                   multiple
                   noOptionsText={t('deleghe.table.no-group-found')}

--- a/packages/pn-personagiuridica-webapp/src/models/groups.ts
+++ b/packages/pn-personagiuridica-webapp/src/models/groups.ts
@@ -1,6 +1,7 @@
 export enum GroupStatus {
   ACTIVE = 'ACTIVE',
   SUSPENDED = 'SUSPENDED',
+  DELETED = 'DELETED',
 }
 
 export interface Groups {


### PR DESCRIPTION
## Short description
Deleted groups handling. Show only active groups when insert/modify a new notification, api key and delegations.

## List of changes proposed in this pull request
- Deleted groups handling

## How to test
On PA:
- When yuo create a new notification or a new api key you should see only active groups
On PG:
- When accept a new delegation you can assign only to an active group
- When you filter delegation of the company you should see only active groups