### PR TITLE
Added mobile support for NewNotificationCard buttons

### DIFF
--- a/packages/pn-pa-webapp/src/components/NewNotification/NewNotificationCard.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/NewNotificationCard.tsx
@@ -2,7 +2,7 @@ import { Fragment, ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Box, Button, Paper, Typography } from '@mui/material';
-import { SectionHeading } from '@pagopa-pn/pn-commons';
+import { SectionHeading, useIsMobile } from '@pagopa-pn/pn-commons';
 
 type Props = {
   children: ReactNode;
@@ -26,6 +26,7 @@ const NewNotificationCard = ({
   previousStepOnClick,
 }: Props) => {
   const { t } = useTranslation(['common', 'notifiche']);
+  const isMobile = useIsMobile();
 
   return (
     <Fragment>
@@ -43,7 +44,7 @@ const NewNotificationCard = ({
       {noPaper && <Box>{children}</Box>}
       <Box
         display="flex"
-        flexDirection="row-reverse"
+        flexDirection={isMobile ? 'column' : 'row-reverse'}
         justifyContent="space-between"
         alignItems="center"
         sx={{ marginTop: '40px', marginBottom: '20px' }}
@@ -54,6 +55,7 @@ const NewNotificationCard = ({
           type="submit"
           disabled={isContinueDisabled}
           data-testid="step-submit"
+          fullWidth={isMobile}
         >
           {submitLabel || t('button.continue')}
         </Button>
@@ -64,6 +66,8 @@ const NewNotificationCard = ({
             type="button"
             onClick={previousStepOnClick}
             data-testid="previous-step"
+            fullWidth={isMobile}
+            sx={{ marginTop: isMobile ? 2 : 0 }}
           >
             {previousStepLabel}
           </Button>


### PR DESCRIPTION
## Short description
Added mobile support for NewNotificationCard component in the same way as done with modals.

## List of changes proposed in this pull request
- Modified NewNotificationCard component

## How to test
Enter PA, create new notification in mobile mode. You should see previous and submit buttons in column view.