### PR TITLE
Fixed issue with non clearable input date in filter notifications

### DIFF
--- a/packages/pn-pa-webapp/src/components/Notifications/FilterNotificationsFormBody.tsx
+++ b/packages/pn-pa-webapp/src/components/Notifications/FilterNotificationsFormBody.tsx
@@ -129,9 +129,8 @@ const FilterNotificationsFormBody = ({
         inputFormat={DATE_FORMAT}
         value={startDate}
         onChange={(value: DatePickerTypes) => {
-          const value2 = value || tenYearsAgo;
-          void formikInstance.setFieldValue('startDate', value2).then(() => {
-            setStartDate(value2);
+          void formikInstance.setFieldValue('startDate', value || tenYearsAgo).then(() => {
+            setStartDate(value);
             trackEventByType(TrackEventType.NOTIFICATION_FILTER_DATE, { source: 'from date' });
           });
         }}
@@ -163,10 +162,9 @@ const FilterNotificationsFormBody = ({
         inputFormat={DATE_FORMAT}
         value={endDate}
         onChange={(value: DatePickerTypes) => {
-          const value2 = value || today;
-          void formikInstance.setFieldValue('endDate', value2).then(() => {
+          void formikInstance.setFieldValue('endDate', value || today).then(() => {
             trackEventByType(TrackEventType.NOTIFICATION_FILTER_DATE, { source: 'to date' });
-            setEndDate(value2);
+            setEndDate(value);
           });
         }}
         renderInput={(params) => (


### PR DESCRIPTION
## Short description
Fixed issue with non clearable input date in filter notifications. Changes are quite simple: removed a const and given directly the value in the `setFieldValue()` function same as already done in PF and PG. Cause is probably due to "lifecycle" of variable assignment of `value`.

## List of changes proposed in this pull request
- Fixed for PA

## How to test
You should be able to remove date in the filter notification section now.