### PR TITLE
Pn 7405 fe rework test generale pg

### DIFF
--- a/packages/pn-personafisica-webapp/src/__test__/test-utils.tsx
+++ b/packages/pn-personafisica-webapp/src/__test__/test-utils.tsx
@@ -85,10 +85,20 @@ function mockApi(
   return mock;
 }
 
+/**
+ * Utility function to cleanup a Mock
+ * @param client Axios client or Mock Adapter instance
+ */
+function cleanupMock(client: AxiosInstance | MockAdapter) {
+  const mock = client instanceof MockAdapter ? client : new MockAdapter(client);
+  mock.reset();
+  mock.restore();
+};
+
 // re-exporting everything
 export * from '@testing-library/react';
 // override render method
 export { customRender as render };
 export { axe };
 // utility functions
-export { mockApi };
+export { mockApi, cleanupMock };

--- a/packages/pn-personafisica-webapp/src/api/consents/__test__/Consents.api.test.ts
+++ b/packages/pn-personafisica-webapp/src/api/consents/__test__/Consents.api.test.ts
@@ -24,6 +24,20 @@ describe('Consents api tests', () => {
     cleanupMock(mock);
   });
 
+  it('getConsentByType with status code 400', async () => {
+    const mock = mockApi(
+      apiClient,
+      'GET',
+      GET_CONSENTS(ConsentType.TOS),
+      400,
+      undefined,
+      { error: 'Invalid request' },
+    );
+    await expect(ConsentsApi.getConsentByType(ConsentType.TOS))
+    .rejects.toThrow("Request failed with status code 400");
+    cleanupMock(mock);
+  });
+
   it('setConsentByType', async () => {
     const mock = mockApi(
       apiClient,
@@ -35,6 +49,24 @@ describe('Consents api tests', () => {
     );
     const res = await ConsentsApi.setConsentByType(ConsentType.TOS, 'mocked-version-1', { action: ConsentActionType.ACCEPT });
     expect(res).toStrictEqual('success');
+    cleanupMock(mock);
+  });
+
+  it('setConsentByType with status code 400', async () => {
+    const mock = mockApi(
+      apiClient,
+      'PUT',
+      SET_CONSENTS(ConsentType.TOS, 'mocked-version-1'),
+      400,
+      undefined,
+      { error: 'Invalid request' },
+    );
+    await expect(
+      ConsentsApi.setConsentByType(
+        ConsentType.TOS,
+        'mocked-version-1',
+        { action: ConsentActionType.ACCEPT }))
+      .rejects.toThrow("Request failed with status code 400");
     cleanupMock(mock);
   });
 });

--- a/packages/pn-personafisica-webapp/src/api/consents/__test__/Consents.api.test.ts
+++ b/packages/pn-personafisica-webapp/src/api/consents/__test__/Consents.api.test.ts
@@ -5,25 +5,36 @@ import { ConsentActionType, ConsentType } from '../../../models/consents';
 import { apiClient } from '../../apiClients';
 import { ConsentsApi } from '../Consents.api';
 import { GET_CONSENTS, SET_CONSENTS } from '../consents.routes';
+import { cleanupMock, mockApi } from '../../../__test__/test-utils';
 
 describe('Consents api tests', () => {
   mockAuthentication();
 
   it('getConsentByType', async () => {
-    const mock = new MockAdapter(apiClient);
-    mock.onGet(GET_CONSENTS(ConsentType.TOS)).reply(200, {recipientId: 'mocked-recipientId', consentType: ConsentType.TOS, accepted: false});
+    const mock = mockApi(
+      apiClient,
+      'GET',
+      GET_CONSENTS(ConsentType.TOS),
+      200,
+      undefined,
+      { recipientId: 'mocked-recipientId', consentType: ConsentType.TOS, accepted: false },
+    );
     const res = await ConsentsApi.getConsentByType(ConsentType.TOS);
-    expect(res).toStrictEqual({recipientId: 'mocked-recipientId', consentType: ConsentType.TOS, accepted: false});
-    mock.reset();
-    mock.restore();
+    expect(res).toStrictEqual({ recipientId: 'mocked-recipientId', consentType: ConsentType.TOS, accepted: false });
+    cleanupMock(mock);
   });
 
   it('setConsentByType', async () => {
-    const mock = new MockAdapter(apiClient);
-    mock.onPut(SET_CONSENTS(ConsentType.TOS, 'mocked-version-1'), {action: ConsentActionType.ACCEPT}).reply(200);
-    const res = await ConsentsApi.setConsentByType(ConsentType.TOS, 'mocked-version-1', {action: ConsentActionType.ACCEPT});
+    const mock = mockApi(
+      apiClient,
+      'PUT',
+      SET_CONSENTS(ConsentType.TOS, 'mocked-version-1'),
+      200,
+      undefined,
+      { action: ConsentActionType.ACCEPT },
+    );
+    const res = await ConsentsApi.setConsentByType(ConsentType.TOS, 'mocked-version-1', { action: ConsentActionType.ACCEPT });
     expect(res).toStrictEqual('success');
-    mock.reset();
-    mock.restore();
+    cleanupMock(mock);
   });
 });

--- a/packages/pn-personafisica-webapp/src/api/contacts/__test__/Contacts.api.test.ts
+++ b/packages/pn-personafisica-webapp/src/api/contacts/__test__/Contacts.api.test.ts
@@ -1,7 +1,7 @@
 import { mockAuthentication } from '../../../redux/auth/__test__/test-utils';
 import { digitalAddresses } from '../../../redux/contact/__test__/test-utils';
 import { LegalChannelType, CourtesyChannelType } from '../../../models/contacts';
-import { mockApi } from '../../../__test__/test-utils';
+import { mockApi, cleanupMock } from '../../../__test__/test-utils';
 import { apiClient } from '../../apiClients';
 import { ContactsApi } from '../Contacts.api';
 import { CONTACTS_LIST, COURTESY_CONTACT, LEGAL_CONTACT } from '../contacts.routes';
@@ -13,85 +13,143 @@ describe('Contacts api tests', () => {
     const mock = mockApi(apiClient, 'GET', CONTACTS_LIST(), 200, undefined, digitalAddresses);
     const res = await ContactsApi.getDigitalAddresses();
     expect(res).toStrictEqual(digitalAddresses);
-    mock.reset();
-    mock.restore();
+    cleanupMock(mock);
   });
 
