### PR TITLE
Fixed issue with today label date

### DIFF
--- a/packages/pn-commons/src/utility/__test__/notification.utility.test.ts
+++ b/packages/pn-commons/src/utility/__test__/notification.utility.test.ts
@@ -646,10 +646,6 @@ describe('parse notification & filters', () => {
       _.cloneDeep(notificationDTOMultiRecipient)
     );
     expect(calculatedParsedNotification).toStrictEqual(notificationToFeMultiRecipient);
-    // check sentAt date format
-    expect(calculatedParsedNotification.sentAt).toBe(
-      formatDate(notificationDTOMultiRecipient.sentAt)
-    );
     // check the order
     let previousStepTimestamp: string | null = null;
     for (const status of calculatedParsedNotification.notificationStatusHistory) {

--- a/packages/pn-commons/src/utility/notification.utility.ts
+++ b/packages/pn-commons/src/utility/notification.utility.ts
@@ -7,31 +7,30 @@ import _ from 'lodash';
 
 import {
   AarDetails,
+  AppIoCourtesyMessageEventType,
   DigitalDomicileType,
+  ExtRegistriesPaymentDetails,
+  F24PaymentDetails,
   INotificationDetailTimeline,
   LegalFactType,
   NotificationDeliveryMode,
   NotificationDetail,
   NotificationDetailDocument,
+  NotificationDetailPayment,
   NotificationDetailRecipient,
+  NotificationDetailTimelineDetails,
   NotificationStatus,
   NotificationStatusHistory,
+  PagoPAPaymentFullDetails,
   PaidDetails,
   PaymentDetails,
+  PaymentStatus,
   SendCourtesyMessageDetails,
   SendDigitalDetails,
   SendPaperDetails,
   TimelineCategory,
   ViewedDetails,
-  AppIoCourtesyMessageEventType,
-  ExtRegistriesPaymentDetails,
-  F24PaymentDetails,
-  NotificationDetailPayment,
-  NotificationDetailTimelineDetails,
-  PagoPAPaymentFullDetails,
-  PaymentStatus,
 } from '../models';
-import { formatDate } from '../utility';
 import { getLocalizedOrDefaultLabel } from '../utility/localization.utility';
 import { TimelineStepInfo } from './TimelineUtils/TimelineStep';
 import { TimelineStepFactory } from './TimelineUtils/TimelineStepFactory';
@@ -1029,7 +1028,6 @@ export function parseNotificationDetail(
   const parsedNotification = {
     ...notificationDetail,
     otherDocuments: populateOtherDocuments(notificationDetail),
-    sentAt: formatDate(notificationDetail.sentAt),
   };
   insertCancelledStatusInTimeline(parsedNotification);
   /* eslint-disable functional/immutable-data */

--- a/packages/pn-pa-webapp/src/__mocks__/Notifications.mock.ts
+++ b/packages/pn-pa-webapp/src/__mocks__/Notifications.mock.ts
@@ -57,8 +57,4 @@ export const emptyNotificationsFromBe: GetNotificationsResponse = {
 
 export const notificationsToFe: GetNotificationsResponse = {
   ...notificationsDTO,
-  resultsPage: notificationsDTO.resultsPage.map((r) => ({
-    ...r,
-    sentAt: formatDate(r.sentAt),
-  })),
 };

--- a/packages/pn-pa-webapp/src/api/notifications/Notifications.api.ts
+++ b/packages/pn-pa-webapp/src/api/notifications/Notifications.api.ts
@@ -44,13 +44,7 @@ export const NotificationsApi = {
   getSentNotifications: (params: GetNotificationsParams): Promise<GetNotificationsResponse> =>
     apiClient.get<GetNotificationsResponse>(NOTIFICATIONS_LIST(params)).then((response) => {
       if (response.data?.resultsPage) {
-        const notifications = response.data.resultsPage.map((d) => ({
-          ...d,
-        }));
-        return {
-          ...response.data,
-          resultsPage: notifications,
-        };
+        return response.data;
       }
       return {
         resultsPage: [],

--- a/packages/pn-pa-webapp/src/api/notifications/Notifications.api.ts
+++ b/packages/pn-pa-webapp/src/api/notifications/Notifications.api.ts
@@ -8,7 +8,6 @@ import {
   NotificationDetailOtherDocument,
   PaymentAttachment,
   PaymentAttachmentNameType,
-  formatDate,
   parseNotificationDetail,
 } from '@pagopa-pn/pn-commons';
 
@@ -47,7 +46,6 @@ export const NotificationsApi = {
       if (response.data?.resultsPage) {
         const notifications = response.data.resultsPage.map((d) => ({
           ...d,
-          sentAt: formatDate(d.sentAt),
         }));
         return {
           ...response.data,

--- a/packages/pn-pa-webapp/src/components/Notifications/DesktopNotifications.tsx
+++ b/packages/pn-pa-webapp/src/components/Notifications/DesktopNotifications.tsx
@@ -13,6 +13,7 @@ import {
   NotificationStatus,
   Sort,
   StatusTooltip,
+  formatDate,
   getNotificationStatusInfos,
 } from '@pagopa-pn/pn-commons';
 import { Tag, TagGroup } from '@pagopa/mui-italia';
@@ -111,7 +112,7 @@ const DesktopNotifications = ({
       width: '11%',
       sortable: false, // TODO: will be re-enabled in PN-1124
       getCellLabel(value: string) {
-        return value;
+        return formatDate(value);
       },
       onClick(row: Item) {
         handleRowClick(row);

--- a/packages/pn-pa-webapp/src/components/Notifications/MobileNotifications.tsx
+++ b/packages/pn-pa-webapp/src/components/Notifications/MobileNotifications.tsx
@@ -18,6 +18,7 @@ import {
   NotificationStatus,
   Sort,
   StatusTooltip,
+  formatDate,
   getNotificationStatusInfos,
 } from '@pagopa-pn/pn-commons';
 import { ButtonNaked, Tag } from '@pagopa/mui-italia';
@@ -114,7 +115,7 @@ const MobileNotifications = ({
       id: 'sentAt',
       label: t('table.date'),
       getLabel(value: string) {
-        return <Typography>{value}</Typography>;
+        return <Typography>{formatDate(value)}</Typography>;
       },
       gridProps: {
         xs: 4,

--- a/packages/pn-pa-webapp/src/components/Notifications/NotificationDetailTableSender.tsx
+++ b/packages/pn-pa-webapp/src/components/Notifications/NotificationDetailTableSender.tsx
@@ -9,6 +9,7 @@ import {
   NotificationDetailTableRow,
   TimelineCategory,
   dataRegex,
+  formatDate,
   formatEurocentToCurrency,
   useIsCancelled,
 } from '@pagopa-pn/pn-commons';
@@ -82,8 +83,8 @@ const NotificationDetailTableSender: React.FC<Props> = ({ notification, onCancel
     },
     {
       label: t('detail.date', { ns: 'notifiche' }),
-      rawValue: notification.sentAt,
-      value: <Box fontWeight={600}>{notification.sentAt}</Box>,
+      rawValue: formatDate(notification.sentAt),
+      value: <Box fontWeight={600}>{formatDate(notification.sentAt)}</Box>,
     },
     {
       label: t('detail.payment-terms', { ns: 'notifiche' }),

--- a/packages/pn-personafisica-webapp/src/__mocks__/Notifications.mock.ts
+++ b/packages/pn-personafisica-webapp/src/__mocks__/Notifications.mock.ts
@@ -47,8 +47,4 @@ export const emptyNotificationsFromBe: GetNotificationsResponse = {
 
 export const notificationsToFe: GetNotificationsResponse = {
   ...notificationsDTO,
-  resultsPage: notificationsDTO.resultsPage.map((r) => ({
-    ...r,
-    sentAt: formatDate(r.sentAt),
-  })),
 };

--- a/packages/pn-personafisica-webapp/src/api/notifications/Notifications.api.ts
+++ b/packages/pn-personafisica-webapp/src/api/notifications/Notifications.api.ts
@@ -10,7 +10,6 @@ import {
   PaymentAttachment,
   PaymentAttachmentNameType,
   PaymentNotice,
-  formatDate,
 } from '@pagopa-pn/pn-commons';
 
 import { NotificationDetailForRecipient } from '../../models/NotificationDetail';
@@ -49,7 +48,6 @@ export const NotificationsApi = {
       if (response.data && response.data.resultsPage) {
         const notifications = response.data.resultsPage.map((d) => ({
           ...d,
-          sentAt: formatDate(d.sentAt),
         }));
         return {
           ...response.data,

--- a/packages/pn-personafisica-webapp/src/api/notifications/Notifications.api.ts
+++ b/packages/pn-personafisica-webapp/src/api/notifications/Notifications.api.ts
@@ -46,13 +46,7 @@ export const NotificationsApi = {
   getReceivedNotifications: (params: GetNotificationsParams): Promise<GetNotificationsResponse> =>
     apiClient.get<GetNotificationsResponse>(NOTIFICATIONS_LIST(params)).then((response) => {
       if (response.data && response.data.resultsPage) {
-        const notifications = response.data.resultsPage.map((d) => ({
-          ...d,
-        }));
-        return {
-          ...response.data,
-          resultsPage: notifications,
-        };
+        return response.data;
       }
       return {
         resultsPage: [],

--- a/packages/pn-personafisica-webapp/src/components/Notifications/DesktopNotifications.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Notifications/DesktopNotifications.tsx
@@ -13,6 +13,7 @@ import {
   NotificationStatus,
   Sort,
   StatusTooltip,
+  formatDate,
   getNotificationStatusInfos,
 } from '@pagopa-pn/pn-commons';
 
@@ -101,7 +102,7 @@ const DesktopNotifications = ({
       width: '11%',
       sortable: false, // TODO: will be re-enabled in PN-1124
       getCellLabel(value: string) {
-        return value;
+        return formatDate(value);
       },
       onClick(row: Item) {
         handleRowClick(row);

--- a/packages/pn-personafisica-webapp/src/components/Notifications/MobileNotifications.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Notifications/MobileNotifications.tsx
@@ -17,6 +17,7 @@ import {
   NotificationStatus,
   Sort,
   StatusTooltip,
+  formatDate,
   getNotificationStatusInfos,
 } from '@pagopa-pn/pn-commons';
 import { ButtonNaked } from '@pagopa/mui-italia';
@@ -108,12 +109,12 @@ const MobileNotifications = ({ notifications, sort, onChangeSorting, currentDele
                 {badge}
               </Typography>
               <Typography display="inline" variant="body2">
-                {row.sentAt}
+                {formatDate(row.sentAt as string)}
               </Typography>
             </Fragment>
           );
         }
-        return <Typography variant="body2">{row.sentAt}</Typography>;
+        return <Typography variant="body2">{formatDate(row.sentAt as string)}</Typography>;
       },
       gridProps: {
         xs: 4,

--- a/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
@@ -22,6 +22,7 @@ import {
   PnBreadcrumb,
   TimedMessage,
   TitleBox,
+  formatDate,
   useDownloadDocument,
   useErrors,
   useIsCancelled,
@@ -126,8 +127,8 @@ const NotificationDetail = () => {
     },
     {
       label: t('detail.date', { ns: 'notifiche' }),
-      rawValue: notification.sentAt,
-      value: <Box fontWeight={600}>{notification.sentAt}</Box>,
+      rawValue: formatDate(notification.sentAt),
+      value: <Box fontWeight={600}>{formatDate(notification.sentAt)}</Box>,
     },
     {
       label: t('detail.payment-terms', { ns: 'notifiche' }),

--- a/packages/pn-personafisica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
@@ -11,6 +11,7 @@ import {
   PaymentStatus,
   ResponseEventDispatcher,
   TimelineCategory,
+  formatDate,
   getF24Payments,
   getPagoPaF24Payments,
   populatePaymentsPagoPaF24,
@@ -134,7 +135,7 @@ describe('NotificationDetail Page', () => {
     expect(tableRows![1]).toHaveTextContent(
       `detail.recipient${notificationToFe.recipients[2].denomination}`
     );
-    expect(tableRows![2]).toHaveTextContent(`detail.date${notificationToFe.sentAt}`);
+    expect(tableRows![2]).toHaveTextContent(`detail.date${formatDate(notificationToFe.sentAt)}`);
     expect(tableRows![3]).toHaveTextContent(`detail.iun${notificationToFe.iun}`);
     // check documents box
     const notificationDetailDocuments = result?.getAllByTestId('notificationDetailDocuments');
@@ -456,7 +457,7 @@ describe('NotificationDetail Page', () => {
     expect(tableRows![1]).toHaveTextContent(
       `detail.recipient${notificationToFe.recipients[2].denomination}`
     );
-    expect(tableRows![2]).toHaveTextContent(`detail.date${notificationToFe.sentAt}`);
+    expect(tableRows![2]).toHaveTextContent(`detail.date${formatDate(notificationToFe.sentAt)}`);
     expect(tableRows![3]).toHaveTextContent(`detail.iun${notificationToFe.iun}`);
     // check documents box
     const notificationDetailDocuments = result?.getAllByTestId('notificationDetailDocuments');

--- a/packages/pn-personagiuridica-webapp/src/__mocks__/Notifications.mock.ts
+++ b/packages/pn-personagiuridica-webapp/src/__mocks__/Notifications.mock.ts
@@ -47,8 +47,4 @@ export const emptyNotificationsFromBe: GetNotificationsResponse = {
 
 export const notificationsToFe: GetNotificationsResponse = {
   ...notificationsDTO,
-  resultsPage: notificationsDTO.resultsPage.map((r) => ({
-    ...r,
-    sentAt: formatDate(r.sentAt),
-  })),
 };

--- a/packages/pn-personagiuridica-webapp/src/api/notifications/Notifications.api.ts
+++ b/packages/pn-personagiuridica-webapp/src/api/notifications/Notifications.api.ts
@@ -10,7 +10,6 @@ import {
   PaymentAttachment,
   PaymentAttachmentNameType,
   PaymentNotice,
-  formatDate,
 } from '@pagopa-pn/pn-commons';
 
 import { NotificationDetailForRecipient } from '../../models/NotificationDetail';
@@ -53,7 +52,6 @@ export const NotificationsApi = {
         if (response.data && response.data.resultsPage) {
           const notifications = response.data.resultsPage.map((d) => ({
             ...d,
-            sentAt: formatDate(d.sentAt),
           }));
           return {
             ...response.data,

--- a/packages/pn-personagiuridica-webapp/src/api/notifications/Notifications.api.ts
+++ b/packages/pn-personagiuridica-webapp/src/api/notifications/Notifications.api.ts
@@ -50,13 +50,7 @@ export const NotificationsApi = {
       .get<GetNotificationsResponse>(NOTIFICATIONS_LIST(payload, isDelegatedPage))
       .then((response) => {
         if (response.data && response.data.resultsPage) {
-          const notifications = response.data.resultsPage.map((d) => ({
-            ...d,
-          }));
-          return {
-            ...response.data,
-            resultsPage: notifications,
-          };
+          return response.data;
         }
         return {
           resultsPage: [],

--- a/packages/pn-personagiuridica-webapp/src/components/Notifications/DesktopNotifications.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Notifications/DesktopNotifications.tsx
@@ -13,6 +13,7 @@ import {
   NotificationStatus,
   Sort,
   StatusTooltip,
+  formatDate,
   getNotificationStatusInfos,
 } from '@pagopa-pn/pn-commons';
 
@@ -86,7 +87,7 @@ const DesktopNotifications = ({
       width: '11%',
       sortable: false, // TODO: will be re-enabled in PN-1124
       getCellLabel(value: string) {
-        return value;
+        return formatDate(value);
       },
       onClick(row: Item) {
         handleRowClick(row);

--- a/packages/pn-personagiuridica-webapp/src/components/Notifications/MobileNotifications.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Notifications/MobileNotifications.tsx
@@ -17,6 +17,7 @@ import {
   NotificationStatus,
   Sort,
   StatusTooltip,
+  formatDate,
   getNotificationStatusInfos,
 } from '@pagopa-pn/pn-commons';
 import { ButtonNaked } from '@pagopa/mui-italia';
@@ -101,12 +102,12 @@ const MobileNotifications = ({
                 {badge}
               </Typography>
               <Typography display="inline" variant="body2">
-                {row.sentAt}
+                {formatDate(row.sentAt as string)}
               </Typography>
             </Fragment>
           );
         }
-        return <Typography variant="body2">{row.sentAt}</Typography>;
+        return <Typography variant="body2">{formatDate(row.sentAt as string)}</Typography>;
       },
       gridProps: {
         xs: 4,

--- a/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
@@ -22,6 +22,7 @@ import {
   PnBreadcrumb,
   TimedMessage,
   TitleBox,
+  formatDate,
   useDownloadDocument,
   useErrors,
   useHasPermissions,
@@ -128,8 +129,8 @@ const NotificationDetail = () => {
     },
     {
       label: t('detail.date', { ns: 'notifiche' }),
-      rawValue: notification.sentAt,
-      value: <Box fontWeight={600}>{notification.sentAt}</Box>,
+      rawValue: formatDate(notification.sentAt),
+      value: <Box fontWeight={600}>{formatDate(notification.sentAt)}</Box>,
     },
     {
       label: t('detail.payment-terms', { ns: 'notifiche' }),

--- a/packages/pn-personagiuridica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
@@ -11,6 +11,7 @@ import {
   PaymentStatus,
   ResponseEventDispatcher,
   TimelineCategory,
+  formatDate,
   getF24Payments,
   getPagoPaF24Payments,
   populatePaymentsPagoPaF24,
@@ -140,7 +141,7 @@ describe('NotificationDetail Page', () => {
     expect(tableRows![1]).toHaveTextContent(
       `detail.recipient${notificationToFe.recipients[1].denomination}`
     );
-    expect(tableRows![2]).toHaveTextContent(`detail.date${notificationToFe.sentAt}`);
+    expect(tableRows![2]).toHaveTextContent(`detail.date${formatDate(notificationToFe.sentAt)}`);
     expect(tableRows![3]).toHaveTextContent(`detail.iun${notificationToFe.iun}`);
     // check documents box
     const notificationDetailDocuments = result?.getAllByTestId('notificationDetailDocuments');
@@ -468,7 +469,7 @@ describe('NotificationDetail Page', () => {
     expect(tableRows![1]).toHaveTextContent(
       `detail.recipient${notificationToFe.recipients[1].denomination}`
     );
-    expect(tableRows![2]).toHaveTextContent(`detail.date${notificationToFe.sentAt}`);
+    expect(tableRows![2]).toHaveTextContent(`detail.date${formatDate(notificationToFe.sentAt)}`);
     expect(tableRows![3]).toHaveTextContent(`detail.iun${notificationToFe.iun}`);
     // check documents box
     const notificationDetailDocuments = result?.getAllByTestId('notificationDetailDocuments');
@@ -554,7 +555,7 @@ describe('NotificationDetail Page', () => {
     expect(tableRows![1]).toHaveTextContent(
       `detail.recipient${notificationToFe.recipients[1].denomination}`
     );
-    expect(tableRows![2]).toHaveTextContent(`detail.date${notificationToFe.sentAt}`);
+    expect(tableRows![2]).toHaveTextContent(`detail.date${formatDate(notificationToFe.sentAt)}`);
     expect(tableRows![3]).toHaveTextContent(`detail.iun${notificationToFe.iun}`);
     // check documents box
     const notificationDetailDocuments = result?.getAllByTestId('notificationDetailDocuments');


### PR DESCRIPTION
## Short description
Moved formatDate from api parsing to tables components. This allows the today label to be properly updated when switch language

## List of changes proposed in this pull request
- Done for PA, PG and PF
- Reworked mocks for tests

## How to test
Enter a webapp with current day notifications. Switch language to whatever you want. Now the "Oggi" should be translated.