### PR TITLE
Chore: replaced translation string for Active in delegation page

### DIFF
--- a/packages/pn-personafisica-webapp/public/locales/en/deleghe.json
+++ b/packages/pn-personafisica-webapp/public/locales/en/deleghe.json
@@ -41,7 +41,7 @@
       "accept": "Accept",
       "notificationsFrom": "Notifications from:",
       "allNotifications": "All notifications",
-      "active": "Activate",
+      "active": "Active",
       "pending": "Awaiting confirmation"
     }
   },

--- a/packages/pn-personagiuridica-webapp/public/locales/en/deleghe.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/en/deleghe.json
@@ -47,7 +47,7 @@
       "accept": "Accept",
       "notificationsFrom": "Notifications from:",
       "allNotifications": "All notifications",
-      "active": "Activate",
+      "active": "Active",
       "pending": "Pending",
       "rejected": "Declined",
       "groups": "Groups",


### PR DESCRIPTION
## Short description
replaced translation string for Active in delegation page.

## List of changes proposed in this pull request
- deleghe.json for PF and PG

## How to test
Enter PF or PG and go in delegations page, look for active one then switch in English language. It should be labeled as 'active' and not in 'activated'