### PR TITLE
Pn 7098

### DIFF
--- a/packages/pn-commons/src/utils/__test__/genericFunctions.utility.test.tsx
+++ b/packages/pn-commons/src/utils/__test__/genericFunctions.utility.test.tsx
@@ -85,7 +85,7 @@ describe('disableFormatDetection function', () => {
     const mockText = 'mocked text with a phone number +393200000000';
     expect(disableFormatDetection(mockText)).toStrictEqual(
       <a
-        href="javascript:void(0);"
+        href="javascript:() => {};"
         style={{ color: 'inherit', textDecoration: 'inherit', cursor: 'inherit' }}
       >
         mocked text with a phone number +393200000000

--- a/packages/pn-commons/src/utils/genericFunctions.utility.tsx
+++ b/packages/pn-commons/src/utils/genericFunctions.utility.tsx
@@ -55,14 +55,15 @@ export function sortArray<TArray>(
  */
 export function disableFormatDetection<ReactNode>(param: string | ReactNode) {
   /*
-    Using href="#" makes the browser to reload the webapp, so we are using href="javascript:void(0);" instead.
+    Using href="#" makes the browser to reload the webapp, so we are using href="javascript:() => {};" instead.
   */
- return (
-   <a
-     href="javascript:void(0);"
-     style={{ color: 'inherit', textDecoration: 'inherit', cursor: 'inherit' }}
-   >
-     {param}
-   </a>
- );
+
+  return (
+    <a
+      href="javascript:() => {};"
+      style={{ color: 'inherit', textDecoration: 'inherit', cursor: 'inherit' }}
+    >
+      {param}
+    </a>
+  );
 }

--- a/packages/pn-pa-webapp/public/index.html
+++ b/packages/pn-pa-webapp/public/index.html
@@ -7,7 +7,6 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta http-equiv="x-ua-compatible" content="ie=edge" />
-  <meta name="format-detection" content="telephone=no" />
 
   <title>SEND</title>
   <meta name="description" content="Modulo di backoffice per SEND - Servizio Notifiche Digitali" />

--- a/packages/pn-personafisica-webapp/public/index.html
+++ b/packages/pn-personafisica-webapp/public/index.html
@@ -7,7 +7,6 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta http-equiv="x-ua-compatible" content="ie=edge" />
-  <meta name="format-detection" content="telephone=no" />
   
   <title>SEND</title>
   <meta name="description" content="Servizio notifiche digitali per il cittadino" />

--- a/packages/pn-personafisica-webapp/src/component/Contacts/DigitalContactElem.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Contacts/DigitalContactElem.tsx
@@ -24,6 +24,7 @@ import {
 import { ButtonNaked } from '@pagopa/mui-italia';
 
 import { useIsMobile } from '@pagopa-pn/pn-commons';
+import { disableFormatDetection } from '@pagopa-pn/pn-commons/src/utils/genericFunctions.utility';
 import { CourtesyChannelType, LegalChannelType } from '../../models/contacts';
 import { deleteCourtesyAddress, deleteLegalAddress } from '../../redux/contact/actions';
 import { DeleteDigitalAddressParams } from '../../redux/contact/types';
@@ -106,7 +107,7 @@ const DeleteDialog: React.FC<DialogProps> = ({
         {removeModalTitle}
       </DialogTitle>
       <DialogContent sx={{ px: 4 }}>
-        <DialogContentText id="dialog-description">{removeModalBody}</DialogContentText>
+        <DialogContentText id="dialog-description">{disableFormatDetection(removeModalBody)}</DialogContentText>
       </DialogContent>
       <DialogActions
         disableSpacing={isMobile}

--- a/packages/pn-personagiuridica-webapp/public/index.html
+++ b/packages/pn-personagiuridica-webapp/public/index.html
@@ -6,7 +6,6 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta http-equiv="x-ua-compatible" content="ie=edge" />
-    <meta name="format-detection" content="telephone=no" />
 
     <title>SEND</title>
     <meta name="description" content="Servizio notifiche digitali per le aziende" />

--- a/packages/pn-personagiuridica-webapp/src/component/Contacts/DigitalContactElem.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Contacts/DigitalContactElem.tsx
@@ -24,6 +24,7 @@ import {
 import { ButtonNaked } from '@pagopa/mui-italia';
 
 import { useIsMobile } from '@pagopa-pn/pn-commons';
+import { disableFormatDetection } from '@pagopa-pn/pn-commons/src/utils/genericFunctions.utility';
 import { CourtesyChannelType, LegalChannelType } from '../../models/contacts';
 import { deleteCourtesyAddress, deleteLegalAddress } from '../../redux/contact/actions';
 import { DeleteDigitalAddressParams } from '../../redux/contact/types';
@@ -104,7 +105,7 @@ const DeleteDialog: React.FC<DialogProps> = ({
     >
       <DialogTitle id="dialog-title" sx={{ textAlign: textPosition, pt: 4, px: 4 }}>{removeModalTitle}</DialogTitle>
       <DialogContent sx={{ px: 4 }}>
-        <DialogContentText id="dialog-description">{removeModalBody}</DialogContentText>
+        <DialogContentText id="dialog-description">{disableFormatDetection(removeModalBody)}</DialogContentText>
       </DialogContent>
       <DialogActions
         disableSpacing={isMobile}


### PR DESCRIPTION
## Short description
Attempting another method to disable Safari iOS auto formatting.

## List of changes proposed in this pull request
- meta tag "format-detection" doesn't works anymore
- used a function that wrap text in a empty link

## How to test
Safari auto-formatting should be gone.