### PR TITLE
PN-8243 - FAQ on multi-payment notification

### DIFF
--- a/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentRecipient.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentRecipient.tsx
@@ -23,6 +23,7 @@ type Props = {
   payments: PaymentsData;
   isCancelled: boolean;
   timerF24: number;
+  landingSiteUrl: string;
   getPaymentAttachmentAction: (
     name: PaymentAttachmentSName,
     attachmentIdx?: number
@@ -38,6 +39,7 @@ const NotificationPaymentRecipient: React.FC<Props> = ({
   payments,
   isCancelled,
   timerF24,
+  landingSiteUrl,
   getPaymentAttachmentAction,
   onPayClick,
   handleReloadPayment,
@@ -52,9 +54,20 @@ const NotificationPaymentRecipient: React.FC<Props> = ({
     (payment) => payment.pagoPa?.status === PaymentStatus.SUCCEEDED
   );
 
+  const FAQ_NOTIFICATION_COSTS = '/faq#costi-di-notifica';
+  const FAQ_NOTIFICATION_CANCELLED_REFUND = '/faq#notifica-pagata-rimborso';
+
+  const notificationCostsFaqLink = `${landingSiteUrl}${FAQ_NOTIFICATION_COSTS}`;
+  const cancelledNotificationFAQ = `${landingSiteUrl}${FAQ_NOTIFICATION_CANCELLED_REFUND}`;
+
   const getTitle = () => {
     const FaqLink = (
-      <Link href={void 0} target="_blank" fontWeight="bold" sx={{ cursor: 'pointer' }}>
+      <Link
+        href={notificationCostsFaqLink}
+        target="_blank"
+        fontWeight="bold"
+        sx={{ cursor: 'pointer' }}
+      >
         {getLocalizedOrDefaultLabel('notifications', 'detail.payment.how')}
       </Link>
     );
@@ -120,7 +133,12 @@ const NotificationPaymentRecipient: React.FC<Props> = ({
         <Alert tabIndex={0} data-testid="cancelledAlertPayment" severity="info">
           {getLocalizedOrDefaultLabel('notifications', 'detail.payment.cancelled-message')}
           &nbsp;
-          <Link href={void 0} target="_blank" fontWeight="bold" sx={{ cursor: 'pointer' }}>
+          <Link
+            href={cancelledNotificationFAQ}
+            target="_blank"
+            fontWeight="bold"
+            sx={{ cursor: 'pointer' }}
+          >
             {getLocalizedOrDefaultLabel('notifications', 'detail.payment.disclaimer-link')}
           </Link>
         </Alert>

--- a/packages/pn-commons/src/components/PnBreadcrumb.tsx
+++ b/packages/pn-commons/src/components/PnBreadcrumb.tsx
@@ -56,7 +56,7 @@ const PnBreadcrumb = ({
         </ButtonNaked>
       )}
       <Breadcrumbs aria-label="breadcrumb">
-        <BreadcrumbLink to={linkRoute} {...linkProps}>
+        <BreadcrumbLink to={linkRoute} data-testid="breadcrumb-link" {...linkProps}>
           {linkLabel}
         </BreadcrumbLink>
         <Typography

--- a/packages/pn-pa-webapp/public/conf/env/config.dev.json
+++ b/packages/pn-pa-webapp/public/conf/env/config.dev.json
@@ -9,7 +9,7 @@
   "ONE_TRUST_DRAFT_MODE": false,
   "ONE_TRUST_PP": "4824a110-316e-42fd-b492-8e2b0513db70",
   "ONE_TRUST_TOS": "083fb982-149c-4241-be09-12ae67d88b66",
-  "LANDING_SITE_URL": "https://www.dev.notifichedigitali.it/",
+  "LANDING_SITE_URL": "https://www.dev.notifichedigitali.it",
   "IS_PAYMENT_ENABLED": false,
   "WORK_IN_PROGRESS": false
 }

--- a/packages/pn-personafisica-webapp/public/conf/env/config.dev.json
+++ b/packages/pn-personafisica-webapp/public/conf/env/config.dev.json
@@ -9,7 +9,7 @@
   "OT_DOMAIN_ID": "29cc1c86-f2ef-494d-8242-9bec8009cd29-test",
   "PAGOPA_HELP_EMAIL": "destinatari-send@assistenza.pagopa.it",
   "URL_FE_LOGIN": "https://login.dev.notifichedigitali.it/",
-  "LANDING_SITE_URL": "https://www.dev.notifichedigitali.it/",
+  "LANDING_SITE_URL": "https://www.dev.notifichedigitali.it",
   "DELEGATIONS_TO_PG_ENABLED": true,
   "WORK_IN_PROGRESS": false,
   "F24_DOWNLOAD_WAIT_TIME": 15000

--- a/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
@@ -76,7 +76,7 @@ const NotificationDetail = () => {
   const isMobile = useIsMobile();
   const { hasApiErrors } = useErrors();
   const [pageReady, setPageReady] = useState(false);
-  const { F24_DOWNLOAD_WAIT_TIME } = getConfiguration();
+  const { F24_DOWNLOAD_WAIT_TIME, LANDING_SITE_URL } = getConfiguration();
   const navigate = useNavigate();
 
   const currentUser = useAppSelector((state: RootState) => state.userState.user);
@@ -404,6 +404,7 @@ const NotificationDetail = () => {
                         handleReloadPayment={fetchPaymentsInfo}
                         getPaymentAttachmentAction={getPaymentAttachmentAction}
                         timerF24={F24_DOWNLOAD_WAIT_TIME}
+                        landingSiteUrl={LANDING_SITE_URL}
                       />
                     </ApiErrorWrapper>
                   </Paper>

--- a/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
@@ -284,6 +284,9 @@ const NotificationDetail = () => {
         return acc;
       }, []) as Array<{ noticeCode: string; creditorTaxId: string }>;
 
+      if (paymentInfoRequest.length === 0) {
+        return;
+      }
       void dispatch(
         getNotificationPaymentInfo({
           taxId: currentRecipient.taxId,

--- a/packages/pn-personafisica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
@@ -124,7 +124,7 @@ describe('NotificationDetail Page', () => {
     expect(mock.history.get[0].url).toContain('/notifications/received');
     expect(mock.history.post[0].url).toBe(NOTIFICATION_PAYMENT_INFO());
     expect(mock.history.get[1].url).toContain('/downtime/v1/history');
-    expect(result?.getByRole('link')).toHaveTextContent(/detail.breadcrumb-root/i);
+    expect(result?.getByTestId('breadcrumb-link')).toHaveTextContent(/detail.breadcrumb-root/i);
     expect(result?.container).toHaveTextContent(notificationToFe.abstract!);
     // check summary table
     const notificationDetailTable = result?.getByTestId('notificationDetailTable');
@@ -446,7 +446,7 @@ describe('NotificationDetail Page', () => {
     expect(mock.history.get[0].url).toContain('/notifications/received');
     expect(mock.history.post[0].url).toBe(NOTIFICATION_PAYMENT_INFO());
     expect(mock.history.get[1].url).toContain('/downtime/v1/history');
-    expect(result?.getByRole('link')).toHaveTextContent(/detail.breadcrumb-root/i);
+    expect(result?.getByTestId('breadcrumb-link')).toHaveTextContent(/detail.breadcrumb-root/i);
     expect(result?.container).toHaveTextContent(notificationToFe.abstract!);
     // check summary table
     const notificationDetailTable = result?.getByTestId('notificationDetailTable');

--- a/packages/pn-personagiuridica-webapp/public/conf/env/config.dev.json
+++ b/packages/pn-personagiuridica-webapp/public/conf/env/config.dev.json
@@ -9,7 +9,7 @@
   "SELFCARE_BASE_URL": "https://imprese.dev.notifichedigitali.it",
   "PAGOPA_HELP_EMAIL": "destinatari-send@assistenza.pagopa.it",
   "URL_FE_LOGIN": "https://imprese.dev.notifichedigitali.it/auth/login",
-  "LANDING_SITE_URL": "https://www.dev.notifichedigitali.it/",
+  "LANDING_SITE_URL": "https://www.dev.notifichedigitali.it",
   "DELEGATIONS_TO_PG_ENABLED": true,
   "WORK_IN_PROGRESS": false,
   "F24_DOWNLOAD_WAIT_TIME": 15000

--- a/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
@@ -52,9 +52,9 @@ import {
   resetState,
 } from '../redux/notification/reducers';
 import { RootState } from '../redux/store';
+import { getConfiguration } from '../services/configuration.service';
 import { TrackEventType } from '../utility/events';
 import { trackEventByType } from '../utility/mixpanel';
-import { getConfiguration } from '../services/configuration.service';
 
 // state for the invocations to this component
 // (to include in navigation or Link to the route/s arriving to it)
@@ -78,7 +78,7 @@ const NotificationDetail = () => {
   const isMobile = useIsMobile();
   const { hasApiErrors } = useErrors();
   const [pageReady, setPageReady] = useState(false);
-  const { F24_DOWNLOAD_WAIT_TIME } = getConfiguration();
+  const { F24_DOWNLOAD_WAIT_TIME, LANDING_SITE_URL } = getConfiguration();
   const navigate = useNavigate();
 
   const currentUser = useAppSelector((state: RootState) => state.userState.user);
@@ -406,6 +406,7 @@ const NotificationDetail = () => {
                         handleReloadPayment={fetchPaymentsInfo}
                         getPaymentAttachmentAction={getPaymentAttachmentAction}
                         timerF24={F24_DOWNLOAD_WAIT_TIME}
+                        landingSiteUrl={LANDING_SITE_URL}
                       />
                     </ApiErrorWrapper>
                   </Paper>

--- a/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
@@ -283,6 +283,9 @@ const NotificationDetail = () => {
         return acc;
       }, []) as Array<{ noticeCode: string; creditorTaxId: string }>;
 
+      if (paymentInfoRequest.length === 0) {
+        return;
+      }
       void dispatch(
         getNotificationPaymentInfo({
           taxId: currentRecipient.taxId,

--- a/packages/pn-personagiuridica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
@@ -130,7 +130,7 @@ describe('NotificationDetail Page', () => {
     expect(mock.history.get[0].url).toContain('/notifications/received');
     expect(mock.history.get[1].url).toContain('/downtime/v1/history');
     expect(mock.history.post[0].url).toBe(NOTIFICATION_PAYMENT_INFO());
-    expect(result?.getByRole('link')).toHaveTextContent(/detail.breadcrumb-root/i);
+    expect(result?.getByTestId('breadcrumb-link')).toHaveTextContent(/detail.breadcrumb-root/i);
     expect(result?.container).toHaveTextContent(notificationToFe.abstract!);
     // check summary table
     const notificationDetailTable = result?.getByTestId('notificationDetailTable');
@@ -458,7 +458,7 @@ describe('NotificationDetail Page', () => {
     expect(mock.history.get).toHaveLength(2);
     expect(mock.history.get[0].url).toContain('/notifications/received');
     expect(mock.history.get[1].url).toContain('/downtime/v1/history');
-    expect(result?.getByRole('link')).toHaveTextContent(/detail.breadcrumb-root/i);
+    expect(result?.getByTestId('breadcrumb-link')).toHaveTextContent(/detail.breadcrumb-root/i);
     expect(result?.container).toHaveTextContent(notificationToFe.abstract!);
     // check summary table
     const notificationDetailTable = result?.getByTestId('notificationDetailTable');
@@ -544,7 +544,7 @@ describe('NotificationDetail Page', () => {
     expect(mock.history.get[0].url).toContain('/notifications/received');
     expect(mock.history.get[1].url).toContain('/downtime/v1/history');
     expect(mock.history.post[0].url).toBe(NOTIFICATION_PAYMENT_INFO());
-    expect(result?.getByRole('link')).toHaveTextContent(/detail.breadcrumb-root/i);
+    expect(result?.getByTestId('breadcrumb-link')).toHaveTextContent(/detail.breadcrumb-root/i);
     expect(result?.container).toHaveTextContent(notificationToFe.abstract!);
     // check summary table
     const notificationDetailTable = result?.getByTestId('notificationDetailTable');


### PR DESCRIPTION
## Short description
Added link to FAQ for multi payment notification and on cancelled notification box. 
Also fixed some wrong urls of landing site in configuration files.

## List of changes proposed in this pull request
- Added link to FAQ
- Fix Landing site url on DEV

## How to test
Start PF or PG and go to a notification with payments and click on "Come mai" link. Also go to a cancelled notification and click on "Scopri di più" link