### PR TITLE
fix: removed email icon from breadcrumb and fixed mobile alignment

### DIFF
--- a/packages/pn-commons/src/components/PnBreadcrumb.tsx
+++ b/packages/pn-commons/src/components/PnBreadcrumb.tsx
@@ -41,12 +41,7 @@ const PnBreadcrumb = ({
     goBackLabel || getLocalizedOrDefaultLabel('common', 'button.indietro', 'Indietro');
 
   return (
-    <Stack
-      direction={{ xs: 'column', sm: 'row' }}
-      alignItems={{ xs: 'start', sm: 'center' }}
-      justifyContent="start"
-      spacing={3}
-    >
+    <Stack direction="row" alignItems="center" justifyContent="start" spacing={3}>
       {showBackAction && (
         <ButtonNaked
           color="primary"

--- a/packages/pn-pa-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/NotificationDetail.page.tsx
@@ -339,7 +339,7 @@ const NotificationDetail = () => {
   const properBreadcrumb = (
     <PnBreadcrumb
       linkRoute={routes.DASHBOARD}
-      linkLabel={<Fragment>{t('detail.breadcrumb-root', { ns: 'notifiche' })}</Fragment>}
+      linkLabel={t('detail.breadcrumb-root', { ns: 'notifiche' })}
       currentLocationLabel={t('detail.breadcrumb-leaf', { ns: 'notifiche' })}
       goBackLabel={t('button.indietro', { ns: 'common' })}
     />

--- a/packages/pn-pa-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/NotificationDetail.page.tsx
@@ -17,7 +17,6 @@ import {
   Alert,
 } from '@mui/material';
 import { makeStyles } from '@mui/styles';
-import EmailIcon from '@mui/icons-material/Email';
 import {
   // PN-1714
   // NotificationStatus,
@@ -340,12 +339,7 @@ const NotificationDetail = () => {
   const properBreadcrumb = (
     <PnBreadcrumb
       linkRoute={routes.DASHBOARD}
-      linkLabel={
-        <Fragment>
-          <EmailIcon sx={{ mr: 0.5 }} />
-          {t('detail.breadcrumb-root', { ns: 'notifiche' })}
-        </Fragment>
-      }
+      linkLabel={<Fragment>{t('detail.breadcrumb-root', { ns: 'notifiche' })}</Fragment>}
       currentLocationLabel={t('detail.breadcrumb-leaf', { ns: 'notifiche' })}
       goBackLabel={t('button.indietro', { ns: 'common' })}
     />

--- a/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
@@ -4,7 +4,6 @@ import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Grid, Box, Paper, Stack, Typography, Alert } from '@mui/material';
 import { makeStyles } from '@mui/styles';
-import EmailIcon from '@mui/icons-material/Email';
 import {
   LegalFactId,
   NotificationDetailDocuments,
@@ -267,12 +266,7 @@ const NotificationDetail = () => {
       <PnBreadcrumb
         showBackAction={!fromQrCode}
         linkRoute={backRoute}
-        linkLabel={
-          <Fragment>
-            <EmailIcon sx={{ mr: 0.5 }} />
-            {t('detail.breadcrumb-root', { ns: 'notifiche' })}
-          </Fragment>
-        }
+        linkLabel={<Fragment>{t('detail.breadcrumb-root', { ns: 'notifiche' })}</Fragment>}
         currentLocationLabel={`${t('detail.breadcrumb-leaf', { ns: 'notifiche' })}`}
         goBackAction={() => navigate(backRoute)}
       />

--- a/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
@@ -266,7 +266,7 @@ const NotificationDetail = () => {
       <PnBreadcrumb
         showBackAction={!fromQrCode}
         linkRoute={backRoute}
-        linkLabel={<Fragment>{t('detail.breadcrumb-root', { ns: 'notifiche' })}</Fragment>}
+        linkLabel={t('detail.breadcrumb-root', { ns: 'notifiche' })}
         currentLocationLabel={`${t('detail.breadcrumb-leaf', { ns: 'notifiche' })}`}
         goBackAction={() => navigate(backRoute)}
       />

--- a/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
@@ -4,7 +4,6 @@ import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Grid, Box, Paper, Stack, Typography, Alert } from '@mui/material';
 import { makeStyles } from '@mui/styles';
-import EmailIcon from '@mui/icons-material/Email';
 import {
   LegalFactId,
   NotificationDetailDocuments,
@@ -267,12 +266,7 @@ const NotificationDetail = () => {
       <PnBreadcrumb
         showBackAction={!fromQrCode}
         linkRoute={backRoute}
-        linkLabel={
-          <Fragment>
-            <EmailIcon sx={{ mr: 0.5 }} />
-            {t('detail.breadcrumb-root', { ns: 'notifiche' })}
-          </Fragment>
-        }
+        linkLabel={<Fragment>{t('detail.breadcrumb-root', { ns: 'notifiche' })}</Fragment>}
         currentLocationLabel={`${t('detail.breadcrumb-leaf', { ns: 'notifiche' })}`}
         goBackAction={() => navigate(backRoute)}
       />

--- a/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
@@ -266,7 +266,7 @@ const NotificationDetail = () => {
       <PnBreadcrumb
         showBackAction={!fromQrCode}
         linkRoute={backRoute}
-        linkLabel={<Fragment>{t('detail.breadcrumb-root', { ns: 'notifiche' })}</Fragment>}
+        linkLabel={t('detail.breadcrumb-root', { ns: 'notifiche' })}
         currentLocationLabel={`${t('detail.breadcrumb-leaf', { ns: 'notifiche' })}`}
         goBackAction={() => navigate(backRoute)}
       />


### PR DESCRIPTION
## Short description
Removed icons from breadcrumb of notification detail. Fixed also mobile alignment of breadcrumb

## List of changes proposed in this pull request
- Removed icon from breadcrum
- Fixed mobile alignment

## How to test
Go to notification detail of PA, PF and PG and breadcrumb shouldn't have the email icon. On mobile it should be inline