### PR TITLE
PN-6745 - fix/change platform name for PG

### DIFF
--- a/packages/pn-personagiuridica-webapp/public/locales/it/common.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/it/common.json
@@ -34,7 +34,7 @@
   "header": {
     "product": {
       "organization-dashboard": "La tua impresa",
-      "notification-platform": "Notifiche digitali"
+      "notification-platform": "SEND - Servizio Notifiche Digitali"
     },
     "logout": "Esci",
     "pago-pa-link": "Sito di PagoPA S.p.A."


### PR DESCRIPTION
## Short description
Just changed the platform name for PG to "SEND - Servizio Notifiche Digitali".
![image](https://github.com/pagopa/pn-frontend/assets/5519535/ceb65d61-6303-4fa3-b132-4758db17d20b)


## List of changes proposed in this pull request
- Modified the corresponding entry in the `common.json` file for PG.

## How to test
Just enter PG, the title at top left should read as indicated.