### PR TITLE
Removed note about limit of 7 days to accept a delegation

### DIFF
--- a/packages/pn-personafisica-webapp/public/locales/it/deleghe.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/deleghe.json
@@ -26,7 +26,7 @@
     "no_delegates": "Non hai delegato nessuno alla visualizzazione delle tue notifiche. <0>Aggiungi una delega</0>",
     "no_delegators": "Non hai deleghe a tuo carico.",
     "show_code_title": "Codice di verifica per la delega a {{name}}",
-    "show_code_subtitle": "Condividi questo codice con la persona delegata: dovrà inserirlo all’accettazione della delega. Il codice è valido per 7 giorni dalla creazione della richiesta di delega.",
+    "show_code_subtitle": "Condividi questo codice con la persona delegata: dovrà inserirlo all’accettazione della delega.",
     "verification_code": "Codice di verifica",
     "code_copied": "Codice copiato",
     "table": {
@@ -67,7 +67,7 @@
       "date-duration": "Periodo di validità della delega*",
       "endDate": "Termine delega",
       "verificationCode": "Codice di verifica",
-      "verificationCodeDescr": "Condividi questo codice con la persona delegata: dovrà inserirlo all’accettazione della delega. Il codice è valido per 7 giorni dalla creazione della richiesta di delega.",
+      "verificationCodeDescr": "Condividi questo codice con la persona delegata: dovrà inserirlo all’accettazione della delega.",
       "submit": "Invia la richiesta",
       "mandatoryField": "Campi obbligatori*",
       "party-not-found": "Nessun ente trovato"

--- a/packages/pn-personagiuridica-webapp/public/locales/it/deleghe.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/it/deleghe.json
@@ -29,7 +29,7 @@
     "no_delegators": "Non c'è nessuna delega a carico di {{organizationName}}.",
     "no_delegators_after_filters": "I filtri che hai aggiunto non hanno dato nessun risultato. <0>Rimuovi filtri</0>.",
     "show_code_title": "Codice di verifica per la delega a {{name}}",
-    "show_code_subtitle": "Condividi questo codice con la persona delegata: dovrà inserirlo all’accettazione della delega. Il codice è valido per 7 giorni dalla creazione della richiesta di delega.",
+    "show_code_subtitle": "Condividi questo codice con la persona delegata: dovrà inserirlo all’accettazione della delega.",
     "verification_code": "Codice di verifica",
     "code_copied": "Codice copiato",
     "tab_aria_label": "Tab deleghe",
@@ -99,7 +99,7 @@
       "date-duration": "Periodo di validità della delega*",
       "endDate": "Termine delega",
       "verificationCode": "Codice di verifica",
-      "verificationCodeDescr": "Condividi questo codice con la persona delegata: dovrà inserirlo all’accettazione della delega. Il codice è valido per 7 giorni dalla creazione della richiesta di delega.",
+      "verificationCodeDescr": "Condividi questo codice con la persona delegata: dovrà inserirlo all’accettazione della delega.",
       "submit": "Invia la richiesta",
       "mandatoryField": "Campi obbligatori*",
       "party-not-found": "Nessun ente trovato"


### PR DESCRIPTION
## Short description
Removed the note about of the limit of 7 days to accept a delegation, for both PF and PG.

## List of changes proposed in this pull request
Just changed the corresponding entries in the `deleghe.json` files in PF and PG, erasing the note about the limit that was added through previous PRs.

*Note*: this note was present only for the messages in Italian language.

## How to test
Enter either PF or PG, go to "Deleghe". The message which used to include the removed note are present in two points, see below. In neither case the text "Il codice è valido per 7 giorni dalla creazione della richiesta di delega." should be present.

(1) 
In the form for a new delegation.
![image](https://github.com/pagopa/pn-frontend/assets/5519535/982e10e1-def5-413b-9d36-143b90fae063)

(2)
In the modal that appears when the option "Mostra codice" appears in the contextual menu for a pending ("In attesa di conferma") delegation
![image](https://github.com/pagopa/pn-frontend/assets/5519535/3132717f-15bc-4697-b21b-f9ca63a7d19d)

And here's the modal
![image](https://github.com/pagopa/pn-frontend/assets/5519535/65d1dbb7-e0c8-47b8-bf51-c292a97e5512)

The following is an example of a wrong message, since it includes the legend that should be erased through this PR
![image](https://github.com/pagopa/pn-frontend/assets/5519535/3ff9c01e-e9e7-4229-bb93-73aa8ecfe8b5)



