### PR TITLE
fix(PN-7003) and fix(PN-7004): update sentences for pf and pg in proxy page and modal

### DIFF
--- a/packages/pn-personafisica-webapp/public/locales/it/deleghe.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/deleghe.json
@@ -26,7 +26,7 @@
     "no_delegates": "Non hai delegato nessuno alla visualizzazione delle tue notifiche. <0>Aggiungi una delega</0>",
     "no_delegators": "Non hai deleghe a tuo carico.",
     "show_code_title": "Codice di verifica per la delega a {{name}}",
-    "show_code_subtitle": "Condividi questo codice con la persona delegata: dovrà inserirlo all’accettazione della delega.",
+    "show_code_subtitle": "Condividi questo codice con la persona delegata: dovrà inserirlo all’accettazione della delega. Il codice è valido per 7 giorni dalla creazione della richiesta di delega.",
     "verification_code": "Codice di verifica",
     "code_copied": "Codice copiato",
     "table": {
@@ -67,7 +67,7 @@
       "date-duration": "Periodo di validità della delega*",
       "endDate": "Termine delega",
       "verificationCode": "Codice di verifica",
-      "verificationCodeDescr": "Condividi questo codice con la persona delegata: dovrà inserirlo all’accettazione della delega.",
+      "verificationCodeDescr": "Condividi questo codice con la persona delegata: dovrà inserirlo all’accettazione della delega. Il codice è valido per 7 giorni dalla creazione della richiesta di delega.",
       "submit": "Invia la richiesta",
       "mandatoryField": "Campi obbligatori*",
       "party-not-found": "Nessun ente trovato"

--- a/packages/pn-personagiuridica-webapp/public/locales/it/deleghe.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/it/deleghe.json
@@ -29,7 +29,7 @@
     "no_delegators": "Non c'è nessuna delega a carico di {{organizationName}}.",
     "no_delegators_after_filters": "I filtri che hai aggiunto non hanno dato nessun risultato. <0>Rimuovi filtri</0>.",
     "show_code_title": "Codice di verifica per la delega a {{name}}",
-    "show_code_subtitle": "Condividi questo codice con la persona delegata: dovrà inserirlo all’accettazione della delega.",
+    "show_code_subtitle": "Condividi questo codice con la persona delegata: dovrà inserirlo all’accettazione della delega. Il codice è valido per 7 giorni dalla creazione della richiesta di delega.",
     "verification_code": "Codice di verifica",
     "code_copied": "Codice copiato",
     "tab_aria_label": "Tab deleghe",
@@ -99,7 +99,7 @@
       "date-duration": "Periodo di validità della delega*",
       "endDate": "Termine delega",
       "verificationCode": "Codice di verifica",
-      "verificationCodeDescr": "Condividi questo codice con la persona delegata: dovrà inserirlo all’accettazione della delega.",
+      "verificationCodeDescr": "Condividi questo codice con la persona delegata: dovrà inserirlo all’accettazione della delega. Il codice è valido per 7 giorni dalla creazione della richiesta di delega.",
       "submit": "Invia la richiesta",
       "mandatoryField": "Campi obbligatori*",
       "party-not-found": "Nessun ente trovato"


### PR DESCRIPTION
## Short description
Updated sentences in proxy creation page and modal for showing code in pf and pg

## List of changes proposed in this pull request
- Replaced “Condividi questo codice con la persona delegata: dovrà inserirlo all’accettazione della delega.” with “Condividi questo codice con la persona delegata: dovrà inserirlo all’accettazione della delega. Il codice è valido per 7 giorni dalla creazione della richiesta di delega.” in proxy creation page
- Replaced “Condividi questo codice con la persona delegata: dovrà inserirlo all’accettazione della delega.” with “Condividi questo codice con la persona delegata: dovrà inserirlo all’accettazione della delega. Il codice è valido per 7 giorni dalla creazione della richiesta di delega.” in modal for showing code

## How to test
Login with pf, go in "Deleghe" page and add new proxy. In the "Codice di verifica" box check if the sentence is “Condividi questo codice con la persona delegata: dovrà inserirlo all’accettazione della delega. Il codice è valido per 7 giorni dalla creazione della richiesta di delega.”.

Login with pg, go in "Deleghe" page and add new proxy. In the "Codice di verifica" box check if the sentence is “Condividi questo codice con la persona delegata: dovrà inserirlo all’accettazione della delega. Il codice è valido per 7 giorni dalla creazione della richiesta di delega.”.