### PR TITLE
Added taxId validation according to PF or PG recipient

### DIFF
--- a/packages/pn-pa-webapp/src/__mocks__/NewNotification.mock.ts
+++ b/packages/pn-pa-webapp/src/__mocks__/NewNotification.mock.ts
@@ -70,7 +70,7 @@ const newNotificationRecipients: Array<NewNotificationRecipient> = [
   {
     id: 'recipient.1',
     idx: 1,
-    taxId: 'SRAGLL00P48H501U',
+    taxId: '12345678901',
     firstName: 'Sara Gallo srl',
     lastName: '',
     recipientType: RecipientType.PG,

--- a/packages/pn-pa-webapp/src/components/NewNotification/__test__/Recipient.test.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/__test__/Recipient.test.tsx
@@ -280,16 +280,22 @@ describe('Recipient Component with payment enabled', () => {
     expect(firstNameError).toHaveTextContent('forbidden-characters-denomination-error');
     await testInput(form!, 'recipients[1].firstName', randomString(81));
     expect(firstNameError).toHaveTextContent('too-long-field-error');
-    // taxId
+    // taxId empty
     await testInput(form, 'recipients[1].taxId', '', true);
     const taxIdError = form.querySelector('[id="recipients[1].taxId-helper-text"]');
     expect(taxIdError).toHaveTextContent('required-field');
+    // taxId using PF type on PG recipient
+    await testInput(form, 'recipients[1].taxId', newNotification.recipients[0].taxId, true);
+    expect(taxIdError).toHaveTextContent('fiscal-code-error');
+    // taxId error
     await testInput(form!, 'recipients[1].taxId', 'wrong-fiscal-code');
     expect(taxIdError).toHaveTextContent('fiscal-code-error');
     expect(submitButton).toBeDisabled();
     // identical taxId
-    await testInput(form!, 'recipients[0].taxId', newNotification.recipients[0].taxId);
-    await testInput(form!, 'recipients[1].taxId', newNotification.recipients[0].taxId);
+    const radioPhysicalPerson = result?.queryAllByLabelText('physical-person')[1];
+    fireEvent.click(radioPhysicalPerson!);
+    await testInput(form!, 'recipients[0].taxId', newNotification.recipients[0].taxId, true);
+    await testInput(form!, 'recipients[1].taxId', newNotification.recipients[0].taxId, true);
     expect(taxIdError).toHaveTextContent('identical-fiscal-codes-error');
     // identical creditorTaxId and noticeCode
     await testInput(

--- a/packages/pn-pa-webapp/src/utility/__test__/validation.utility.test.ts
+++ b/packages/pn-pa-webapp/src/utility/__test__/validation.utility.test.ts
@@ -35,6 +35,11 @@ describe('test custom validation for recipients', () => {
     expect(result).toBeFalsy();
   });
 
+  it('taxIdDependingOnRecipientType (PF errors with a taxId legal person formed value)', () => {
+    const result = taxIdDependingOnRecipientType('12345678910', RecipientType.PF);
+    expect(result).toBeFalsy();
+  });
+
   it('taxIdDependingOnRecipientType (PG no errors)', () => {
     const result = taxIdDependingOnRecipientType('12345678910', RecipientType.PG);
     expect(result).toBeTruthy();
@@ -42,6 +47,11 @@ describe('test custom validation for recipients', () => {
 
   it('taxIdDependingOnRecipientType (PG errors)', () => {
     const result = taxIdDependingOnRecipientType('fakePIva', RecipientType.PG);
+    expect(result).toBeFalsy();
+  });
+
+  it('taxIdDependingOnRecipientType (PG errors with a taxId physical person formed value)', () => {
+    const result = taxIdDependingOnRecipientType('LVLDAA85T50G702B', RecipientType.PG);
     expect(result).toBeFalsy();
   });
 

--- a/packages/pn-pa-webapp/src/utility/validation.utility.ts
+++ b/packages/pn-pa-webapp/src/utility/validation.utility.ts
@@ -47,7 +47,9 @@ export function taxIdDependingOnRecipientType(
   }
   const isCF16 = dataRegex.fiscalCode.test(value);
   const isCF11 = dataRegex.pIva.test(value);
-  return isCF16 || (recipientType === RecipientType.PG && isCF11);
+  return (
+    (recipientType === RecipientType.PF && isCF16) || (recipientType === RecipientType.PG && isCF11)
+  );
 }
 
 export function identicalTaxIds(


### PR DESCRIPTION
## Short description
Added taxId validation according to PF or PG recipient.
This means that you cannot add physical person taxId in PG or viceversa add legal person taxId in PF

## List of changes proposed in this pull request
- Reworked taxIdDependingOnRecipientType function
- Added / edited tests

## How to test
Enter PA and start new notification, then enter recipients step. Set as legal person and try to add a physical person taxId. An error should appear.