### PR TITLE
Refactored links replace in Privacy pages

### DIFF
--- a/packages/pn-commons/src/hooks/useRewriteLinks.ts
+++ b/packages/pn-commons/src/hooks/useRewriteLinks.ts
@@ -2,15 +2,13 @@ import { useLayoutEffect } from 'react';
 
 export const useRewriteLinks = (contentLoaded: boolean, route: any, selectorString: string) => {
   useLayoutEffect(() => {
-    setTimeout(() => {
-      const links = document.querySelectorAll(selectorString);
-      links.forEach((l) => {
-        const href = l.getAttribute('href');
-        if (href?.startsWith('#')) {
-          const newHref = `${route}${href}`;
-          l.setAttribute('href', newHref);
-        }
-      });
-    }, 1000);
+    const links = document.querySelectorAll(selectorString);
+    links.forEach((l) => {
+      const href = l.getAttribute('href');
+      if (href?.startsWith('#')) {
+        const newHref = `${route}${href}`;
+        l.setAttribute('href', newHref);
+      }
+    });
   }, [contentLoaded]);
 };

--- a/packages/pn-commons/src/utils/__test__/dom.utility.test.tsx
+++ b/packages/pn-commons/src/utils/__test__/dom.utility.test.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from 'react';
+
+import { act, render } from '../../test-utils';
+import { WaitForElementResult, waitForElement } from '../dom.utility';
+
+const myInjectedElement = <div className="mocked-class">mocked-test</div>;
+
+const MockComponent = ({
+  renderInjectedElement = false,
+  delay,
+}: {
+  renderInjectedElement?: boolean;
+  delay?: number;
+}) => {
+  const [renderElement, setRenderElement] = useState(false);
+  useEffect(() => {
+    if (renderInjectedElement && !delay) {
+      setRenderElement(true);
+    } else if (renderInjectedElement && delay) {
+      setTimeout(() => act(() => setRenderElement(true)));
+    }
+  }, []);
+  return (
+    <div data-testid="mocked-component">
+      <div>Mocked component</div>
+      {renderElement && <div>{myInjectedElement}</div>}
+    </div>
+  );
+};
+
+describe('waitForElement', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('render MockComponent with injected element', async () => {
+    render(<MockComponent renderInjectedElement={true} />);
+    const waitResult = await waitForElement('.mocked-class');
+    expect(waitResult).toBe(WaitForElementResult.DOM_ELEMENT_ALREADY_EXISTS);
+  });
+
+  it('render MockComponent with injected element after a while simulating time request', async () => {
+    render(<MockComponent renderInjectedElement={true} delay={1000} />);
+    const waitResult = await waitForElement('.mocked-class');
+    expect(waitResult).toBe(WaitForElementResult.DOM_ELEMENT_FOUND);
+  });
+});

--- a/packages/pn-commons/src/utils/dom.utility.ts
+++ b/packages/pn-commons/src/utils/dom.utility.ts
@@ -1,0 +1,33 @@
+// DOM utilities
+
+export enum WaitForElementResult {
+  DOM_ELEMENT_ALREADY_EXISTS = 'DOM_ELEMENT_ALREADY_EXISTS',
+  DOM_ELEMENT_FOUND = 'DOM_ELEMENT_FOUND',
+}
+
+/** Waits for existing element in DOM
+ * @param {string} selector The selector to observe
+ *
+ * @example
+ * // waits for myQuerySelector to be injected in the DOM.
+ * waitForElem('.myQuerySelector').then(() => successCbk());
+ */
+export function waitForElement(selector: string) {
+  return new Promise((resolve) => {
+    if (document.querySelector(selector)) {
+      return resolve(WaitForElementResult.DOM_ELEMENT_ALREADY_EXISTS);
+    }
+
+    const observer = new MutationObserver(() => {
+      if (document.querySelector(selector)) {
+        observer.disconnect();
+        return resolve(WaitForElementResult.DOM_ELEMENT_FOUND);
+      }
+    });
+
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+  });
+}

--- a/packages/pn-commons/src/utils/index.ts
+++ b/packages/pn-commons/src/utils/index.ts
@@ -18,6 +18,7 @@ import {
   tenYearsAgo,
   today,
 } from './date.utility';
+import { waitForElement } from './dom.utility';
 import { calcUnit8Array } from './file.utility';
 import { filtersApplied, getValidValue, sortArray } from './genericFunctions.utility';
 import { IUN_regex, formatIun } from './iun.utility';
@@ -109,4 +110,5 @@ export {
   sortArray,
   calcUnit8Array,
   lazyRetry,
+  waitForElement,
 };

