### PR TITLE
Change transition direction for mobile timeline details

### DIFF
--- a/packages/pn-commons/src/components/NotificationDetail/NotificationDetailTimeline.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationDetailTimeline.tsx
@@ -126,7 +126,7 @@ const NotificationDetailTimeline = ({
           timelineComponent
         )}
       </TimelineNotification>
-      <CustomDrawer anchor="left" open={state} onClose={toggleHistoryDrawer}>
+      <CustomDrawer anchor="bottom" open={state} onClose={toggleHistoryDrawer}>
         <Grid
           container
           direction="row"


### PR DESCRIPTION
## Short description
Changed transition direction for mobile timeline details.

## List of changes proposed in this pull request
- Drawer anchor set from "left" to "bottom" as required

## How to test
Just enter in any webapp via mobile and open timeline detail. The drawer will appear from bottom now.