### PR TITLE
Fixed the filter that would have close even though the iun or recipie…

### DIFF
--- a/packages/pn-commons/src/components/CustomMobileDialog/CustomMobileDialogContent.tsx
+++ b/packages/pn-commons/src/components/CustomMobileDialog/CustomMobileDialogContent.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, ReactElement, ReactNode, Ref } from "react";
+import { forwardRef, ReactElement, ReactNode, Ref, useImperativeHandle } from "react";
 import { Dialog, DialogTitle, Grid, Slide, Typography } from "@mui/material";
 import { styled } from '@mui/material/styles';
 import { TransitionProps } from "@mui/material/transitions";
@@ -51,12 +51,16 @@ const Transition = forwardRef(function Transition(
  * @param children the react component for the body and the actions
  * @param title title to show in the dialog header
  */
-const CustomMobileDialogContent = ({children, title}: Props) => {
+const CustomMobileDialogContent = forwardRef<{ toggleOpen: () => void }, Props>(({ children, title }: Props, ref) => {
   const { open, toggleOpen } = useCustomMobileDialogContext();
 
   const handleClose = () => {
     toggleOpen();
   }
+
+  useImperativeHandle(ref, () => ({
+    toggleOpen,
+  }));
 
   return (
     <MobileDialog
@@ -93,6 +97,6 @@ const CustomMobileDialogContent = ({children, title}: Props) => {
       {children}
     </MobileDialog>
   );
-};
+});
 
 export default CustomMobileDialogContent;

--- a/packages/pn-pa-webapp/src/pages/components/Notifications/FilterNotifications.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/Notifications/FilterNotifications.tsx
@@ -130,6 +130,9 @@ const FilterNotifications = forwardRef(({ showFilters }: Props, ref) => {
     }
   };
 
+  const isOneRegexValid: boolean = IUN_regex.test(formik.values.iunMatch) || dataRegex.pIvaAndFiscalCode.test(formik.values.recipientId);
+  
+
   useEffect(() => {
     void formik.validateForm();
   }, []);
@@ -155,6 +158,7 @@ const FilterNotifications = forwardRef(({ showFilters }: Props, ref) => {
   if (!showFilters) {
     return <></>;
   }
+
   const isInitialSearch = _.isEqual(formik.values, initialEmptyValues);
   return isMobile ? (
     <CustomMobileDialog>
@@ -184,6 +188,7 @@ const FilterNotifications = forwardRef(({ showFilters }: Props, ref) => {
           </DialogContent>
           <DialogActions>
             <FilterNotificationsFormActions
+              isValid={isOneRegexValid}
               cleanFilters={cancelSearch}
               filtersApplied={isFilterapplied(filtersCount)}
               isInitialSearch={isInitialSearch}

--- a/packages/pn-pa-webapp/src/pages/components/Notifications/FilterNotifications.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/Notifications/FilterNotifications.tsx
@@ -1,4 +1,4 @@
-import { useEffect, Fragment, useState, forwardRef, useImperativeHandle } from 'react';
+import { useEffect, Fragment, useState, forwardRef, useImperativeHandle, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FormikValues, useFormik } from 'formik';
 import * as yup from 'yup';
@@ -77,6 +77,8 @@ const FilterNotifications = forwardRef(({ showFilters }: Props, ref) => {
   const [endDate, setEndDate] = useState<Date | null>(null);
   const isMobile = useIsMobile();
   const { t } = useTranslation(['common', 'notifiche']);
+  const dialogRef = useRef<{toggleOpen: () => void}>(null);
+
 
   const validationSchema = yup.object({
     recipientId: yup
@@ -113,6 +115,7 @@ const FilterNotifications = forwardRef(({ showFilters }: Props, ref) => {
       trackEventByType(TrackEventType.NOTIFICATION_FILTER_SEARCH);
       dispatch(setNotificationFilters(currentFilters));
       setPrevFilters(currentFilters);
+      dialogRef.current?.toggleOpen();
     },
   });
 
@@ -128,10 +131,7 @@ const FilterNotifications = forwardRef(({ showFilters }: Props, ref) => {
     if (!_.isEqual(filters.endDate, formatToTimezoneString(today))) {
       setEndDate(formik.values.endDate);
     }
-  };
-
-  const isOneRegexValid: boolean = IUN_regex.test(formik.values.iunMatch) || dataRegex.pIvaAndFiscalCode.test(formik.values.recipientId);
-  
+  };  
 
   useEffect(() => {
     void formik.validateForm();
@@ -159,7 +159,9 @@ const FilterNotifications = forwardRef(({ showFilters }: Props, ref) => {
     return <></>;
   }
 
+
   const isInitialSearch = _.isEqual(formik.values, initialEmptyValues);
+
   return isMobile ? (
     <CustomMobileDialog>
       <CustomMobileDialogToggle
@@ -175,7 +177,7 @@ const FilterNotifications = forwardRef(({ showFilters }: Props, ref) => {
       >
         {t('button.filtra')}
       </CustomMobileDialogToggle>
-      <CustomMobileDialogContent title={t('button.filtra')}>
+      <CustomMobileDialogContent title={t('button.filtra')} ref={dialogRef}>
         <form onSubmit={formik.handleSubmit}>
           <DialogContent>
             <FilterNotificationsFormBody
@@ -188,7 +190,6 @@ const FilterNotifications = forwardRef(({ showFilters }: Props, ref) => {
           </DialogContent>
           <DialogActions>
             <FilterNotificationsFormActions
-              isValid={isOneRegexValid}
               cleanFilters={cancelSearch}
               filtersApplied={isFilterapplied(filtersCount)}
               isInitialSearch={isInitialSearch}

--- a/packages/pn-pa-webapp/src/pages/components/Notifications/FilterNotificationsFormActions.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/Notifications/FilterNotificationsFormActions.tsx
@@ -21,7 +21,6 @@ type Props = {
   isInitialSearch: boolean;
   cleanFilters: () => void;
   isInDialog?: boolean;
-  isValid?: boolean;
 };
 
 const FilterNotificationsFormActions = ({
@@ -29,7 +28,6 @@ const FilterNotificationsFormActions = ({
   cleanFilters,
   isInDialog = false,
   isInitialSearch,
-  isValid = true,
 
 }: Props) => {
   const classes = useStyles();
@@ -63,7 +61,7 @@ const FilterNotificationsFormActions = ({
   return (
     <Fragment>
       {isInDialog ? (
-        <CustomMobileDialogAction closeOnClick={isValid}>{confirmAction}</CustomMobileDialogAction>
+        <CustomMobileDialogAction >{confirmAction}</CustomMobileDialogAction>
       ) : (
         confirmAction
       )}

--- a/packages/pn-pa-webapp/src/pages/components/Notifications/FilterNotificationsFormActions.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/Notifications/FilterNotificationsFormActions.tsx
@@ -21,6 +21,7 @@ type Props = {
   isInitialSearch: boolean;
   cleanFilters: () => void;
   isInDialog?: boolean;
+  isValid?: boolean;
 };
 
 const FilterNotificationsFormActions = ({
@@ -28,6 +29,8 @@ const FilterNotificationsFormActions = ({
   cleanFilters,
   isInDialog = false,
   isInitialSearch,
+  isValid = true,
+
 }: Props) => {
   const classes = useStyles();
   const { t } = useTranslation(['common']);
@@ -60,7 +63,7 @@ const FilterNotificationsFormActions = ({
   return (
     <Fragment>
       {isInDialog ? (
-        <CustomMobileDialogAction closeOnClick>{confirmAction}</CustomMobileDialogAction>
+        <CustomMobileDialogAction closeOnClick={isValid}>{confirmAction}</CustomMobileDialogAction>
       ) : (
         confirmAction
       )}

--- a/packages/pn-personafisica-webapp/src/component/Notifications/FilterNotifications.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Notifications/FilterNotifications.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, forwardRef, useImperativeHandle } from 'react';
+import { useEffect, useState, forwardRef, useImperativeHandle, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { useFormik } from 'formik';
@@ -80,6 +80,7 @@ const FilterNotifications = forwardRef(({ showFilters, currentDelegator }: Props
   const [endDate, setEndDate] = useState<Date | null>(null);
   const isMobile = useIsMobile();
   const classes = useStyles();
+  const dialogRef = useRef<{toggleOpen: () => void}>(null);
 
   const emptyValues = {
     startDate: formatToTimezoneString(tenYearsAgo),
@@ -119,6 +120,7 @@ const FilterNotifications = forwardRef(({ showFilters, currentDelegator }: Props
       }
       dispatch(setNotificationFilters(currentFilters));
       setPrevFilters(currentFilters);
+      dialogRef.current?.toggleOpen();
     },
   });
 
@@ -162,8 +164,6 @@ const FilterNotifications = forwardRef(({ showFilters, currentDelegator }: Props
     return <></>;
   }
 
-  const isRegexValid = IUN_regex.test(formik.values.iunMatch);
-
   const isInitialSearch = _.isEqual(formik.values, initialEmptyValues);
   return isMobile ? (
     <CustomMobileDialog>
@@ -180,7 +180,7 @@ const FilterNotifications = forwardRef(({ showFilters, currentDelegator }: Props
       >
         {t('button.filtra')}
       </CustomMobileDialogToggle>
-      <CustomMobileDialogContent title={t('button.filtra')}>
+      <CustomMobileDialogContent title={t('button.filtra')} ref={dialogRef}>
         <form onSubmit={formik.handleSubmit}>
           <DialogContent>
             <FilterNotificationsFormBody
@@ -193,7 +193,6 @@ const FilterNotifications = forwardRef(({ showFilters, currentDelegator }: Props
           </DialogContent>
           <DialogActions>
             <FilterNotificationsFormActions
-              isValid={isRegexValid}
               cleanFilters={cleanFilters}
               filtersApplied={isFilterApplied(filtersCount)}
               isInitialSearch={isInitialSearch}

--- a/packages/pn-personafisica-webapp/src/component/Notifications/FilterNotifications.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Notifications/FilterNotifications.tsx
@@ -162,6 +162,8 @@ const FilterNotifications = forwardRef(({ showFilters, currentDelegator }: Props
     return <></>;
   }
 
+  const isRegexValid = IUN_regex.test(formik.values.iunMatch);
+
   const isInitialSearch = _.isEqual(formik.values, initialEmptyValues);
   return isMobile ? (
     <CustomMobileDialog>
@@ -191,6 +193,7 @@ const FilterNotifications = forwardRef(({ showFilters, currentDelegator }: Props
           </DialogContent>
           <DialogActions>
             <FilterNotificationsFormActions
+              isValid={isRegexValid}
               cleanFilters={cleanFilters}
               filtersApplied={isFilterApplied(filtersCount)}
               isInitialSearch={isInitialSearch}

--- a/packages/pn-personafisica-webapp/src/component/Notifications/FilterNotificationsFormActions.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Notifications/FilterNotificationsFormActions.tsx
@@ -8,6 +8,7 @@ type Props = {
   isInitialSearch: boolean;
   cleanFilters: () => void;
   isInDialog?: boolean;
+  isValid?: boolean;
 };
 
 const FilterNotificationsFormActions = ({
@@ -15,6 +16,7 @@ const FilterNotificationsFormActions = ({
   cleanFilters,
   isInDialog = false,
   isInitialSearch,
+  isValid = true,
 }: Props) => {
   const { t } = useTranslation(['common']);
 
@@ -48,7 +50,7 @@ const FilterNotificationsFormActions = ({
   return (
     <Fragment>
       {isInDialog ? (
-        <CustomMobileDialogAction closeOnClick>{confirmAction}</CustomMobileDialogAction>
+        <CustomMobileDialogAction closeOnClick={isValid}>{confirmAction}</CustomMobileDialogAction>
       ) : (
         confirmAction
       )}

--- a/packages/pn-personafisica-webapp/src/component/Notifications/FilterNotificationsFormActions.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Notifications/FilterNotificationsFormActions.tsx
@@ -8,7 +8,6 @@ type Props = {
   isInitialSearch: boolean;
   cleanFilters: () => void;
   isInDialog?: boolean;
-  isValid?: boolean;
 };
 
 const FilterNotificationsFormActions = ({
@@ -16,7 +15,6 @@ const FilterNotificationsFormActions = ({
   cleanFilters,
   isInDialog = false,
   isInitialSearch,
-  isValid = true,
 }: Props) => {
   const { t } = useTranslation(['common']);
 
@@ -50,7 +48,7 @@ const FilterNotificationsFormActions = ({
   return (
     <Fragment>
       {isInDialog ? (
-        <CustomMobileDialogAction closeOnClick={isValid}>{confirmAction}</CustomMobileDialogAction>
+        <CustomMobileDialogAction>{confirmAction}</CustomMobileDialogAction>
       ) : (
         confirmAction
       )}

--- a/packages/pn-personagiuridica-webapp/src/component/Notifications/FilterNotifications.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Notifications/FilterNotifications.tsx
@@ -136,6 +136,8 @@ const FilterNotifications = forwardRef(({ showFilters, currentDelegator }: Props
     }
   };
 
+  const isRegexValid: boolean = IUN_regex.test(formik.values.iunMatch);
+
   useEffect(() => {
     void formik.validateForm();
   }, []);
@@ -191,6 +193,7 @@ const FilterNotifications = forwardRef(({ showFilters, currentDelegator }: Props
           </DialogContent>
           <DialogActions>
             <FilterNotificationsFormActions
+              isValid={isRegexValid}
               cleanFilters={cleanFilters}
               filtersApplied={isFilterApplied(filtersCount)}
               isInitialSearch={isInitialSearch}

--- a/packages/pn-personagiuridica-webapp/src/component/Notifications/FilterNotifications.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Notifications/FilterNotifications.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, forwardRef, useImperativeHandle } from 'react';
+import { useEffect, useState, forwardRef, useImperativeHandle, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { useFormik } from 'formik';
@@ -80,6 +80,7 @@ const FilterNotifications = forwardRef(({ showFilters, currentDelegator }: Props
   const [endDate, setEndDate] = useState<Date | null>(null);
   const isMobile = useIsMobile();
   const classes = useStyles();
+  const dialogRef = useRef<{toggleOpen: () => void}>(null);
 
   const emptyValues = {
     startDate: formatToTimezoneString(tenYearsAgo),
@@ -119,6 +120,7 @@ const FilterNotifications = forwardRef(({ showFilters, currentDelegator }: Props
       }
       dispatch(setNotificationFilters(currentFilters));
       setPrevFilters(currentFilters);
+      dialogRef.current?.toggleOpen();
     },
   });
 
@@ -135,8 +137,6 @@ const FilterNotifications = forwardRef(({ showFilters, currentDelegator }: Props
       setEndDate(formik.values.endDate);
     }
   };
-
-  const isRegexValid: boolean = IUN_regex.test(formik.values.iunMatch);
 
   useEffect(() => {
     void formik.validateForm();
@@ -180,7 +180,7 @@ const FilterNotifications = forwardRef(({ showFilters, currentDelegator }: Props
       >
         {t('button.filtra')}
       </CustomMobileDialogToggle>
-      <CustomMobileDialogContent title={t('button.filtra')}>
+      <CustomMobileDialogContent title={t('button.filtra')} ref={dialogRef}>
         <form onSubmit={formik.handleSubmit}>
           <DialogContent>
             <FilterNotificationsFormBody
@@ -193,7 +193,6 @@ const FilterNotifications = forwardRef(({ showFilters, currentDelegator }: Props
           </DialogContent>
           <DialogActions>
             <FilterNotificationsFormActions
-              isValid={isRegexValid}
               cleanFilters={cleanFilters}
               filtersApplied={isFilterApplied(filtersCount)}
               isInitialSearch={isInitialSearch}

--- a/packages/pn-personagiuridica-webapp/src/component/Notifications/FilterNotificationsFormActions.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Notifications/FilterNotificationsFormActions.tsx
@@ -8,6 +8,7 @@ type Props = {
   isInitialSearch: boolean;
   cleanFilters: () => void;
   isInDialog?: boolean;
+  isValid?: boolean;
 };
 
 const FilterNotificationsFormActions = ({
@@ -15,6 +16,7 @@ const FilterNotificationsFormActions = ({
   cleanFilters,
   isInDialog = false,
   isInitialSearch,
+  isValid = true,
 }: Props) => {
   const { t } = useTranslation(['common']);
 
@@ -48,7 +50,7 @@ const FilterNotificationsFormActions = ({
   return (
     <Fragment>
       {isInDialog ? (
-        <CustomMobileDialogAction closeOnClick>{confirmAction}</CustomMobileDialogAction>
+        <CustomMobileDialogAction closeOnClick={isValid}>{confirmAction}</CustomMobileDialogAction>
       ) : (
         confirmAction
       )}

--- a/packages/pn-personagiuridica-webapp/src/component/Notifications/FilterNotificationsFormActions.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Notifications/FilterNotificationsFormActions.tsx
@@ -8,7 +8,6 @@ type Props = {
   isInitialSearch: boolean;
   cleanFilters: () => void;
   isInDialog?: boolean;
-  isValid?: boolean;
 };
 
 const FilterNotificationsFormActions = ({
@@ -16,7 +15,6 @@ const FilterNotificationsFormActions = ({
   cleanFilters,
   isInDialog = false,
   isInitialSearch,
-  isValid = true,
 }: Props) => {
   const { t } = useTranslation(['common']);
 
@@ -50,7 +48,7 @@ const FilterNotificationsFormActions = ({
   return (
     <Fragment>
       {isInDialog ? (
-        <CustomMobileDialogAction closeOnClick={isValid}>{confirmAction}</CustomMobileDialogAction>
+        <CustomMobileDialogAction>{confirmAction}</CustomMobileDialogAction>
       ) : (
         confirmAction
       )}


### PR DESCRIPTION
…ntId was wrong

## Short description
The filter dialog on mobile was closing on submit even though one field such as iun and recipientId was not valid.

## List of changes proposed in this pull request

- Added a boolean prop for FilterNotificationsFormActions on each service to manage the dialog's closing system.
- Added a const boolean value that evaluates if the regex of the fields are correct.

## How to test
On mobile you can now type a wrong iun or recipientId and verify if it closes. 