-  it('createOrUpdateDigitalAddress (email to verify)', async () => {
-    const body = { value: 'a@a.it' };
+  it('getDigitalAddresses with status code 400', async () => {
     const mock = mockApi(
       apiClient,
-      'POST',
-      LEGAL_CONTACT('mocked-senderId', LegalChannelType.PEC),
-      200,
-      body
-    );
-    const res = await ContactsApi.createOrUpdateLegalAddress(
-      'mocked-recipientId',
-      'mocked-senderId',
-      LegalChannelType.PEC,
-      body
-    );
-    expect(res).toStrictEqual(undefined);
-    mock.reset();
-    mock.restore();
+      'GET',
+      CONTACTS_LIST(),
+      400,
+      { Error: 'Invalid Request' });
+    await expect(ContactsApi.getDigitalAddresses())
+      .rejects
+      .toThrowError('Request failed with status code 400');
+    cleanupMock(mock);
   });
 
-  it('createOrUpdateDigitalAddress (email to validate)', async () => {
-    const body = { value: 'a@a.it', verificationCode: '12345' };
-    const mock = mockApi(
-      apiClient,
-      'POST',
-      LEGAL_CONTACT('mocked-senderId', LegalChannelType.PEC),
-      200,
-      body,
-      { result: 'PEC_VALIDATION_REQUIRED' }
-    );
-    const res = await ContactsApi.createOrUpdateLegalAddress(
-      'mocked-recipientId',
-      'mocked-senderId',
-      LegalChannelType.PEC,
-      body
-    );
-    expect(res).toStrictEqual({
-      value: '',
-      pecValid: false,
-      addressType: 'legal',
-      channelType: LegalChannelType.PEC,
-      recipientId: 'mocked-recipientId',
-      senderId: 'mocked-senderId',
-      senderName: undefined,
+  describe('createOrUpdateDigitalAddress', () => {
+    it('digital email to verify', async () => {
+      const body = { value: 'a@a.it' };
+      const mock = mockApi(
+        apiClient,
+        'POST',
+        LEGAL_CONTACT('mocked-senderId', LegalChannelType.PEC),
+        200,
+        body
+      );
+      const res = await ContactsApi.createOrUpdateLegalAddress(
+        'mocked-recipientId',
+        'mocked-senderId',
+        LegalChannelType.PEC,
+        body
+      );
+      expect(res).toStrictEqual(undefined);
+      cleanupMock(mock);
     });
-    mock.reset();
-    mock.restore();
+
+    it('digital email to validate', async () => {
+      const body = { value: 'a@a.it', verificationCode: '12345' };
+      const mock = mockApi(
+        apiClient,
+        'POST',
+        LEGAL_CONTACT('mocked-senderId', LegalChannelType.PEC),
+        200,
+        body,
+        { result: 'PEC_VALIDATION_REQUIRED' }
+      );
+      const res = await ContactsApi.createOrUpdateLegalAddress(
+        'mocked-recipientId',
+        'mocked-senderId',
+        LegalChannelType.PEC,
+        body
+      );
+      expect(res).toStrictEqual({
+        value: '',
+        pecValid: false,
+        addressType: 'legal',
+        channelType: LegalChannelType.PEC,
+        recipientId: 'mocked-recipientId',
+        senderId: 'mocked-senderId',
+        senderName: undefined,
+      });
+      cleanupMock(mock);
+    });
+
+    it('digital email verified', async () => {
+      const body = { value: 'a@a.it', verificationCode: '12345' };
+      const mock = mockApi(
+        apiClient,
+        'POST',
+        LEGAL_CONTACT('mocked-senderId', LegalChannelType.PEC),
+        204,
+        body
+      );
+      const res = await ContactsApi.createOrUpdateLegalAddress(
+        'mocked-recipientId',
+        'mocked-senderId',
+        LegalChannelType.PEC,
+        body
+      );
+      expect(res).toStrictEqual({
+        value: body.value,
+        pecValid: true,
+        addressType: 'legal',
+        channelType: LegalChannelType.PEC,
+        recipientId: 'mocked-recipientId',
+        senderId: 'mocked-senderId',
+        senderName: undefined,
+      });
+      cleanupMock(mock);
+    });
   });
 
-  it('createOrUpdateDigitalAddress (email verified)', async () => {
-    const body = { value: 'a@a.it', verificationCode: '12345' };
-    const mock = mockApi(
-      apiClient,
-      'POST',
-      LEGAL_CONTACT('mocked-senderId', LegalChannelType.PEC),
-      204,
-      body
-    );
-    const res = await ContactsApi.createOrUpdateLegalAddress(
-      'mocked-recipientId',
-      'mocked-senderId',
-      LegalChannelType.PEC,
-      body
-    );
-    expect(res).toStrictEqual({
-      value: body.value,
-      pecValid: true,
-      addressType: 'legal',
-      channelType: LegalChannelType.PEC,
-      recipientId: 'mocked-recipientId',
-      senderId: 'mocked-senderId',
-      senderName: undefined,
+  describe('createOrUpdateCourtesyAddress', () => {
+    it('courtesy email to verify', async () => {
+      const body = { value: 'a@a.it', verificationCode: '12345' };
+      const mock = mockApi(
+        apiClient,
+        'POST',
+        COURTESY_CONTACT('mocked-senderId', CourtesyChannelType.EMAIL),
+        200,
+        body
+      );
+      const res = await ContactsApi.createOrUpdateCourtesyAddress(
+        'mocked-recipientId',
+        'mocked-senderId',
+        CourtesyChannelType.EMAIL,
+        body
+      );
+      expect(res).toStrictEqual(undefined);
+      cleanupMock(mock);
     });
-    mock.reset();
-    mock.restore();
+
+    it('courtesy email verified', async () => {
+      const body = { value: 'a@a.it', verificationCode: '12345' };
+      const mock = mockApi(
+        apiClient,
+        'POST',
+        COURTESY_CONTACT('mocked-senderId', CourtesyChannelType.EMAIL),
+        204,
+        body
+      );
+      const res = await ContactsApi.createOrUpdateCourtesyAddress(
+        'mocked-recipientId',
+        'mocked-senderId',
+        CourtesyChannelType.EMAIL,
+        body
+      );
+      expect(res).toStrictEqual({
+        value: body.value,
+        addressType: 'courtesy',
+        channelType: CourtesyChannelType.EMAIL,
+        recipientId: 'mocked-recipientId',
+        senderId: 'mocked-senderId',
+        senderName: undefined,
+      });
+      cleanupMock(mock);
+    });
   });
 
   it('deleteLegalAddress', async () => {
@@ -103,55 +161,7 @@ describe('Contacts api tests', () => {
     );
     const res = await ContactsApi.deleteLegalAddress('mocked-senderId', LegalChannelType.PEC);
     expect(res).toStrictEqual('mocked-senderId');
-    mock.reset();
-    mock.restore();
-  });
-
-  it('createOrUpdateCourtesyAddress (email to verify)', async () => {
-    const body = { value: 'a@a.it', verificationCode: '12345' };
-    const mock = mockApi(
-      apiClient,
-      'POST',
-      COURTESY_CONTACT('mocked-senderId', CourtesyChannelType.EMAIL),
-      200,
-      body
-    );
-    const res = await ContactsApi.createOrUpdateCourtesyAddress(
-      'mocked-recipientId',
-      'mocked-senderId',
-      CourtesyChannelType.EMAIL,
-      body
-    );
-    expect(res).toStrictEqual(undefined);
-    mock.reset();
-    mock.restore();
-  });
-
-  it('createOrUpdateCourtesyAddress (email verified)', async () => {
-    const body = { value: 'a@a.it', verificationCode: '12345' };
-    const mock = mockApi(
-      apiClient,
-      'POST',
-      COURTESY_CONTACT('mocked-senderId', CourtesyChannelType.EMAIL),
-      204,
-      body
-    );
-    const res = await ContactsApi.createOrUpdateCourtesyAddress(
-      'mocked-recipientId',
-      'mocked-senderId',
-      CourtesyChannelType.EMAIL,
-      body
-    );
-    expect(res).toStrictEqual({
-      value: body.value,
-      addressType: 'courtesy',
-      channelType: CourtesyChannelType.EMAIL,
-      recipientId: 'mocked-recipientId',
-      senderId: 'mocked-senderId',
-      senderName: undefined,
-    });
-    mock.reset();
-    mock.restore();
+    cleanupMock(mock);
   });
 
   it('deleteCourtesyAddress', async () => {
@@ -166,7 +176,6 @@ describe('Contacts api tests', () => {
       CourtesyChannelType.EMAIL
     );
     expect(res).toStrictEqual('mocked-senderId');
-    mock.reset();
-    mock.restore();
+    cleanupMock(mock);
   });
 });

--- a/packages/pn-personafisica-webapp/src/api/external-registries/__test__/External-registries.api.test.ts
+++ b/packages/pn-personafisica-webapp/src/api/external-registries/__test__/External-registries.api.test.ts
@@ -1,18 +1,29 @@
 import MockAdapter from 'axios-mock-adapter';
 
-import { mockAuthentication} from "../../../redux/auth/__test__/test-utils";
+import { mockAuthentication } from "../../../redux/auth/__test__/test-utils";
 import { ExternalRegistriesAPI } from "../External-registries.api";
 import { apiClient } from "../../apiClients";
 import { GET_ALL_ACTIVATED_PARTIES } from "../external-registries-routes";
+import { cleanupMock, mockApi } from '../../../__test__/test-utils';
 
 describe('ExternalRegistries API tests', () => {
   mockAuthentication();
-  test('getAllActivatedParties 200', async () => {
-    const mock = new MockAdapter(apiClient);
-    mock.onGet(GET_ALL_ACTIVATED_PARTIES(undefined)).reply(200, []);
+  it('getAllActivatedParties 200', async () => {
+    const mock = mockApi(apiClient, 'GET', GET_ALL_ACTIVATED_PARTIES(undefined), 200, undefined, []);
     const res = await ExternalRegistriesAPI.getAllActivatedParties();
     expect(res).toStrictEqual([]);
-    mock.reset();
-    mock.restore();
+    cleanupMock(mock);
   })
+
+  it('getAllActivatedParties with status code 400', async () => {
+    const mock = mockApi(apiClient, 'GET', GET_ALL_ACTIVATED_PARTIES(undefined), 400, undefined, { error: "Invalid request" });
+    await expect(ExternalRegistriesAPI.getAllActivatedParties()).rejects.toThrow("Request failed with status code 400");
+    cleanupMock(mock);
+  });
+
+  it('getAllActivatedParties with status code 500', async () => {
+    const mock = mockApi(apiClient, 'GET', GET_ALL_ACTIVATED_PARTIES(undefined), 500, undefined, { error: "Internal Server Error" });
+    await expect(ExternalRegistriesAPI.getAllActivatedParties()).rejects.toThrow("Request failed with status code 500");
+    cleanupMock(mock);
+  });
 })

--- a/packages/pn-personafisica-webapp/src/api/notifications/__test__/Notifications.api.test.ts
+++ b/packages/pn-personafisica-webapp/src/api/notifications/__test__/Notifications.api.test.ts
@@ -19,7 +19,7 @@ import {
   notificationToFe,
 } from '../../../redux/notification/__test__/test-utils';
 import { mockAuthentication } from '../../../redux/auth/__test__/test-utils';
-import { mockApi } from '../../../__test__/test-utils';
+import { cleanupMock, mockApi } from '../../../__test__/test-utils';
 import {
   NOTIFICATIONS_LIST,
   NOTIFICATION_DETAIL,
@@ -36,45 +36,77 @@ describe('Notifications api tests', () => {
   mockAuthentication();
 
   it('getReceivedNotifications', async () => {
-    const mock = new MockAdapter(apiClient);
-    mock
-      .onGet(
-        NOTIFICATIONS_LIST({
-          startDate: formatToTimezoneString(tenYearsAgo),
-          endDate: formatToTimezoneString(getNextDay(today)),
-        })
-      )
-      .reply(200, notificationsFromBe);
+    const mock = mockApi(apiClient, 'GET', NOTIFICATIONS_LIST({
+      startDate: formatToTimezoneString(tenYearsAgo),
+      endDate: formatToTimezoneString(getNextDay(today)),
+    }), 200, undefined, notificationsFromBe);
     const res = await NotificationsApi.getReceivedNotifications({
       startDate: formatToTimezoneString(tenYearsAgo),
       endDate: formatToTimezoneString(getNextDay(today)),
     });
     expect(res).toStrictEqual(notificationsToFe);
-    mock.reset();
-    mock.restore();
+    cleanupMock(mock);
+  });
+
+  it('getReceivedNotifications with invalid date range', async () => {
+    const startDate = formatToTimezoneString(today);
+    const endDate = formatToTimezoneString(tenYearsAgo);
+    const mock = mockApi(apiClient, 'GET', NOTIFICATIONS_LIST({
+      startDate,
+      endDate
+    }), 400, undefined, { error: 'Invalid date range' });
+    await expect(
+      NotificationsApi.getReceivedNotifications({
+        startDate,
+        endDate,
+      })
+    ).rejects.toThrowError('Request failed with status code 400');
+    cleanupMock(mock);
+  });
+
+  it('getReceivedNotifications with server error', async () => {
+    const startDate = formatToTimezoneString(tenYearsAgo);
+    const endDate = formatToTimezoneString(today);
+    const mock = mockApi(apiClient, 'GET', NOTIFICATIONS_LIST({
+      startDate,
+      endDate
+    }), 500);
+    await expect(
+      NotificationsApi.getReceivedNotifications({
+        startDate,
+        endDate,
+      })
+    ).rejects.toThrow(Error);
+    cleanupMock(mock);
   });
 
   it('getReceivedNotification', async () => {
     const iun = 'mocked-iun';
-    const mock = new MockAdapter(apiClient);
-    mock.onGet(NOTIFICATION_DETAIL(iun)).reply(200, notificationFromBe);
+    const mock = mockApi(
+      apiClient,
+      'GET',
+      NOTIFICATION_DETAIL(iun),
+      200,
+      undefined,
+      notificationFromBe);
     const res = await NotificationsApi.getReceivedNotification(iun, 'CGNNMO80A03H501U', []);
     expect(res).toStrictEqual(notificationToFe);
-    mock.reset();
-    mock.restore();
+    cleanupMock(mock);
   });
 
   it('getReceivedNotificationDocument', async () => {
     const iun = 'mocked-iun';
     const documentIndex = '0';
-    const mock = new MockAdapter(apiClient);
-    mock
-      .onGet(NOTIFICATION_DETAIL_DOCUMENTS(iun, documentIndex))
-      .reply(200, { url: 'http://mocked-url.com' });
+    const mock = mockApi(
+      apiClient,
+      'GET',
+      NOTIFICATION_DETAIL_DOCUMENTS(iun, documentIndex),
+      200,
+      undefined,
+      { url: 'http://mocked-url.com' });
     const res = await NotificationsApi.getReceivedNotificationDocument(iun, documentIndex);
     expect(res).toStrictEqual({ url: 'http://mocked-url.com' });
-    mock.reset();
-    mock.restore();
+    cleanupMock(mock);
   });
 
   it('getReceivedNotificationOtherDocument', async () => {
@@ -83,14 +115,16 @@ describe('Notifications api tests', () => {
       documentId: 'mocked-id',
       documentType: 'mocked-type',
     };
-    const mock = new MockAdapter(apiClient);
-    mock
-      .onGet(NOTIFICATION_DETAIL_OTHER_DOCUMENTS(iun, otherDocument))
-      .reply(200, { url: 'http://mocked-url.com' });
+    const mock = mockApi(
+      apiClient,
+      'GET',
+      NOTIFICATION_DETAIL_OTHER_DOCUMENTS(iun, otherDocument),
+      200,
+      undefined,
+      { url: 'http://mocked-url.com' });
     const res = await NotificationsApi.getReceivedNotificationOtherDocument(iun, otherDocument);
     expect(res).toStrictEqual({ url: 'http://mocked-url.com' });
-    mock.reset();
-    mock.restore();
+    cleanupMock(mock);
   });
 
   it('getReceivedNotificationLegalfact', async () => {
@@ -99,28 +133,34 @@ describe('Notifications api tests', () => {
       key: 'mocked-key',
       category: LegalFactType.ANALOG_DELIVERY,
     };
-    const mock = new MockAdapter(apiClient);
-    mock.onGet(NOTIFICATION_DETAIL_LEGALFACT(iun, legalFact)).reply(200, undefined);
+    const mock = mockApi(
+      apiClient,
+      'GET',
+      NOTIFICATION_DETAIL_LEGALFACT(iun, legalFact),
+      200,
+      undefined,
+      undefined);
     const res = await NotificationsApi.getReceivedNotificationLegalfact(iun, legalFact);
     expect(res).toStrictEqual({ url: '' });
-    mock.reset();
-    mock.restore();
+    cleanupMock(mock);
   });
 
   it('getPaymentAttachment', async () => {
     const iun = 'mocked-iun';
     const attachmentName = 'mocked-attachmentName';
-    const mock = new MockAdapter(apiClient);
-    mock
-      .onGet(NOTIFICATION_PAYMENT_ATTACHMENT(iun, attachmentName))
-      .reply(200, { url: 'http://mocked-url.com' });
+    const mock = mockApi(
+      apiClient,
+      'GET',
+      NOTIFICATION_PAYMENT_ATTACHMENT(iun, attachmentName),
+      200,
+      undefined,
+      { url: 'http://mocked-url.com' });
     const res = await NotificationsApi.getPaymentAttachment(
       iun,
       attachmentName as PaymentAttachmentNameType
     );
     expect(res).toStrictEqual({ url: 'http://mocked-url.com' });
-    mock.reset();
-    mock.restore();
+    cleanupMock(mock);
   });
 
   it('getNotificationPaymentInfo', async () => {
@@ -142,16 +182,18 @@ describe('Notifications api tests', () => {
       status: 'SUCCEEDED',
       amount: 10,
     });
-    mock.reset();
-    mock.restore();
+    cleanupMock(mock);
   });
 
   it('getNotificationPaymentUrl', async () => {
     const taxId = 'mocked-taxId';
     const noticeCode = 'mocked-noticeCode';
-    const mock = new MockAdapter(apiClient);
-    mock
-      .onPost(NOTIFICATION_PAYMENT_URL(), {
+    const mock = mockApi(
+      apiClient,
+      'POST',
+      NOTIFICATION_PAYMENT_URL(),
+      200,
+      {
         paymentNotice: {
           noticeNumber: noticeCode,
           fiscalCode: taxId,
@@ -160,10 +202,11 @@ describe('Notifications api tests', () => {
           description: 'Mocked title',
         },
         returnUrl: 'mocked-return-url',
-      })
-      .reply(200, {
+      },
+      {
         checkoutUrl: 'mocked-url',
-      });
+      }
+    );
     const res = await NotificationsApi.getNotificationPaymentUrl(
       {
         noticeNumber: noticeCode,
@@ -177,25 +220,37 @@ describe('Notifications api tests', () => {
     expect(res).toStrictEqual({
       checkoutUrl: 'mocked-url',
     });
-    mock.reset();
-    mock.restore();
+    cleanupMock(mock);
   });
 
   it('exchangeNotificationQrCode', async () => {
-    const mock = new MockAdapter(apiClient);
-    mock.onPost(NOTIFICATION_ID_FROM_QRCODE(), { aarQrCodeValue: 'qr1' }).reply(200, {
-      iun: 'mock-notification-1',
-      mandateId: 'mock-mandate-1',
-    });
+    const mock = mockApi(
+      apiClient,
+      'POST',
+      NOTIFICATION_ID_FROM_QRCODE(),
+      200,
+      { aarQrCodeValue: 'qr1' },
+      {
+        iun: 'mock-notification-1',
+        mandateId: 'mock-mandate-1',
+      }
+    );
     mock.onPost(NOTIFICATION_ID_FROM_QRCODE(), { aarQrCodeValue: 'qr2' }).reply(200, {
       iun: 'mock-notification-2',
     });
-    const res = await NotificationsApi.exchangeNotificationQrCode('qr1');
-    expect(res).toStrictEqual({
-      iun: 'mock-notification-1',
-      mandateId: 'mock-mandate-1',
+    const allRes = {
+      res1: await NotificationsApi.exchangeNotificationQrCode('qr1'),
+      res2: await NotificationsApi.exchangeNotificationQrCode('qr2')
+    };
+    expect(allRes).toStrictEqual({
+      res1: {
+        iun: 'mock-notification-1',
+        mandateId: 'mock-mandate-1',
+      },
+      res2: {
+        iun: 'mock-notification-2',
+      }
     });
-    mock.reset();
-    mock.restore();
+    cleanupMock(mock);
   });
 });

--- a/packages/pn-personafisica-webapp/src/redux/delegation/__test__/test.utils.ts
+++ b/packages/pn-personafisica-webapp/src/redux/delegation/__test__/test.utils.ts
@@ -4,6 +4,7 @@ export const mockCreateDelegation = {
   delegate: {
     firstName: 'Davide',
     lastName: 'Legato',
+    displayName: 'Davide Legato',
     companyName: 'eni',
     fiscalCode: 'DVDLGT83C12H501C',
     person: true,

--- a/packages/pn-personagiuridica-webapp/src/api/consents/__test__/Consents.api.test.ts
+++ b/packages/pn-personagiuridica-webapp/src/api/consents/__test__/Consents.api.test.ts
@@ -1,29 +1,43 @@
 import MockAdapter from 'axios-mock-adapter';
 
-import { mockAuthentication } from '../../../redux/auth/__test__/test-utils';
+import { mockApi } from '../../../__test__/test-utils';
 import { ConsentActionType, ConsentType } from '../../../models/consents';
+import { mockAuthentication } from '../../../redux/auth/__test__/test-utils';
 import { apiClient } from '../../apiClients';
 import { ConsentsApi } from '../Consents.api';
 import { GET_CONSENTS, SET_CONSENTS } from '../consents.routes';
 
 describe('Consents api tests', () => {
+  let mock: MockAdapter;
+  afterEach(() => {
+    if (mock) {
+      mock.restore();
+      mock.reset();
+    }
+  });
   mockAuthentication();
 
   it('getConsentByType', async () => {
-    const mock = new MockAdapter(apiClient);
-    mock.onGet(GET_CONSENTS(ConsentType.TOS)).reply(200, {recipientId: 'mocked-recipientId', consentType: ConsentType.TOS, accepted: false});
+    mock = mockApi(apiClient, 'GET', GET_CONSENTS(ConsentType.TOS), 200, undefined, {
+      recipientId: 'mocked-recipientId',
+      consentType: ConsentType.TOS,
+      accepted: false,
+    });
     const res = await ConsentsApi.getConsentByType(ConsentType.TOS);
-    expect(res).toStrictEqual({recipientId: 'mocked-recipientId', consentType: ConsentType.TOS, accepted: false});
-    mock.reset();
-    mock.restore();
+    expect(res).toStrictEqual({
+      recipientId: 'mocked-recipientId',
+      consentType: ConsentType.TOS,
+      accepted: false,
+    });
   });
 
   it('setConsentByType', async () => {
-    const mock = new MockAdapter(apiClient);
-    mock.onPut(SET_CONSENTS(ConsentType.TOS, 'mocked-version-1'), {action: ConsentActionType.ACCEPT}).reply(200);
-    const res = await ConsentsApi.setConsentByType(ConsentType.TOS, 'mocked-version-1', {action: ConsentActionType.ACCEPT});
+    mock = mockApi(apiClient, 'PUT', SET_CONSENTS(ConsentType.TOS, 'mocked-version-1'), 200, {
+      action: ConsentActionType.ACCEPT,
+    });
+    const res = await ConsentsApi.setConsentByType(ConsentType.TOS, 'mocked-version-1', {
+      action: ConsentActionType.ACCEPT,
+    });
     expect(res).toStrictEqual('success');
-    mock.reset();
-    mock.restore();
   });
 });

--- a/packages/pn-personagiuridica-webapp/src/api/contacts/__test__/Contacts.api.test.ts
+++ b/packages/pn-personagiuridica-webapp/src/api/contacts/__test__/Contacts.api.test.ts
@@ -1,25 +1,32 @@
+import MockAdapter from 'axios-mock-adapter';
+
+import { mockApi } from '../../../__test__/test-utils';
+import { CourtesyChannelType, LegalChannelType } from '../../../models/contacts';
 import { mockAuthentication } from '../../../redux/auth/__test__/test-utils';
 import { digitalAddresses } from '../../../redux/contact/__test__/test-utils';
-import { LegalChannelType, CourtesyChannelType } from '../../../models/contacts';
-import { mockApi } from '../../../__test__/test-utils';
 import { apiClient } from '../../apiClients';
 import { ContactsApi } from '../Contacts.api';
 import { CONTACTS_LIST, COURTESY_CONTACT, LEGAL_CONTACT } from '../contacts.routes';
 
 describe('Contacts api tests', () => {
+  let mock: MockAdapter;
+  afterEach(() => {
+    if (mock) {
+      mock.restore();
+      mock.reset();
+    }
+  });
   mockAuthentication();
 
   it('getDigitalAddresses', async () => {
-    const mock = mockApi(apiClient, 'GET', CONTACTS_LIST(), 200, undefined, digitalAddresses);
+    mock = mockApi(apiClient, 'GET', CONTACTS_LIST(), 200, undefined, digitalAddresses);
     const res = await ContactsApi.getDigitalAddresses();
     expect(res).toStrictEqual(digitalAddresses);
-    mock.reset();
-    mock.restore();
   });
 
   it('createOrUpdateDigitalAddress (email to verify)', async () => {
     const body = { value: 'a@a.it' };
-    const mock = mockApi(
+    mock = mockApi(
       apiClient,
       'POST',
       LEGAL_CONTACT('mocked-senderId', LegalChannelType.PEC),
@@ -33,13 +40,11 @@ describe('Contacts api tests', () => {
       body
     );
     expect(res).toStrictEqual(undefined);
-    mock.reset();
-    mock.restore();
   });
 
   it('createOrUpdateDigitalAddress (email to validate)', async () => {
     const body = { value: 'a@a.it', verificationCode: '12345' };
-    const mock = mockApi(
+    mock = mockApi(
       apiClient,
       'POST',
       LEGAL_CONTACT('mocked-senderId', LegalChannelType.PEC),
@@ -62,13 +67,11 @@ describe('Contacts api tests', () => {
       senderId: 'mocked-senderId',
       senderName: undefined,
     });
-    mock.reset();
-    mock.restore();
   });
 
   it('createOrUpdateDigitalAddress (email verified)', async () => {
     const body = { value: 'a@a.it', verificationCode: '12345' };
-    const mock = mockApi(
+    mock = mockApi(
       apiClient,
       'POST',
       LEGAL_CONTACT('mocked-senderId', LegalChannelType.PEC),
@@ -90,12 +93,10 @@ describe('Contacts api tests', () => {
       senderId: 'mocked-senderId',
       senderName: undefined,
     });
-    mock.reset();
-    mock.restore();
   });
 
   it('deleteLegalAddress', async () => {
-    const mock = mockApi(
+    mock = mockApi(
       apiClient,
       'DELETE',
       LEGAL_CONTACT('mocked-senderId', LegalChannelType.PEC),
@@ -103,13 +104,11 @@ describe('Contacts api tests', () => {
     );
     const res = await ContactsApi.deleteLegalAddress('mocked-senderId', LegalChannelType.PEC);
     expect(res).toStrictEqual('mocked-senderId');
-    mock.reset();
-    mock.restore();
   });
 
   it('createOrUpdateCourtesyAddress (email to verify)', async () => {
     const body = { value: 'a@a.it', verificationCode: '12345' };
-    const mock = mockApi(
+    mock = mockApi(
       apiClient,
       'POST',
       COURTESY_CONTACT('mocked-senderId', CourtesyChannelType.EMAIL),
@@ -123,13 +122,11 @@ describe('Contacts api tests', () => {
       body
     );
     expect(res).toStrictEqual(undefined);
-    mock.reset();
-    mock.restore();
   });
 
   it('createOrUpdateCourtesyAddress (email verified)', async () => {
     const body = { value: 'a@a.it', verificationCode: '12345' };
-    const mock = mockApi(
+    mock = mockApi(
       apiClient,
       'POST',
       COURTESY_CONTACT('mocked-senderId', CourtesyChannelType.EMAIL),
@@ -150,12 +147,10 @@ describe('Contacts api tests', () => {
       senderId: 'mocked-senderId',
       senderName: undefined,
     });
-    mock.reset();
-    mock.restore();
   });
 
   it('deleteCourtesyAddress', async () => {
-    const mock = mockApi(
+    mock = mockApi(
       apiClient,
       'DELETE',
       COURTESY_CONTACT('mocked-senderId', CourtesyChannelType.EMAIL),
@@ -166,7 +161,5 @@ describe('Contacts api tests', () => {
       CourtesyChannelType.EMAIL
     );
     expect(res).toStrictEqual('mocked-senderId');
-    mock.reset();
-    mock.restore();
   });
 });

--- a/packages/pn-personagiuridica-webapp/src/api/delegations/__test__/Delegations.api.test.ts
+++ b/packages/pn-personagiuridica-webapp/src/api/delegations/__test__/Delegations.api.test.ts
@@ -1,3 +1,7 @@
+import MockAdapter from 'axios-mock-adapter';
+
+import { mockApi } from '../../../__test__/test-utils';
+import { DelegationStatus } from '../../../models/Deleghe';
 import { mockAuthentication } from '../../../redux/auth/__test__/test-utils';
 import {
   arrayOfDelegates,
@@ -17,104 +21,84 @@ import {
   REVOKE_DELEGATION,
   UPDATE_DELEGATION,
 } from '../delegations.routes';
-import { mockApi } from '../../../__test__/test-utils';
-import { DelegationStatus } from '../../../models/Deleghe';
 
 describe('Delegations api tests', () => {
+  let mock: MockAdapter;
   mockAuthentication();
+  afterEach(() => {
+    if (mock) {
+      mock.restore();
+      mock.reset();
+    }
+  });
 
   it('gets non empty delegates', async () => {
-    const mock = mockApi(
-      apiClient,
-      'GET',
-      DELEGATIONS_BY_DELEGATOR(),
-      200,
-      undefined,
-      arrayOfDelegates
-    );
+    mock = mockApi(apiClient, 'GET', DELEGATIONS_BY_DELEGATOR(), 200, undefined, arrayOfDelegates);
     const res = await DelegationsApi.getDelegatesByCompany();
     expect(res).toStrictEqual(arrayOfDelegates);
-    mock.reset();
-    mock.restore();
   });
 
   it('gets empty delegates', async () => {
-    const mock = mockApi(apiClient, 'GET', DELEGATIONS_BY_DELEGATOR(), 200, undefined, []);
+    mock = mockApi(apiClient, 'GET', DELEGATIONS_BY_DELEGATOR(), 200, undefined, []);
     const res = await DelegationsApi.getDelegatesByCompany();
     expect(res).toHaveLength(0);
-    mock.reset();
-    mock.restore();
   });
 
   it('gets non empty delegators', async () => {
-    const mock = mockApi(apiClient, 'POST', DELEGATIONS_BY_DELEGATE({ size: 10 }), 200, undefined, {
+    mock = mockApi(apiClient, 'POST', DELEGATIONS_BY_DELEGATE({ size: 10 }), 200, undefined, {
       resultsPage: arrayOfDelegators,
       moreResult: false,
       nextPagesKey: [],
     });
     const res = await DelegationsApi.getDelegators({ size: 10 });
     expect(res.resultsPage).toStrictEqual(arrayOfDelegators);
-    mock.reset();
-    mock.restore();
   });
 
   it('gets empty delegators', async () => {
-    const mock = mockApi(apiClient, 'POST', DELEGATIONS_BY_DELEGATE({ size: 10 }), 200, undefined, {
+    mock = mockApi(apiClient, 'POST', DELEGATIONS_BY_DELEGATE({ size: 10 }), 200, undefined, {
       resultsPage: [],
       moreResult: false,
       nextPagesKey: [],
     });
     const res = await DelegationsApi.getDelegators({ size: 10 });
     expect(res.resultsPage).toHaveLength(0);
-    mock.reset();
-    mock.restore();
   });
 
   it('revokes a delegation', async () => {
-    const mock = mockApi(apiClient, 'PATCH', REVOKE_DELEGATION('7'), 204);
+    mock = mockApi(apiClient, 'PATCH', REVOKE_DELEGATION('7'), 204);
     const res = await DelegationsApi.revokeDelegation('7');
     expect(res).toStrictEqual({ id: '7' });
-    mock.reset();
-    mock.restore();
   });
 
   it("doesn't revoke a delegation", async () => {
-    const mock = mockApi(apiClient, 'PATCH', REVOKE_DELEGATION('10'), 200);
+    mock = mockApi(apiClient, 'PATCH', REVOKE_DELEGATION('10'), 200);
     const res = await DelegationsApi.revokeDelegation('10');
     expect(res).toStrictEqual({ id: '-1' });
-    mock.reset();
-    mock.restore();
   });
 
   it('rejects a delegation', async () => {
-    const mock = mockApi(apiClient, 'PATCH', REJECT_DELEGATION('8'), 204);
+    mock = mockApi(apiClient, 'PATCH', REJECT_DELEGATION('8'), 204);
     const res = await DelegationsApi.rejectDelegation('8');
     expect(res).toStrictEqual({ id: '8' });
-    mock.reset();
-    mock.restore();
   });
 
   it("doesn't reject a delegation", async () => {
-    const mock = mockApi(apiClient, 'PATCH', REJECT_DELEGATION('10'), 200);
+    mock = mockApi(apiClient, 'PATCH', REJECT_DELEGATION('10'), 200);
     const res = await DelegationsApi.rejectDelegation('10');
     expect(res).toStrictEqual({ id: '-1' });
-    mock.reset();
-    mock.restore();
   });
 
   it('accept a delegation', async () => {
-    const mock = mockApi(apiClient, 'PATCH', ACCEPT_DELEGATION('9'), 204, undefined, {});
+    mock = mockApi(apiClient, 'PATCH', ACCEPT_DELEGATION('9'), 204, undefined, {});
     const res = await DelegationsApi.acceptDelegation('9', {
       verificationCode: '12345',
       groups: [{ id: 'group-1', name: 'Group 1' }],
     });
     expect(res).toStrictEqual({ id: '9', groups: [{ id: 'group-1', name: 'Group 1' }] });
-    mock.reset();
-    mock.restore();
   });
 
   it('creates a new delegation', async () => {
-    const mock = mockApi(
+    mock = mockApi(
       apiClient,
       'POST',
       CREATE_DELEGATION(),
@@ -124,27 +108,18 @@ describe('Delegations api tests', () => {
     );
     const res = await DelegationsApi.createDelegation(mockCreateDelegation);
     expect(res).toStrictEqual(mockCreateDelegation);
-    mock.reset();
-    mock.restore();
   });
 
   it('count delegators', async () => {
-    const mock = mockApi(
-      apiClient,
-      'GET',
-      COUNT_DELEGATORS(DelegationStatus.PENDING),
-      200,
-      undefined,
-      { value: 5 }
-    );
+    mock = mockApi(apiClient, 'GET', COUNT_DELEGATORS(DelegationStatus.PENDING), 200, undefined, {
+      value: 5,
+    });
     const res = await DelegationsApi.countDelegators(DelegationStatus.PENDING);
     expect(res).toStrictEqual({ value: 5 });
-    mock.reset();
-    mock.restore();
   });
 
   it('gets non empty delegators names', async () => {
-    const mock = mockApi(
+    mock = mockApi(
       apiClient,
       'GET',
       DELEGATIONS_NAME_BY_DELEGATE(),
@@ -160,23 +135,17 @@ describe('Delegations api tests', () => {
         mandateIds: [delegator.mandateId],
       }))
     );
-    mock.reset();
-    mock.restore();
   });
 
   it('gets empty delegators names', async () => {
-    const mock = mockApi(apiClient, 'GET', DELEGATIONS_NAME_BY_DELEGATE(), 200, undefined, []);
+    mock = mockApi(apiClient, 'GET', DELEGATIONS_NAME_BY_DELEGATE(), 200, undefined, []);
     const res = await DelegationsApi.getDelegatorsNames();
     expect(res).toHaveLength(0);
-    mock.reset();
-    mock.restore();
   });
 
   it('update a delegation', async () => {
-    const mock = mockApi(apiClient, 'PATCH', UPDATE_DELEGATION('9'), 204, undefined, {});
+    mock = mockApi(apiClient, 'PATCH', UPDATE_DELEGATION('9'), 204, undefined, {});
     const res = await DelegationsApi.updateDelegation('9', [{ id: 'group-1', name: 'Group 1' }]);
     expect(res).toStrictEqual({ id: '9', groups: [{ id: 'group-1', name: 'Group 1' }] });
-    mock.reset();
-    mock.restore();
   });
 });

--- a/packages/pn-personagiuridica-webapp/src/api/external-registries/__test__/External-registries.api.test.ts
+++ b/packages/pn-personagiuridica-webapp/src/api/external-registries/__test__/External-registries.api.test.ts
@@ -1,8 +1,8 @@
 import MockAdapter from 'axios-mock-adapter';
 
 import { mockApi } from '../../../__test__/test-utils';
-import { mockAuthentication } from '../../../redux/auth/__test__/test-utils';
 import { GroupStatus } from '../../../models/groups';
+import { mockAuthentication } from '../../../redux/auth/__test__/test-utils';
 import { apiClient } from '../../apiClients';
 import { ExternalRegistriesAPI } from '../External-registries.api';
 import { GET_ALL_ACTIVATED_PARTIES, GET_GROUPS } from '../external-registries-routes';
@@ -19,13 +19,13 @@ describe('ExternalRegistries API tests', () => {
   });
 
   it('getAllActivatedParties 200', async () => {
-    mockApi(apiClient, 'GET', GET_ALL_ACTIVATED_PARTIES(undefined), 200, undefined, []);
+    mock = mockApi(apiClient, 'GET', GET_ALL_ACTIVATED_PARTIES(undefined), 200, undefined, []);
     const res = await ExternalRegistriesAPI.getAllActivatedParties();
     expect(res).toStrictEqual([]);
-  })
+  });
 
   it('getGroups 200', async () => {
-    mockApi(apiClient, 'GET', GET_GROUPS(), 200, undefined, [
+    mock = mockApi(apiClient, 'GET', GET_GROUPS(), 200, undefined, [
       {
         id: 'group-1',
         name: 'Group 1',

--- a/packages/pn-personagiuridica-webapp/src/api/external-registries/__test__/External-registries.api.test.ts
+++ b/packages/pn-personagiuridica-webapp/src/api/external-registries/__test__/External-registries.api.test.ts
@@ -8,19 +8,24 @@ import { ExternalRegistriesAPI } from '../External-registries.api';
 import { GET_ALL_ACTIVATED_PARTIES, GET_GROUPS } from '../external-registries-routes';
 
 describe('ExternalRegistries API tests', () => {
+  let mock: MockAdapter;
   mockAuthentication();
 
-  test('getAllActivatedParties 200', async () => {
-    const mock = new MockAdapter(apiClient);
-    mock.onGet(GET_ALL_ACTIVATED_PARTIES(undefined)).reply(200, []);
-    const res = await ExternalRegistriesAPI.getAllActivatedParties();
-    expect(res).toStrictEqual([]);
-    mock.reset();
-    mock.restore();
+  afterEach(() => {
+    if (mock) {
+      mock.restore();
+      mock.reset();
+    }
   });
 
-  test('getGroups 200', async () => {
-    const mock = mockApi(apiClient, 'GET', GET_GROUPS(), 200, undefined, [
+  it('getAllActivatedParties 200', async () => {
+    mockApi(apiClient, 'GET', GET_ALL_ACTIVATED_PARTIES(undefined), 200, undefined, []);
+    const res = await ExternalRegistriesAPI.getAllActivatedParties();
+    expect(res).toStrictEqual([]);
+  })
+
+  it('getGroups 200', async () => {
+    mockApi(apiClient, 'GET', GET_GROUPS(), 200, undefined, [
       {
         id: 'group-1',
         name: 'Group 1',
@@ -37,7 +42,5 @@ describe('ExternalRegistries API tests', () => {
         status: GroupStatus.ACTIVE,
       },
     ]);
-    mock.reset();
-    mock.restore();
   });
 });

--- a/packages/pn-personagiuridica-webapp/src/api/notifications/__test__/Notifications.api.test.ts
+++ b/packages/pn-personagiuridica-webapp/src/api/notifications/__test__/Notifications.api.test.ts
@@ -1,15 +1,17 @@
 import MockAdapter from 'axios-mock-adapter';
+
 import {
-  tenYearsAgo,
-  today,
   LegalFactId,
   LegalFactType,
   PaymentAttachmentNameType,
   formatToTimezoneString,
   getNextDay,
+  tenYearsAgo,
+  today,
 } from '@pagopa-pn/pn-commons';
-import { apiClient } from '../../apiClients';
-import { NotificationsApi } from '../Notifications.api';
+
+import { mockApi } from '../../../../../pn-personafisica-webapp/src/__test__/test-utils';
+import { mockAuthentication } from '../../../redux/auth/__test__/test-utils';
 import {
   notificationsFromBe,
   notificationsToFe,
@@ -18,7 +20,8 @@ import {
   notificationFromBe,
   notificationToFe,
 } from '../../../redux/notification/__test__/test-utils';
-import { mockAuthentication } from '../../../redux/auth/__test__/test-utils';
+import { apiClient } from '../../apiClients';
+import { NotificationsApi } from '../Notifications.api';
 import {
   NOTIFICATIONS_LIST,
   NOTIFICATION_DETAIL,
@@ -29,7 +32,6 @@ import {
   NOTIFICATION_PAYMENT_INFO,
   NOTIFICATION_PAYMENT_URL,
 } from '../notifications.routes';
-import { mockApi } from '../../../../../pn-personafisica-webapp/src/__test__/test-utils';
 
 describe('Notifications api tests', () => {
   let mock: MockAdapter;
@@ -43,10 +45,17 @@ describe('Notifications api tests', () => {
   });
 
   it('getReceivedNotifications', async () => {
-    mockApi(apiClient, 'GET', NOTIFICATIONS_LIST({
-      startDate: formatToTimezoneString(tenYearsAgo),
-      endDate: formatToTimezoneString(getNextDay(today)),
-    }), 200, undefined, notificationsFromBe);
+    mock = mockApi(
+      apiClient,
+      'GET',
+      NOTIFICATIONS_LIST({
+        startDate: formatToTimezoneString(tenYearsAgo),
+        endDate: formatToTimezoneString(getNextDay(today)),
+      }),
+      200,
+      undefined,
+      notificationsFromBe
+    );
     const res = await NotificationsApi.getReceivedNotifications({
       startDate: formatToTimezoneString(tenYearsAgo),
       endDate: formatToTimezoneString(getNextDay(today)),
@@ -57,12 +66,7 @@ describe('Notifications api tests', () => {
 
   it('getReceivedNotification', async () => {
     const iun = 'mocked-iun';
-    mockApi(apiClient,
-      'GET',
-      NOTIFICATION_DETAIL(iun),
-      200,
-      undefined,
-      notificationFromBe);
+    mock = mockApi(apiClient, 'GET', NOTIFICATION_DETAIL(iun), 200, undefined, notificationFromBe);
     const res = await NotificationsApi.getReceivedNotification(iun);
     expect(res).toStrictEqual(notificationToFe);
   });
@@ -70,12 +74,16 @@ describe('Notifications api tests', () => {
   it('getReceivedNotificationDocument', async () => {
     const iun = 'mocked-iun';
     const documentIndex = '0';
-    mockApi(apiClient,
+    mock = mockApi(
+      apiClient,
       'GET',
       NOTIFICATION_DETAIL_DOCUMENTS(iun, documentIndex),
       200,
       undefined,
-      { url: 'http://mocked-url.com' });
+      {
+        url: 'http://mocked-url.com',
+      }
+    );
     const res = await NotificationsApi.getReceivedNotificationDocument(iun, documentIndex);
     expect(res).toStrictEqual({ url: 'http://mocked-url.com' });
   });
@@ -86,12 +94,14 @@ describe('Notifications api tests', () => {
       key: 'mocked-key',
       category: LegalFactType.ANALOG_DELIVERY,
     };
-    mockApi(apiClient,
+    mock = mockApi(
+      apiClient,
       'GET',
       NOTIFICATION_DETAIL_LEGALFACT(iun, legalFact),
       200,
       undefined,
-      undefined);
+      undefined
+    );
     const res = await NotificationsApi.getReceivedNotificationLegalfact(iun, legalFact);
     expect(res).toStrictEqual({ url: '' });
   });
@@ -99,12 +109,14 @@ describe('Notifications api tests', () => {
   it('getPaymentAttachment', async () => {
     const iun = 'mocked-iun';
     const attachmentName = 'mocked-attachmentName';
-    mockApi(apiClient,
+    mock = mockApi(
+      apiClient,
       'GET',
       NOTIFICATION_PAYMENT_ATTACHMENT(iun, attachmentName),
       200,
       undefined,
-      { url: 'http://mocked-url.com' });
+      { url: 'http://mocked-url.com' }
+    );
     const res = await NotificationsApi.getPaymentAttachment(
       iun,
       attachmentName as PaymentAttachmentNameType
@@ -115,15 +127,10 @@ describe('Notifications api tests', () => {
   it('getNotificationPaymentInfo', async () => {
     const taxId = 'mocked-taxId';
     const noticeCode = 'mocked-noticeCode';
-    mockApi(apiClient,
-      'GET',
-      NOTIFICATION_PAYMENT_INFO(taxId, noticeCode),
-      200,
-      undefined,
-      {
-        status: 'SUCCEEDED',
-        amount: 10,
-      });
+    mock = mockApi(apiClient, 'GET', NOTIFICATION_PAYMENT_INFO(taxId, noticeCode), 200, undefined, {
+      status: 'SUCCEEDED',
+      amount: 10,
+    });
     const res = await NotificationsApi.getNotificationPaymentInfo(noticeCode, taxId);
     expect(res).toStrictEqual({
       status: 'SUCCEEDED',
@@ -134,7 +141,8 @@ describe('Notifications api tests', () => {
   it('getNotificationPaymentUrl', async () => {
     const taxId = 'mocked-taxId';
     const noticeCode = 'mocked-noticeCode';
-    mockApi(apiClient,
+    mock = mockApi(
+      apiClient,
       'POST',
       NOTIFICATION_PAYMENT_URL(),
       200,
@@ -150,7 +158,8 @@ describe('Notifications api tests', () => {
       },
       {
         checkoutUrl: 'mocked-url',
-      });
+      }
+    );
     const res = await NotificationsApi.getNotificationPaymentUrl(
       {
         noticeNumber: noticeCode,
@@ -167,7 +176,8 @@ describe('Notifications api tests', () => {
   });
 
   it('exchangeNotificationQrCode', async () => {
-    mockApi(apiClient,
+    mock = mockApi(
+      apiClient,
       'POST',
       NOTIFICATION_ID_FROM_QRCODE(),
       200,
@@ -175,11 +185,12 @@ describe('Notifications api tests', () => {
       {
         iun: 'mock-notification-1',
         mandateId: 'mock-mandate-1',
-      });
+      }
+    );
     const res = await NotificationsApi.exchangeNotificationQrCode('qr1');
     expect(res).toStrictEqual({
       iun: 'mock-notification-1',
-      mandateId: 'mock-mandate-1'
+      mandateId: 'mock-mandate-1',
     });
   });
 });

--- a/packages/pn-personagiuridica-webapp/src/api/notifications/__test__/Notifications.api.test.ts
+++ b/packages/pn-personagiuridica-webapp/src/api/notifications/__test__/Notifications.api.test.ts
@@ -29,51 +29,55 @@ import {
   NOTIFICATION_PAYMENT_INFO,
   NOTIFICATION_PAYMENT_URL,
 } from '../notifications.routes';
+import { mockApi } from '../../../../../pn-personafisica-webapp/src/__test__/test-utils';
 
 describe('Notifications api tests', () => {
+  let mock: MockAdapter;
   mockAuthentication();
 
+  afterEach(() => {
+    if (mock) {
+      mock.restore();
+      mock.reset();
+    }
+  });
+
   it('getReceivedNotifications', async () => {
-    const mock = new MockAdapter(apiClient);
-    mock
-      .onGet(
-        NOTIFICATIONS_LIST({
-          startDate: formatToTimezoneString(tenYearsAgo),
-          endDate: formatToTimezoneString(getNextDay(today)),
-        })
-      )
-      .reply(200, notificationsFromBe);
+    mockApi(apiClient, 'GET', NOTIFICATIONS_LIST({
+      startDate: formatToTimezoneString(tenYearsAgo),
+      endDate: formatToTimezoneString(getNextDay(today)),
+    }), 200, undefined, notificationsFromBe);
     const res = await NotificationsApi.getReceivedNotifications({
       startDate: formatToTimezoneString(tenYearsAgo),
       endDate: formatToTimezoneString(getNextDay(today)),
       isDelegatedPage: false,
     });
     expect(res).toStrictEqual(notificationsToFe);
-    mock.reset();
-    mock.restore();
   });
 
   it('getReceivedNotification', async () => {
     const iun = 'mocked-iun';
-    const mock = new MockAdapter(apiClient);
-    mock.onGet(NOTIFICATION_DETAIL(iun)).reply(200, notificationFromBe);
+    mockApi(apiClient,
+      'GET',
+      NOTIFICATION_DETAIL(iun),
+      200,
+      undefined,
+      notificationFromBe);
     const res = await NotificationsApi.getReceivedNotification(iun);
     expect(res).toStrictEqual(notificationToFe);
-    mock.reset();
-    mock.restore();
   });
 
   it('getReceivedNotificationDocument', async () => {
     const iun = 'mocked-iun';
     const documentIndex = '0';
-    const mock = new MockAdapter(apiClient);
-    mock
-      .onGet(NOTIFICATION_DETAIL_DOCUMENTS(iun, documentIndex))
-      .reply(200, { url: 'http://mocked-url.com' });
+    mockApi(apiClient,
+      'GET',
+      NOTIFICATION_DETAIL_DOCUMENTS(iun, documentIndex),
+      200,
+      undefined,
+      { url: 'http://mocked-url.com' });
     const res = await NotificationsApi.getReceivedNotificationDocument(iun, documentIndex);
     expect(res).toStrictEqual({ url: 'http://mocked-url.com' });
-    mock.reset();
-    mock.restore();
   });
 
   it('getReceivedNotificationLegalfact', async () => {
@@ -82,53 +86,59 @@ describe('Notifications api tests', () => {
       key: 'mocked-key',
       category: LegalFactType.ANALOG_DELIVERY,
     };
-    const mock = new MockAdapter(apiClient);
-    mock.onGet(NOTIFICATION_DETAIL_LEGALFACT(iun, legalFact)).reply(200, undefined);
+    mockApi(apiClient,
+      'GET',
+      NOTIFICATION_DETAIL_LEGALFACT(iun, legalFact),
+      200,
+      undefined,
+      undefined);
     const res = await NotificationsApi.getReceivedNotificationLegalfact(iun, legalFact);
     expect(res).toStrictEqual({ url: '' });
-    mock.reset();
-    mock.restore();
   });
 
   it('getPaymentAttachment', async () => {
     const iun = 'mocked-iun';
     const attachmentName = 'mocked-attachmentName';
-    const mock = new MockAdapter(apiClient);
-    mock
-      .onGet(NOTIFICATION_PAYMENT_ATTACHMENT(iun, attachmentName))
-      .reply(200, { url: 'http://mocked-url.com' });
+    mockApi(apiClient,
+      'GET',
+      NOTIFICATION_PAYMENT_ATTACHMENT(iun, attachmentName),
+      200,
+      undefined,
+      { url: 'http://mocked-url.com' });
     const res = await NotificationsApi.getPaymentAttachment(
       iun,
       attachmentName as PaymentAttachmentNameType
     );
     expect(res).toStrictEqual({ url: 'http://mocked-url.com' });
-    mock.reset();
-    mock.restore();
   });
 
   it('getNotificationPaymentInfo', async () => {
     const taxId = 'mocked-taxId';
     const noticeCode = 'mocked-noticeCode';
-    const mock = new MockAdapter(apiClient);
-    mock.onGet(NOTIFICATION_PAYMENT_INFO(taxId, noticeCode)).reply(200, {
-      status: 'SUCCEEDED',
-      amount: 10,
-    });
+    mockApi(apiClient,
+      'GET',
+      NOTIFICATION_PAYMENT_INFO(taxId, noticeCode),
+      200,
+      undefined,
+      {
+        status: 'SUCCEEDED',
+        amount: 10,
+      });
     const res = await NotificationsApi.getNotificationPaymentInfo(noticeCode, taxId);
     expect(res).toStrictEqual({
       status: 'SUCCEEDED',
       amount: 10,
     });
-    mock.reset();
-    mock.restore();
   });
 
   it('getNotificationPaymentUrl', async () => {
     const taxId = 'mocked-taxId';
     const noticeCode = 'mocked-noticeCode';
-    const mock = new MockAdapter(apiClient);
-    mock
-      .onPost(NOTIFICATION_PAYMENT_URL(), {
+    mockApi(apiClient,
+      'POST',
+      NOTIFICATION_PAYMENT_URL(),
+      200,
+      {
         paymentNotice: {
           noticeNumber: noticeCode,
           fiscalCode: taxId,
@@ -137,8 +147,8 @@ describe('Notifications api tests', () => {
           description: 'Mocked title',
         },
         returnUrl: 'mocked-return-url',
-      })
-      .reply(200, {
+      },
+      {
         checkoutUrl: 'mocked-url',
       });
     const res = await NotificationsApi.getNotificationPaymentUrl(
@@ -154,25 +164,22 @@ describe('Notifications api tests', () => {
     expect(res).toStrictEqual({
       checkoutUrl: 'mocked-url',
     });
-    mock.reset();
-    mock.restore();
   });
 
   it('exchangeNotificationQrCode', async () => {
-    const mock = new MockAdapter(apiClient);
-    mock.onPost(NOTIFICATION_ID_FROM_QRCODE(), { aarQrCodeValue: 'qr1' }).reply(200, {
-      iun: 'mock-notification-1',
-      mandateId: 'mock-mandate-1',
-    });
-    mock.onPost(NOTIFICATION_ID_FROM_QRCODE(), { aarQrCodeValue: 'qr2' }).reply(200, {
-      iun: 'mock-notification-2',
-    });
+    mockApi(apiClient,
+      'POST',
+      NOTIFICATION_ID_FROM_QRCODE(),
+      200,
+      { aarQrCodeValue: 'qr1' },
+      {
+        iun: 'mock-notification-1',
+        mandateId: 'mock-mandate-1',
+      });
     const res = await NotificationsApi.exchangeNotificationQrCode('qr1');
     expect(res).toStrictEqual({
       iun: 'mock-notification-1',
-      mandateId: 'mock-mandate-1',
+      mandateId: 'mock-mandate-1'
     });
-    mock.reset();
-    mock.restore();
   });
 });


### PR DESCRIPTION
## Short description
Refactor of tests with `mockApi()`

## List of changes proposed in this pull request
- Removed `MockAdapter `instances and changed them into` mockApi()`.
- Added `afterEach()` so that every test can reset e restore the mock.

## How to test
Just run tests into `packages\pn-personagiuridica-webapp`