### PR TITLE
Removed unused method in AppError class

### DIFF
--- a/packages/pn-commons/src/utils/AppError/AppError.ts
+++ b/packages/pn-commons/src/utils/AppError/AppError.ts
@@ -1,4 +1,4 @@
-import { ServerResponseError, ErrorMessage, AppResponseError } from '../../types/AppResponse';
+import { AppResponseError, ErrorMessage, ServerResponseError } from '../../types/AppResponse';
 
 abstract class AppError {
   protected code: string;
@@ -9,14 +9,6 @@ abstract class AppError {
     this.code = error.code;
     this.element = error.element || '';
     this.detail = error.detail || '';
-  }
-
-  getErrorDetail(): ServerResponseError {
-    return {
-      code: this.code,
-      element: this.element,
-      detail: this.detail,
-    };
   }
 
   getResponseError(): AppResponseError {


### PR DESCRIPTION
## Short description
Cleaning AppError class.

## List of changes proposed in this pull request
- Removed method getErrorDetail() from AppError class. It was never used.
