### PR TITLE
Added checks for empty groups in API Keys

### DIFF
--- a/packages/pn-pa-webapp/src/components/ApiKeys/ApiKeyDataSwitch.tsx
+++ b/packages/pn-pa-webapp/src/components/ApiKeys/ApiKeyDataSwitch.tsx
@@ -123,13 +123,15 @@ const ApiKeyContextMenu = ({
             {t('context-menu.enable')}
           </MenuItem>
         )}
-        <MenuItem
-          id="button-view-groups-id"
-          data-testid="buttonViewGroupsId"
-          onClick={() => handleModalClick(ModalApiKeyView.VIEW_GROUPS_ID, apiKeyId)}
-        >
-          {t('context-menu.view-groups-id')}
-        </MenuItem>
+        {data.groups.length > 0 && (
+          <MenuItem
+            id="button-view-groups-id"
+            data-testid="buttonViewGroupsId"
+            onClick={() => handleModalClick(ModalApiKeyView.VIEW_GROUPS_ID, apiKeyId)}
+          >
+            {t('context-menu.view-groups-id')}
+          </MenuItem>
+        )}
       </Menu>
     </Box>
   );
@@ -183,33 +185,37 @@ const ApiKeyDataSwitch: React.FC<{
   if (type === 'groups') {
     return (
       <Box sx={{ display: 'flex', alignItems: 'center' }}>
-        <CustomTooltip
-          openOnClick={false}
-          tooltipContent={
-            <Box sx={{ textAlign: 'left' }}>
-              {data.groups.map((v) => (
-                <Box key={`tooltip_${v.id}`} sx={{ fontWeight: 'normal' }}>
-                  <strong>Group ID</strong> {v.id}
+        {data.groups.length > 0 && (
+          <>
+            <CustomTooltip
+              openOnClick={false}
+              tooltipContent={
+                <Box sx={{ textAlign: 'left' }}>
+                  {data.groups.map((v) => (
+                    <Box key={`tooltip_${v.id}`} sx={{ fontWeight: 'normal' }}>
+                      <strong>Group ID</strong> {v.id}
+                    </Box>
+                  ))}
                 </Box>
-              ))}
-            </Box>
-          }
-        >
-          <Box>
-            <CustomTagGroup visibleItems={3} disableTooltip>
-              {data.groups.map((v, i) => (
-                <Box key={i} sx={{ my: 1 }}>
-                  <Tag value={v.name} />
-                </Box>
-              ))}
-            </CustomTagGroup>
-          </Box>
-        </CustomTooltip>
-        <CopyToClipboardButton
-          data-testid="copyToClipboardGroupsId"
-          tooltipTitle={t('groups-id-copied')}
-          value={() => data.groups.map((g) => g.id).join(',') || ''}
-        />
+              }
+            >
+              <Box>
+                <CustomTagGroup visibleItems={3} disableTooltip>
+                  {data.groups.map((v, i) => (
+                    <Box key={i} sx={{ my: 1 }}>
+                      <Tag value={v.name} />
+                    </Box>
+                  ))}
+                </CustomTagGroup>
+              </Box>
+            </CustomTooltip>
+            <CopyToClipboardButton
+              data-testid="copyToClipboardGroupsId"
+              tooltipTitle={t('groups-id-copied')}
+              value={() => data.groups.map((g) => g.id).join(',') || ''}
+            />
+          </>
+        )}
       </Box>
     );
   }

--- a/packages/pn-pa-webapp/src/components/ApiKeys/__test__/ApiKeyDataSwitch.test.tsx
+++ b/packages/pn-pa-webapp/src/components/ApiKeys/__test__/ApiKeyDataSwitch.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { formatDate } from '@pagopa-pn/pn-commons';
 
 import { mockApiKeysForFE } from '../../../__mocks__/ApiKeys.mock';
-import { render } from '../../../__test__/test-utils';
+import { fireEvent, render, waitFor } from '../../../__test__/test-utils';
 import { getApiKeyStatusInfos } from '../../../utility/apikeys.utility';
 import ApiKeyDataSwitch from '../ApiKeyDataSwitch';
 
@@ -17,14 +17,20 @@ jest.mock('react-i18next', () => ({
 const data = mockApiKeysForFE.items[0];
 
 describe('ApiKeyDataSwitch Component', () => {
+  const mockClick = jest.fn();
+
   it('renders component - name', () => {
-    const { container } = render(<ApiKeyDataSwitch data={data} type="name" />);
+    const { container } = render(
+      <ApiKeyDataSwitch handleModalClick={mockClick} data={data} type="name" />
+    );
     const regexp = new RegExp(`^${data.name}$`, 'ig');
     expect(container).toHaveTextContent(regexp);
   });
 
   it('renders component - value', () => {
-    const { container, getByTestId } = render(<ApiKeyDataSwitch data={data} type="value" />);
+    const { container, getByTestId } = render(
+      <ApiKeyDataSwitch handleModalClick={mockClick} data={data} type="value" />
+    );
     const regexp = new RegExp(`^${data.value.substring(0, 10)}...$`, 'ig');
     expect(container).toHaveTextContent(regexp);
     const clipboard = getByTestId('copyToClipboard');
@@ -32,13 +38,17 @@ describe('ApiKeyDataSwitch Component', () => {
   });
 
   it('renders component - lastUpdate', () => {
-    const { container } = render(<ApiKeyDataSwitch data={data} type="lastUpdate" />);
+    const { container } = render(
+      <ApiKeyDataSwitch handleModalClick={mockClick} data={data} type="lastUpdate" />
+    );
     const regexp = new RegExp(`^${formatDate(data.lastUpdate)}$`, 'ig');
     expect(container).toHaveTextContent(regexp);
   });
 
-  it.only('renders component - groups', () => {
-    const { container, getByTestId } = render(<ApiKeyDataSwitch data={data} type="groups" />);
+  it('renders component - groups', () => {
+    const { container, getByTestId } = render(
+      <ApiKeyDataSwitch handleModalClick={mockClick} data={data} type="groups" />
+    );
     const groupsString =
       data.groups.length > 3
         ? data.groups
@@ -54,16 +64,54 @@ describe('ApiKeyDataSwitch Component', () => {
     expect(clipboard).toBeInTheDocument();
   });
 
+  it('renders component - no groups', () => {
+    const dataWithNoGroups = {
+      ...data,
+      groups: [],
+    };
+
+    const { queryByTestId } = render(
+      <ApiKeyDataSwitch handleModalClick={mockClick} data={dataWithNoGroups} type="groups" />
+    );
+    const clipboard = queryByTestId('copyToClipboardGroupsId');
+    expect(clipboard).not.toBeInTheDocument();
+  });
+
   it('renders component - status', () => {
     const { label } = getApiKeyStatusInfos(data.status, data.statusHistory);
-    const { container } = render(<ApiKeyDataSwitch data={data} type="status" />);
+    const { container } = render(
+      <ApiKeyDataSwitch handleModalClick={mockClick} data={data} type="status" />
+    );
     const regexp = new RegExp(`^${label}$`, 'ig');
     expect(container).toHaveTextContent(regexp);
   });
 
-  it('renders component - contextMenu', () => {
-    const { getByTestId } = render(<ApiKeyDataSwitch data={data} type="contextMenu" />);
-    const contextMenu = getByTestId('contextMenu');
+  it('renders component - contextMenu', async () => {
+    const { getByTestId } = render(
+      <ApiKeyDataSwitch handleModalClick={mockClick} data={data} type="contextMenu" />
+    );
+    const contextMenu = getByTestId('contextMenuButton');
     expect(contextMenu).toBeInTheDocument();
+    fireEvent.click(contextMenu);
+    const viewGroupsId = getByTestId('buttonViewGroupsId');
+    expect(viewGroupsId).toBeInTheDocument();
+    fireEvent.click(viewGroupsId);
+    expect(mockClick).toBeCalledTimes(1);
+  });
+
+  it('renders component - contextMenu no groups', async () => {
+    const dataWithNoGroups = {
+      ...data,
+      groups: [],
+    };
+
+    const { getByTestId, queryByTestId } = render(
+      <ApiKeyDataSwitch handleModalClick={mockClick} data={dataWithNoGroups} type="contextMenu" />
+    );
+    const contextMenu = getByTestId('contextMenuButton');
+    expect(contextMenu).toBeInTheDocument();
+    await waitFor(() => fireEvent.click(contextMenu));
+    const viewGroupsId = queryByTestId('buttonViewGroupsId');
+    expect(viewGroupsId).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Short description
Added checks for empty groups in API Keys. It hide copy to clipboard button under status column and also hide view groups id item in contex menu when there are no groups.

## List of changes proposed in this pull request
- Edited ApiKeysDataSwitch
- Added new tests

## How to test
Login PA with user without groups (example: grossini, comune di Sappada, DEV). Copy to Clipboard button and view groups id should not be visible.