### PR TITLE
Loading feedback in mobile devices - Fix/pn 7076

### DIFF
--- a/packages/pn-pa-webapp/src/navigation/SessionGuard.tsx
+++ b/packages/pn-pa-webapp/src/navigation/SessionGuard.tsx
@@ -2,12 +2,13 @@ import {
   AppResponsePublisher,
   appStateActions,
   InactivityHandler,
+  LoadingPage,
   SessionModal,
   useErrors,
   useProcess,
   useSessionCheck,
 } from '@pagopa-pn/pn-commons';
-import { Fragment, useCallback, useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 
@@ -92,7 +93,7 @@ const SessionGuardRender = () => {
       </InactivityHandler>
     );
 
-  return isInitialized ? renderIfInitialized() : <Fragment></Fragment>;
+  return isInitialized ? renderIfInitialized() : <LoadingPage renderType="whole" />;
 };
 
 const SessionGuard = () => {

--- a/packages/pn-personafisica-webapp/src/App.tsx
+++ b/packages/pn-personafisica-webapp/src/App.tsx
@@ -44,7 +44,7 @@ import { PFAppErrorFactory } from './utils/AppError/PFAppErrorFactory';
 import { goToLoginPortal } from './navigation/navigation.utility';
 import { setUpInterceptor } from './api/interceptors';
 import { getCurrentAppStatus } from './redux/appStatus/actions';
-import { getConfiguration } from "./services/configuration.service";
+import { getConfiguration } from './services/configuration.service';
 
 // TODO: get products list from be (?)
 const productsList: Array<ProductSwitchItem> = [
@@ -64,8 +64,8 @@ const productsList: Array<ProductSwitchItem> = [
 // E.g. if a user types the URL with the path /non-accessbile, the App component runs just once.
 // In "normal" cases, the SessionGuard initialization forces App to render more than one
 // and therefore to make i18n to be initialized by the time something actually renders.
-// 
-// In turn, adding the ternary operator in the return statement provokes 
+//
+// In turn, adding the ternary operator in the return statement provokes
 // the "too high computational complexity" warning to appear
 // (in fact it jumps to <= 15 to 30!!).
 // The only way I found to prevent it is to split the initialization in a separate React component.
@@ -86,7 +86,7 @@ const App = () => {
     }
   }, [isInitialized]);
 
-  return isInitialized ? <ActualApp /> : <div/>;
+  return isInitialized ? <ActualApp /> : <div />;
 };
 
 const ActualApp = () => {

--- a/packages/pn-personafisica-webapp/src/navigation/SessionGuard.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/SessionGuard.tsx
@@ -4,12 +4,13 @@ import {
   // AppRouteType,
   appStateActions,
   InactivityHandler,
+  LoadingPage,
   SessionModal,
   useErrors,
   useProcess,
   useSessionCheck,
 } from '@pagopa-pn/pn-commons';
-import { Fragment, useCallback, useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { AUTH_ACTIONS, exchangeToken, logout } from '../redux/auth/actions';
@@ -101,7 +102,7 @@ const SessionGuardRender = () => {
       </InactivityHandler>
     );
 
-  return isInitialized ? renderIfInitialized() : <Fragment></Fragment>;
+  return isInitialized ? renderIfInitialized() : <LoadingPage renderType="whole" />;
 };
 
 /**

--- a/packages/pn-personafisica-webapp/src/navigation/routes.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/routes.tsx
@@ -2,7 +2,7 @@ import React, { Suspense } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import { AppNotAccessible, LoadingPage, NotFound } from '@pagopa-pn/pn-commons';
 
-import { getConfiguration } from "../services/configuration.service";
+import { getConfiguration } from '../services/configuration.service';
 import * as routes from './routes.const';
 import SessionGuard from './SessionGuard';
 import RouteGuard from './RouteGuard';

--- a/packages/pn-personagiuridica-webapp/src/navigation/SessionGuard.tsx
+++ b/packages/pn-personagiuridica-webapp/src/navigation/SessionGuard.tsx
@@ -4,12 +4,13 @@ import {
   // AppRouteType,
   appStateActions,
   InactivityHandler,
+  LoadingPage,
   SessionModal,
   useErrors,
   useProcess,
   useSessionCheck,
 } from '@pagopa-pn/pn-commons';
-import { Fragment, useCallback, useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { AUTH_ACTIONS, exchangeToken, logout } from '../redux/auth/actions';
@@ -100,7 +101,7 @@ const SessionGuardRender = () => {
       </InactivityHandler>
     );
 
-  return isInitialized ? renderIfInitialized() : <Fragment></Fragment>;
+  return isInitialized ? renderIfInitialized() : <LoadingPage renderType="whole" />;
 };
 
 /**


### PR DESCRIPTION
## Short description
Added skeleton also when validating selfcare token to avoid a no feedback case

## List of changes proposed in this pull request
- Added skeleton in SessionGuard component (pf/pg/pa)

## How to test
Use emulator or wait for the pr being merged. Clear the browser's cache, navigate to the app and check that during page loading, there aren't no-feedback cases (i.e. white page without skeleton or loading)