### PR TITLE
PN-8735 - Fix overflow of f24 items on notification payment box of PA

### DIFF
--- a/packages/pn-pa-webapp/src/components/Notifications/NotificationPaymentF24.tsx
+++ b/packages/pn-pa-webapp/src/components/Notifications/NotificationPaymentF24.tsx
@@ -52,7 +52,6 @@ const NotificationPaymentF24: React.FC<Props> = ({ iun, payments }) => {
           {t('payment.f24-attached')}
         </Typography>
       </Box>
-      {/* Box should start a new line */}
       <Box display="flex" flexWrap="wrap" alignItems="center">
         <CollapsedList
           maxNumberOfItems={5}

--- a/packages/pn-pa-webapp/src/components/Notifications/NotificationPaymentF24.tsx
+++ b/packages/pn-pa-webapp/src/components/Notifications/NotificationPaymentF24.tsx
@@ -52,41 +52,44 @@ const NotificationPaymentF24: React.FC<Props> = ({ iun, payments }) => {
           {t('payment.f24-attached')}
         </Typography>
       </Box>
-      <CollapsedList
-        maxNumberOfItems={5}
-        items={payments}
-        renderItem={(f24) => (
-          <Typography
-            variant="caption"
-            color="text.secondary"
-            mr={1}
-            key={`${f24.recIndex} - ${f24.attachmentIdx}`}
-            data-testid="f24"
-          >
-            {f24.title}
-          </Typography>
-        )}
-        renderRemainingItem={(count) => (
-          <Typography variant="caption" color="text.secondary" data-testid="remaining-f24">
-            &nbsp;+&nbsp;{count}&nbsp;{t('payment.attachments')}
-            <ButtonNaked
-              sx={{ verticalAlign: 'inherit', ml: 1 }}
-              data-testid="show-all-attachments"
-              onClick={() => setOpen(true)}
+      {/* Box should start a new line */}
+      <Box display="flex" flexWrap="wrap" alignItems="center">
+        <CollapsedList
+          maxNumberOfItems={5}
+          items={payments}
+          renderItem={(f24) => (
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              mr={1}
+              key={`${f24.recIndex} - ${f24.attachmentIdx}`}
+              data-testid="f24"
             >
-              <Typography
-                color="primary"
-                variant="body2"
-                tabIndex={0}
-                aria-label={t('detail.show-all')}
-                fontWeight={'bold'}
+              {f24.title}
+            </Typography>
+          )}
+          renderRemainingItem={(count) => (
+            <Typography variant="caption" color="text.secondary" data-testid="remaining-f24">
+              &nbsp;+&nbsp;{count}&nbsp;{t('payment.attachments')}
+              <ButtonNaked
+                sx={{ verticalAlign: 'inherit', ml: 1 }}
+                data-testid="show-all-attachments"
+                onClick={() => setOpen(true)}
               >
-                {t('detail.show-all')}
-              </Typography>
-            </ButtonNaked>
-          </Typography>
-        )}
-      />
+                <Typography
+                  color="primary"
+                  variant="body2"
+                  tabIndex={0}
+                  aria-label={t('detail.show-all')}
+                  fontWeight={'bold'}
+                >
+                  {t('detail.show-all')}
+                </Typography>
+              </ButtonNaked>
+            </Typography>
+          )}
+        />
+      </Box>
     </>
   );
 };


### PR DESCRIPTION
## Short description
Fix overflow of F24 file name on notification payment box of sender

## List of changes proposed in this pull request
- Added box with flexWrap to avoid overflow of items

## How to test
NZKT-TQMQ-TWQW-202310-K-1 from Comune di Palermo in TEST. F24 items should not overflow the container