### PR TITLE
Fixed mobile modal buttons and tests

### DIFF
--- a/packages/pn-commons/src/components/CodeModal/CodeModal.tsx
+++ b/packages/pn-commons/src/components/CodeModal/CodeModal.tsx
@@ -147,7 +147,7 @@ const CodeModal = memo(
               onClick={cancelCallback}
               fullWidth={isMobile}
               data-testid="codeCancelButton"
-              sx={{ marginTop: isMobile ? "16px" : 0 }}
+              sx={{ mt: isMobile ? 2 : 0 }}
             >
               {cancelLabel}
             </Button>

--- a/packages/pn-commons/src/components/CodeModal/CodeModal.tsx
+++ b/packages/pn-commons/src/components/CodeModal/CodeModal.tsx
@@ -103,7 +103,7 @@ const CodeModal = memo(
           <Typography fontSize={16} fontWeight={600} sx={{ textAlign: textPosition }}>
             {codeSectionTitle}
           </Typography>
-          <Box sx={{ marginTop: '10px', textAlign: textPosition }}>
+          <Box sx={{ mt:2, textAlign: textPosition }}>
             <CodeInput
               initialValues={initialValues}
               isReadOnly={isReadOnly}
@@ -147,7 +147,7 @@ const CodeModal = memo(
               onClick={cancelCallback}
               fullWidth={isMobile}
               data-testid="codeCancelButton"
-              sx={{ marginTop: isMobile ? '10px' : 0 }}
+              sx={{ marginTop: isMobile ? "10px" : 0 }}
             >
               {cancelLabel}
             </Button>

--- a/packages/pn-commons/src/components/CodeModal/CodeModal.tsx
+++ b/packages/pn-commons/src/components/CodeModal/CodeModal.tsx
@@ -136,7 +136,7 @@ const CodeModal = memo(
           disableSpacing={isMobile}
           sx={{
             textAlign: textPosition,
-            flexDirection: isMobile ? 'column' : 'row',
+            flexDirection: isMobile ? 'column-reverse' : 'row',
             px: 4,
             pb: 4,
           }}
@@ -147,6 +147,7 @@ const CodeModal = memo(
               onClick={cancelCallback}
               fullWidth={isMobile}
               data-testid="codeCancelButton"
+              sx={{ marginTop: isMobile ? '10px' : 0 }}
             >
               {cancelLabel}
             </Button>
@@ -158,7 +159,6 @@ const CodeModal = memo(
               onClick={confirmHandler}
               disabled={!codeIsValid}
               fullWidth={isMobile}
-              sx={{ marginTop: isMobile ? '10px' : 0 }}
             >
               {confirmLabel}
             </Button>

--- a/packages/pn-commons/src/components/CodeModal/CodeModal.tsx
+++ b/packages/pn-commons/src/components/CodeModal/CodeModal.tsx
@@ -147,7 +147,7 @@ const CodeModal = memo(
               onClick={cancelCallback}
               fullWidth={isMobile}
               data-testid="codeCancelButton"
-              sx={{ marginTop: isMobile ? "10px" : 0 }}
+              sx={{ marginTop: isMobile ? "16px" : 0 }}
             >
               {cancelLabel}
             </Button>

--- a/packages/pn-commons/src/components/DisclaimerModal.tsx
+++ b/packages/pn-commons/src/components/DisclaimerModal.tsx
@@ -62,7 +62,7 @@ const DisclaimerModal = ({
         disableSpacing={isMobile}
         sx={{
           textAlign: textPosition,
-          flexDirection: isMobile ? 'column' : 'row',
+          flexDirection: isMobile ? 'column-reverse' : 'row',
           p: 4,
           pt: 0,
         }}
@@ -72,7 +72,6 @@ const DisclaimerModal = ({
           onClick={onCancel}
           fullWidth={isMobile}
           data-testid="disclaimer-cancel-button"
-          sx={{ mb: isMobile ? 2 : 0 }}
         >
           {getLocalizedOrDefaultLabel('common', 'button.annulla', 'Annulla')}
         </Button>
@@ -82,6 +81,7 @@ const DisclaimerModal = ({
           disabled={disabledConfirm}
           fullWidth={isMobile}
           data-testid="disclaimer-confirm-button"
+          sx={{ mb: isMobile ? 2 : 0 }}
         >
           {confirmLabel}
         </Button>

--- a/packages/pn-personafisica-webapp/src/component/Contacts/DigitalContactElem.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Contacts/DigitalContactElem.tsx
@@ -6,6 +6,7 @@ import {
   ReactChild,
   SetStateAction,
   useImperativeHandle,
+  useMemo,
   useState,
 } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -22,6 +23,7 @@ import {
 } from '@mui/material';
 import { ButtonNaked } from '@pagopa/mui-italia';
 
+import { useIsMobile } from '@pagopa-pn/pn-commons';
 import { CourtesyChannelType, LegalChannelType } from '../../models/contacts';
 import { deleteCourtesyAddress, deleteLegalAddress } from '../../redux/contact/actions';
 import { DeleteDigitalAddressParams } from '../../redux/contact/types';
@@ -72,17 +74,23 @@ const DeleteDialog: React.FC<DialogProps> = ({
   confirmHandler,
 }) => {
   const { t } = useTranslation(['common']);
-
+  const isMobile = useIsMobile();
+  const textPosition = useMemo(() => (isMobile ? 'center' : 'left'), [isMobile]);
+  
   const deleteModalActions = blockDelete ? (
-    <Button onClick={handleModalClose} variant="outlined">
+    <Button onClick={handleModalClose} variant="outlined" sx={{ width: isMobile ? '100%' : null }}>
       {t('button.close')}
     </Button>
   ) : (
     <>
-      <Button onClick={handleModalClose} variant="outlined">
+      <Button
+        onClick={handleModalClose}
+        variant="outlined"
+        sx={isMobile ? { width: '100%', mt: 2 } : null}
+      >
         {t('button.annulla')}
       </Button>
-      <Button onClick={confirmHandler} variant="contained">
+      <Button onClick={confirmHandler} variant="contained" sx={{ width: isMobile ? '100%' : null }}>
         {t('button.conferma')}
       </Button>
     </>
@@ -94,11 +102,23 @@ const DeleteDialog: React.FC<DialogProps> = ({
       aria-labelledby="dialog-title"
       aria-describedby="dialog-description"
     >
-      <DialogTitle id="dialog-title">{removeModalTitle}</DialogTitle>
-      <DialogContent>
+      <DialogTitle id="dialog-title" sx={{ textAlign: textPosition, pt: 4, px: 4 }}>
+        {removeModalTitle}
+      </DialogTitle>
+      <DialogContent sx={{ px: 4 }}>
         <DialogContentText id="dialog-description">{removeModalBody}</DialogContentText>
       </DialogContent>
-      <DialogActions>{deleteModalActions}</DialogActions>
+      <DialogActions
+        disableSpacing={isMobile}
+        sx={{
+          textAlign: textPosition,
+          flexDirection: isMobile ? 'column-reverse' : 'row',
+          px: 4,
+          pb: 4,
+        }}
+      >
+        {deleteModalActions}
+      </DialogActions>
     </Dialog>
   );
 };

--- a/packages/pn-personafisica-webapp/src/component/Deleghe/ConfirmationModal.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Deleghe/ConfirmationModal.tsx
@@ -53,7 +53,7 @@ export default function ConfirmationModal({
             pb={isMobile ? 4 : 0}
             data-testid="dialogStack"
           >
-            <Grid item sx={{ width: isMobile ? '100%' : null }} mt={isMobile ? 1 : 4} mr={isMobile ? 0 : 1}>
+            <Grid item sx={{ width: isMobile ? '100%' : null }} mt={isMobile ? 2 : 4} mr={isMobile ? 0 : 1}>
               <Button
                 sx={{ width: isMobile ? '100%' : null }}
                 onClick={handleClose}

--- a/packages/pn-personafisica-webapp/src/component/Deleghe/ConfirmationModal.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Deleghe/ConfirmationModal.tsx
@@ -46,14 +46,14 @@ export default function ConfirmationModal({
           </Grid>
 
           <Stack
-            direction={isMobile ? 'column' : 'row'}
+            direction={isMobile ? 'column-reverse' : 'row'}
             justifyContent={'flex-end'}
             alignItems={'center'}
             ml={'auto'}
             pb={isMobile ? 4 : 0}
             data-testid="dialogStack"
           >
-            <Grid item sx={{ width: isMobile ? '100%' : null }} mt={4} mr={isMobile ? 0 : 1}>
+            <Grid item sx={{ width: isMobile ? '100%' : null }} mt={isMobile ? 1 : 4} mr={isMobile ? 0 : 1}>
               <Button
                 sx={{ width: isMobile ? '100%' : null }}
                 onClick={handleClose}

--- a/packages/pn-personafisica-webapp/src/component/Deleghe/__test__/ConfirmationModal.test.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Deleghe/__test__/ConfirmationModal.test.tsx
@@ -109,6 +109,6 @@ describe('ConfirmationModal Component', () => {
 
     expect(dialog).toBeInTheDocument();
     expect(buttons).toHaveLength(2);
-    expect(stack).toHaveStyle('flex-direction: column');
+    expect(stack).toHaveStyle('flex-direction: column-reverse');
   });
 });

--- a/packages/pn-personagiuridica-webapp/src/component/Contacts/DigitalContactElem.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Contacts/DigitalContactElem.tsx
@@ -6,6 +6,7 @@ import {
   ReactChild,
   SetStateAction,
   useImperativeHandle,
+  useMemo,
   useState,
 } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -22,6 +23,7 @@ import {
 } from '@mui/material';
 import { ButtonNaked } from '@pagopa/mui-italia';
 
+import { useIsMobile } from '@pagopa-pn/pn-commons';
 import { CourtesyChannelType, LegalChannelType } from '../../models/contacts';
 import { deleteCourtesyAddress, deleteLegalAddress } from '../../redux/contact/actions';
 import { DeleteDigitalAddressParams } from '../../redux/contact/types';
@@ -72,17 +74,23 @@ const DeleteDialog: React.FC<DialogProps> = ({
   confirmHandler,
 }) => {
   const { t } = useTranslation(['common']);
+  const isMobile = useIsMobile();
+  const textPosition = useMemo(() => (isMobile ? 'center' : 'left'), [isMobile]);
 
   const deleteModalActions = blockDelete ? (
-    <Button onClick={handleModalClose} variant="outlined">
+    <Button onClick={handleModalClose} variant="outlined" sx={{ width: isMobile ? '100%' : null }}>
       {t('button.close')}
     </Button>
   ) : (
     <>
-      <Button onClick={handleModalClose} variant="outlined">
+      <Button
+        onClick={handleModalClose}
+        variant="outlined"
+        sx={isMobile ? { width: '100%', mt: 2 } : null}
+      >
         {t('button.annulla')}
       </Button>
-      <Button onClick={confirmHandler} variant="contained">
+      <Button onClick={confirmHandler} variant="contained" sx={{ width: isMobile ? '100%' : null }}>
         {t('button.conferma')}
       </Button>
     </>
@@ -94,11 +102,19 @@ const DeleteDialog: React.FC<DialogProps> = ({
       aria-labelledby="dialog-title"
       aria-describedby="dialog-description"
     >
-      <DialogTitle id="dialog-title">{removeModalTitle}</DialogTitle>
-      <DialogContent>
+      <DialogTitle id="dialog-title" sx={{ textAlign: textPosition, pt: 4, px: 4 }}>{removeModalTitle}</DialogTitle>
+      <DialogContent sx={{ px: 4 }}>
         <DialogContentText id="dialog-description">{removeModalBody}</DialogContentText>
       </DialogContent>
-      <DialogActions>{deleteModalActions}</DialogActions>
+      <DialogActions
+        disableSpacing={isMobile}
+        sx={{
+          textAlign: textPosition,
+          flexDirection: isMobile ? 'column-reverse' : 'row',
+          px: 4,
+          pb: 4,
+        }}
+      >{deleteModalActions}</DialogActions>
     </Dialog>
   );
 };

--- a/packages/pn-personagiuridica-webapp/src/component/Deleghe/ConfirmationModal.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Deleghe/ConfirmationModal.tsx
@@ -50,14 +50,14 @@ export default function ConfirmationModal({
           )}
 
           <Stack
-            direction={isMobile ? 'column' : 'row'}
+            direction={isMobile ? 'column-reverse' : 'row'}
             justifyContent={'flex-end'}
             alignItems={'center'}
             ml={'auto'}
             pb={4}
             data-testid="dialogStack"
           >
-            <Grid item sx={{ width: isMobile ? '100%' : null }} mt={4} mr={isMobile ? 0 : 1}>
+            <Grid item sx={{ width: isMobile ? '100%' : null }} mt={isMobile ? 1 : 4} mr={isMobile ? 0 : 1}>
               <Button
                 sx={{ width: isMobile ? '100%' : null }}
                 onClick={onClose}

--- a/packages/pn-personagiuridica-webapp/src/component/Deleghe/ConfirmationModal.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Deleghe/ConfirmationModal.tsx
@@ -57,7 +57,7 @@ export default function ConfirmationModal({
             pb={4}
             data-testid="dialogStack"
           >
-            <Grid item sx={{ width: isMobile ? '100%' : null }} mt={isMobile ? 1 : 4} mr={isMobile ? 0 : 1}>
+            <Grid item sx={{ width: isMobile ? '100%' : null }} mt={isMobile ? 2 : 4} mr={isMobile ? 0 : 1}>
               <Button
                 sx={{ width: isMobile ? '100%' : null }}
                 onClick={onClose}

--- a/packages/pn-personagiuridica-webapp/src/component/Deleghe/__test__/ConfirmationModal.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Deleghe/__test__/ConfirmationModal.test.tsx
@@ -109,6 +109,6 @@ describe('ConfirmationModal Component', () => {
 
     expect(dialog).toBeInTheDocument();
     expect(buttons).toHaveLength(2);
-    expect(stack).toHaveStyle('flex-direction: column');
+    expect(stack).toHaveStyle('flex-direction: column-reverse');
   });
 });


### PR DESCRIPTION
## Short description
Fixed mobile modal buttons and tests.

## List of changes proposed in this pull request
- Fixed flex-direction in mobile modals view
- Fixed tests

## How to test
For example login in PF and revoke or make a delegation. In desktop buttons sequece is "Cancel" -> "Submit". In mobile should be now as "Submit" -> "Cancel"