### PR TITLE
Chore: Fixed wrong label path translation

### DIFF
--- a/packages/pn-commons/src/components/CodeModal/CodeModal.tsx
+++ b/packages/pn-commons/src/components/CodeModal/CodeModal.tsx
@@ -119,7 +119,7 @@ const CodeModal = memo(
                 value={initialValues.join('')}
                 tooltipTitle={getLocalizedOrDefaultLabel(
                   'delegations',
-                  'code_copied',
+                  'deleghe.code_copied',
                   'Codice copiato'
                 )}
               />


### PR DESCRIPTION
## Short description
Fixed wrong label path translation.

## List of changes proposed in this pull request
- Fixed wrong label path translation from 'code_copied' to 'deleghe.code_copied'

## How to test
Translation of tooltip when copy code should be fine now.