--- a/packages/pn-pa-webapp/src/pages/PrivacyPolicy.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/PrivacyPolicy.page.tsx
@@ -1,5 +1,7 @@
-import { useEffect, useState, useMemo } from 'react';
-import { useRewriteLinks, compileOneTrustPath } from '@pagopa-pn/pn-commons';
+import { useEffect, useMemo, useState } from 'react';
+
+import { compileOneTrustPath, useRewriteLinks, waitForElement } from '@pagopa-pn/pn-commons';
+
 import * as routes from '../navigation/routes.const';
 import { getConfiguration } from '../services/configuration.service';
 
@@ -23,18 +25,16 @@ const PrivacyPolicyPage = () => {
     if (ONE_TRUST_PP) {
       OneTrust.NoticeApi.Initialized.then(function () {
         OneTrust.NoticeApi.LoadNotices(
-          [
-            compileOneTrustPath(
-              ONE_TRUST_PP,
-              ONE_TRUST_DRAFT_MODE
-            ),
-          ],
+          [compileOneTrustPath(ONE_TRUST_PP, ONE_TRUST_DRAFT_MODE)],
           false
         );
-        setContentLoaded(true);
       });
     }
   }, []);
+
+  void waitForElement('.otnotice-content').then(() => {
+    setContentLoaded(true);
+  });
 
   useRewriteLinks(contentLoaded, routes.PRIVACY_POLICY, '.otnotice-content a');
 

--- a/packages/pn-personafisica-webapp/src/pages/PrivacyPolicy.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/PrivacyPolicy.page.tsx
@@ -1,8 +1,9 @@
-import { compileOneTrustPath, useRewriteLinks } from '@pagopa-pn/pn-commons';
 import { useEffect, useState } from 'react';
 
+import { compileOneTrustPath, useRewriteLinks, waitForElement } from '@pagopa-pn/pn-commons';
+
 import * as routes from '../navigation/routes.const';
-import { getConfiguration } from "../services/configuration.service";
+import { getConfiguration } from '../services/configuration.service';
 
 declare const OneTrust: {
   NoticeApi: {
@@ -15,24 +16,22 @@ declare const OneTrust: {
 
 const PrivacyPolicyPage = () => {
   const [contentLoaded, setContentLoaded] = useState(false);
-  const { ONE_TRUST_DRAFT_MODE, ONE_TRUST_PP} = getConfiguration();
+  const { ONE_TRUST_DRAFT_MODE, ONE_TRUST_PP } = getConfiguration();
 
   useEffect(() => {
     if (ONE_TRUST_PP) {
       OneTrust.NoticeApi.Initialized.then(function () {
         OneTrust.NoticeApi.LoadNotices(
-          [
-            compileOneTrustPath(
-              ONE_TRUST_PP,
-              ONE_TRUST_DRAFT_MODE
-            ),
-          ],
+          [compileOneTrustPath(ONE_TRUST_PP, ONE_TRUST_DRAFT_MODE)],
           false
         );
-        setContentLoaded(true);
       });
     }
   }, []);
+
+  void waitForElement('.otnotice-content').then(() => {
+    setContentLoaded(true);
+  });
 
   useRewriteLinks(contentLoaded, routes.PRIVACY_POLICY, '.otnotice-content a');
   return (

--- a/packages/pn-personagiuridica-webapp/src/pages/PrivacyPolicy.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/PrivacyPolicy.page.tsx
@@ -1,8 +1,9 @@
-import { compileOneTrustPath, useRewriteLinks } from '@pagopa-pn/pn-commons';
 import { useEffect, useState } from 'react';
 
+import { compileOneTrustPath, useRewriteLinks, waitForElement } from '@pagopa-pn/pn-commons';
+
 import * as routes from '../navigation/routes.const';
-import { getConfiguration } from "../services/configuration.service";
+import { getConfiguration } from '../services/configuration.service';
 
 declare const OneTrust: {
   NoticeApi: {
@@ -21,18 +22,16 @@ const PrivacyPolicyPage = () => {
     if (ONE_TRUST_PP) {
       OneTrust.NoticeApi.Initialized.then(function () {
         OneTrust.NoticeApi.LoadNotices(
-          [
-            compileOneTrustPath(
-              ONE_TRUST_PP,
-              ONE_TRUST_DRAFT_MODE
-            ),
-          ],
+          [compileOneTrustPath(ONE_TRUST_PP, ONE_TRUST_DRAFT_MODE)],
           false
         );
-        setContentLoaded(true);
       });
     }
   }, []);
+
+  void waitForElement('.otnotice-content').then(() => {
+    setContentLoaded(true);
+  });
 
   useRewriteLinks(contentLoaded, routes.PRIVACY_POLICY, '.otnotice-content a');
 


### PR DESCRIPTION
## Short description
Refactored links replace in Privacy pages.

## List of changes proposed in this pull request
- Removed setTimeout() to useRewriteLinks hook
- Added DOM utility that waits for element to be in the DOM
- And tests

## How to test
Open any Privacy Page. The side menu links should still redirect to page anchors.