### PR TITLE
Replaced regex for testPathIgnorePattern parameter in PA

### DIFF
--- a/packages/pn-pa-webapp/package.json
+++ b/packages/pn-pa-webapp/package.json
@@ -41,8 +41,8 @@
   "scripts": {
     "start": "craco start",
     "build": "craco build",
-    "test": "craco test --watchAll=false --testPathIgnorePatterns=\"\\.a11y\\.test\\.(tsx|ts)$\"",
-    "test:a11y": "craco test --watchAll=false --testPathPattern=\"\\.a11y\\.test\\.(tsx|ts)$\"",
+    "test": "craco test --watchAll=false --testPathIgnorePatterns=\"\\.a11y\\.test\\.tsx?$\"",
+    "test:a11y": "craco test --watchAll=false --testPathPattern=\"\\.a11y\\.test\\.tsx?$\"",
     "test:all": "craco test --watchAll=false",
     "test:coverage": "craco test --watchAll=false --ci --coverage --testResultsProcessor=jest-sonar-reporter --testPathIgnorePatterns=\"\\.a11y\\.test\\.(tsx|ts)$\" --coveragePathIgnorePatterns=\"\\.a11y\\.test\\.(tsx|ts)$|.src.models\"",
     "eject": "craco eject",

--- a/packages/pn-pa-webapp/package.json
+++ b/packages/pn-pa-webapp/package.json
@@ -41,8 +41,8 @@
   "scripts": {
     "start": "craco start",
     "build": "craco build",
-    "test": "craco test --watchAll=false --testPathIgnorePatterns=\"\\.a11y\\.test\\.tsx?$\"",
-    "test:a11y": "craco test --watchAll=false --testPathPattern=\"\\.a11y\\.test\\.tsx?$\"",
+    "test": "craco test --watchAll=false --testPathIgnorePatterns=\"\\.a11y\\.test\\.(tsx|ts)$\"",
+    "test:a11y": "craco test --watchAll=false --testPathPattern=\"\\.a11y\\.test\\.(tsx|ts)$\"",
     "test:all": "craco test --watchAll=false",
     "test:coverage": "craco test --watchAll=false --ci --coverage --testResultsProcessor=jest-sonar-reporter --testPathIgnorePatterns=\"\\.a11y\\.test\\.(tsx|ts)$\" --coveragePathIgnorePatterns=\"\\.a11y\\.test\\.(tsx|ts)$|.src.models\"",
     "eject": "craco eject",
@@ -85,7 +85,6 @@
     "eslint-plugin-sonarjs": "^0.10.0",
     "jest-axe": "^5.0.1",
     "jest-sonar-reporter": "^2.0.0",
-    "mkdirp": "^1.0.4",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.4.1",
     "react-scripts": "^5.0.1",

--- a/packages/pn-validator/src/ruleValidators/BooleanRuleValidator.ts
+++ b/packages/pn-validator/src/ruleValidators/BooleanRuleValidator.ts
@@ -1,7 +1,7 @@
-import { BooleanRules } from '../types/BooleanRules';
 import { Rule } from '../Rule';
-import { CommonRuleValidator } from './CommonRuleValidator';
+import { BooleanRules } from '../types/BooleanRules';
 import { NotRuleValidator } from '../types/CommonRules';
+import { CommonRuleValidator } from './CommonRuleValidator';
 
 export class BooleanRuleValidator<TModel, TValue>
   extends CommonRuleValidator<TModel, TValue>

--- a/packages/pn-validator/src/ruleValidators/StringRuleValidator.ts
+++ b/packages/pn-validator/src/ruleValidators/StringRuleValidator.ts
@@ -1,8 +1,8 @@
-import { NotStringRuleValidator, StringRules } from '../types/StringRules';
+import { Rule } from '../Rule';
 import { IsEmpty } from '../rules/IsEmpty';
 import { Length } from '../rules/Length';
 import { Matches } from '../rules/Matches';
-import { Rule } from '../Rule';
+import { NotStringRuleValidator, StringRules } from '../types/StringRules';
 import { CommonRuleValidator } from './CommonRuleValidator';
 
 export class StringRuleValidator<TModel, TValue>
@@ -34,10 +34,8 @@ export class StringRuleValidator<TModel, TValue>
    * Check if value is empty
    * @param {string} [customErrorMessage] custom message to show when validation fails
    */
-  public readonly isEmpty = (customErrorMessage?: string): StringRuleValidator<TModel, TValue> => {
-    return this.addIsEmptyRule(false, customErrorMessage);
-  };
-
+  public readonly isEmpty = (customErrorMessage?: string): StringRuleValidator<TModel, TValue> =>
+    this.addIsEmptyRule(false, customErrorMessage);
   /**
    * Check if value has the desired length
    * @param {number} [minLength] min desired length
@@ -61,21 +59,15 @@ export class StringRuleValidator<TModel, TValue>
   public readonly matches = (
     pattern: RegExp,
     customErrorMessage?: string
-  ): StringRuleValidator<TModel, TValue> => {
-    return this.addMatchesRule(pattern, false, customErrorMessage);
-  };
-
+  ): StringRuleValidator<TModel, TValue> => this.addMatchesRule(pattern, false, customErrorMessage);
   /**
    * Negate next rule
    */
   public readonly not = (): NotStringRuleValidator<TModel, TValue> =>
     ({
       ...this.commonNot(),
-      isEmpty: (customErrorMessage?: string) => {
-        return this.addIsEmptyRule(true, customErrorMessage);
-      },
-      matches: (pattern: RegExp, customErrorMessage?: string) => {
-        return this.addMatchesRule(pattern, true, customErrorMessage);
-      },
+      isEmpty: (customErrorMessage?: string) => this.addIsEmptyRule(true, customErrorMessage),
+      matches: (pattern: RegExp, customErrorMessage?: string) =>
+        this.addMatchesRule(pattern, true, customErrorMessage),
     } as unknown as NotStringRuleValidator<TModel, TValue>);
 }

--- a/packages/pn-validator/src/rules/IsBoolean.ts
+++ b/packages/pn-validator/src/rules/IsBoolean.ts
@@ -1,9 +1,8 @@
-import { isBoolean } from './../utility/IsBoolean';
-import { isDefined } from '../utility/IsDefined';
 import { Rule } from '../Rule';
+import { isBoolean } from '../utility/IsBoolean';
+import { isDefined } from '../utility/IsDefined';
 
 export class IsBoolean<TModel, TValue> extends Rule<TModel, TValue> {
-
   constructor(customErrorMessage?: string) {
     super(customErrorMessage);
   }
@@ -13,7 +12,7 @@ export class IsBoolean<TModel, TValue> extends Rule<TModel, TValue> {
       return null;
     }
     if (!isBoolean(value)) {
-        return 'Value must be of type boolean';
+      return 'Value must be of type boolean';
     }
     return null;
   };

--- a/packages/pn-validator/src/rules/IsEqual.ts
+++ b/packages/pn-validator/src/rules/IsEqual.ts
@@ -1,7 +1,7 @@
-import { isDate } from './../utility/IsDate';
-import { isArray } from './../utility/IsArray';
-import { isObject } from '../utility/IsObject';
 import { Rule } from '../Rule';
+import { isArray } from '../utility/IsArray';
+import { isDate } from '../utility/IsDate';
+import { isObject } from '../utility/IsObject';
 
 export class IsEqual<TModel, TValue> extends Rule<TModel, TValue> {
   private not?: boolean;
@@ -39,10 +39,7 @@ export class IsEqual<TModel, TValue> extends Rule<TModel, TValue> {
   };
 
   private compareArray = <TArg>(value: TArg, valueToCompare: TArg): boolean => {
-    if (
-      isArray(value) &&
-      isArray(valueToCompare)
-    ) {
+    if (isArray(value) && isArray(valueToCompare)) {
       if (value.length === valueToCompare.length) {
         return value.every((elem, index) => {
           return this.compare(elem, valueToCompare[index]);
@@ -61,10 +58,7 @@ export class IsEqual<TModel, TValue> extends Rule<TModel, TValue> {
       if (isArray(value)) {
         return this.compareArray(value, valueToCompare);
       }
-      if (
-        (isDate(value) && this.compareDate(value, valueToCompare)) ||
-        value === valueToCompare
-      ) {
+      if ((isDate(value) && this.compareDate(value, valueToCompare)) || value === valueToCompare) {
         return true;
       }
     }

--- a/packages/pn-validator/src/rules/IsOneOf.ts
+++ b/packages/pn-validator/src/rules/IsOneOf.ts
@@ -1,11 +1,11 @@
-import { isDefined } from '../utility/IsDefined';
 import { Rule } from '../Rule';
+import { isDefined } from '../utility/IsDefined';
 
 export class IsOneOf<TModel, TValue> extends Rule<TModel, TValue> {
-  private possibleValues: TValue[];
+  private possibleValues: Array<TValue>;
   private not?: boolean;
 
-  constructor(possibleValues: TValue[], not?: boolean, customErrorMessage?: string) {
+  constructor(possibleValues: Array<TValue>, not?: boolean, customErrorMessage?: string) {
     super(customErrorMessage);
     this.possibleValues = possibleValues;
     this.not = not;

--- a/packages/pn-validator/src/types/CommonRules.ts
+++ b/packages/pn-validator/src/types/CommonRules.ts
@@ -1,9 +1,9 @@
-import { BooleanRuleValidator } from './../ruleValidators/BooleanRuleValidator';
-import { NumberRuleValidator } from '../ruleValidators/NumberRuleValidator';
-import { StringRuleValidator } from '../ruleValidators/StringRuleValidator';
-import { DateRuleValidator } from '../ruleValidators/DateRuleValidator';
-import { ObjectRuleValidator } from '../ruleValidators/ObjectRuleValidator';
 import { ArrayRuleValidator } from '../ruleValidators/ArrayRuleValidator';
+import { BooleanRuleValidator } from '../ruleValidators/BooleanRuleValidator';
+import { DateRuleValidator } from '../ruleValidators/DateRuleValidator';
+import { NumberRuleValidator } from '../ruleValidators/NumberRuleValidator';
+import { ObjectRuleValidator } from '../ruleValidators/ObjectRuleValidator';
+import { StringRuleValidator } from '../ruleValidators/StringRuleValidator';
 import { ValidationResult } from './ValidationResult';
 
 export type RuleValidators<TModel, TValue> =
@@ -18,14 +18,14 @@ export type NotRuleValidator<TModel, TValue> = {
   readonly isNull: () => RuleValidators<TModel, TValue>;
   readonly isUndefined: () => RuleValidators<TModel, TValue>;
   readonly isEqual: (value: TValue) => RuleValidators<TModel, TValue>;
-  readonly isOneOf: (possibleValues: TValue[]) => RuleValidators<TModel, TValue>;
+  readonly isOneOf: (possibleValues: Array<TValue>) => RuleValidators<TModel, TValue>;
 };
 
 export interface CommonRules<TModel, TValue> {
   readonly isNull: () => RuleValidators<TModel, TValue>;
   readonly isUndefined: () => RuleValidators<TModel, TValue>;
   readonly isEqual: (value: TValue) => RuleValidators<TModel, TValue>;
-  readonly isOneOf: (possibleValues: TValue[]) => RuleValidators<TModel, TValue>;
+  readonly isOneOf: (possibleValues: Array<TValue>) => RuleValidators<TModel, TValue>;
   readonly customValidator: (
     validator: (value: TValue, model: TModel) => ValidationResult<TValue>
   ) => RuleValidators<TModel, TValue>;

--- a/packages/pn-validator/src/types/TypeRules.ts
+++ b/packages/pn-validator/src/types/TypeRules.ts
@@ -1,9 +1,9 @@
-import { BooleanRuleValidator } from './../ruleValidators/BooleanRuleValidator';
-import { NumberRuleValidator } from './../ruleValidators/NumberRuleValidator';
-import { StringRuleValidator } from './../ruleValidators/StringRuleValidator';
-import { DateRuleValidator } from './../ruleValidators/DateRuleValidator';
+import { ArrayRuleValidator } from '../ruleValidators/ArrayRuleValidator';
+import { BooleanRuleValidator } from '../ruleValidators/BooleanRuleValidator';
+import { DateRuleValidator } from '../ruleValidators/DateRuleValidator';
+import { NumberRuleValidator } from '../ruleValidators/NumberRuleValidator';
 import { ObjectRuleValidator } from '../ruleValidators/ObjectRuleValidator';
-import { ArrayRuleValidator } from './../ruleValidators/ArrayRuleValidator';
+import { StringRuleValidator } from '../ruleValidators/StringRuleValidator';
 
 // When conditional types act on a generic type, they become distributive when given a union type
 // Surrounding with [], we can avoid this behaviour


### PR DESCRIPTION
## Short description
This PR aims to fix a weird issue that causes all the tests in PA to fails in certain computers and OSs and it happens only in PA. In this case is on Windows 11 x64. The replacemente is simple. It's just another way to check for files with extensions .ts or .tsx

## List of changes proposed in this pull request
- package.json for PA

## How to test
Check if builds and tests are ok.