### PR TITLE
Pn 8608 fe pagina stato piattaforma in lingua straniera

### DIFF
--- a/packages/pn-commons/src/components/AppStatus/AppStatusRender.tsx
+++ b/packages/pn-commons/src/components/AppStatus/AppStatusRender.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { Box, Stack, Typography } from '@mui/material';
 
@@ -95,14 +95,14 @@ export const AppStatusRender = (props: Props) => {
     setPagination(paginationData);
   };
 
-  const lastCheckTimestampFormatted = useMemo(() => {
+  const lastCheckTimestampFormatted = () => {
     if (currentStatus) {
       const dateAndTime = formatDateTime(currentStatus.lastCheckTimestamp);
       return `${dateAndTime}`;
     } else {
       return '';
     }
-  }, [currentStatus]);
+  };
 
   // resultPages includes one element per page, *including the first page*
   // check the comments in the reducer
@@ -126,7 +126,7 @@ export const AppStatusRender = (props: Props) => {
     'appStatus',
     'appStatus.lastCheckLegend',
     'Timestamp ultima verifica',
-    { lastCheckTimestamp: lastCheckTimestampFormatted }
+    { lastCheckTimestamp: lastCheckTimestampFormatted() }
   );
   const downtimeListTitle = getLocalizedOrDefaultLabel(
     'appStatus',


### PR DESCRIPTION
## Short description
Fixed today label in App Status page not updating when change language.

## List of changes proposed in this pull request
- Removed useMemo

## How to test
Go in App Status Page and change language. Today label should be fine.