### PR TITLE
Added file size limit to FileUploader component

### DIFF
--- a/packages/pn-commons/src/components/FileUpload.tsx
+++ b/packages/pn-commons/src/components/FileUpload.tsx
@@ -73,10 +73,14 @@ const reducer = (state: UploadState, action: { type: string; payload?: any }) =>
     case 'FILE_SIZE_EXCEEDED':
       return {
         ...state,
+        ...action.payload,
         error: getLocalizedOrDefaultLabel(
           'common',
           'upload-file.file-size-exceeded',
-          'Il file selezionato supera la dimensione massima di 200MB.'
+          `Il file selezionato supera la dimensione massima di ${action.payload}.`,
+          {
+            limit: action.payload,
+          },
         ),
       };
     case 'UPLOAD_IN_ERROR':
@@ -192,7 +196,7 @@ const FileUpload = ({
 
   const uploadFile = async (file: any) => {
     if (file && file.size > fileSizeLimit) {
-      dispatch({ type: 'FILE_SIZE_EXCEEDED' });
+      dispatch({ type: 'FILE_SIZE_EXCEEDED', payload: parseFileSize(fileSizeLimit) });
       return;
     }
     if (file && file.type && accept.indexOf(file.type) > -1) {

--- a/packages/pn-commons/src/components/FileUpload.tsx
+++ b/packages/pn-commons/src/components/FileUpload.tsx
@@ -14,7 +14,12 @@ import AttachFileIcon from '@mui/icons-material/AttachFile';
 import CloseIcon from '@mui/icons-material/Close';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import { ButtonNaked } from '@pagopa/mui-italia';
-import { calcUnit8Array, calcSha256String, calcBase64String } from '../utils/file.utility';
+import {
+  calcUnit8Array,
+  calcSha256String,
+  calcBase64String,
+  parseFileSize,
+} from '../utils/file.utility';
 import { getLocalizedOrDefaultLabel } from '../services/localization.service';
 import CustomTooltip from './CustomTooltip';
 
@@ -66,14 +71,14 @@ const reducer = (state: UploadState, action: { type: string; payload?: any }) =>
         ),
       };
     case 'FILE_SIZE_EXCEEDED':
-        return {
-          ...state,
-          error: getLocalizedOrDefaultLabel(
-            'common',
-            'upload-file.file-size-exceeded',
-            'Il file selezionato supera la dimensione massima di 200MB.'
-          ),
-        };
+      return {
+        ...state,
+        error: getLocalizedOrDefaultLabel(
+          'common',
+          'upload-file.file-size-exceeded',
+          'Il file selezionato supera la dimensione massima di 200MB.'
+        ),
+      };
     case 'UPLOAD_IN_ERROR':
       return {
         ...state,
@@ -189,7 +194,7 @@ const FileUpload = ({
     if (file && file.size > fileSizeLimit) {
       dispatch({ type: 'FILE_SIZE_EXCEEDED' });
       return;
-    };
+    }
     if (file && file.type && accept.indexOf(file.type) > -1) {
       dispatch({ type: 'ADD_FILE', payload: file });
       try {
@@ -323,7 +328,7 @@ const FileUpload = ({
               <AttachFileIcon color="primary" />
               <Typography color="primary">{data.file.name}</Typography>
               <Typography fontWeight={600} sx={{ marginLeft: '30px' }}>
-                {(data.file.size / 1024).toFixed(2)}&nbsp;KB
+                {parseFileSize(data.file.size)}
               </Typography>
             </Box>
             <IconButton

--- a/packages/pn-commons/src/components/FileUpload.tsx
+++ b/packages/pn-commons/src/components/FileUpload.tsx
@@ -35,6 +35,7 @@ type Props = {
   calcSha256?: boolean;
   fileFormat?: 'base64' | 'uint8Array';
   fileUploaded?: any;
+  fileSizeLimit?: number;
 };
 
 enum UploadStatus {
@@ -64,6 +65,15 @@ const reducer = (state: UploadState, action: { type: string; payload?: any }) =>
           'Estensione file non supportata. Riprovare con un altro file.'
         ),
       };
+    case 'FILE_SIZE_EXCEEDED':
+        return {
+          ...state,
+          error: getLocalizedOrDefaultLabel(
+            'common',
+            'upload-file.file-size-exceeded',
+            'Il file selezionato supera la dimensione massima di 200MB.'
+          ),
+        };
     case 'UPLOAD_IN_ERROR':
       return {
         ...state,
@@ -121,6 +131,7 @@ const OrientedBox = ({ vertical, children }: { vertical: boolean; children: Reac
  * @param calcSha256 flag to calculate the sha256
  * @param fileFormat format of the file after loading
  * @param fileUploaded file previously uploaded
+ * @param fileSizeLimit max file size limit - default is 209715200 (200MB)
  * @returns
  */
 const FileUpload = ({
@@ -135,6 +146,7 @@ const FileUpload = ({
   calcSha256 = false,
   fileFormat,
   fileUploaded,
+  fileSizeLimit = 209715200,
 }: Props) => {
   const [data, dispatch] = useReducer(reducer, {
     status: UploadStatus.TO_UPLOAD,
@@ -174,6 +186,10 @@ const FileUpload = ({
   };
 
   const uploadFile = async (file: any) => {
+    if (file && file.size > fileSizeLimit) {
+      dispatch({ type: 'FILE_SIZE_EXCEEDED' });
+      return;
+    };
     if (file && file.type && accept.indexOf(file.type) > -1) {
       dispatch({ type: 'ADD_FILE', payload: file });
       try {

--- a/packages/pn-commons/src/components/__test__/FileUpload.test.tsx
+++ b/packages/pn-commons/src/components/__test__/FileUpload.test.tsx
@@ -71,7 +71,7 @@ describe('FileUpload Component', () => {
       expect(mockUploadFn).not.toBeCalled();
       expect(result.container).toHaveTextContent(/Mocked upload text/i);
       expect(result.container).toHaveTextContent(
-        /Il file selezionato supera la dimensione massima di 200MB./i
+        /Il file selezionato supera la dimensione massima di 14 Bytes./i
       );
     });
   });

--- a/packages/pn-commons/src/components/__test__/FileUpload.test.tsx
+++ b/packages/pn-commons/src/components/__test__/FileUpload.test.tsx
@@ -10,8 +10,14 @@ describe('FileUpload Component', () => {
 
   const mockUploadFileHandler = jest.fn();
   const mockRemoveFileHandler = jest.fn();
+
   const file = new Blob(['mocked content'], { type: 'text/plain' });
+  const bigFile = new Blob(['mocked content big'], { type: 'text/plain' });
+  const wrongTypeFile = new Blob(['mocked content'], { type: 'application/pdf' });
+
   (file as any).name = 'Mocked file';
+  (bigFile as any).name ='Mocked big file';
+  (wrongTypeFile as any).name ='Mocked big file';
 
   async function testFileUploading() {
     const fileInput = result.queryByTestId('fileInput');
@@ -36,6 +42,7 @@ describe('FileUpload Component', () => {
         uploadFn={mockUploadFn}
         onFileUploaded={mockUploadFileHandler}
         onRemoveFile={mockRemoveFileHandler}
+        fileSizeLimit={file.size}
       />
     );
   });
@@ -55,11 +62,25 @@ describe('FileUpload Component', () => {
     await testFileUploading();
   });
 
+  it('uploads file (file too big)', async () => {
+    const fileInput = result.queryByTestId('fileInput');
+    expect(fileInput).toBeInTheDocument();
+    const input = fileInput?.querySelector('input');
+    fireEvent.change(input!, { target: { files: [bigFile] } });
+    await waitFor(() => {
+      expect(mockUploadFn).not.toBeCalled();
+      expect(result.container).toHaveTextContent(/Mocked upload text/i);
+      expect(result.container).toHaveTextContent(
+        /Il file selezionato supera la dimensione massima di 200MB./i
+      );
+    });
+  });
+
   it('uploads file (wrong format)', async () => {
     const fileInput = result.queryByTestId('fileInput');
     expect(fileInput).toBeInTheDocument();
     const input = fileInput?.querySelector('input');
-    fireEvent.change(input!, { target: { files: [new Blob(['mocked content'], { type: 'application/pdf' })] } });
+    fireEvent.change(input!, { target: { files: [wrongTypeFile] } });
     await waitFor(() => {
       expect(mockUploadFn).not.toBeCalled();
       expect(result.container).toHaveTextContent(/Mocked upload text/i);

--- a/packages/pn-commons/src/utils/__test__/file.utility.test.ts
+++ b/packages/pn-commons/src/utils/__test__/file.utility.test.ts
@@ -1,0 +1,33 @@
+import { parseFileSize } from '../file.utility';
+
+describe('File utility', () => {
+  it('Parse file size (0 bytes)', () => {
+    const result = parseFileSize(0);
+    expect(result).toBe('0 Bytes');
+  });
+
+  it('Parse file size (200 bytes)', () => {
+    const result = parseFileSize(200);
+    expect(result).toBe('200 Bytes');
+  });
+
+  it('Parse file size (500 KB)', () => {
+    const result = parseFileSize(500 * 1024);
+    expect(result).toBe('500 KB');
+  });
+
+  it('Parse file size (54 MB)', () => {
+    const result = parseFileSize(54 * 1024 ** 2);
+    expect(result).toBe('54 MB');
+  });
+
+  it('Parse file size (3 GB)', () => {
+    const result = parseFileSize(3 * 1024 ** 3);
+    expect(result).toBe('3 GB');
+  });
+
+  it('Parse file size (10 TB)', () => {
+    const result = parseFileSize(10 * 1024 ** 4);
+    expect(result).toBe('10 TB');
+  });
+});

--- a/packages/pn-commons/src/utils/file.utility.ts
+++ b/packages/pn-commons/src/utils/file.utility.ts
@@ -67,3 +67,18 @@ export const calcSha256String = (file: any): Promise<{ hashHex: string; hashBase
     /* eslint-enable functional/immutable-data */
   });
 };
+
+/**
+ * Returs the size of a file in format KB, MB or GB
+ * @param size size in bytes
+ */
+export const parseFileSize = (size: number, decimals = 2): string => {
+  if (!size) {
+    return '0 Bytes';
+  }
+  const unit = 1024;
+  const dm = decimals < 0 ? 0 : decimals;
+  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
+  const i = Math.floor(Math.log(size) / Math.log(unit));
+  return `${parseFloat((size / Math.pow(unit, i)).toFixed(dm))} ${sizes[i]}`;
+};

--- a/packages/pn-pa-webapp/public/locales/it/common.json
+++ b/packages/pn-pa-webapp/public/locales/it/common.json
@@ -140,7 +140,7 @@
     "hash-code": "Codice hash",
     "hash-code-descr": "Il codice hash è un codice alfanumerico univoco utilizzato per identificare un determinato file",
     "ext-not-supported": "Estensione file non supportata. Riprovare con un altro file.",
-    "file-size-exceeded": "Il file selezionato supera la dimensione massima di 200MB.",
+    "file-size-exceeded": "Il file selezionato supera la dimensione massima di {{limit}}.",
     "loading-error": "Si è verificato un errore durante il caricamento del file. Si prega di riprovare."
   },
   "roles": {

--- a/packages/pn-pa-webapp/public/locales/it/common.json
+++ b/packages/pn-pa-webapp/public/locales/it/common.json
@@ -140,6 +140,7 @@
     "hash-code": "Codice hash",
     "hash-code-descr": "Il codice hash è un codice alfanumerico univoco utilizzato per identificare un determinato file",
     "ext-not-supported": "Estensione file non supportata. Riprovare con un altro file.",
+    "file-size-exceeded": "Il file selezionato supera la dimensione massima di 200MB.",
     "loading-error": "Si è verificato un errore durante il caricamento del file. Si prega di riprovare."
   },
   "roles": {


### PR DESCRIPTION
## Short description
Added file size limit to FileUploader component with default value as 200MB.

## List of changes proposed in this pull request
- Added new optional parameter to FileUploader fileSizeLimit with default value
- Added new test

## How to test
In PA you have to upload a > 200MB file and test the error message.