### PR TITLE
chore: updated sonar-scanner version to include last sonar scanner sc…

### DIFF
--- a/packages/pn-commons/package.json
+++ b/packages/pn-commons/package.json
@@ -76,7 +76,7 @@
     "eslint-plugin-sonarjs": "^0.10.0",
     "jsdom": "^16.7.0",
     "prettier": "^2.4.1",
-    "sonarqube-scanner": "^3.0.0",
+    "sonarqube-scanner": "^3.3.0",
     "vite": "^4.5.0",
     "vitest": "0.34.6",
     "vitest-sonar-reporter": "0.5.0"

--- a/packages/pn-pa-webapp/package.json
+++ b/packages/pn-pa-webapp/package.json
@@ -86,7 +86,7 @@
     "eslint-plugin-sonarjs": "^0.10.0",
     "jest-axe": "^6.0.0",
     "prettier": "^2.4.1",
-    "sonarqube-scanner": "^3.0.0",
+    "sonarqube-scanner": "^3.3.0",
     "vite": "^4.5.0",
     "vitest": "0.34.6",
     "vitest-sonar-reporter": "0.5.0"

--- a/packages/pn-personafisica-login/package.json
+++ b/packages/pn-personafisica-login/package.json
@@ -75,7 +75,7 @@
     "eslint-plugin-react-hooks": "^4.3.0",
     "eslint-plugin-sonarjs": "^0.10.0",
     "prettier": "^2.4.1",
-    "sonarqube-scanner": "^3.0.0",
+    "sonarqube-scanner": "^3.3.0",
     "vite": "^4.5.0",
     "vitest": "0.34.6",
     "vitest-sonar-reporter": "0.5.0",

--- a/packages/pn-personafisica-webapp/package.json
+++ b/packages/pn-personafisica-webapp/package.json
@@ -90,7 +90,7 @@
     "eslint-plugin-sonarjs": "^0.10.0",
     "jest-axe": "^6.0.0",
     "prettier": "^2.4.1",
-    "sonarqube-scanner": "^3.0.0",
+    "sonarqube-scanner": "^3.3.0",
     "vite": "^4.5.0",
     "vitest": "0.34.6",
     "vitest-sonar-reporter": "0.5.0"

--- a/packages/pn-personagiuridica-webapp/package.json
+++ b/packages/pn-personagiuridica-webapp/package.json
@@ -90,7 +90,7 @@
     "eslint-plugin-sonarjs": "^0.10.0",
     "jest-axe": "^6.0.0",
     "prettier": "^2.4.1",
-    "sonarqube-scanner": "^3.0.0",
+    "sonarqube-scanner": "^3.3.0",
     "vite": "^4.5.0",
     "vitest": "0.34.6",
     "vitest-sonar-reporter": "0.5.0"

--- a/packages/pn-validator/package.json
+++ b/packages/pn-validator/package.json
@@ -27,7 +27,7 @@
     "eslint-plugin-functional": "^3.7.2",
     "eslint-plugin-import": "^2.25.3",
     "eslint-plugin-sonarjs": "^0.10.0",
-    "sonarqube-scanner": "^3.0.0",
+    "sonarqube-scanner": "^3.3.0",
     "vitest": "0.34.6",
     "vitest-sonar-reporter": "0.5.0"
   }


### PR DESCRIPTION
Since release 3.1.0 sonarqube-scanner [https://github.com/SonarSource/sonar-scanner-npm/releases](https://github.com/SonarSource/sonar-scanner-npm/releases) has updated java version used to compile sonar scanner script.