### PR TITLE
fix/PN-7063 - date in new delegation clears when user deletes the content

### DIFF
--- a/packages/pn-personafisica-webapp/src/pages/NuovaDelega.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/NuovaDelega.page.tsx
@@ -443,7 +443,7 @@ const NuovaDelega = () => {
                             <CustomDatePicker
                               label={t('nuovaDelega.form.endDate')}
                               inputFormat={DATE_FORMAT}
-                              value={new Date(values.expirationDate)}
+                              value={values.expirationDate && new Date(values.expirationDate)}
                               minDate={tomorrow}
                               onChange={(value: DatePickerTypes) => {
                                 setFieldTouched('expirationDate', true, false);

--- a/packages/pn-personagiuridica-webapp/src/pages/NuovaDelega.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/NuovaDelega.page.tsx
@@ -419,9 +419,11 @@ const NuovaDelega = () => {
                             <CustomDatePicker
                               label={t('nuovaDelega.form.endDate')}
                               inputFormat={DATE_FORMAT}
-                              value={new Date(values.expirationDate)}
+                              value={values.expirationDate && new Date(values.expirationDate)}
                               minDate={tomorrow}
                               onChange={(value: DatePickerTypes) => {
+                                console.log('changing date');
+                                console.log(value);
                                 setFieldTouched('expirationDate', true, false);
                                 setFieldValue('expirationDate', value);
                               }}

--- a/packages/pn-personagiuridica-webapp/src/pages/NuovaDelega.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/NuovaDelega.page.tsx
@@ -422,8 +422,6 @@ const NuovaDelega = () => {
                               value={values.expirationDate && new Date(values.expirationDate)}
                               minDate={tomorrow}
                               onChange={(value: DatePickerTypes) => {
-                                console.log('changing date');
-                                console.log(value);
                                 setFieldTouched('expirationDate', true, false);
                                 setFieldValue('expirationDate', value);
                               }}


### PR DESCRIPTION
## Short description
This PR implements a fix for the action of deleting the end-of-delegation date in the new delegation ("Nuova delega") form.  
- Before this PR, the date was reset to 01/01/1970.  
- After this PR, the date contents actually get empty.

## List of changes proposed in this pull request
Just retouched how the value of the end-of-delegation date is defined in `NuovaDelega.page.tsx`.

## How to test
Just access to the creation of a new delegation in both PF and PG, clean the contents of the end-of-delegation ("Termine delega") field. The field should actually be empty. That's all.
