### PR TITLE
removed trailing slash in prod config

### DIFF
--- a/packages/pn-pa-webapp/public/conf/env/config.prod.json
+++ b/packages/pn-pa-webapp/public/conf/env/config.prod.json
@@ -3,7 +3,7 @@
     "SELFCARE_URL_FE_LOGIN": "https://selfcare.pagopa.it/auth/login",
     "SELFCARE_BASE_URL": "https://selfcare.pagopa.it",
     "API_BASE_URL": "https://webapi.notifichedigitali.it/",
-    "LANDING_SITE_URL": "https://notifichedigitali.pagopa.it/",
+    "LANDING_SITE_URL": "https://notifichedigitali.pagopa.it",
     "DISABLE_INACTIVITY_HANDLER": false,
     "OT_DOMAIN_ID": "62ebb6a0-1a65-48a4-8ca0-837de03b1199",
     "MIXPANEL_TOKEN": "e860a58bfce634272eca1e0ce288f33a",

--- a/packages/pn-personafisica-webapp/public/conf/env/config.prod.json
+++ b/packages/pn-personafisica-webapp/public/conf/env/config.prod.json
@@ -9,7 +9,7 @@
     "OT_DOMAIN_ID": "29cc1c86-f2ef-494d-8242-9bec8009cd29",
     "PAGOPA_HELP_EMAIL": "destinatari-send@assistenza.pagopa.it",
     "URL_FE_LOGIN": "https://login.notifichedigitali.it/",
-    "LANDING_SITE_URL": "https://notifichedigitali.pagopa.it/",
+    "LANDING_SITE_URL": "https://notifichedigitali.pagopa.it",
     "DELEGATIONS_TO_PG_ENABLED": true,
     "WORK_IN_PROGRESS": false
 }

--- a/packages/pn-personagiuridica-webapp/public/conf/env/config.prod.json
+++ b/packages/pn-personagiuridica-webapp/public/conf/env/config.prod.json
@@ -9,7 +9,7 @@
     "SELFCARE_BASE_URL": "https://imprese.notifichedigitali.it",
     "PAGOPA_HELP_EMAIL": "destinatari-send@assistenza.pagopa.it",
     "URL_FE_LOGIN": "https://imprese.notifichedigitali.it/auth/login",
-    "LANDING_SITE_URL": "https://notifichedigitali.pagopa.it/",
+    "LANDING_SITE_URL": "https://notifichedigitali.pagopa.it",
     "DELEGATIONS_TO_PG_ENABLED": true,
     "WORK_IN_PROGRESS": false
 }


### PR DESCRIPTION
in config.prod.json there was a trailing slash that broke faq and other links from portal to landing page.
