### PR TITLE
PN-7557 - Shifted Axios interceptor init from App to index.tsx in PA / PF / PG

### DIFF
--- a/packages/pn-pa-webapp/src/App.tsx
+++ b/packages/pn-pa-webapp/src/App.tsx
@@ -28,7 +28,7 @@ import { useLocation } from 'react-router-dom';
 import Router from './navigation/routes';
 import { AUTH_ACTIONS, logout } from './redux/auth/actions';
 import { useAppDispatch, useAppSelector } from './redux/hooks';
-import { RootState, store } from './redux/store';
+import { RootState } from './redux/store';
 import { getMenuItems } from './utils/role.utility';
 
 import * as routes from './navigation/routes.const';
@@ -37,7 +37,6 @@ import { TrackEventType } from './utils/events';
 import { trackEventByType } from './utils/mixpanel';
 import './utils/onetrust';
 import { PAAppErrorFactory } from './utils/AppError/PAAppErrorFactory';
-import { setUpInterceptor } from './api/interceptors';
 import { getConfiguration } from './services/configuration.service';
 
 
@@ -67,7 +66,6 @@ const ActualApp = () => {
   useUnload(() => {
     trackEventByType(TrackEventType.APP_UNLOAD);
   });
-  setUpInterceptor(store);
 
   const loggedUser = useAppSelector((state: RootState) => state.userState.user);
   const loggedUserOrganizationParty = loggedUser.organization;

--- a/packages/pn-pa-webapp/src/index.tsx
+++ b/packages/pn-pa-webapp/src/index.tsx
@@ -6,14 +6,15 @@ import { BrowserRouter } from 'react-router-dom';
 import { CssBaseline, ThemeProvider } from '@mui/material';
 import { theme } from '@pagopa/mui-italia';
 
-import App from './App';
 import { initAxiosClients } from './api/apiClients';
-import './i18n';
-import './index.css';
 import { initStore, store } from './redux/store';
-import reportWebVitals from './reportWebVitals';
 import { loadPaConfiguration } from './services/configuration.service';
 import { initOneTrust } from './utils/onetrust';
+import { setUpInterceptor } from './api/interceptors';
+import App from './App';
+import './i18n';
+import './index.css';
+import reportWebVitals from './reportWebVitals';
 
 async function doTheRender() {
   try {
@@ -24,6 +25,8 @@ async function doTheRender() {
     initOneTrust();
     initStore();
     initAxiosClients();
+    // move initialization of the Axios interceptor - PN-7557
+    setUpInterceptor(store);
 
     ReactDOM.render(
       <React.StrictMode>

--- a/packages/pn-personafisica-webapp/src/App.tsx
+++ b/packages/pn-personafisica-webapp/src/App.tsx
@@ -34,7 +34,7 @@ import * as routes from './navigation/routes.const';
 import Router from './navigation/routes';
 import { logout } from './redux/auth/actions';
 import { useAppDispatch, useAppSelector } from './redux/hooks';
-import { RootState, store } from './redux/store';
+import { RootState } from './redux/store';
 import { Delegation } from './redux/delegation/types';
 import { getDomicileInfo, getSidemenuInformation } from './redux/sidemenu/actions';
 import { trackEventByType } from './utils/mixpanel';
@@ -42,7 +42,6 @@ import { TrackEventType } from './utils/events';
 import './utils/onetrust';
 import { PFAppErrorFactory } from './utils/AppError/PFAppErrorFactory';
 import { goToLoginPortal } from './navigation/navigation.utility';
-import { setUpInterceptor } from './api/interceptors';
 import { getCurrentAppStatus } from './redux/appStatus/actions';
 import { getConfiguration } from './services/configuration.service';
 
@@ -90,7 +89,6 @@ const App = () => {
 };
 
 const ActualApp = () => {
-  setUpInterceptor(store);
   const dispatch = useAppDispatch();
   const { t, i18n } = useTranslation(['common', 'notifiche']);
   const loggedUser = useAppSelector((state: RootState) => state.userState.user);

--- a/packages/pn-personafisica-webapp/src/index.tsx
+++ b/packages/pn-personafisica-webapp/src/index.tsx
@@ -7,14 +7,15 @@ import { CssBaseline, ThemeProvider } from '@mui/material';
 import { LoadingPage } from '@pagopa-pn/pn-commons';
 import { theme } from '@pagopa/mui-italia';
 
-import App from './App';
 import { initAxiosClients } from './api/apiClients';
-import './i18n';
-import './index.css';
+import { setUpInterceptor } from './api/interceptors';
 import { initStore, store } from './redux/store';
-import reportWebVitals from './reportWebVitals';
 import { loadPfConfiguration } from './services/configuration.service';
 import { initOneTrust } from './utils/onetrust';
+import App from './App';
+import './i18n';
+import './index.css';
+import reportWebVitals from './reportWebVitals';
 
 async function doTheRender() {
   try {
@@ -25,6 +26,8 @@ async function doTheRender() {
     initOneTrust();
     initStore();
     initAxiosClients();
+    // move initialization of the Axios interceptor - PN-7557
+    setUpInterceptor(store);
 
     ReactDOM.render(
       <React.StrictMode>

--- a/packages/pn-personagiuridica-webapp/src/App.tsx
+++ b/packages/pn-personagiuridica-webapp/src/App.tsx
@@ -34,7 +34,7 @@ import * as routes from './navigation/routes.const';
 import Router from './navigation/routes';
 import { logout } from './redux/auth/actions';
 import { useAppDispatch, useAppSelector } from './redux/hooks';
-import { RootState, store } from './redux/store';
+import { RootState } from './redux/store';
 import { getDomicileInfo, getSidemenuInformation } from './redux/sidemenu/actions';
 import { PNRole } from './redux/auth/types';
 import { trackEventByType } from './utils/mixpanel';
@@ -42,7 +42,6 @@ import { TrackEventType } from './utils/events';
 import './utils/onetrust';
 import { PGAppErrorFactory } from './utils/AppError/PGAppErrorFactory';
 import { goToLoginPortal } from './navigation/navigation.utility';
-import { setUpInterceptor } from './api/interceptors';
 import { getCurrentAppStatus } from './redux/appStatus/actions';
 import { getConfiguration } from './services/configuration.service';
 
@@ -70,7 +69,6 @@ const App = () => {
 
 const ActualApp = () => {
   const { MIXPANEL_TOKEN, PAGOPA_HELP_EMAIL, VERSION } = getConfiguration();
-  setUpInterceptor(store);
   const dispatch = useAppDispatch();
   const { t, i18n } = useTranslation(['common', 'notifiche']);
   const loggedUser = useAppSelector((state: RootState) => state.userState.user);

--- a/packages/pn-personagiuridica-webapp/src/index.tsx
+++ b/packages/pn-personagiuridica-webapp/src/index.tsx
@@ -7,14 +7,15 @@ import { CssBaseline, ThemeProvider } from '@mui/material';
 import { LoadingPage } from '@pagopa-pn/pn-commons';
 import { theme } from '@pagopa/mui-italia';
 
-import App from './App';
 import { initAxiosClients } from './api/apiClients';
-import './i18n';
-import './index.css';
 import { initStore, store } from './redux/store';
-import reportWebVitals from './reportWebVitals';
 import { loadPgConfiguration } from './services/configuration.service';
 import { initOneTrust } from './utils/onetrust';
+import { setUpInterceptor } from './api/interceptors';
+import App from './App';
+import './i18n';
+import './index.css';
+import reportWebVitals from './reportWebVitals';
 
 async function doTheRender() {
   try {
@@ -25,6 +26,8 @@ async function doTheRender() {
     initOneTrust();
     initStore();
     initAxiosClients();
+    // move initialization of the Axios interceptor - PN-7557
+    setUpInterceptor(store);
 
     ReactDOM.render(
       <React.StrictMode>


### PR DESCRIPTION
## Short description
The axios interceptor was set many times, once for each re-render of the main `App` component, in all of PA / PF / PG apps. This led to wrong behavior.  
The goal of this PR is to fix this initialization action so that it runs exactly once when the webapp is loaded.

## List of changes proposed in this pull request
- Moved the code that sets the action interceptor from the `App` component to the `index.tsx` file, along with other one-time initialization actions (those which were moved from previously static code, cfr. https://github.com/pagopa/pn-frontend/pull/674).

## How to test
Just open either app, it should run normally.

For more details, you can check that the interceptors are added exactly once by adding an additional interceptor that sends something to console for a specific API call, this is an example for PA.
```
  apiClient.interceptors.response.use(
    (response) => {
      if (response.config?.url === '/delivery/notifications/sent/XHJK-MWDE-KXEU-202308-J-1') {
        console.log('ciaoooooo');
      } 
      return response;
    },
    (error) => Promise.reject(error)
  );
};
```
If the code runs as expected, then you should see exactly one log line in the console each time the API is called. In the situation preceding this PR, you would have several log lines in the console instead of just one.