### PR TITLE
Fix/PN-6869 - simultaneous timeline events

### DIFF
--- a/packages/pn-commons/src/types/NotificationDetail.ts
+++ b/packages/pn-commons/src/types/NotificationDetail.ts
@@ -74,6 +74,7 @@ export interface INotificationDetailTimeline {
   details: NotificationDetailTimelineDetails;
   // only fe
   hidden?: boolean;
+  index?: number;
 }
 
 export enum ResponseStatus {

--- a/packages/pn-commons/src/utils/__test__/notification.utility.test.ts
+++ b/packages/pn-commons/src/utils/__test__/notification.utility.test.ts
@@ -1101,6 +1101,56 @@ describe('parse notification & filters', () => {
     expect(currentSteps && currentSteps[1].category).toEqual(TimelineCategory.REQUEST_ACCEPTED);
   });
 
+  it('reverse status and events - simultaneous events', () => {
+    const timeline = acceptedDeliveringDeliveredTimeline();
+    const timelineElementToBeClonedIndex = timeline.findIndex(elem => elem.elementId === 'digital_progress_0_PLATFORM');
+    if (timelineElementToBeClonedIndex === -1) {
+      fail('cannot build the test scenario');
+    }
+    const timelineElementToBeCloned = timeline[timelineElementToBeClonedIndex];
+    const newTimelineElement = {...timelineElementToBeCloned, elementId: 'digital_progress_1_PLATFORM'};
+    (newTimelineElement.details as SendDigitalDetails).deliveryDetailCode = 'C002';
+    newTimelineElement.timestamp = timeline[timelineElementToBeClonedIndex+1].timestamp;
+    timeline.splice(timelineElementToBeClonedIndex+1, 0, newTimelineElement);
+    sourceNotification.timeline = timeline;
+    const statusHistory = acceptedDeliveringDeliveredTimelineStatusHistory();
+    const deliveringStatus = statusHistory.find(status => status.status === NotificationStatus.DELIVERING);
+    if (!deliveringStatus) {
+      fail('cannot build the test scenario');
+    }
+    const insertionIndex = deliveringStatus.relatedTimelineElements.findIndex(elem => elem === 'digital_progress_0_PLATFORM') + 1;
+    deliveringStatus?.relatedTimelineElements.splice(insertionIndex, 0, 'digital_progress_1_PLATFORM');
+    sourceNotification.notificationStatusHistory = statusHistory;
+
+    // parse
+    const parsedNotification = parseNotificationDetail(sourceNotification);
+
+    // ----------- checks
+    // DELIVERING events -- FEEDBACK comes before both PROGRESS
+    let currentSteps = parsedNotification.notificationStatusHistory[1].steps;
+    expect(currentSteps && currentSteps[0].category).toEqual(
+      TimelineCategory.SEND_DIGITAL_FEEDBACK
+    );
+    expect(currentSteps && currentSteps[1].category).toEqual(
+      TimelineCategory.SEND_DIGITAL_PROGRESS
+    );
+    expect(currentSteps && currentSteps[1].elementId).toEqual(
+      'digital_progress_1_PLATFORM'
+    );
+    expect(currentSteps && currentSteps[1].timestamp).toEqual(
+      currentSteps && currentSteps[0].timestamp
+    );
+    expect(currentSteps && currentSteps[2].category).toEqual(
+      TimelineCategory.SEND_DIGITAL_PROGRESS
+    );
+    expect(currentSteps && currentSteps[2].elementId).toEqual(
+      'digital_progress_0_PLATFORM'
+    );
+    expect(currentSteps && currentSteps[2].timestamp).not.toEqual(
+      currentSteps && currentSteps[0].timestamp
+    );
+  });
+
   it('duplicates ACCEPTED events - hidden copies', () => {
     sourceNotification.timeline = acceptedDeliveringDeliveredTimeline();
     sourceNotification.notificationStatusHistory =

--- a/packages/pn-commons/src/utils/__test__/test-utils.ts
+++ b/packages/pn-commons/src/utils/__test__/test-utils.ts
@@ -155,10 +155,10 @@ export const parsedNotification: NotificationDetail = {
   paymentHistory: [],
   notificationStatus: NotificationStatus.ACCEPTED,
   notificationStatusHistory: [
-    { ...statusHistory[0], steps: [{ ...timeline[0], hidden: false }] },
-    { ...statusHistory[1], steps: [{ ...timeline[1], hidden: false }] },
+    { ...statusHistory[0], steps: [{ ...timeline[0], index: 0, hidden: false }] },
+    { ...statusHistory[1], steps: [{ ...timeline[1], index: 1, hidden: false }] },
   ],
-  timeline: timeline.map((t) => ({ ...t, hidden: false })),
+  timeline: timeline.map((t, index) => ({ ...t, index, hidden: false })),
   physicalCommunicationType: PhysicalCommunicationType.REGISTERED_LETTER_890,
   notificationFeePolicy: NotificationFeePolicy.DELIVERY_MODE,
 };

--- a/packages/pn-commons/src/utils/notification.utility.ts
+++ b/packages/pn-commons/src/utils/notification.utility.ts
@@ -276,10 +276,13 @@ export const getNotificationAllowedStatus = () => [
   },
 ];
 
-
-function legalFactTypeForAnalogEvent(timelineStep: INotificationDetailTimeline, legalFactKey?: string) {
+function legalFactTypeForAnalogEvent(
+  timelineStep: INotificationDetailTimeline,
+  legalFactKey?: string
+) {
   const attachments = (timelineStep.details as SendPaperDetails).attachments;
-  const matchingAttachment = legalFactKey && attachments && attachments.find(att => att.url === legalFactKey);
+  const matchingAttachment =
+    legalFactKey && attachments && attachments.find((att) => att.url === legalFactKey);
   return matchingAttachment ? matchingAttachment.documentType : undefined;
 }
 
@@ -292,7 +295,7 @@ function legalFactTypeForAnalogEvent(timelineStep: INotificationDetailTimeline, 
 export function getLegalFactLabel(
   timelineStep: INotificationDetailTimeline,
   legalFactType?: LegalFactType,
-  legalFactKey?: string,
+  legalFactKey?: string
 ): string {
   const legalFactLabel = getLocalizedOrDefaultLabel(
     'notifications',
@@ -310,8 +313,8 @@ export function getLegalFactLabel(
   // Hence I keep the condition on the category only.
   // -------------------------
   // Update as of 2023.04.21
-  // 
-  // As far as the new specification seems to indicate, 
+  //
+  // As far as the new specification seems to indicate,
   // the attachments for the analog flow will be always linked to
   // SEND_ANALOG_PROGRESS events and not to SEND_ANALOG_FEEDBACK ones.
   // As this is quite recent and maybe not that stable, I prefer to keep this code commented out
@@ -341,7 +344,7 @@ export function getLegalFactLabel(
   // -------------------------
   // Carlos Lombardi
   if (
-    timelineStep.category === TimelineCategory.SEND_ANALOG_PROGRESS || 
+    timelineStep.category === TimelineCategory.SEND_ANALOG_PROGRESS ||
     timelineStep.category === TimelineCategory.SEND_SIMPLE_REGISTERED_LETTER_PROGRESS
   ) {
     const type = legalFactTypeForAnalogEvent(timelineStep, legalFactKey) || 'generic';
@@ -359,12 +362,11 @@ export function getLegalFactLabel(
       );
     }
     return text;
-  // Carlos Lombardi
+    // Carlos Lombardi
 
-
-  // PN-5484  
+    // PN-5484
   } else if (
-    timelineStep.category === TimelineCategory.COMPLETELY_UNREACHABLE && 
+    timelineStep.category === TimelineCategory.COMPLETELY_UNREACHABLE &&
     legalFactType === LegalFactType.ANALOG_FAILURE_DELIVERY
   ) {
     return getLocalizedOrDefaultLabel(
@@ -373,7 +375,7 @@ export function getLegalFactLabel(
       'Deposito di avvenuta ricezione'
     );
   } else if (
-    timelineStep.category === TimelineCategory.ANALOG_FAILURE_WORKFLOW && 
+    timelineStep.category === TimelineCategory.ANALOG_FAILURE_WORKFLOW &&
     legalFactType === LegalFactType.AAR
   ) {
     return getLocalizedOrDefaultLabel(
@@ -381,7 +383,6 @@ export function getLegalFactLabel(
       'detail.timeline.aar-document',
       'Avviso di avvenuta ricezione'
     );
-
   } else if (
     timelineStep.category === TimelineCategory.SEND_DIGITAL_PROGRESS &&
     legalFactType === LegalFactType.PEC_RECEIPT
@@ -450,8 +451,8 @@ export function getLegalFactLabel(
       'mancato recapito digitale'
     )}`;
 
-  // this is (at least in the examples I've seen)
-  // related to the category NOTIFICATION_VIEWED
+    // this is (at least in the examples I've seen)
+    // related to the category NOTIFICATION_VIEWED
   } else if (legalFactType === LegalFactType.RECIPIENT_ACCESS) {
     return `${legalFactLabel}: ${getLocalizedOrDefaultLabel(
       'notifications',
@@ -473,15 +474,17 @@ export function getNotificationTimelineStatusInfos(
   recipients: Array<NotificationDetailRecipient>,
   allStepsForThisStatus?: Array<INotificationDetailTimeline>
 ): TimelineStepInfo | null {
-  const recipient = _.isNil(step.details.recIndex) 
-    ?  undefined
-    // For the accesses from recipient apps (cittadino / impresa)
+  const recipient = _.isNil(step.details.recIndex)
+    ? undefined
+    : // For the accesses from recipient apps (cittadino / impresa)
     // the API response will probably (in some future) include only the info about the requester recipient,
-    // i.e. recipients will be an array with exactly one element, disregarding how many recipients are included 
+    // i.e. recipients will be an array with exactly one element, disregarding how many recipients are included
     // in the notification being requested.
-    // In that case, we don't consider the recIndex indicated in each timeline step, 
+    // In that case, we don't consider the recIndex indicated in each timeline step,
     // but otherwise take all steps as related with the only recipient included in the API response.
-    : recipients.length === 1 ? recipients[0] : recipients[step.details.recIndex];
+    recipients.length === 1
+    ? recipients[0]
+    : recipients[step.details.recIndex];
 
   // we show the multirecipient versions of the step descriptions
   // only if the array of recipients include more than one "full" element
@@ -495,10 +498,12 @@ export function getNotificationTimelineStatusInfos(
   return TimelineStepFactory.createTimelineStep(step).getTimelineStepInfo({
     step,
     recipient,
-    isMultiRecipient: recipients
-      .filter(recDescription => recDescription.denomination && recDescription.taxId && recDescription.recipientType)
-      .length > 1,
-    allStepsForThisStatus
+    isMultiRecipient:
+      recipients.filter(
+        (recDescription) =>
+          recDescription.denomination && recDescription.taxId && recDescription.recipientType
+      ).length > 1,
+    allStepsForThisStatus,
   });
 }
 
@@ -515,7 +520,7 @@ const TimelineAllowedStatus = [
   TimelineCategory.NOT_HANDLED,
   TimelineCategory.SEND_ANALOG_PROGRESS,
   TimelineCategory.SEND_ANALOG_FEEDBACK,
-  TimelineCategory.SEND_SIMPLE_REGISTERED_LETTER_PROGRESS
+  TimelineCategory.SEND_SIMPLE_REGISTERED_LETTER_PROGRESS,
 ];
 
 const AnalogFlowAllowedCodes = [
@@ -615,15 +620,23 @@ function populateMacroStep(
       // PN-4484 - hide the internal events related to the courtesy messages sent through app IO
     } else if (isInternalAppIoEvent(step)) {
       status.steps!.push({ ...step, hidden: true });
-    // add legal facts for ANALOG_FAILURE_WORKFLOW steps with linked generatedAarUrl
-    // since the AAR for such steps must be shown in timeline exactly the same way as legalFacts.
-    // Cfr. comment in the definition of INotificationDetailTimeline in src/types/NotificationDetail.ts.
-    } else if (step.category === TimelineCategory.ANALOG_FAILURE_WORKFLOW && (step.details as AarDetails).generatedAarUrl) {
-      status.steps!.push({ 
-        ...step, 
-        legalFactsIds: [{ documentId: (step.details as AarDetails).generatedAarUrl as string, documentType: LegalFactType.AAR }] 
+      // add legal facts for ANALOG_FAILURE_WORKFLOW steps with linked generatedAarUrl
+      // since the AAR for such steps must be shown in timeline exactly the same way as legalFacts.
+      // Cfr. comment in the definition of INotificationDetailTimeline in src/types/NotificationDetail.ts.
+    } else if (
+      step.category === TimelineCategory.ANALOG_FAILURE_WORKFLOW &&
+      (step.details as AarDetails).generatedAarUrl
+    ) {
+      status.steps!.push({
+        ...step,
+        legalFactsIds: [
+          {
+            documentId: (step.details as AarDetails).generatedAarUrl as string,
+            documentType: LegalFactType.AAR,
+          },
+        ],
       });
-    // remove legal facts for those microsteps that are releated to accepted status
+      // remove legal facts for those microsteps that are releated to accepted status
     } else if (acceptedStatusItems.length && acceptedStatusItems.indexOf(step.elementId) > -1) {
       status.steps!.push({ ...step, legalFactsIds: [] });
       // default case
@@ -643,9 +656,7 @@ function fromLatestToEarliest(a: INotificationDetailTimeline, b: INotificationDe
   } else if (differenceInTimeline < 0) {
     return -1;
   } else {
-    console.log('fromLatestToEarliest - same timestamp');
-    console.log({a,b,differenceInIndex});
-    return differenceInIndex > 0 ? 1 : (differenceInIndex < 0 ? -1 : 0);
+    return differenceInIndex > 0 ? 1 : differenceInIndex < 0 ? -1 : 0;
   }
 }
 
@@ -717,9 +728,9 @@ function populateMacroSteps(parsedNotification: NotificationDetail) {
           !preventShiftFromDeliveredToDelivering
         ) {
           if (
-            (step.category === TimelineCategory.DIGITAL_FAILURE_WORKFLOW 
-              || step.category === TimelineCategory.SEND_SIMPLE_REGISTERED_LETTER 
-              || step.category === TimelineCategory.SEND_SIMPLE_REGISTERED_LETTER_PROGRESS) &&
+            (step.category === TimelineCategory.DIGITAL_FAILURE_WORKFLOW ||
+              step.category === TimelineCategory.SEND_SIMPLE_REGISTERED_LETTER ||
+              step.category === TimelineCategory.SEND_SIMPLE_REGISTERED_LETTER_PROGRESS) &&
             !lastDeliveredIndexToShiftIsFixed
           ) {
             lastDeliveredIndexToShift = ix;
@@ -798,9 +809,10 @@ const populateOtherDocuments = (
     return timelineFiltered.map((t) => {
       const recIndex = t.details.recIndex;
       const recipients = notificationDetail.recipients;
-      const recipientData = (isMultiRecipient && recIndex != null)
-        ? ` - ${recipients[recIndex].denomination} (${recipients[recIndex].taxId})`
-        : '';
+      const recipientData =
+        isMultiRecipient && recIndex != null
+          ? ` - ${recipients[recIndex].denomination} (${recipients[recIndex].taxId})`
+          : '';
       const title = `${getLocalizedOrDefaultLabel(
         'notifications',
         'detail.timeline.aar-document',
@@ -845,9 +857,9 @@ const populatePaymentHistory = (
       if (recIndex !== null && recIndex !== undefined) {
         // For the accesses from recipient apps (cittadino / impresa)
         // the API response will probably (in some future) include only the info about the requester recipient,
-        // i.e. recipients will be an array with exactly one element, disregarding how many recipients are included 
+        // i.e. recipients will be an array with exactly one element, disregarding how many recipients are included
         // in the notification being requested.
-        // In that case, we don't consider the recIndex indicated in each timeline step, 
+        // In that case, we don't consider the recIndex indicated in each timeline step,
         // but otherwise take all steps as related with the only recipient included in the API response.
         const recipient = recipients.length === 1 ? recipients[0] : recipients[recIndex];
         /* eslint-disable-next-line functional/immutable-data */
@@ -863,12 +875,10 @@ const populatePaymentHistory = (
   return paymentHistory;
 };
 
-
-
 function timelineElementMustBeShown(t: INotificationDetailTimeline): boolean {
   if (
-    t.category === TimelineCategory.SEND_ANALOG_PROGRESS || 
-    t.category === TimelineCategory.SEND_ANALOG_FEEDBACK || 
+    t.category === TimelineCategory.SEND_ANALOG_PROGRESS ||
+    t.category === TimelineCategory.SEND_ANALOG_FEEDBACK ||
     t.category === TimelineCategory.SEND_SIMPLE_REGISTERED_LETTER_PROGRESS
   ) {
     const deliveryDetailCode = (t.details as SendPaperDetails).deliveryDetailCode;

--- a/packages/pn-commons/src/utils/notification.utility.ts
+++ b/packages/pn-commons/src/utils/notification.utility.ts
@@ -635,10 +635,18 @@ function populateMacroStep(
 }
 
 function fromLatestToEarliest(a: INotificationDetailTimeline, b: INotificationDetailTimeline) {
-  if (new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime() >= 0) {
+  const differenceInTimeline = new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime();
+  const differenceInIndex = b.index && a.index ? b.index - a.index : 0;
+
+  if (differenceInTimeline > 0) {
     return 1;
+  } else if (differenceInTimeline < 0) {
+    return -1;
+  } else {
+    console.log('fromLatestToEarliest - same timestamp');
+    console.log({a,b,differenceInIndex});
+    return differenceInIndex > 0 ? 1 : (differenceInIndex < 0 ? -1 : 0);
   }
-  return -1;
 }
 
 function populateMacroSteps(parsedNotification: NotificationDetail) {
@@ -884,8 +892,9 @@ export function parseNotificationDetail(
   /* eslint-disable functional/immutable-data */
   /* eslint-disable functional/no-let */
   // set which elements are visible
-  parsedNotification.timeline = parsedNotification.timeline.map((t) => ({
+  parsedNotification.timeline = parsedNotification.timeline.map((t, index) => ({
     ...t,
+    index,
     hidden: !timelineElementMustBeShown(t),
   }));
   // populate notification macro steps with corresponding timeline micro steps


### PR DESCRIPTION
## Short description
Implemented a little modification on how timeline events are sorted to be shown in the notification detail, so that whenever the timestamp of two events is identical, the one having a least index in the list of events included in the notification-detail API response is considered as precedent (so is shown *below* in the FE timeline).

## List of changes proposed in this pull request
- Added the index taken the API response, to the FE representation of each timeline event.
- Changed the sorting function defined in `notification.utility.ts`, to use the indexes for comparison if the timestamps are identical.
- Added a specific test.
- Fixed the test which analyses the whole notification FE representation, adding the timeline event indexes to the "witness" notification structure used for comparison.

## How to test
Enter a notification having two timeline events with identical timelines. Examples
- in TEST environment: RALG-WJMH-WNPY-202306-T-1 (comune di Palermo / Ada Lovelace).
- in UAT environment: UPZE-YTUK-UNEM-202306-U-1 (comune di Sappada / Gaio Giulio Cesare).

Of course, testing this PR in any environment makes sense only if the corresponding BE fix of [PN-6860](https://pagopa.atlassian.net/browse/PN-6860) is available.

[PN-6860]: https://pagopa.atlassian.net/browse/PN-6860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