### PR TITLE
chore: added a script into bin folder to remove node_modules recursively

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Starting applications
 
 - `yarn start:pf` to start app for citizens in local
 - `yarn start:pa` to start app for public administration in local
+- `yarn start:pg` to start app for legal entities in local
 - `yarn start:login` to start the login section for citizens in local (url: localhost:3000)
 
 You can also run `yarn start` in the relative package folder:
@@ -31,7 +32,14 @@ To build all the monorepo
 Other scripts
 
 - `yarn refresh:monorepo` reinstalls all the dependencies of the whole workspace
-- `yarn clean:win` or `yarn clean:nx` deletes node_modules folder in the workspace (use win in you use Windows OS or nx if you use linux-based OS)
+- `yarn clean` deletes node_modules folder recursively in the workspace
+
+### How to contribute
+
+Our branching model is based on [GitFlow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow). Usually you can conclude your changes opening a PR.
+To generate a consistent changelog, we use [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/).
+Keep that in mind when you commit your changes or merge PRs.
+As rule of thumb, merge with squash is preferred over merge. Rebase is not advised as merge procedure.
 
 ### Lerna
 
@@ -55,18 +63,21 @@ You can run a task analysis with sonar-scanner using this script in each package
   To run it locally, you need to add env variable SONAR_TOKEN which contains the token of the project.
   The analysis will bel available [here](https://sonarcloud.io/project/overview?id=pagopa_pn-frontend)
 
-### Version
 
-Use `yarn run version` from branch `main` to tag a new version of the project and generate the relative changelog. This script uses [lerna version](https://github.com/lerna/lerna/blob/main/commands/version/README.md). To generate a consistent changelog, we use [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
+### Versioning
+These scripts use [lerna version](https://github.com/lerna/lerna/blob/main/commands/version/README.md).
 
-The tool automatically detects the modified packages starting from the previous version and then executes git commit and tag.
+Release a prepatch:
 
-Examples:
+`npx lerna version prepatch --conventional-commits --no-push --preid RC`
 
-- `yarn run version 1.0.1` to directly specify a version number
-- `yarn run version patch` to update the project according SemVer mode
-- `yarn run version` to make choices from prompt
+Increment a prerelease RC:
+`npx lerna version prerelease --conventional-prerelease --no-push --preid RC`
 
-When you have chosen desired version, you can end the procedure with `git push origin --tags` which will push the new tag.
+Promote a new version after prereleases:
 
-For more details and options, please visit [github](https://github.com/lerna/lerna/tree/main/commands/version)
+`npx lerna version --conventional-commits --conventional-graduate --no-push`
+
+After you obtain desired versioning, check the generated changelog and version e push commit and tag on desired branch:
+
+`git push --atomic origin <branch name> <tag>`

--- a/bin/cleanup.mjs
+++ b/bin/cleanup.mjs
@@ -1,0 +1,62 @@
+import fs from "fs/promises";
+import path from "path";
+
+const rootPath = process.cwd(); // Get the path of the project's root directory
+
+const checkIfNodeModulesExists = async (directory) => {
+  try {
+    await fs.access(directory);
+    return true;
+  } catch (error) {
+    return false;
+  }
+};
+
+const cleanup = async () => {
+  try {
+    const rootNodeModulesPath = path.join(rootPath, "node_modules");
+    // Check if node_modules exist in the project's root and removes it
+    if (await checkIfNodeModulesExists(rootNodeModulesPath)) {
+      console.log(`Removing node_modules in:`, rootNodeModulesPath);
+      try {
+        await fs.rm(rootNodeModulesPath, { recursive: true });
+      } catch (error) {
+        console.error(
+          "Error while removing node_modules in: " + rootNodeModulesPath,
+          err
+        );
+      }
+    } else {
+      console.log("No node_modules in: " + rootNodeModulesPath);
+    }
+
+    const packages = await fs.readdir(rootPath + "/packages");
+    for (const node_modules of packages) {
+      const packageNodeModulesPath = path.join(
+        rootPath,
+        "packages",
+        node_modules,
+        "node_modules"
+      );
+      // Check if node_modules exist in the package and removes it
+      if (await checkIfNodeModulesExists(packageNodeModulesPath)) {
+        console.log(`Removing node_modules in:`, packageNodeModulesPath);
+        try {
+          await fs.rm(packageNodeModulesPath, { recursive: true });
+        } catch (error) {
+          console.error(
+            "Error while removing node_modules in: " + packageNodeModulesPath,
+            err
+          );
+        }
+      } else {
+        console.log("No node_modules in: " + packageNodeModulesPath);
+      }
+    }
+    console.log("All node_modules directories removed successfully.");
+  } catch (error) {
+    console.error("Error:", error);
+  }
+};
+
+cleanup();

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "refresh:monorepo": "lerna clean -y && yarn install",
     "lint": "lerna run --scope @pagopa-pn/* lint",
     "format": "lerna run --scope @pagopa-pn/* format",
-    "version-preid": "lerna version --no-push --conventional-commits --preid RC",
     "clean": "node bin/cleanup.mjs"
   },
   "workspaces": {

--- a/package.json
+++ b/package.json
@@ -18,12 +18,10 @@
     "build": "lerna run --scope @pagopa-pn/pn-pa-webapp --scope @pagopa-pn/pn-personafisica-webapp build",
     "test": "lerna run --scope @pagopa-pn/* test",
     "refresh:monorepo": "lerna clean -y && yarn install",
-    "clean:win": "rmdir node_modules /s",
-    "clean:nx": "rm -rf node_modules **/**/node_modules",
     "lint": "lerna run --scope @pagopa-pn/* lint",
     "format": "lerna run --scope @pagopa-pn/* format",
     "version-preid": "lerna version --no-push --conventional-commits --preid RC",
-    "clean": "find . -name 'node_modules' -type d -prune -exec rm -rf '{}' +"
+    "clean": "node bin/cleanup.mjs"
   },
   "workspaces": {
     "packages": [


### PR DESCRIPTION
## Short description
Added a script that enables recursive removal of node modules, compatible with all operating systems.

## List of changes proposed in this pull request
- added a new script for recursive `node_modules` removal into `/bin` folder.
- updated the command `clean` in order to execute the script.
- removed commands: `clean:win` and `clean:nx`.
 
## How to test
The script has been tested and validated on various platforms, including Windows and Linux.
Run the script from the root project directory with the comand `yarn clean`. It will scan for and remove `node_modules` both in the root directory and within nested packages.