### PR TITLE
Chore: replaced strings traslation for subtitle in notification detail page

### DIFF
--- a/packages/pn-personafisica-webapp/public/locales/en/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/en/notifiche.json
@@ -70,7 +70,7 @@
     "disclaimer-link": "Find out more",
     "payment": {
       "title": "Payment",
-      "subtitle": "In this notification, there are multiple payment alerts: select the one you want to pay. Some alerts include notification fees.",
+      "subtitle": "In this notification, there are multiple payment notices: select the one you want to pay. Some alerts include notification fees.",
       "subtitle-f24": "You can pay for this notification via F24. To see the details, open the forms.",
       "subtitle-mixed": "In this notification, there are more payment options: select or download what you want to pay. Some amounts include notification fees.",
       "how": "Why is that?",

--- a/packages/pn-personafisica-webapp/public/locales/en/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/en/notifiche.json
@@ -70,7 +70,7 @@
     "disclaimer-link": "Find out more",
     "payment": {
       "title": "Payment",
-      "subtitle": "In this notification, there are multiple payment notices: select the one you want to pay. Some alerts include notification fees.",
+      "subtitle": "In this notification, there are multiple payment notices: select the one you want to pay. Some notices include notification fees.",
       "subtitle-f24": "You can pay for this notification via F24. To see the details, open the forms.",
       "subtitle-mixed": "In this notification, there are more payment options: select or download what you want to pay. Some amounts include notification fees.",
       "how": "Why is that?",

--- a/packages/pn-personagiuridica-webapp/public/locales/en/notifiche.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/en/notifiche.json
@@ -73,7 +73,7 @@
     "disclaimer-link": "Learn more",
     "payment": {
       "title": "Payment",
-      "subtitle": "In this notification, there are multiple payment alerts: select the one you want to pay. Some alerts include notification fees.",
+      "subtitle": "In this notification, there are multiple payment notices: select the one you want to pay. Some alerts include notification fees.",
       "subtitle-f24": "You can pay for this notification via F24. To see the details, open the forms.",
       "subtitle-mixed": "In this notification, there are more payment options: select or download the one you want to pay. Some amounts include the notification fees.",
       "how": "Why is that?",

--- a/packages/pn-personagiuridica-webapp/public/locales/en/notifiche.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/en/notifiche.json
@@ -73,7 +73,7 @@
     "disclaimer-link": "Learn more",
     "payment": {
       "title": "Payment",
-      "subtitle": "In this notification, there are multiple payment notices: select the one you want to pay. Some alerts include notification fees.",
+      "subtitle": "In this notification, there are multiple payment notices: select the one you want to pay. Some notices include notification fees.",
       "subtitle-f24": "You can pay for this notification via F24. To see the details, open the forms.",
       "subtitle-mixed": "In this notification, there are more payment options: select or download the one you want to pay. Some amounts include the notification fees.",
       "how": "Why is that?",


### PR DESCRIPTION

## Short description
replaced strings traslation for subtitle in notification detail page.

## List of changes proposed in this pull request
- notifiche.json for PF and PG replaced occurrences of "payment alerts" in "payment notices"

## How to test
Check subtitle in notification detail page.