### PR TITLE
fix/PN-7032 - fixed links 'Certificazioni' and 'Sicurezza delle Informazioni' in footer

### DIFF
--- a/packages/pn-commons/src/utils/costants.tsx
+++ b/packages/pn-commons/src/utils/costants.tsx
@@ -109,13 +109,13 @@ export const preLoginLinks = (
         },
         {
           ...getFooterLinkLabels('certifications', 'Certificazioni'),
-          href: 'https://www.pagopa.it/static/e1979a4c34b4756ec4e8ff9fe115b92a/Certificazine_ISO27001.pdf',
+          href: 'https://www.pagopa.it/it/certificazioni/',
           ariaLabel: 'Vai al link: Certificazioni',
           linkType: 'internal',
         },
         {
           ...getFooterLinkLabels('security', 'Sicurezza delle informazioni'),
-          href: 'https://www.pagopa.it/static/781646994f1f8ddad2d95af3aaedac3d/Sicurezza-delle-informazioni_PagoPA-S.p.A..pdf',
+          href: 'https://www.pagopa.it/it/politiche-per-la-sicurezza-delle-informazioni/',
           ariaLabel: 'Vai al link: Sicurezza delle informazioni',
           linkType: 'internal',
         },


### PR DESCRIPTION
## Short description
Fixed the links 'Certificazioni' and 'Sicurezza delle Informazioni' present in the third column in the footer for the initial page (the page that leads to the login) for the PA / PF / PG apps. Now clicking these links lead to the right URLs.
Landing page had already the right links prior to this PR.

## List of changes proposed in this pull request
Just changed the pointers in the `costants.tsx` file (SIC) in `pn-commons`.

## How to test
Enter the initial page for PA / PF / PG, click the indicated links in the footer; see image below. You should be directed to pages inside the PagoPA site referring to the subject mentioned in each link.
![image](https://github.com/pagopa/pn-frontend/assets/5519535/2d045d51-b53d-4a41-b2b6-db1cb24a885e)


