### PR TITLE
Fixed issue with non closing modal on edit groups

### DIFF
--- a/packages/pn-personagiuridica-webapp/src/components/Deleghe/DelegationsElements.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Deleghe/DelegationsElements.tsx
@@ -90,6 +90,11 @@ export const Menu: React.FC<Props> = ({ menuType, id, userLogged, row, onAction 
     setAnchorEl(null);
   };
 
+  const handleOpenUpdateModalClick = () => {
+    setShowUpdateModal(true);
+    setAnchorEl(null);
+  };
+
   const handleOpenVerificationCodeModal = () => {
     if (row?.name && row?.verificationCode) {
       setShowCodeModal(true);
@@ -155,6 +160,7 @@ export const Menu: React.FC<Props> = ({ menuType, id, userLogged, row, onAction 
           onAction(groups);
         }
       });
+    handleCloseAcceptModal();
   };
 
   useEffect(() => {
@@ -209,11 +215,7 @@ export const Menu: React.FC<Props> = ({ menuType, id, userLogged, row, onAction 
     if (row?.status === DelegationStatus.ACTIVE && groups.length) {
       // eslint-disable-next-line functional/immutable-data
       menuItems.push(
-        <MenuItem
-          id="update-delegation-button"
-          key="update"
-          onClick={() => setShowUpdateModal(true)}
-        >
+        <MenuItem id="update-delegation-button" key="update" onClick={handleOpenUpdateModalClick}>
           {t('deleghe.update')}
         </MenuItem>
       );


### PR DESCRIPTION
## Short description
Modal wich edits delegators groups won't close when you click Confirm. The PR aims to fix it.

## List of changes proposed in this pull request
- Fixed issue with non closing modal on edit groups in delegators
- Fixed also issue when context menu won't close when you click "Edit"

## How to test
Modal should close correctly now.