### PR TITLE
Fixed clipping statuses tooltips

### DIFF
--- a/packages/pn-commons/src/components/CustomTooltip.tsx
+++ b/packages/pn-commons/src/components/CustomTooltip.tsx
@@ -1,7 +1,8 @@
-import { cloneElement, ReactElement, useState } from 'react'; // ReactNode, cloneElement
-import Tooltip from '@mui/material/Tooltip';
-import ClickAwayListener from '@mui/material/ClickAwayListener';
+import { ReactElement, cloneElement, useState } from 'react';
+
 import { Box, SxProps } from '@mui/material';
+import ClickAwayListener from '@mui/material/ClickAwayListener';
+import Tooltip from '@mui/material/Tooltip';
 
 type Props = {
   tooltipContent: any;
@@ -33,9 +34,6 @@ function CustomTooltip({ openOnClick, tooltipContent, children, sx, onOpen }: Pr
           arrow
           leaveTouchDelay={5000}
           title={tooltipContent}
-          PopperProps={{
-            disablePortal: true,
-          }}
           onClose={handleTooltipClose}
           open={openOnClick ? open : undefined}
           disableFocusListener={openOnClick}

--- a/packages/pn-commons/src/components/__test__/CustomTooltip.test.tsx
+++ b/packages/pn-commons/src/components/__test__/CustomTooltip.test.tsx
@@ -1,4 +1,6 @@
-import { fireEvent, waitFor, screen } from '@testing-library/react';
+import React from 'react';
+
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 
 import { render } from '../../test-utils';
 import CustomTooltip from '../CustomTooltip';


### PR DESCRIPTION
## Short description
Fixed clipping statuses tooltips.

## List of changes proposed in this pull request
- Removed disablePortal option
- Reordered imports, for test too.

## How to test
How to replicate the bug: resize window heigh to make visible only one row then do the hover to status chip. The tooltip should be correctly visible now.