### PR TITLE
fix: accessibility of AppStatus page

### DIFF
--- a/packages/pn-commons/src/components/AppStatus/AppStatusRender.tsx
+++ b/packages/pn-commons/src/components/AppStatus/AppStatusRender.tsx
@@ -148,7 +148,12 @@ export const AppStatusRender = (props: Props) => {
           {currentStatus && <AppStatusBar status={currentStatus} />}
           {currentStatus && (
             <Stack direction="row" justifyContent="center" data-testid="appStatus-lastCheck">
-              <Typography variant="caption" sx={{ mt: 2, color: 'text.secondary' }}>
+              <Typography
+                variant="caption"
+                sx={{ mt: 2, color: 'text.secondary' }}
+                tabIndex={0}
+                aria-label={lastCheckLegend}
+              >
                 {lastCheckLegend}
               </Typography>
             </Stack>
@@ -156,7 +161,12 @@ export const AppStatusRender = (props: Props) => {
         </ApiErrorWrapper>
 
         {/* Titolo elenco di downtime */}
-        <Typography variant="h6" sx={{ mt: '36px', mb: 2 }}>
+        <Typography
+          variant="h6"
+          sx={{ mt: '36px', mb: 2 }}
+          tabIndex={0}
+          aria-label={downtimeListTitle}
+        >
           {downtimeListTitle}
         </Typography>
 


### PR DESCRIPTION
## Short description
Added some aria-label to AppStatus page 

## List of changes proposed in this pull request
- Added aria-labels

## How to test
On PF/PA/PG go to "Stato della piattaforma" with 'VoiceOver' on MacOS and with 'Assistente Vocale' on Windows and go to "Ultimo aggiornamento" label and table's title 