### PR TITLE
fix: moved documents above payments box and changed title variant

### DIFF
--- a/packages/pn-commons/src/components/NotificationDetail/NotificationDetailDocuments.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationDetailDocuments.tsx
@@ -1,5 +1,5 @@
 import AttachFileIcon from '@mui/icons-material/AttachFile';
-import { Box, Grid, Stack, Typography } from '@mui/material';
+import { Box, Grid, Stack, Typography, TypographyProps } from '@mui/material';
 // import DownloadIcon from '@mui/icons-material/Download';
 import { ButtonNaked } from '@pagopa/mui-italia';
 
@@ -13,6 +13,7 @@ type Props = {
   downloadFilesMessage?: string;
   downloadFilesLink?: string;
   disableDownloads?: boolean;
+  titleVariant?: TypographyProps['variant'];
 };
 
 /**
@@ -34,6 +35,7 @@ const NotificationDetailDocuments: React.FC<Props> = (
     documentsAvailable = true,
     downloadFilesMessage,
     disableDownloads = false,
+    titleVariant = 'overline',
   } // TODO: remove comment when link ready downloadFilesLink
 ) => {
   const mapOtherDocuments = (documents: Array<NotificationDetailDocument>) =>
@@ -107,10 +109,7 @@ const NotificationDetailDocuments: React.FC<Props> = (
           <Typography
             id="notification-detail-document-attached"
             color="text.primary"
-            variant="overline"
-            fontWeight={700}
-            textTransform="uppercase"
-            fontSize={14}
+            variant={titleVariant}
           >
             {title}
           </Typography>

--- a/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
@@ -392,6 +392,20 @@ const NotificationDetail = () => {
                   </Alert>
                 )}
                 <NotificationDetailTable rows={detailTableRows} />
+
+                <Paper sx={{ p: 3 }} elevation={0}>
+                  <NotificationDetailDocuments
+                    title={t('detail.acts', { ns: 'notifiche' })}
+                    documents={notification.documents}
+                    clickHandler={documentDowloadHandler}
+                    documentsAvailable={notification.documentsAvailable}
+                    downloadFilesMessage={getDownloadFilesMessage('attachments')}
+                    downloadFilesLink={t('detail.acts_files.effected_faq', { ns: 'notifiche' })}
+                    disableDownloads={isCancelled.cancellationInTimeline}
+                    titleVariant="h6"
+                  />
+                </Paper>
+
                 {checkIfUserHasPayments && (
                   <Paper sx={{ p: 3 }} elevation={0}>
                     <ApiErrorWrapper
@@ -415,17 +429,6 @@ const NotificationDetail = () => {
                 )}
 
                 {!mandateId && <DomicileBanner />}
-                <Paper sx={{ p: 3 }} elevation={0}>
-                  <NotificationDetailDocuments
-                    title={t('detail.acts', { ns: 'notifiche' })}
-                    documents={notification.documents}
-                    clickHandler={documentDowloadHandler}
-                    documentsAvailable={notification.documentsAvailable}
-                    downloadFilesMessage={getDownloadFilesMessage('attachments')}
-                    downloadFilesLink={t('detail.acts_files.effected_faq', { ns: 'notifiche' })}
-                    disableDownloads={isCancelled.cancellationInTimeline}
-                  />
-                </Paper>
                 <Paper sx={{ p: 3, mb: 3 }} elevation={0}>
                   <NotificationDetailDocuments
                     title={t('detail.aar-acts', { ns: 'notifiche' })}

--- a/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
@@ -394,6 +394,20 @@ const NotificationDetail = () => {
                   </Alert>
                 )}
                 <NotificationDetailTable rows={detailTableRows} />
+
+                <Paper sx={{ p: 3 }} elevation={0}>
+                  <NotificationDetailDocuments
+                    title={t('detail.acts', { ns: 'notifiche' })}
+                    documents={notification.documents}
+                    clickHandler={documentDowloadHandler}
+                    documentsAvailable={notification.documentsAvailable}
+                    downloadFilesMessage={getDownloadFilesMessage('attachments')}
+                    downloadFilesLink={t('detail.acts_files.effected_faq', { ns: 'notifiche' })}
+                    disableDownloads={isCancelled.cancellationInTimeline}
+                    titleVariant="h6"
+                  />
+                </Paper>
+
                 {checkIfUserHasPayments && (
                   <Paper sx={{ p: 3 }} elevation={0}>
                     <ApiErrorWrapper
@@ -417,17 +431,6 @@ const NotificationDetail = () => {
                 )}
 
                 {visibleDomicileBanner() && <DomicileBanner />}
-                <Paper sx={{ p: 3 }} elevation={0}>
-                  <NotificationDetailDocuments
-                    title={t('detail.acts', { ns: 'notifiche' })}
-                    documents={notification.documents}
-                    clickHandler={documentDowloadHandler}
-                    documentsAvailable={notification.documentsAvailable}
-                    downloadFilesMessage={getDownloadFilesMessage('attachments')}
-                    downloadFilesLink={t('detail.acts_files.effected_faq', { ns: 'notifiche' })}
-                    disableDownloads={isCancelled.cancellationInTimeline}
-                  />
-                </Paper>
                 <Paper sx={{ p: 3, mb: 3 }} elevation={0}>
                   <NotificationDetailDocuments
                     title={t('detail.aar-acts', { ns: 'notifiche' })}


### PR DESCRIPTION
## Short description
Moved documents box above payments box and changed title variant of attached documents box 

## List of changes proposed in this pull request
- Moved documents box
- Changed title variant

## How to test
Go to a notification and you should see the attached documents box before payments box.
And the title of the attached documents box should be like the title of payments box