### PR TITLE
fix: removed unnecessary character from notification paid detail

### DIFF
--- a/packages/pn-commons/src/components/NotificationDetail/NotificationPaidDetail.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationPaidDetail.tsx
@@ -76,13 +76,13 @@ const PaymentTable = ({ paymentDetails, showRecipientType }: PaymentTableProps) 
             dataTestId="paymentObject"
           />
         )}
-        {paymentDetails.amount && (
+        {paymentDetails.amount && paymentDetails.amount !== 0 ? (
           <CustomTableRow
             label={getLocalizedOrDefaultLabel('notifiche', 'detail.payment.amount', 'Importo')}
             value={formatEurocentToCurrency(paymentDetails.amount)}
             dataTestId="amount"
           />
-        )}
+        ) : null}
         <CustomTableRow
           label={getLocalizedOrDefaultLabel(
             'notifiche',


### PR DESCRIPTION
## Short description
Removed unnecessary character from notification paid detail

## List of changes proposed in this pull request
- Removed character

## How to test
Go to a paid notification and you'll not see unnecessary characters under 'type of recipient' 