### PR TITLE
Disabled mixpanel in login portal

### DIFF
--- a/packages/pn-personafisica-login/src/App.tsx
+++ b/packages/pn-personafisica-login/src/App.tsx
@@ -2,15 +2,16 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Box } from '@mui/material';
-import { initLocalization, useMultiEvent, useTracking } from '@pagopa-pn/pn-commons';
+import { initLocalization, useMultiEvent } from '@pagopa-pn/pn-commons';
 
 import Router from './navigation/routes';
 import { getConfiguration } from './services/configuration.service';
 import './utility/onetrust';
 
 const App = () => {
-  const { MIXPANEL_TOKEN, VERSION } = getConfiguration();
-  useTracking(MIXPANEL_TOKEN, process.env.NODE_ENV);
+  const { VERSION } = getConfiguration();
+  // PN-9008 - turn off Mixpanel tracking in pf-personafisica-login
+  // useTracking(MIXPANEL_TOKEN, process.env.NODE_ENV);
 
   const [clickVersion] = useMultiEvent({
     callback: () => console.log(`v${VERSION}`),

--- a/packages/pn-personafisica-login/src/utility/mixpanel.ts
+++ b/packages/pn-personafisica-login/src/utility/mixpanel.ts
@@ -7,7 +7,15 @@ import { TrackEventType, events } from './events';
  * @param trackEventType event name
  * @param attributes event attributes
  */
-export const trackEventByType = (trackEventType: TrackEventType, attributes?: object) => {
+export const trackEventByType = (trackEventType: TrackEventType, attributes?: object) => 
+  // PN-9008 - turn off Mixpanel tracking in pf-personafisica-login
+  // I leave a nonsense implementation in order to avoid compilation errors
+  trackEventType && attributes;
+
+
+// PN-9008 - The actual implementation is kept in a separate function in order to ease its recovering,
+//           in particular to leave the imports.
+export const trackEventByTypeReal = (trackEventType: TrackEventType, attributes?: object) => {
   const eventParameters = attributes
     ? { ...events[trackEventType], ...attributes }
     : events[trackEventType];


### PR DESCRIPTION
## Short description
Disabled the generation of mixpanel events in the login portal.

## List of changes proposed in this pull request
Just modified the `trackEventByType` to make it a no-op.

## How to test
Enter the login portal, you should see in the dev tools console that no events related to mixpanel (issued by `tracking.service`) should be shown.