### PR TITLE
Fixed issue with voice over in Windows 11

### DIFF
--- a/packages/pn-personafisica-webapp/src/component/Contacts/CourtesyContacts.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Contacts/CourtesyContacts.tsx
@@ -29,6 +29,7 @@ const CourtesyContacts: React.FC<Props> = ({ recipientId, contacts }) => {
       </Box>
       <Alert
         tabIndex={0}
+        role="banner"
         aria-label={t('courtesy-contacts.disclaimer-message', { ns: 'recapiti' })}
         sx={{ mt: 4 }}
         severity="info"

--- a/packages/pn-personafisica-webapp/src/component/Contacts/IOContact.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Contacts/IOContact.tsx
@@ -95,6 +95,7 @@ const IOContact: React.FC<Props> = ({ recipientId, contact }) => {
       return (
         <Alert
           tabIndex={0}
+          role="banner"
           sx={{ mt: 4 }}
           aria-label={
             status === IOContactStatus.UNAVAILABLE

--- a/packages/pn-personafisica-webapp/src/component/Contacts/InsertLegalContact.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Contacts/InsertLegalContact.tsx
@@ -85,6 +85,7 @@ const InsertLegalContact = ({ recipientId }: Props) => {
         </Grid>
         <Alert
           tabIndex={0}
+          role="banner"
           aria-label={t('legal-contacts.disclaimer-message', { ns: 'recapiti' })}
           sx={{ mt: 4 }}
           severity="info"

--- a/packages/pn-personafisica-webapp/src/component/Contacts/LegalContactsList.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Contacts/LegalContactsList.tsx
@@ -167,6 +167,7 @@ const LegalContactsList = ({ recipientId, legalAddresses }: Props) => {
         )}
         <Alert
           tabIndex={0}
+          role="banner"
           aria-label={t('legal-contacts.disclaimer-message', { ns: 'recapiti' })}
           sx={{ mt: 4 }}
           severity="info"

--- a/packages/pn-personafisica-webapp/src/component/Contacts/__test__/IOContact.test.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Contacts/__test__/IOContact.test.tsx
@@ -84,7 +84,7 @@ describe('IOContact component', () => {
       const ioCheckbox = result?.queryByRole('checkbox', { name: 'io-contact.switch-label' });
       expect(ioCheckbox).not.toBeInTheDocument();
 
-      const alert = result?.queryByRole('alert');
+      const alert = result?.queryByTestId('appIO-contact-disclaimer');
       expect(alert).not.toBeInTheDocument();
 
       const link = result?.container.querySelector('a');
@@ -106,7 +106,7 @@ describe('IOContact component', () => {
       const ioCheckbox = result?.queryByRole('checkbox', { name: 'io-contact.switch-label' });
       expect(ioCheckbox).not.toBeInTheDocument();
 
-      const alert = result?.getByRole('alert');
+      const alert = result?.getByTestId('appIO-contact-disclaimer');
       expect(alert).toBeInTheDocument();
       expect(alert).toHaveTextContent('io-contact.disclaimer-message-unavailable');
 
@@ -137,7 +137,7 @@ describe('IOContact component', () => {
       expect(enableBtn).toBeInTheDocument();
       expect(enableBtn).toBeEnabled();
 
-      const alert = result?.getByRole('alert');
+      const alert = result?.getByTestId('appIO-contact-disclaimer');
       expect(alert).toBeInTheDocument();
       expect(alert).toHaveTextContent('io-contact.disclaimer-message');
 
@@ -184,7 +184,7 @@ describe('IOContact component', () => {
       expect(enableBtn).toBeInTheDocument();
       expect(enableBtn).toBeEnabled();
 
-      const alert = result?.getByRole('alert');
+      const alert = result?.getByTestId('appIO-contact-disclaimer');
       expect(alert).toBeInTheDocument();
       expect(alert).toHaveTextContent('io-contact.disclaimer-message');
 

--- a/packages/pn-personagiuridica-webapp/src/component/Contacts/CourtesyContacts.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Contacts/CourtesyContacts.tsx
@@ -29,6 +29,7 @@ const CourtesyContacts: React.FC<Props> = ({ recipientId, contacts }) => {
       </Box>
       <Alert
         tabIndex={0}
+        role="banner"
         aria-label={t('courtesy-contacts.disclaimer-message', { ns: 'recapiti' })}
         sx={{ mt: 4 }}
         severity="info"

--- a/packages/pn-personagiuridica-webapp/src/component/Contacts/InsertLegalContact.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Contacts/InsertLegalContact.tsx
@@ -84,6 +84,7 @@ const InsertLegalContact = ({ recipientId }: Props) => {
           </Grid>
         </Grid>
         <Alert
+          role="banner"
           tabIndex={0}
           aria-label={t('legal-contacts.disclaimer-message', { ns: 'recapiti' })}
           sx={{ mt: 4 }}

--- a/packages/pn-personagiuridica-webapp/src/component/Contacts/LegalContactsList.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Contacts/LegalContactsList.tsx
@@ -165,6 +165,7 @@ const LegalContactsList = ({ recipientId, legalAddresses }: Props) => {
           </Box>
         )}
         <Alert
+          role="banner"
           tabIndex={0}
           aria-label={t('legal-contacts.disclaimer-message', { ns: 'recapiti' })}
           sx={{ mt: 4 }}


### PR DESCRIPTION
## Short description
Fixed issue with voice over in Windows 11 where when the user switches to the contact pages (both PF and PG), the voice over automatically talk about banners inside the page.

## List of changes proposed in this pull request
- Changed roles for Alert component from "alert" to "banner"
- Fixed a test

## How to test
The voice over should not automatically talk about banners in contacts page now.