### PR TITLE
fix: hide groups if empty on mobile notifications

### DIFF
--- a/packages/pn-pa-webapp/src/pages/components/Notifications/MobileNotifications.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/Notifications/MobileNotifications.tsx
@@ -121,7 +121,7 @@ const MobileNotifications = ({
       id: 'group',
       label: t('table.groups'),
       getLabel(value: string, row: Item) {
-        return (
+        return value ? (
           <CustomTagGroup visibleItems={1}>
             {[
               <Box sx={{ mb: 1, mr: 1, display: 'inline-block' }} key={row.id}>
@@ -129,7 +129,7 @@ const MobileNotifications = ({
               </Box>,
             ]}
           </CustomTagGroup>
-        );
+        ) : null;
       },
       hideIfEmpty: true,
     },


### PR DESCRIPTION
## Short description
Hide groups if empty on mobile notifications

## List of changes proposed in this pull request
- Edit mobile notifications

## How to test
On a PA go to notifications mobile and you should not see the group labels if groups are empty