### PR TITLE
Added regex validation for zip input field

### DIFF
--- a/packages/pn-commons/src/utils/string.utility.ts
+++ b/packages/pn-commons/src/utils/string.utility.ts
@@ -39,7 +39,7 @@ export const dataRegex = {
   denomination: /^([\x20-\xFF]{1,80})$/,
   denominationSearch: /([\x20-\xFF]*)/g,
   noticeCode: /^\d{18}$/,
-
+  zipCode: /^(\w|\ |\-)*$/,
   email:
     /^[a-zA-Z0-9]+(?:[.\-_][a-zA-Z0-9]+){0,10}@[a-zA-Z0-9]+(?:[.-][a-zA-Z0-9]+){0,10}(?:\.[a-zA-Z0-9]{2,10})$/,
   // We adopt a regex to validate email addresses, which is stricter than the one adopted by the BE

--- a/packages/pn-pa-webapp/src/pages/components/NewNotification/Recipient.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/NewNotification/Recipient.tsx
@@ -169,7 +169,11 @@ const Recipient: React.FC<Props> = ({
     */
       zip: yup.string().when('showPhysicalAddress', {
         is: true,
-        then: requiredStringFieldValidation(tc, 12),
+        then: yup
+          .string()
+          .required(tc('required-field'))
+          .max(12, tc('too-long-field-error', { maxLength: 12 }))
+          .matches(dataRegex.zipCode, `${t('zip')} ${tc('invalid')}`),
       }),
       municipalityDetails: yup.string().when('showPhysicalAddress', {
         is: true,

--- a/packages/pn-pa-webapp/src/pages/components/NewNotification/__test__/Recipient.test.tsx
+++ b/packages/pn-pa-webapp/src/pages/components/NewNotification/__test__/Recipient.test.tsx
@@ -439,7 +439,9 @@ describe('Recipient Component with payment enabled', () => {
     const houseNumberError = form.querySelector('[id="recipients[0].houseNumber-helper-text"]');
     expect(houseNumberError).toHaveTextContent('required-field');
     // zip
-    await testStringFieldValidation(form, 0, 'zip', 13);
+    await testInput(form, 'recipients[0].zip', '20100&', true);
+    const zipError = form.querySelector('[id="recipients[0].zip-helper-text"]');
+    expect(zipError).toHaveTextContent('zip invalid');
     // municipalityDetails
     await testInput(form, 'recipients[0].municipalityDetails', ' text-with-spaces ', true);
     const municipalityDetailsError = form.querySelector(
@@ -449,7 +451,7 @@ describe('Recipient Component with payment enabled', () => {
     await testInput(form!, 'recipients[0].municipalityDetails', randomString(257));
     expect(municipalityDetailsError).toHaveTextContent('too-long-field-error');
     // municipality
-    await testStringFieldValidation(form, 0, 'zip', 257);
+    await testStringFieldValidation(form, 0, 'municipality', 257);
     // province
     await testStringFieldValidation(form, 0, 'province', 257);
     // foreignState


### PR DESCRIPTION
## Short description
Added regex validation for zip input field in recipients step.

## List of changes proposed in this pull request
- Added zip regex to dataRegex in string.utility.ts
- Reworked validation in recipient.tsx
- Reworked validation test in recipient.test.tsx and meanwhile fixed a bug for municipality validation test

## How to test
Try to add forbidden character in zip field such "20100&". An error should appear.