### PR TITLE
Payments whit no attachment - pn-8869

### DIFF
--- a/packages/pn-commons/src/__mocks__/ExternalRegistry.mock.ts
+++ b/packages/pn-commons/src/__mocks__/ExternalRegistry.mock.ts
@@ -65,4 +65,13 @@ export const paymentInfo: Array<ExtRegistriesPaymentDetails> = [
     causaleVersamento: 'Sesta rata TARI',
     dueDate: '2025-12-25',
   },
+  {
+    creditorTaxId: '77777777777',
+    noticeCode: '302011686772695138',
+    status: PaymentStatus.REQUIRED,
+    amount: 5000,
+    url: 'https://api.uat.platform.pagopa.it/checkout/auth/payments/v2',
+    causaleVersamento: 'Settima rata TARI',
+    dueDate: '2027-12-31',
+  },
 ];

--- a/packages/pn-commons/src/__mocks__/NotificationDetail.mock.ts
+++ b/packages/pn-commons/src/__mocks__/NotificationDetail.mock.ts
@@ -125,6 +125,23 @@ export const payments: Array<NotificationDetailPayment> = [
       },
     },
   },
+  {
+    pagoPa: {
+      noticeCode: '302011686772695138',
+      creditorTaxId: '77777777777',
+      applyCost: false,
+      attachment: {
+        digests: {
+          sha256: 'jezIVxlG1M1woCSUngM6KipUN3/p8cD5RMIPnuEanlA=',
+        },
+        contentType: 'application/pdf',
+        ref: {
+          key: 'PN_NOTIFICATION_ATTACHMENTS-5641ed5bc57442fb3df53abe5b5d38d.pdf',
+          versionToken: 'v1',
+        },
+      },
+    },
+  },
 ];
 
 const recipients: Array<NotificationDetailRecipient> = [

--- a/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentRecipient.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentRecipient.tsx
@@ -238,20 +238,21 @@ const NotificationPaymentRecipient: React.FC<Props> = ({
                 &nbsp;
                 {selectedPayment?.amount ? formatEurocentToCurrency(selectedPayment.amount) : null}
               </Button>
-
-              <Button
-                fullWidth
-                variant="outlined"
-                data-testid="download-pagoPA-notice-button"
-                disabled={!selectedPayment}
-                onClick={() => downloadAttachment(PaymentAttachmentSName.PAGOPA)}
-              >
-                <Download fontSize="small" sx={{ mr: 1 }} />
-                {getLocalizedOrDefaultLabel(
-                  'notifications',
-                  'detail.payment.download-pagoPA-notice'
-                )}
-              </Button>
+              {(!selectedPayment || selectedPayment?.attachment) && (
+                <Button
+                  fullWidth
+                  variant="outlined"
+                  data-testid="download-pagoPA-notice-button"
+                  disabled={!selectedPayment}
+                  onClick={() => downloadAttachment(PaymentAttachmentSName.PAGOPA)}
+                >
+                  <Download fontSize="small" sx={{ mr: 1 }} />
+                  {getLocalizedOrDefaultLabel(
+                    'notifications',
+                    'detail.payment.download-pagoPA-notice'
+                  )}
+                </Button>
+              )}
               {selectedPayment &&
               pagoPaF24.find((payment) => payment.pagoPa?.noticeCode === selectedPayment.noticeCode)
                 ?.f24 ? (

--- a/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentTitle.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentTitle.tsx
@@ -1,0 +1,67 @@
+import { Link } from '@mui/material';
+
+import { EventPaymentRecipientType, F24PaymentDetails, PaymentDetails } from '../../models';
+import { getLocalizedOrDefaultLabel } from '../../utility/localization.utility';
+
+type Props = {
+  landingSiteUrl: string;
+  handleTrackEventFn: (event: EventPaymentRecipientType, param?: object) => void;
+  pagoPaF24: Array<PaymentDetails>;
+  f24Only: Array<F24PaymentDetails>;
+};
+
+const NotificationPaymentTitle: React.FC<Props> = ({
+  landingSiteUrl,
+  handleTrackEventFn,
+  pagoPaF24,
+  f24Only,
+}) => {
+  const FAQ_NOTIFICATION_COSTS = '/faq#costi-di-notifica';
+  const notificationCostsFaqLink = `${landingSiteUrl}${FAQ_NOTIFICATION_COSTS}`;
+  const FaqLink = (
+    <Link
+      href={notificationCostsFaqLink}
+      onClick={() => handleTrackEventFn(EventPaymentRecipientType.SEND_MULTIPAYMENT_MORE_INFO)}
+      target="_blank"
+      fontWeight="bold"
+      sx={{ cursor: 'pointer' }}
+      data-testid="faqNotificationCosts"
+    >
+      {getLocalizedOrDefaultLabel('notifications', 'detail.payment.how')}
+    </Link>
+  );
+
+  if (pagoPaF24.length > 0 && f24Only.length > 0) {
+    return (
+      <>
+        {getLocalizedOrDefaultLabel('notifications', 'detail.payment.subtitle-mixed')}
+        &nbsp;
+        {FaqLink}
+      </>
+    );
+  }
+
+  if (pagoPaF24.length === 1) {
+    return (
+      <>
+        {getLocalizedOrDefaultLabel('notifications', 'detail.payment.single-payment-subtitle')}
+        &nbsp;
+        {FaqLink}
+      </>
+    );
+  }
+
+  if (pagoPaF24.length > 1) {
+    return (
+      <>
+        {getLocalizedOrDefaultLabel('notifications', 'detail.payment.subtitle')}
+        &nbsp;
+        {FaqLink}
+      </>
+    );
+  }
+
+  return <>{getLocalizedOrDefaultLabel('notifications', 'detail.payment.subtitle-f24')}</>;
+};
+
+export default NotificationPaymentTitle;

--- a/packages/pn-commons/src/components/NotificationDetail/__test__/NotificationPaymentRecipient.test.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/__test__/NotificationPaymentRecipient.test.tsx
@@ -267,4 +267,27 @@ describe('NotificationPaymentRecipient Component', () => {
 
     expect(fetchPaymentsInfoMk).toBeCalledTimes(1);
   });
+
+  it('download pagoPa notice hidden if no attachment is present', () => {
+    const { getAllByTestId, queryByTestId } = render(
+      <NotificationPaymentRecipient
+        payments={paymentsData}
+        isCancelled={false}
+        timerF24={F24TIMER}
+        getPaymentAttachmentAction={jest.fn()}
+        onPayClick={() => void 0}
+        handleFetchPaymentsInfo={() => {}}
+        landingSiteUrl=""
+      />
+    );
+    const paymentIndex = paymentsData.pagoPaF24.findIndex(
+      (payment) => payment.pagoPa?.status === PaymentStatus.REQUIRED && !payment.pagoPa.attachment
+    );
+    const item = getAllByTestId('pagopa-item')[paymentIndex];
+    const radioButton = item.querySelector('[data-testid="radio-button"] input');
+    fireEvent.click(radioButton!);
+    // download pagoPA attachments
+    const downloadButton = queryByTestId('download-pagoPA-notice-button');
+    expect(downloadButton).not.toBeInTheDocument();
+  });
 });

--- a/packages/pn-commons/src/components/NotificationDetail/__test__/NotificationPaymentRecipient.test.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/__test__/NotificationPaymentRecipient.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { paymentInfo } from '../../../__mocks__/ExternalRegistry.mock';
 import { notificationToFe, payments } from '../../../__mocks__/NotificationDetail.mock';
 import { PaymentAttachmentSName, PaymentStatus, PaymentsData } from '../../../models';
-import { fireEvent, render, waitFor, within } from '../../../test-utils';
+import { act, fireEvent, render, waitFor, within } from '../../../test-utils';
 import {
   getF24Payments,
   getPagoPaF24Payments,
@@ -39,7 +39,7 @@ describe('NotificationPaymentRecipient Component', () => {
     const subtitle = getByTestId('notification-payment-recipient-subtitle');
     const f24Download = queryByTestId('f24-download');
     const pagoPABox = queryAllByTestId('pagopa-item');
-    const downloadPagoPANotice = getByTestId('download-pagoPA-notice-button');
+    const downloadPagoPANotice = queryByTestId('download-pagoPA-notice-button');
     const payButton = getByTestId('pay-button');
     const f24OnlyBox = getByTestId('f24only-box');
     const paginationBox = getByTestId('pagination-box');
@@ -52,16 +52,16 @@ describe('NotificationPaymentRecipient Component', () => {
     expect(subtitle).toHaveTextContent('detail.payment.subtitle');
     expect(f24Download).not.toBeInTheDocument();
     expect(pagoPABox).toHaveLength(pageLength > 5 ? 5 : pageLength);
-    expect(downloadPagoPANotice).toBeInTheDocument();
+    expect(downloadPagoPANotice).not.toBeInTheDocument();
     expect(payButton).toBeInTheDocument();
-    expect(downloadPagoPANotice).toBeDisabled();
     expect(payButton).toBeDisabled();
     expect(f24OnlyBox).toBeInTheDocument();
     expect(paginationBox).toBeInTheDocument();
   });
 
   it('select and unselect payment', async () => {
-    const { getByTestId, queryAllByTestId } = render(
+    jest.useFakeTimers();
+    const { getByTestId, queryAllByTestId, queryByTestId } = render(
       <NotificationPaymentRecipient
         payments={paymentsData}
         isCancelled={false}
@@ -72,21 +72,24 @@ describe('NotificationPaymentRecipient Component', () => {
         landingSiteUrl=""
       />
     );
-    const downloadPagoPANotice = getByTestId('download-pagoPA-notice-button');
+    let downloadPagoPANotice = queryByTestId('download-pagoPA-notice-button');
     const payButton = getByTestId('pay-button');
-
     const paymentIndex = paymentsData.pagoPaF24.findIndex(
-      (payment) => payment.pagoPa?.status === PaymentStatus.REQUIRED
+      (payment) => payment.pagoPa?.status === PaymentStatus.REQUIRED && payment.pagoPa.attachment
     );
-
     const item = queryAllByTestId('pagopa-item')[paymentIndex];
-
     const radioButton = item.querySelector('[data-testid="radio-button"] input');
-    expect(downloadPagoPANotice).toBeDisabled();
+    expect(downloadPagoPANotice).not.toBeInTheDocument();
     expect(payButton).toBeDisabled();
     // select payment
     fireEvent.click(radioButton!);
-    expect(downloadPagoPANotice).not.toBeDisabled();
+    // after radio button click, there is a timer of 1 second after that the paymeny is enabled
+    // wait...
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    downloadPagoPANotice = getByTestId('download-pagoPA-notice-button');
+    expect(downloadPagoPANotice).toBeInTheDocument();
     expect(payButton).not.toBeDisabled();
     // check f24
     const f24Download = getByTestId('f24-download');
@@ -94,11 +97,12 @@ describe('NotificationPaymentRecipient Component', () => {
     // unselect payment
     fireEvent.click(radioButton!);
     expect(payButton).toBeDisabled();
-    expect(downloadPagoPANotice).toBeDisabled();
+    expect(downloadPagoPANotice).not.toBeInTheDocument();
     expect(f24Download).not.toBeInTheDocument();
   });
 
   it('should dispatch action on pay button click', async () => {
+    jest.useFakeTimers();
     const payClickMk = jest.fn();
     const { getByTestId, queryAllByTestId } = render(
       <NotificationPaymentRecipient
@@ -120,6 +124,11 @@ describe('NotificationPaymentRecipient Component', () => {
 
     const radioButton = item.querySelector('[data-testid="radio-button"] input');
     fireEvent.click(radioButton!);
+    // after radio button click, there is a timer of 1 second after that the paymeny is enabled
+    // wait...
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
     fireEvent.click(payButton);
     await waitFor(() => {
       expect(payClickMk).toBeCalledTimes(1);
@@ -177,6 +186,7 @@ describe('NotificationPaymentRecipient Component', () => {
   });
 
   it('should call handleDownloadAttachment on download button click', async () => {
+    jest.useFakeTimers();
     const getPaymentAttachmentActionMk = jest
       .fn()
       .mockImplementation(() => ({ unwrap: () => new Promise(() => void 0), abort: () => void 0 }));
@@ -198,6 +208,11 @@ describe('NotificationPaymentRecipient Component', () => {
     const item = getAllByTestId('pagopa-item')[paymentIndex];
     const radioButton = item.querySelector('[data-testid="radio-button"] input');
     fireEvent.click(radioButton!);
+    // after radio button click, there is a timer of 1 second after that the paymeny is enabled
+    // wait...
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
     // download pagoPA attachments
     const downloadButton = getByTestId('download-pagoPA-notice-button');
     downloadButton.click();

--- a/packages/pn-commons/src/components/NotificationDetail/__test__/NotificationPaymentTitle.test.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/__test__/NotificationPaymentTitle.test.tsx
@@ -25,14 +25,15 @@ describe('NotificationPaymentTite component', () => {
     const { container, getByTestId } = render(
       <NotificationPaymentTitle
         pagoPaF24={paymentsData.pagoPaF24}
-        f24Only={paymentsData.f24Only}
+        f24Only={[]}
         landingSiteUrl="https://www.mocked-url.com"
         handleTrackEventFn={() => {}}
       />
     );
 
-    expect(container).toHaveTextContent('notifiche - detail.payment.subtitle-mixed');
-    expect(container).toHaveTextContent('notifiche - detail.detail.payment.how');
+    expect(container).toHaveTextContent(
+      'notifiche - detail.payment.subtitle notifiche - detail.payment.how'
+    );
     const faq = getByTestId('faqNotificationCosts');
     expect(faq).toBeInTheDocument();
   });
@@ -41,14 +42,15 @@ describe('NotificationPaymentTite component', () => {
     const { container, getByTestId } = render(
       <NotificationPaymentTitle
         pagoPaF24={[paymentsData.pagoPaF24[0]]}
-        f24Only={paymentsData.f24Only}
+        f24Only={[]}
         landingSiteUrl="https://www.mocked-url.com"
         handleTrackEventFn={() => {}}
       />
     );
 
-    expect(container).toHaveTextContent('notifiche - detail.payment.single-payment-subtitle');
-    expect(container).toHaveTextContent('notifiche - detail.detail.payment.how');
+    expect(container).toHaveTextContent(
+      'notifiche - detail.payment.single-payment-subtitle notifiche - detail.payment.how'
+    );
     const faq = getByTestId('faqNotificationCosts');
     expect(faq).toBeInTheDocument();
   });
@@ -63,8 +65,9 @@ describe('NotificationPaymentTite component', () => {
       />
     );
 
-    expect(container).toHaveTextContent('notifiche - detail.payment.subtitle');
-    expect(container).toHaveTextContent('notifiche - detail.detail.payment.how');
+    expect(container).toHaveTextContent(
+      'notifiche - detail.payment.subtitle notifiche - detail.payment.how'
+    );
     const faq = getByTestId('faqNotificationCosts');
     expect(faq).toBeInTheDocument();
   });

--- a/packages/pn-commons/src/components/NotificationDetail/__test__/NotificationPaymentTitle.test.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/__test__/NotificationPaymentTitle.test.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+
+import { paymentInfo } from '../../../__mocks__/ExternalRegistry.mock';
+import { notificationToFe, payments } from '../../../__mocks__/NotificationDetail.mock';
+import { PaymentsData } from '../../../models';
+import { initLocalizationForTest, render } from '../../../test-utils';
+import { getF24Payments, getPagoPaF24Payments, populatePaymentsPagoPaF24 } from '../../../utility';
+import NotificationPaymentTitle from '../NotificationPaymentTitle';
+
+describe('NotificationPaymentTite component', () => {
+  const paymentsData: PaymentsData = {
+    pagoPaF24: populatePaymentsPagoPaF24(
+      notificationToFe.timeline,
+      getPagoPaF24Payments(payments, 0),
+      paymentInfo
+    ),
+    f24Only: getF24Payments(payments, 0),
+  };
+
+  beforeAll(() => {
+    initLocalizationForTest();
+  });
+
+  it('render component - multi payments', () => {
+    const { container, getByTestId } = render(
+      <NotificationPaymentTitle
+        pagoPaF24={paymentsData.pagoPaF24}
+        f24Only={paymentsData.f24Only}
+        landingSiteUrl="https://www.mocked-url.com"
+        handleTrackEventFn={() => {}}
+      />
+    );
+
+    expect(container).toHaveTextContent('notifiche - detail.payment.subtitle-mixed');
+    expect(container).toHaveTextContent('notifiche - detail.detail.payment.how');
+    const faq = getByTestId('faqNotificationCosts');
+    expect(faq).toBeInTheDocument();
+  });
+
+  it('render component - one payment', () => {
+    const { container, getByTestId } = render(
+      <NotificationPaymentTitle
+        pagoPaF24={[paymentsData.pagoPaF24[0]]}
+        f24Only={paymentsData.f24Only}
+        landingSiteUrl="https://www.mocked-url.com"
+        handleTrackEventFn={() => {}}
+      />
+    );
+
+    expect(container).toHaveTextContent('notifiche - detail.payment.single-payment-subtitle');
+    expect(container).toHaveTextContent('notifiche - detail.detail.payment.how');
+    const faq = getByTestId('faqNotificationCosts');
+    expect(faq).toBeInTheDocument();
+  });
+
+  it('render component - multi payments whit no f24', () => {
+    const { container, getByTestId } = render(
+      <NotificationPaymentTitle
+        pagoPaF24={paymentsData.pagoPaF24}
+        f24Only={[]}
+        landingSiteUrl="https://www.mocked-url.com"
+        handleTrackEventFn={() => {}}
+      />
+    );
+
+    expect(container).toHaveTextContent('notifiche - detail.payment.subtitle');
+    expect(container).toHaveTextContent('notifiche - detail.detail.payment.how');
+    const faq = getByTestId('faqNotificationCosts');
+    expect(faq).toBeInTheDocument();
+  });
+
+  it('render component - only f24', () => {
+    const { container, queryByTestId } = render(
+      <NotificationPaymentTitle
+        pagoPaF24={[]}
+        f24Only={paymentsData.f24Only}
+        landingSiteUrl="https://www.mocked-url.com"
+        handleTrackEventFn={() => {}}
+      />
+    );
+
+    expect(container).toHaveTextContent('notifiche - detail.payment.subtitle-f24');
+    const faq = queryByTestId('faqNotificationCosts');
+    expect(faq).not.toBeInTheDocument();
+  });
+});

--- a/packages/pn-commons/src/components/NotificationDetail/__test__/NotificationPaymentTitle.test.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/__test__/NotificationPaymentTitle.test.tsx
@@ -25,14 +25,14 @@ describe('NotificationPaymentTite component', () => {
     const { container, getByTestId } = render(
       <NotificationPaymentTitle
         pagoPaF24={paymentsData.pagoPaF24}
-        f24Only={[]}
+        f24Only={paymentsData.f24Only}
         landingSiteUrl="https://www.mocked-url.com"
         handleTrackEventFn={() => {}}
       />
     );
 
     expect(container).toHaveTextContent(
-      'notifiche - detail.payment.subtitle notifiche - detail.payment.how'
+      'notifiche - detail.payment.subtitle-mixed notifiche - detail.payment.how'
     );
     const faq = getByTestId('faqNotificationCosts');
     expect(faq).toBeInTheDocument();

--- a/packages/pn-personafisica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
@@ -513,6 +513,7 @@ describe('NotificationDetail Page', () => {
   });
 
   it('should dispatch getNotificationPaymentUrl on pay button click', async () => {
+    jest.useFakeTimers();
     const paymentHistory = populatePaymentsPagoPaF24(
       notificationToFe.timeline,
       paymentsData.pagoPaF24,
@@ -554,6 +555,11 @@ describe('NotificationDetail Page', () => {
     expect(item).toBeInTheDocument();
     const radioButton = item?.querySelector('[data-testid="radio-button"] input');
     fireEvent.click(radioButton!);
+    // after radio button click, there is a timer of 1 second after that the paymeny is enabled
+    // wait...
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
     expect(payButton).toBeEnabled();
     fireEvent.click(payButton!);
     expect(mock.history.post).toHaveLength(2);

--- a/packages/pn-personagiuridica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
@@ -584,6 +584,7 @@ describe('NotificationDetail Page', () => {
   });
 
   it('should dispatch getNotificationPaymentUrl on pay button click', async () => {
+    jest.useFakeTimers();
     const paymentHistory = populatePaymentsPagoPaF24(
       notificationToFe.timeline,
       paymentsData.pagoPaF24,
@@ -625,6 +626,11 @@ describe('NotificationDetail Page', () => {
     expect(item).toBeInTheDocument();
     const radioButton = item?.querySelector('[data-testid="radio-button"] input');
     fireEvent.click(radioButton!);
+    // after radio button click, there is a timer of 1 second after that the paymeny is enabled
+    // wait...
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
     expect(payButton).toBeEnabled();
     fireEvent.click(payButton!);
     expect(mock.history.post).toHaveLength(2);


### PR DESCRIPTION
## Short description
Sometimes the payment attachment (no F24) is included in the act and not in the payment. So when the user select a payment, the button to download the attachment must be shown/hidden based on this condition.
We also added a delay of 1 second after the selection, before the payment is enabled

## List of changes proposed in this pull request
- Updated NotificationPaymentRecipient to manage the logic described above
- Created NotificationPaymentTitle component to have a cleaner code
- Updated the tests
- Reworked the NotificationPaymentRecipient component to reduce the complexity

## How to test
- Login with pf on dev (colombo) -> search the notification AGYX-HKJK-WGTD-202311-T-1 -> select one payment and check that the button to download the attachment is shown/hidden correctly
- Login with pf on dev (ada) -> search the notification ATMG-XVDH-WPTR-202311-T-1 -> the only payment available mustn't have the button to download the attachment
- Login with pf on dev -> search a notification with only one payment and with the attachment linked to it -> he only payment available must have the button to download the attachment