### PR TITLE
fix: alignment of notification detail table on mobile

### DIFF
--- a/packages/pn-commons/src/components/NotificationDetail/NotificationDetailTable.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationDetailTable.tsx
@@ -12,7 +12,7 @@ type Props = {
  * @param rows data to show
  */
 const NotificationDetailTable = ({ rows }: Props) => (
-  <TableContainer component={Paper} sx={{ px: 3, py: 2 }} className="paperContainer">
+  <TableContainer component={Paper} sx={{ px: 3, py: { xs: 3, lg: 2 } }} className="paperContainer">
     <Table
       aria-label={getLocalizedOrDefaultLabel(
         'notifications',

--- a/packages/pn-commons/src/components/NotificationDetail/NotificationDetailTable.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationDetailTable.tsx
@@ -13,12 +13,30 @@ type Props = {
  */
 const NotificationDetailTable = ({ rows }: Props) => (
   <TableContainer component={Paper} sx={{ px: 3, py: 2 }} className="paperContainer">
-    <Table aria-label={getLocalizedOrDefaultLabel('notifications', 'detail.table-aria-label', 'Dettaglio notifica')}>
+    <Table
+      aria-label={getLocalizedOrDefaultLabel(
+        'notifications',
+        'detail.table-aria-label',
+        'Dettaglio notifica'
+      )}
+    >
       <TableBody>
         {rows.map((row) => (
-          <TableRow key={row.id} sx={{ '& td': { border: 'none' }, verticalAlign: 'top' }}>
-            <TableCell padding="none" sx={{ py: 1 }}>{row.label}</TableCell>
-            <TableCell padding="none" sx={{ py: 1 }}>{row.value}</TableCell>
+          <TableRow
+            key={row.id}
+            sx={{
+              '& td': { border: 'none' },
+              verticalAlign: 'top',
+              display: { xs: 'flex', lg: 'table-row' },
+              flexDirection: { xs: 'column', lg: 'row' },
+            }}
+          >
+            <TableCell padding="none" sx={{ py: { xs: 0, lg: 1 } }}>
+              {row.label}
+            </TableCell>
+            <TableCell padding="none" sx={{ pb: 1, pt: { xs: 0, lg: 1 } }}>
+              {row.value}
+            </TableCell>
           </TableRow>
         ))}
       </TableBody>

--- a/packages/pn-commons/src/components/NotificationDetail/NotificationDetailTimeline.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationDetailTimeline.tsx
@@ -17,7 +17,7 @@ type Props = {
   recipients: Array<NotificationDetailRecipient>;
   statusHistory: Array<NotificationStatusHistory>;
   title: string;
-  // legalFact can be either a LegalFactId, or a NotificationDetailOtherDocument 
+  // legalFact can be either a LegalFactId, or a NotificationDetailOtherDocument
   // (generated from details.generatedAarUrl in ANALOG_FAILURE_WORKFLOW timeline elements).
   // Cfr. comment in the definition of INotificationDetailTimeline in src/types/NotificationDetail.ts.
   clickHandler: (legalFactId: LegalFactId | NotificationDetailOtherDocument) => void;
@@ -56,7 +56,7 @@ const NotificationDetailTimeline = ({
   historyButtonLabel,
   showMoreButtonLabel,
   showLessButtonLabel,
-  eventTrackingCallbackShowMore
+  eventTrackingCallbackShowMore,
 }: Props) => {
   const [state, setState] = useState(false);
   const isMobile = useIsMobile();
@@ -85,7 +85,7 @@ const NotificationDetailTimeline = ({
       recipients={recipients}
       position={getPosition(i)}
       clickHandler={clickHandler}
-      key={'timeline_sep_' + i}
+      key={`timeline_sep_${i}`}
       showMoreButtonLabel={showMoreButtonLabel}
       showLessButtonLabel={showLessButtonLabel}
       eventTrackingCallbackShowMore={eventTrackingCallbackShowMore}
@@ -121,13 +121,19 @@ const NotificationDetailTimeline = ({
             historyButtonLabel={historyButtonLabel}
             showHistoryButton
             historyButtonClickHandler={toggleHistoryDrawer}
-            />
+          />
         ) : (
           timelineComponent
         )}
       </TimelineNotification>
       <CustomDrawer anchor="left" open={state} onClose={toggleHistoryDrawer}>
-        <Grid container direction="row" justifyContent="space-between" alignItems="center" sx={{ p: 3 }}>
+        <Grid
+          container
+          direction="row"
+          justifyContent="space-between"
+          alignItems="center"
+          sx={{ p: 3 }}
+        >
           <Grid item>
             <Typography
               color="text.primary"

--- a/packages/pn-pa-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/NotificationDetail.page.tsx
@@ -502,7 +502,7 @@ const NotificationDetail = () => {
               </Stack>
             </Grid>
             <Grid item lg={5} xs={12}>
-              <Box sx={{ backgroundColor: 'white', height: '100%', p: 3 }}>
+              <Box sx={{ backgroundColor: 'white', height: '100%', p: 3, pb: 0 }}>
                 <TimedMessage
                   timeout={timeoutMessage}
                   message={

--- a/packages/pn-pa-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/NotificationDetail.page.tsx
@@ -502,7 +502,7 @@ const NotificationDetail = () => {
               </Stack>
             </Grid>
             <Grid item lg={5} xs={12}>
-              <Box sx={{ backgroundColor: 'white', height: '100%', p: 3, pb: 0 }}>
+              <Box sx={{ backgroundColor: 'white', height: '100%', p: 3, pb: { xs: 0, lg: 3 } }}>
                 <TimedMessage
                   timeout={timeoutMessage}
                   message={

--- a/packages/pn-pa-webapp/src/pages/components/Notifications/MobileNotifications.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/Notifications/MobileNotifications.tsx
@@ -132,6 +132,7 @@ const MobileNotifications = ({
         ) : null;
       },
       hideIfEmpty: true,
+      notWrappedInTypography: true,
     },
   ];
 

--- a/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
@@ -371,7 +371,7 @@ const NotificationDetail = () => {
             <Grid item lg={5} xs={12}>
               <Box
                 component="section"
-                sx={{ backgroundColor: 'white', height: '100%', p: 3, pb: 0 }}
+                sx={{ backgroundColor: 'white', height: '100%', p: 3, pb: { xs: 0, lg: 3 } }}
               >
                 <TimedMessage
                   timeout={timeoutMessage}

--- a/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
@@ -369,7 +369,10 @@ const NotificationDetail = () => {
               </Stack>
             </Grid>
             <Grid item lg={5} xs={12}>
-              <Box component="section" sx={{ backgroundColor: 'white', height: '100%', p: 3 }}>
+              <Box
+                component="section"
+                sx={{ backgroundColor: 'white', height: '100%', p: 3, pb: 0 }}
+              >
                 <TimedMessage
                   timeout={timeoutMessage}
                   message={

--- a/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
@@ -371,7 +371,7 @@ const NotificationDetail = () => {
             <Grid item lg={5} xs={12}>
               <Box
                 component="section"
-                sx={{ backgroundColor: 'white', height: '100%', p: 3, pb: 0 }}
+                sx={{ backgroundColor: 'white', height: '100%', p: 3, pb: { xs: 0, lg: 3 } }}
               >
                 <TimedMessage
                   timeout={timeoutMessage}

--- a/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
@@ -369,7 +369,10 @@ const NotificationDetail = () => {
               </Stack>
             </Grid>
             <Grid item lg={5} xs={12}>
-              <Box component="section" sx={{ backgroundColor: 'white', height: '100%', p: 3 }}>
+              <Box
+                component="section"
+                sx={{ backgroundColor: 'white', height: '100%', p: 3, pb: 0 }}
+              >
                 <TimedMessage
                   timeout={timeoutMessage}
                   message={


### PR DESCRIPTION
## Short description
Fixed alignment of notification detail table on mobile view. Now, on mobile, the flex direction is set to column.
Also removed some padding bottom from notification timeline box.  There's still some padding because of Timeline MUI Italia component that must be fixed.

## List of changes proposed in this pull request
- Fixed alignment of notification detail table

## How to test
On PA/PF/PG go to a notification detail and set to mobile view. 