### PR TITLE
PN-8811-fe-pa-nel-portale-pa-sostituire-lemail-di-assistenza-nellheader-con-il-link-assistenza

### DIFF
--- a/packages/pn-pa-webapp/src/App.tsx
+++ b/packages/pn-pa-webapp/src/App.tsx
@@ -212,7 +212,9 @@ const ActualApp = () => {
   };
 
   const handleAssistanceClick = () => {
-    trackEventByType(TrackEventType.CUSTOMER_CARE_MAILTO, { source: 'postlogin' });
+    trackEventByType(TrackEventType.CUSTOMER_CARE_MAILTO, {
+      source: sessionToken ? 'postlogin' : 'prelogin',
+    });
     /* eslint-disable-next-line functional/immutable-data */
     window.location.href = sessionToken
       ? `${SELFCARE_BASE_URL}/assistenza`

--- a/packages/pn-pa-webapp/src/App.tsx
+++ b/packages/pn-pa-webapp/src/App.tsx
@@ -214,7 +214,9 @@ const ActualApp = () => {
   const handleAssistanceClick = () => {
     trackEventByType(TrackEventType.CUSTOMER_CARE_MAILTO, { source: 'postlogin' });
     /* eslint-disable-next-line functional/immutable-data */
-    window.location.href = `mailto:${configuration.PAGOPA_HELP_EMAIL}`;
+    window.location.href = sessionToken
+      ? `${SELFCARE_BASE_URL}/assistenza`
+      : `mailto:${configuration.PAGOPA_HELP_EMAIL}`;
   };
 
   const changeLanguageHandler = async (langCode: string) => {


### PR DESCRIPTION
## Short description
The behavior of the support link in PA has been modified for logged-in users.

## List of changes proposed in this pull request
- Added the link `${SELFCARE_BASE_URL}/assistenza` to `handleAssistanceClick()` once the user is logged in.

## How to test
Simply run `yarn start` for PA and check if the assistance link redirects to a different path after logging in.