### PR TITLE
Added copy for new analog-workflow-attachment-kind 23I

### DIFF
--- a/packages/pn-pa-webapp/public/locales/de/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/de/notifiche.json
@@ -281,6 +281,7 @@
       },
       "analog-workflow-attachment-kind": {
         "AR": "Zustellungsbescheinigung",
+        "23I": "Zustellungsbescheinigung",
         "Plico": "Scan des Umschlags",
         "23L": "Empfangsbestätigung",
         "Indagine": "Scan der Nachforschung",

--- a/packages/pn-pa-webapp/public/locales/en/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/en/notifiche.json
@@ -281,6 +281,7 @@
       },
       "analog-workflow-attachment-kind": {
         "AR": "Receipt of delivery",
+        "23I": "Receipt of delivery",
         "Plico": "Scanning the envelope",
         "23L": "Acknowledgement of receipt",
         "Indagine": "Scanning the survey",

--- a/packages/pn-pa-webapp/public/locales/fr/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/fr/notifiche.json
@@ -281,6 +281,7 @@
       },
       "analog-workflow-attachment-kind": {
         "AR": "Reçu de livraison",
+        "23I": "Reçu de livraison",
         "Plico": "Scan du pli",
         "23L": "Accusé de réception",
         "Indagine": "Scan de l’enquête",

--- a/packages/pn-pa-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/it/notifiche.json
@@ -281,6 +281,7 @@
       },
       "analog-workflow-attachment-kind": {
         "AR": "Ricevuta di consegna",
+        "23I": "Ricevuta di consegna",
         "Plico": "Scansione del plico",
         "23L": "Avviso di ricevimento",
         "Indagine": "Scansione dell'indagine",

--- a/packages/pn-pa-webapp/public/locales/sl/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/sl/notifiche.json
@@ -281,6 +281,7 @@
       },
       "analog-workflow-attachment-kind": {
         "AR": "Potrdilo o dostavi",
+        "23I": "Potrdilo o dostavi",
         "Plico": "Skeniranje ovojnice",
         "23L": "Potrdilo o prejemu",
         "Indagine": "Skeniranje ankete",

--- a/packages/pn-personafisica-webapp/public/locales/de/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/de/notifiche.json
@@ -301,6 +301,7 @@
       },
       "analog-workflow-attachment-kind": {
         "AR": "Zustellungsbescheinigung",
+        "23I": "Zustellungsbescheinigung",
         "Plico": "Scan des Umschlags",
         "23L": "Empfangsbestätigung",
         "Indagine": "Scan der Nachforschung",

--- a/packages/pn-personafisica-webapp/public/locales/en/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/en/notifiche.json
@@ -301,6 +301,7 @@
       },
       "analog-workflow-attachment-kind": {
         "AR": "Receipt of delivery",
+        "23I": "Receipt of delivery",
         "Plico": "Scanning the envelope",
         "23L": "Acknowledgement of receipt",
         "Indagine": "Scanning the survey",

--- a/packages/pn-personafisica-webapp/public/locales/fr/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/fr/notifiche.json
@@ -301,6 +301,7 @@
       },
       "analog-workflow-attachment-kind": {
         "AR": "Reçu de livraison",
+        "23I": "Reçu de livraison",
         "Plico": "Scan du pli",
         "23L": "Accusé de réception",
         "Indagine": "Scan de l’enquête",

--- a/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
@@ -303,6 +303,7 @@
       },
       "analog-workflow-attachment-kind": {
         "AR": "Ricevuta di consegna",
+        "23I": "Ricevuta di consegna",
         "Plico": "Scansione del plico",
         "23L": "Avviso di ricevimento",
         "Indagine": "Scansione dell'indagine",

--- a/packages/pn-personafisica-webapp/public/locales/sl/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/sl/notifiche.json
@@ -301,6 +301,7 @@
       },
       "analog-workflow-attachment-kind": {
         "AR": "Potrdilo o dostavi",
+        "23I": "Potrdilo o dostavi",
         "Plico": "Skeniranje ovojnice",
         "23L": "Potrdilo o prejemu",
         "Indagine": "Skeniranje ankete",

--- a/packages/pn-personagiuridica-webapp/public/locales/de/notifiche.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/de/notifiche.json
@@ -302,7 +302,8 @@
         "RIS": "international einfach"
       },
       "analog-workflow-attachment-kind": {
-        "AR": "Zustellbescheinigung",
+        "AR": "Zustellungsbescheinigung",
+        "23I": "Zustellungsbescheinigung",
         "Plico": "Scan des Umschlags",
         "23L": "Empfangsbestätigung",
         "Indagine": "Scan der Nachforschung",

--- a/packages/pn-personagiuridica-webapp/public/locales/en/notifiche.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/en/notifiche.json
@@ -303,6 +303,7 @@
       },
       "analog-workflow-attachment-kind": {
         "AR": "Receipt of delivery",
+        "23I": "Receipt of delivery",
         "Plico": "Scanning the envelope",
         "23L": "Acknowledgement of receipt",
         "Indagine": "Scanning the enquiry",

--- a/packages/pn-personagiuridica-webapp/public/locales/fr/notifiche.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/fr/notifiche.json
@@ -303,6 +303,7 @@
       },
       "analog-workflow-attachment-kind": {
         "AR": "Reçu de livraison",
+        "23I": "Reçu de livraison",
         "Plico": "Scan du pli",
         "23L": "Accusé de réception",
         "Indagine": "Scan de l’enquête",

--- a/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
@@ -305,6 +305,7 @@
       },
       "analog-workflow-attachment-kind": {
         "AR": "Ricevuta di consegna",
+        "23I": "Ricevuta di consegna",
         "Plico": "Scansione del plico",
         "23L": "Avviso di ricevimento",
         "Indagine": "Scansione dell'indagine",

--- a/packages/pn-personagiuridica-webapp/public/locales/sl/notifiche.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/sl/notifiche.json
@@ -303,6 +303,7 @@
       },
       "analog-workflow-attachment-kind": {
         "AR": "Potrdilo o dostavi",
+        "23I": "Potrdilo o dostavi",
         "Plico": "Skeniranje ovojnice",
         "23L": "Potrdilo o prejemu",
         "Indagine": "Skeniranje ankete",


### PR DESCRIPTION
## Short description
Added the copy for a new kind of analog workflow attachment, namely 23I. Done for all languages (this was easy since the copy is identical to that of an already existing analog workflow attachment kind, i.e. AR), and for PA / PF / PG.

## List of changes proposed in this pull request
Just added the needed elements in the different `notifiche.json` files.

## How to test
Unfortunately there is yet no timeline element including an attachment of kind 23I. So in order to properly test the added copies, we have to do some mocking.

This is what I did for PG in `Notifications.api.ts` 

``` 
  getReceivedNotification: (
    iun: string,
    mandateId?: string
  ): Promise<NotificationDetailForRecipient> =>
    apiClient.get<NotificationDetail>(NOTIFICATION_DETAIL(iun, mandateId)).then((response) => {
      if (response.data) {
        // added from here
        if (iun === 'RPTH-YULD-WKMA-202305-T-1') {
          const elementToModify = response.data.timeline.find(elem => elem.elementId === 'SEND_ANALOG_PROGRESS.IUN_RPTH-YULD-WKMA-202305-T-1.RECINDEX_0.ATTEMPT_0.IDX_2');
          if (elementToModify) {
            // eslint-disable-next-line functional/immutable-data
            (elementToModify.details as any).attachments[0].documentType = '23I';
          }
        }
        // to here
        return parseNotificationDetailForRecipient(response.data);
      } else {
        return {} as NotificationDetailForRecipient;
      }
    }),
``` 
This notification is in DEV, it can be accessed through the user DanteAlighieri, company DivinaCommedia Srl.

I did a similar mock for PA and PF, referring to the notification with IUN DGDL-KQRA-MALZ-202310-V-1 and the timeline element with elementId SEND_ANALOG_PROGRESS.IUN_DGDL-KQRA-MALZ-202310-V-1.RECINDEX_0.ATTEMPT_0.IDX_2.
This notification is also in DEV, recipient Ada, sender Comune di Palermo (accessible through e.g. grossini).
