### PR TITLE
fix/PN-6715 - changed send-analog-error title in PA / PF / PG

### DIFF
--- a/packages/pn-pa-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/it/notifiche.json
@@ -210,7 +210,7 @@
       "send-analog-flow-RECRI003B-description-multirecipient": "C'è un nuovo documento allegato.",
       "send-analog-flow-RECRI004B-description": "C'è un nuovo documento allegato.",
       "send-analog-flow-RECRI004B-description-multirecipient": "C'è un nuovo documento allegato.",
-      "send-analog-error": "Invio per via cartacea non andato a buon fine",
+      "send-analog-error": "L'invio per via cartacea non ha determinato la consegna",
       "send-analog-success": "Invio per via cartacea andato a buon fine",
       "send-analog-outcome-unknown": "Invio per via cartacea completato - esito non determinato",
       "send-analog-unknown": "Evento su spedizione raccomandata - non riconosciuto",

--- a/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
@@ -233,7 +233,7 @@
       "send-analog-flow-RECRI003B-description-multirecipient": "C'è un nuovo documento allegato.",
       "send-analog-flow-RECRI004B-description": "C'è un nuovo documento allegato.",
       "send-analog-flow-RECRI004B-description-multirecipient": "C'è un nuovo documento allegato.",
-      "send-analog-error": "Invio per via cartacea non andato a buon fine",
+      "send-analog-error": "L'invio per via cartacea non ha determinato la consegna",
       "send-analog-success": "Invio per via cartacea andato a buon fine",
       "send-analog-outcome-unknown": "Invio per via cartacea completato - esito non determinato",
       "send-analog-unknown": "Evento su spedizione raccomandata - non riconosciuto",

--- a/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
@@ -231,7 +231,7 @@
       "send-analog-flow-RECRI003B-description-multirecipient": "C'è un nuovo documento allegato.",
       "send-analog-flow-RECRI004B-description": "C'è un nuovo documento allegato.",
       "send-analog-flow-RECRI004B-description-multirecipient": "C'è un nuovo documento allegato.",
-      "send-analog-error": "Invio per via cartacea non andato a buon fine",
+      "send-analog-error": "L'invio per via cartacea non ha determinato la consegna",
       "send-analog-success": "Invio per via cartacea andato a buon fine",
       "send-analog-outcome-unknown": "Invio per via cartacea completato - esito non determinato",
       "send-analog-unknown": "Evento su spedizione raccomandata - non riconosciuto",


### PR DESCRIPTION
## Short description
Change the title for the SEND_ANALOG_FEEDBACK events detected as KO.

## List of changes proposed in this pull request
Changed the corresponding entries in the `notifiche.json` file for PF / PG / PA.

## How to test
Enter the detail of an analog-flow notification for which the shipping failed.
Examples in TEST: 
- IUN WKUZ-VLKN-KVYD-202306-X-1 - comune di Palermo - cristoforocolombo.
- IUN MAZG-EYTL-JKGR-202306-D-1 - comune di Palermo - leonardo