### PR TITLE
Fixed missing translation for Privacy Policy in footer

### DIFF
--- a/packages/pn-commons/src/utility/costants.tsx
+++ b/packages/pn-commons/src/utility/costants.tsx
@@ -221,13 +221,8 @@ export const postLoginLinks = (
   termsOfServiceHref?: string
 ): Array<FooterLinksType> => [
   {
-    label: 'Informativa Privacy',
+    ...getFooterLinkLabels('privacy-info', 'Informativa Privacy'),
     href: privacyPolicyHref || `${window.location.origin}${PRIVACY_LINK_RELATIVE_PATH}`,
-    ariaLabel: `${getLocalizedOrDefaultLabel(
-      'common',
-      'footer.go-to',
-      'Vai al link'
-    )}: Informativa Privacy`,
     linkType: 'internal',
   },
   {

--- a/packages/pn-pa-webapp/public/locales/de/common.json
+++ b/packages/pn-pa-webapp/public/locales/de/common.json
@@ -113,6 +113,7 @@
     "work": "Karriere",
     "certifications": "Zertifizierungen",
     "security": "Informationssicherheit",
+    "privacy-info": "Datenschutzerklärung",
     "personal-data": "Recht auf Schutz personenbezogener Daten",
     "cookie": "Cookie-Einstellungen",
     "terms-conditions": "Allgemeine Geschäftsbedingungen",

--- a/packages/pn-pa-webapp/public/locales/en/common.json
+++ b/packages/pn-pa-webapp/public/locales/en/common.json
@@ -113,6 +113,7 @@
     "work": "Work with us",
     "certifications": "Certifications",
     "security": "Information security",
+    "privacy-info": "Privacy Policy",
     "personal-data": "Right to protection of personal data",
     "cookie": "Cookie Preferences",
     "terms-conditions": "Terms and Conditions",

--- a/packages/pn-pa-webapp/public/locales/fr/common.json
+++ b/packages/pn-pa-webapp/public/locales/fr/common.json
@@ -113,6 +113,7 @@
     "work": "Travaille avec nous",
     "certifications": "Certifications",
     "security": "Sécurité des informations",
+    "privacy-info": "Politique de confidentialité",
     "personal-data": "Droit à la protection des données personnelles",
     "cookie": "Préférences en matière de cookies",
     "terms-conditions": "Conditions générales",

--- a/packages/pn-pa-webapp/public/locales/it/common.json
+++ b/packages/pn-pa-webapp/public/locales/it/common.json
@@ -113,6 +113,7 @@
     "work": "Lavora con noi",
     "certifications": "Certificazioni",
     "security": "Sicurezza delle informazioni",
+    "privacy-info": "Informativa Privacy",
     "personal-data": "Diritto alla protezione dei dati personali",
     "cookie": "Preferenze Cookie",
     "terms-conditions": "Termini e Condizioni",

--- a/packages/pn-pa-webapp/public/locales/sl/common.json
+++ b/packages/pn-pa-webapp/public/locales/sl/common.json
@@ -113,6 +113,7 @@
     "work": "Sodeluj z nami",
     "certifications": "Certifikati",
     "security": "Varnost podatkov",
+    "privacy-info": "Izjava o zasebnosti",
     "personal-data": "Pravica do varstva osebnih podatkov",
     "cookie": "Nastavitve piškotkov",
     "terms-conditions": "Pogoji in določila",


### PR DESCRIPTION
## Short description
Fixed missing translation for Privacy Policy in footer.

## List of changes proposed in this pull request
- Fixed Constants file
- Added missing translation in common.json of PA

## How to test
Translation of Privacy Policy in Footer should be ok now.