### PR TITLE
PN-9541 - Logout from Privacy Policy page

### DIFF
--- a/packages/pn-personafisica-webapp/src/pages/PrivacyPolicy.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/PrivacyPolicy.page.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { compileOneTrustPath, useRewriteLinks, waitForElement } from '@pagopa-pn/pn-commons';
+import { compileOneTrustPath, useRewriteLinks } from '@pagopa-pn/pn-commons';
 
 import * as routes from '../navigation/routes.const';
 import { getConfiguration } from '../services/configuration.service';
@@ -25,15 +25,13 @@ const PrivacyPolicyPage = () => {
           [compileOneTrustPath(ONE_TRUST_PP, ONE_TRUST_DRAFT_MODE)],
           false
         );
+        setContentLoaded(true);
       });
     }
   }, []);
 
-  void waitForElement('.otnotice-content').then(() => {
-    setContentLoaded(true);
-  });
-
   useRewriteLinks(contentLoaded, routes.PRIVACY_POLICY, '.otnotice-content a');
+
   return (
     <>
       <div


### PR DESCRIPTION
## Short description
Fix logout from privacy policy page 

## List of changes proposed in this pull request
- Removed awaitForElement

## How to test
On PF go to privacy policy page ("Informativa privacy" link on footer) and try to logout from header 