### PR TITLE
Avoid popup block on ios opening the attachment on the same window

### DIFF
--- a/packages/pn-commons/src/hooks/useDownloadDocument.ts
+++ b/packages/pn-commons/src/hooks/useDownloadDocument.ts
@@ -2,12 +2,7 @@ import { useEffect } from 'react';
 
 function downloadDocument(url: string) {
   /* eslint-disable functional/immutable-data */
-  const link = document.createElement('a');
-  link.href = url;
-  link.target = '_blank';
-  link.rel = 'noreferrer';
-  link.click();
-  /* eslint-enable functional/immutable-data */
+  window.location.href = url;
 }
 
 type Props = {
@@ -27,7 +22,9 @@ export function useDownloadDocument({ url, clearDownloadAction }: Props) {
   useEffect(() => {
     if (url) {
       downloadDocument(url);
-      clearDownloadAction && clearDownloadAction();
+      if (clearDownloadAction) {
+        clearDownloadAction();
+      }
     }
   }, [url, clearDownloadAction]);
 


### PR DESCRIPTION
## Short description
Fix Popup blocker on safari

## List of changes proposed in this pull request
- Open link on the same window

## How to test
Try to click a link. You should see the attachment on the same window