### PR TITLE
PN-8056 - used Trans component to show bold text in Api Keys's modals

### DIFF
--- a/packages/pn-pa-webapp/src/pages/ApiKeys.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/ApiKeys.page.tsx
@@ -264,9 +264,11 @@ const ApiKeys = () => {
               <ApiKeyModal
                 title={t('block-api-key')}
                 subTitle={
-                  <Trans i18nKey="block-warning1" values={{ apiKeyName: modal.apiKey?.name }}>
-                    {t('block-warning1', { apiKeyName: modal.apiKey?.name })}
-                  </Trans>
+                  <Trans
+                    i18nKey="block-warning1"
+                    ns="apikeys"
+                    values={{ apiKeyName: modal.apiKey?.name }}
+                  />
                 }
                 content={<Typography>{t('block-warning2')}</Typography>}
                 closeButtonLabel={t('cancel-button')}
@@ -279,9 +281,11 @@ const ApiKeys = () => {
               <ApiKeyModal
                 title={t('enable-api-key')}
                 subTitle={
-                  <Trans i18nKey="enable-warning" values={{ apiKeyName: modal.apiKey?.name }}>
-                    {t('enable-warning', { apiKeyName: modal.apiKey?.name })}
-                  </Trans>
+                  <Trans
+                    i18nKey="enable-warning"
+                    ns="apikeys"
+                    values={{ apiKeyName: modal.apiKey?.name }}
+                  />
                 }
                 closeButtonLabel={t('cancel-button')}
                 closeModalHandler={handleCloseModal}
@@ -293,9 +297,11 @@ const ApiKeys = () => {
               <ApiKeyModal
                 title={t('rotate-api-key')}
                 subTitle={
-                  <Trans i18nKey="rotate-warning-1" values={{ apiKeyName: modal.apiKey?.name }}>
-                    {t('rotate-warning1', { apiKeyName: modal.apiKey?.name })}
-                  </Trans>
+                  <Trans
+                    i18nKey="rotate-warning1"
+                    ns="apikeys"
+                    values={{ apiKeyName: modal.apiKey?.name }}
+                  />
                 }
                 content={<Typography>{t('rotate-warning2')}</Typography>}
                 closeButtonLabel={t('cancel-button')}
@@ -308,9 +314,11 @@ const ApiKeys = () => {
               <ApiKeyModal
                 title={t('delete-api-key')}
                 subTitle={
-                  <Trans i18nKey="delete-warning" values={{ apiKeyName: modal.apiKey?.name }}>
-                    {t('delete-warning', { apiKeyName: modal.apiKey?.name })}
-                  </Trans>
+                  <Trans
+                    i18nKey="delete-warning"
+                    ns="apikeys"
+                    values={{ apiKeyName: modal.apiKey?.name }}
+                  />
                 }
                 closeButtonLabel={t('cancel-button')}
                 closeModalHandler={handleCloseModal}

--- a/packages/pn-pa-webapp/src/pages/ApiKeys.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/ApiKeys.page.tsx
@@ -278,7 +278,11 @@ const ApiKeys = () => {
             {modal.view === ModalApiKeyView.ENABLE && (
               <ApiKeyModal
                 title={t('enable-api-key')}
-                subTitle={t('enable-warning', { apiKeyName: modal.apiKey?.name })}
+                subTitle={
+                  <Trans i18nKey="enable-warning" values={{ apiKeyName: modal.apiKey?.name }}>
+                    {t('enable-warning', { apiKeyName: modal.apiKey?.name })}
+                  </Trans>
+                }
                 closeButtonLabel={t('cancel-button')}
                 closeModalHandler={handleCloseModal}
                 actionButtonLabel={t('enable-button')}
@@ -288,7 +292,11 @@ const ApiKeys = () => {
             {modal.view === ModalApiKeyView.ROTATE && (
               <ApiKeyModal
                 title={t('rotate-api-key')}
-                subTitle={t('rotate-warning1', { apiKeyName: modal.apiKey?.name })}
+                subTitle={
+                  <Trans i18nKey="rotate-warning-1" values={{ apiKeyName: modal.apiKey?.name }}>
+                    {t('rotate-warning1', { apiKeyName: modal.apiKey?.name })}
+                  </Trans>
+                }
                 content={<Typography>{t('rotate-warning2')}</Typography>}
                 closeButtonLabel={t('cancel-button')}
                 closeModalHandler={handleCloseModal}
@@ -299,7 +307,11 @@ const ApiKeys = () => {
             {modal.view === ModalApiKeyView.DELETE && (
               <ApiKeyModal
                 title={t('delete-api-key')}
-                subTitle={t('delete-warning', { apiKeyName: modal.apiKey?.name })}
+                subTitle={
+                  <Trans i18nKey="delete-warning" values={{ apiKeyName: modal.apiKey?.name }}>
+                    {t('delete-warning', { apiKeyName: modal.apiKey?.name })}
+                  </Trans>
+                }
                 closeButtonLabel={t('cancel-button')}
                 closeModalHandler={handleCloseModal}
                 actionButtonLabel={t('delete-button')}


### PR DESCRIPTION
## Short description
used Trans component to show bold text in Api Keys's modals

## List of changes proposed in this pull request
- Modified modals content on Api Keys page

## How to test
On PA go to Api Keys page and try to Rotate, block, delete, or activate an api key. You should see the api key name with bold weight 