### PR TITLE
Added max limit to email in contacts

### DIFF
--- a/packages/pn-personafisica-webapp/public/locales/de/recapiti.json
+++ b/packages/pn-personafisica-webapp/public/locales/de/recapiti.json
@@ -115,7 +115,8 @@
   "common": {
     "duplicate-contact-title": "Anschrift bereits vorhanden",
     "duplicate-contact-descr": "Der Kontakt {{value}} ist bereits vorhanden, möchtest du trotzdem fortfahren?",
-    "enti-not-found": "Keine Körperschaft gefunden"
+    "enti-not-found": "Keine Körperschaft gefunden",
+    "too-long-field-error": "Maximal {{maxLength}} Zeichen eingeben"
   },
   "errors": {
     "invalid_verification_code": {

--- a/packages/pn-personafisica-webapp/public/locales/en/recapiti.json
+++ b/packages/pn-personafisica-webapp/public/locales/en/recapiti.json
@@ -115,7 +115,8 @@
   "common": {
     "duplicate-contact-title": "Contact already present",
     "duplicate-contact-descr": "The contact {{value}} is already present, do you want to proceed anyway?",
-    "enti-not-found": "No entity found"
+    "enti-not-found": "No entity found",
+    "too-long-field-error": "Write max {{maxLength}} characters"
   },
   "errors": {
     "invalid_verification_code": {

--- a/packages/pn-personafisica-webapp/public/locales/fr/recapiti.json
+++ b/packages/pn-personafisica-webapp/public/locales/fr/recapiti.json
@@ -115,7 +115,8 @@
   "common": {
     "duplicate-contact-title": "Coordonnées déjà présentes",
     "duplicate-contact-descr": "Le contact {{value}} est déjà présent. Voulez-vous continuer ?",
-    "enti-not-found": "Aucun organisme trouvé"
+    "enti-not-found": "Aucun organisme trouvé",
+    "too-long-field-error": "Saisir {{maxLength}} caractères max"
   },
   "errors": {
     "invalid_verification_code": {

--- a/packages/pn-personafisica-webapp/public/locales/it/recapiti.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/recapiti.json
@@ -117,7 +117,8 @@
   "common": {
     "duplicate-contact-title": "Recapito già presente",
     "duplicate-contact-descr": "Il contatto {{value}} è già presente, vuoi procedere ugualmente?",
-    "enti-not-found": "Nessun ente trovato"
+    "enti-not-found": "Nessun ente trovato",
+    "too-long-field-error": "Scrivi massimo {{maxLength}} caratteri"
   },
   "errors": {
     "invalid_verification_code": {

--- a/packages/pn-personafisica-webapp/public/locales/sl/recapiti.json
+++ b/packages/pn-personafisica-webapp/public/locales/sl/recapiti.json
@@ -115,7 +115,8 @@
   "common": {
     "duplicate-contact-title": "Naslov je že prisoten",
     "duplicate-contact-descr": "Stik {{value}} je že prisoten, želite vseeno nadaljevati?",
-    "enti-not-found": "Ni najdenih subjektov"
+    "enti-not-found": "Ni najdenih subjektov",
+    "too-long-field-error": "Napišite največ {{maxLength}} znakov"
   },
   "errors": {
     "invalid_verification_code": {

--- a/packages/pn-personafisica-webapp/src/component/Contacts/CourtesyContactItem.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Contacts/CourtesyContactItem.tsx
@@ -40,6 +40,7 @@ const CourtesyContactItem = ({ recipientId, type, value, blockDelete }: Props) =
         email: yup
           .string()
           .required(t('courtesy-contacts.valid-email', { ns: 'recapiti' }))
+          .max(254, t('common.too-long-field-error', { ns: 'recapiti', maxLength: 254 }))
           .matches(dataRegex.email, t('courtesy-contacts.valid-email', { ns: 'recapiti' })),
       }),
     []

--- a/packages/pn-personafisica-webapp/src/component/Contacts/InsertLegalContact.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Contacts/InsertLegalContact.tsx
@@ -26,6 +26,7 @@ const InsertLegalContact = ({ recipientId }: Props) => {
       then: yup
         .string()
         .required(t('legal-contacts.valid-pec', { ns: 'recapiti' }))
+        .max(254, t('common.too-long-field-error', { ns: 'recapiti', maxLength: 254 }))
         .matches(dataRegex.email, t('legal-contacts.valid-pec', { ns: 'recapiti' })),
     }),
   });

--- a/packages/pn-personafisica-webapp/src/component/Contacts/LegalContactsList.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Contacts/LegalContactsList.tsx
@@ -47,6 +47,7 @@ const LegalContactsList = ({ recipientId, legalAddresses }: Props) => {
     pec: yup
       .string()
       .required(t('legal-contacts.valid-pec', { ns: 'recapiti' }))
+      .max(254, t('common.too-long-field-error', { ns: 'recapiti', maxLength: 254 }))
       .matches(dataRegex.email, t('legal-contacts.valid-pec', { ns: 'recapiti' })),
   });
 

--- a/packages/pn-personafisica-webapp/src/component/Contacts/SpecialContactElem.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Contacts/SpecialContactElem.tsx
@@ -85,6 +85,7 @@ const SpecialContactElem = memo(({ address, recipientId }: Props) => {
     [`${address.senderId}_pec`]: yup
       .string()
       .required(t('legal-contacts.valid-pec', { ns: 'recapiti' }))
+      .max(254, t('common.too-long-field-error', { ns: 'recapiti', maxLength: 254 }))
       .matches(dataRegex.email, t('legal-contacts.valid-pec', { ns: 'recapiti' })),
     [`${address.senderId}_phone`]: yup
       .string()
@@ -96,6 +97,7 @@ const SpecialContactElem = memo(({ address, recipientId }: Props) => {
     [`${address.senderId}_mail`]: yup
       .string()
       .required(t('courtesy-contacts.valid-email', { ns: 'recapiti' }))
+      .max(254, t('common.too-long-field-error', { ns: 'recapiti', maxLength: 254 }))
       .matches(dataRegex.email, t('courtesy-contacts.valid-email', { ns: 'recapiti' })),
   });
 

--- a/packages/pn-personafisica-webapp/src/component/Contacts/SpecialContacts.tsx
+++ b/packages/pn-personafisica-webapp/src/component/Contacts/SpecialContacts.tsx
@@ -139,6 +139,7 @@ const SpecialContacts = ({ recipientId, legalAddresses, courtesyAddresses }: Pro
       then: yup
         .string()
         .required(t('legal-contacts.valid-pec', { ns: 'recapiti' }))
+        .max(254, t('common.too-long-field-error', { ns: 'recapiti', maxLength: 254 }))
         .matches(dataRegex.email, t('legal-contacts.valid-pec', { ns: 'recapiti' })),
     }),
     s_mail: yup.string().when('addressType', {
@@ -146,6 +147,7 @@ const SpecialContacts = ({ recipientId, legalAddresses, courtesyAddresses }: Pro
       then: yup
         .string()
         .required(t('courtesy-contacts.valid-email', { ns: 'recapiti' }))
+        .max(254, t('common.too-long-field-error', { ns: 'recapiti', maxLength: 254 }))
         .matches(dataRegex.email, t('courtesy-contacts.valid-email', { ns: 'recapiti' })),
     }),
     s_phone: yup.string().when('addressType', {

--- a/packages/pn-personagiuridica-webapp/public/locales/de/recapiti.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/de/recapiti.json
@@ -101,7 +101,8 @@
   "common": {
     "duplicate-contact-title": "Anschrift bereits vorhanden",
     "duplicate-contact-descr": "Der Kontakt {{value}} ist bereits vorhanden, möchtest du trotzdem fortfahren?",
-    "enti-not-found": "Keine Körperschaft gefunden"
+    "enti-not-found": "Keine Körperschaft gefunden",
+    "too-long-field-error": "Maximal {{maxLength}} Zeichen eingeben"
   },
   "errors": {
     "invalid_verification_code": {

--- a/packages/pn-personagiuridica-webapp/public/locales/en/recapiti.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/en/recapiti.json
@@ -101,7 +101,8 @@
   "common": {
     "duplicate-contact-title": "Contact already present",
     "duplicate-contact-descr": "The contact {{value}} is already present, do you want to proceed anyway?",
-    "enti-not-found": "No entity found"
+    "enti-not-found": "No entity found",
+    "too-long-field-error": "Write max {{maxLength}} characters"
   },
   "errors": {
     "invalid_verification_code": {

--- a/packages/pn-personagiuridica-webapp/public/locales/fr/recapiti.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/fr/recapiti.json
@@ -101,7 +101,8 @@
   "common": {
     "duplicate-contact-title": "Coordonnées déjà présentes",
     "duplicate-contact-descr": "Le contact {{value}} est déjà présent. Voulez-vous continuer ?",
-    "enti-not-found": "Aucun organisme trouvé"
+    "enti-not-found": "Aucun organisme trouvé",
+    "too-long-field-error": "Saisir {{maxLength}} caractères max"
   },
   "errors": {
     "invalid_verification_code": {

--- a/packages/pn-personagiuridica-webapp/public/locales/it/recapiti.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/it/recapiti.json
@@ -102,7 +102,8 @@
   "common": {
     "duplicate-contact-title": "Recapito già presente",
     "duplicate-contact-descr": "Il contatto {{value}} è già presente, vuoi procedere ugualmente?",
-    "enti-not-found": "Nessun ente trovato"
+    "enti-not-found": "Nessun ente trovato",
+    "too-long-field-error": "Scrivi massimo {{maxLength}} caratteri"
   },
   "errors": {
     "invalid_verification_code": {

--- a/packages/pn-personagiuridica-webapp/public/locales/sl/recapiti.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/sl/recapiti.json
@@ -101,7 +101,8 @@
   "common": {
     "duplicate-contact-title": "Naslov je že prisoten",
     "duplicate-contact-descr": "Stik {{value}} je že prisoten, želite vseeno nadaljevati?",
-    "enti-not-found": "Ni najdenih subjektov"
+    "enti-not-found": "Ni najdenih subjektov",
+    "too-long-field-error": "Napišite največ {{maxLength}} znakov"
   },
   "errors": {
     "invalid_verification_code": {

--- a/packages/pn-personagiuridica-webapp/src/component/Contacts/CourtesyContactItem.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Contacts/CourtesyContactItem.tsx
@@ -40,6 +40,7 @@ const CourtesyContactItem = ({ recipientId, type, value, blockDelete }: Props) =
         email: yup
           .string()
           .required(t('courtesy-contacts.valid-email', { ns: 'recapiti' }))
+          .max(254, t('common.too-long-field-error', { ns: 'recapiti', maxLength: 254 }))
           .matches(dataRegex.email, t('courtesy-contacts.valid-email', { ns: 'recapiti' })),
       }),
     []

--- a/packages/pn-personagiuridica-webapp/src/component/Contacts/InsertLegalContact.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Contacts/InsertLegalContact.tsx
@@ -26,6 +26,7 @@ const InsertLegalContact = ({ recipientId }: Props) => {
       then: yup
         .string()
         .required(t('legal-contacts.valid-pec', { ns: 'recapiti' }))
+        .max(254, t('common.too-long-field-error', { ns: 'recapiti', maxLength: 254 }))
         .matches(dataRegex.email, t('legal-contacts.valid-pec', { ns: 'recapiti' })),
     }),
   });

--- a/packages/pn-personagiuridica-webapp/src/component/Contacts/LegalContactsList.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Contacts/LegalContactsList.tsx
@@ -47,6 +47,7 @@ const LegalContactsList = ({ recipientId, legalAddresses }: Props) => {
     pec: yup
       .string()
       .required(t('legal-contacts.valid-pec', { ns: 'recapiti' }))
+      .max(254, t('common.too-long-field-error', { ns: 'recapiti', maxLength: 254 }))
       .matches(dataRegex.email, t('legal-contacts.valid-pec', { ns: 'recapiti' })),
   });
 

--- a/packages/pn-personagiuridica-webapp/src/component/Contacts/SpecialContactElem.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Contacts/SpecialContactElem.tsx
@@ -85,6 +85,7 @@ const SpecialContactElem = memo(({ address, recipientId }: Props) => {
     [`${address.senderId}_pec`]: yup
       .string()
       .required(t('legal-contacts.valid-pec', { ns: 'recapiti' }))
+      .max(254, t('common.too-long-field-error', { ns: 'recapiti', maxLength: 254 }))
       .matches(dataRegex.email, t('legal-contacts.valid-pec', { ns: 'recapiti' })),
     [`${address.senderId}_phone`]: yup
       .string()
@@ -96,6 +97,7 @@ const SpecialContactElem = memo(({ address, recipientId }: Props) => {
     [`${address.senderId}_mail`]: yup
       .string()
       .required(t('courtesy-contacts.valid-email', { ns: 'recapiti' }))
+      .max(254, t('common.too-long-field-error', { ns: 'recapiti', maxLength: 254 }))
       .matches(dataRegex.email, t('courtesy-contacts.valid-email', { ns: 'recapiti' })),
   });
 

--- a/packages/pn-personagiuridica-webapp/src/component/Contacts/SpecialContacts.tsx
+++ b/packages/pn-personagiuridica-webapp/src/component/Contacts/SpecialContacts.tsx
@@ -139,6 +139,7 @@ const SpecialContacts = ({ recipientId, legalAddresses, courtesyAddresses }: Pro
       then: yup
         .string()
         .required(t('legal-contacts.valid-pec', { ns: 'recapiti' }))
+        .max(254, t('common.too-long-field-error', { ns: 'recapiti', maxLength: 254 }))
         .matches(dataRegex.email, t('legal-contacts.valid-pec', { ns: 'recapiti' })),
     }),
     s_mail: yup.string().when('addressType', {
@@ -146,6 +147,7 @@ const SpecialContacts = ({ recipientId, legalAddresses, courtesyAddresses }: Pro
       then: yup
         .string()
         .required(t('courtesy-contacts.valid-email', { ns: 'recapiti' }))
+        .max(254, t('common.too-long-field-error', { ns: 'recapiti', maxLength: 254 }))
         .matches(dataRegex.email, t('courtesy-contacts.valid-email', { ns: 'recapiti' })),
     }),
     s_phone: yup.string().when('addressType', {


### PR DESCRIPTION
## Short description
Added max 254 characters limit to email / PEC in contacts pages of PF and PG.

## List of changes proposed in this pull request
- Added limit to proper components
- Added new string translations for all supported languages

## How to test
Try to specify an email longer than 254. A validation error should appear now. Both PF and PG.