### PR TITLE
feat: added new version segment for notification detail and creation API

### DIFF
--- a/packages/pn-pa-webapp/src/api/notifications/__test__/notifications.routes.test.ts
+++ b/packages/pn-pa-webapp/src/api/notifications/__test__/notifications.routes.test.ts
@@ -29,7 +29,7 @@ describe('Notifications routes', () => {
 
   it('should compile NOTIFICATION_DETAIL', () => {
     const route = NOTIFICATION_DETAIL('mocked-iun');
-    expect(route).toEqual('/delivery/v2.1/notifications/sent/mocked-iun');
+    expect(route).toEqual('/delivery/v2.3/notifications/sent/mocked-iun');
   });
 
   it('should compile NOTIFICATION_DETAIL_DOCUMENTS', () => {
@@ -65,7 +65,7 @@ describe('Notifications routes', () => {
 
   it('should compile CREATE_NOTIFICATION', () => {
     const route = CREATE_NOTIFICATION();
-    expect(route).toEqual('/delivery/v2.1/requests');
+    expect(route).toEqual('/delivery/v2.3/requests');
   });
 
   it('should compile NOTIFICATION_PAYMENT_ATTACHMENT', () => {

--- a/packages/pn-pa-webapp/src/api/notifications/notifications.routes.ts
+++ b/packages/pn-pa-webapp/src/api/notifications/notifications.routes.ts
@@ -28,8 +28,6 @@ const API_NOTIFICATIONS_REQUESTS = 'requests';
 const API_NOTIFICATIONS_PA = 'pa';
 const API_VERSION_SEGMENT = 'v1';
 const API_VERSION_SEGMENT_2_0 = 'v2.0';
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const API_VERSION_SEGMENT_2_1 = 'v2.1';
 const API_VERSION_SEGMENT_2_3 = 'v2.3';
 const API_NOTIFICATIONS_GROUPS = 'groups';
 const API_NOTIFICATIONS_PAYMENT = 'payment';

--- a/packages/pn-pa-webapp/src/api/notifications/notifications.routes.ts
+++ b/packages/pn-pa-webapp/src/api/notifications/notifications.routes.ts
@@ -28,7 +28,9 @@ const API_NOTIFICATIONS_REQUESTS = 'requests';
 const API_NOTIFICATIONS_PA = 'pa';
 const API_VERSION_SEGMENT = 'v1';
 const API_VERSION_SEGMENT_2_0 = 'v2.0';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const API_VERSION_SEGMENT_2_1 = 'v2.1';
+const API_VERSION_SEGMENT_2_3 = 'v2.3';
 const API_NOTIFICATIONS_GROUPS = 'groups';
 const API_NOTIFICATIONS_PAYMENT = 'payment';
 
@@ -86,7 +88,7 @@ export function NOTIFICATION_DETAIL(iun: string) {
   return compileRoute({
     prefix: API_DELIVERY_PREFIX,
     path: API_NOTIFICATION_DETAIL_PATH,
-    version: API_VERSION_SEGMENT_2_1,
+    version: API_VERSION_SEGMENT_2_3,
     params: {
       [API_NOTIFICATIONS_IUN_PARAMETER]: iun,
     },
@@ -151,7 +153,7 @@ export function NOTIFICATION_PRELOAD_DOCUMENT() {
 export function CREATE_NOTIFICATION() {
   return compileRoute({
     prefix: API_DELIVERY_PREFIX,
-    version: API_VERSION_SEGMENT_2_1,
+    version: API_VERSION_SEGMENT_2_3,
     path: API_NOTIFICATIONS_REQUESTS,
   });
 }

--- a/packages/pn-personafisica-webapp/src/api/notifications/__test__/notifications.routes.test.ts
+++ b/packages/pn-personafisica-webapp/src/api/notifications/__test__/notifications.routes.test.ts
@@ -27,7 +27,7 @@ describe('Notifications routes', () => {
 
   it('should compile NOTIFICATION_DETAIL', () => {
     const route = NOTIFICATION_DETAIL('mocked-iun');
-    expect(route).toEqual('/delivery/v2.1/notifications/received/mocked-iun');
+    expect(route).toEqual('/delivery/v2.3/notifications/received/mocked-iun');
   });
 
   it('should compile NOTIFICATION_DETAIL_DOCUMENTS', () => {

--- a/packages/pn-personafisica-webapp/src/api/notifications/notifications.routes.ts
+++ b/packages/pn-personafisica-webapp/src/api/notifications/notifications.routes.ts
@@ -16,6 +16,7 @@ const API_EXTERNAL_REGISTRY_PREFIX = 'ext-registry';
 // Segments
 const API_VERSION_SEGMENT = 'v1';
 const API_VERSION_V2_1_SEGMENT = 'v2.1';
+const API_VERSION_V2_3_SEGMENT = 'v2.3';
 const API_NOTIFICATIONS_BASE = 'notifications';
 const API_NOTIFICATIONS_RECEIVED = 'received';
 const API_NOTIFICATIONS_DOCUMENTS = 'documents';
@@ -81,7 +82,7 @@ export function NOTIFICATIONS_LIST(params: GetNotificationsParams<string>) {
 export function NOTIFICATION_DETAIL(iun: string, mandateId?: string) {
   return compileRoute({
     prefix: API_DELIVERY_PREFIX,
-    version: API_VERSION_V2_1_SEGMENT,
+    version: API_VERSION_V2_3_SEGMENT,
     path: API_NOTIFICATION_DETAIL_PATH,
     params: {
       [API_NOTIFICATIONS_IUN_PARAMETER]: iun,

--- a/packages/pn-personagiuridica-webapp/src/api/notifications/__test__/notifications.routes.test.ts
+++ b/packages/pn-personagiuridica-webapp/src/api/notifications/__test__/notifications.routes.test.ts
@@ -41,7 +41,7 @@ describe('Notifications routes', () => {
 
   it('should compile NOTIFICATION_DETAIL', () => {
     const route = NOTIFICATION_DETAIL('mocked-iun');
-    expect(route).toEqual('/delivery/v2.1/notifications/received/mocked-iun');
+    expect(route).toEqual('/delivery/v2.3/notifications/received/mocked-iun');
   });
 
   it('should compile NOTIFICATION_DETAIL_DOCUMENTS', () => {

--- a/packages/pn-personagiuridica-webapp/src/api/notifications/notifications.routes.ts
+++ b/packages/pn-personagiuridica-webapp/src/api/notifications/notifications.routes.ts
@@ -14,6 +14,7 @@ const API_EXTERNAL_REGISTRY_PREFIX = 'ext-registry';
 // Segments
 const API_VERSION_SEGMENT = 'v1';
 const API_VERSION_V2_1_SEGMENT = 'v2.1';
+const API_VERSION_V2_3_SEGMENT = 'v2.3';
 const API_NOTIFICATIONS_BASE = 'notifications';
 const API_NOTIFICATIONS_RECEIVED = 'received';
 const API_NOTIFICATIONS_DELEGATED = 'delegated';
@@ -82,7 +83,7 @@ export function NOTIFICATIONS_LIST(params: GetNotificationsParams<string>, deleg
 export function NOTIFICATION_DETAIL(iun: string, mandateId?: string) {
   return compileRoute({
     prefix: API_DELIVERY_PREFIX,
-    version: API_VERSION_V2_1_SEGMENT,
+    version: API_VERSION_V2_3_SEGMENT,
     path: API_NOTIFICATION_DETAIL_PATH,
     params: {
       [API_NOTIFICATIONS_IUN_PARAMETER]: iun,


### PR DESCRIPTION
## Short description
Changed API version from 2.1 to 2.3 for notification detail and notification request for PA, PF, PG

## How to test
Access as PA sender and:
- try to read a notification (single recipient, cancelled, with payments)
- try to create a new notification

Access as PF or PG:
- try to read a notification (single recipient, cancelled, with payments, as delegate)