### PR TITLE
hide menu when user is a group administrator - pn-6847

### DIFF
--- a/packages/pn-personagiuridica-webapp/src/component/Deleghe/DelegationsOfTheCompany.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Deleghe/DelegationsOfTheCompany.tsx
@@ -63,7 +63,7 @@ const DelegationsOfTheCompany = () => {
   const dispatch = useAppDispatch();
   const isMobile = useIsMobile();
   const firstUpdate = useRef(true);
-  const organization = useAppSelector((state: RootState) => state.userState.user.organization);
+  const { hasGroup, organization } = useAppSelector((state: RootState) => state.userState.user);
   const filters = useAppSelector((state: RootState) => state.delegationsState.filters);
 
   const delegators = useAppSelector(
@@ -188,7 +188,11 @@ const DelegationsOfTheCompany = () => {
         },
       },
     },
-    {
+  ];
+
+  if (!hasGroup) {
+    /* eslint-disable-next-line functional/immutable-data */
+    smartCfg.push({
       id: 'id',
       label: '',
       getValue(value: string, data: Item) {
@@ -203,8 +207,8 @@ const DelegationsOfTheCompany = () => {
           xs: 4,
         },
       },
-    },
-  ];
+    });
+  }
 
   const icon = <CheckBoxOutlineBlankIcon fontSize="small" />;
   const checkedIcon = <CheckBoxIcon fontSize="small" />;


### PR DESCRIPTION
## Short description
A group administrator cannot modify/revoke a delegation

## List of changes proposed in this pull request
- Removed action menù in DelegationsOfTheCompany.tsx

## How to test
- DanteAlighieri -> Convivio Spa -> "Deleghe a carico dell'impresa" -> check that the action menù is visible
- EugenioMontale -> Convivio Spa -> "Deleghe a carico dell'impresa" -> check that the action menù is NOT visible