### PR TITLE
chore: fixes on payment caching

### DIFF
--- a/packages/pn-commons/src/models/NotificationDetail.ts
+++ b/packages/pn-commons/src/models/NotificationDetail.ts
@@ -126,6 +126,7 @@ export interface PrepareAnalogDomicileFailureDetails extends BaseDetails {
 
 interface BaseDetails {
   recIndex?: number;
+  eventTimestamp?: string;
 }
 
 interface DelegateInfo {
@@ -219,7 +220,6 @@ export interface PaidDetails extends BaseDetails {
   creditorTaxId: string;
   noticeCode: string;
   uncertainPaymentDate?: boolean;
-  eventTimestamp?: string;
 }
 
 // PN-1647

--- a/packages/pn-commons/src/models/NotificationDetail.ts
+++ b/packages/pn-commons/src/models/NotificationDetail.ts
@@ -219,6 +219,7 @@ export interface PaidDetails extends BaseDetails {
   creditorTaxId: string;
   noticeCode: string;
   uncertainPaymentDate?: boolean;
+  eventTimestamp?: string;
 }
 
 // PN-1647

--- a/packages/pn-commons/src/models/PaymentCache.ts
+++ b/packages/pn-commons/src/models/PaymentCache.ts
@@ -83,6 +83,7 @@ const pagoPaSchema: yup.SchemaOf<PagoPAPaymentFullDetails> = yup
     url: yup.string().optional(),
     recIndex: yup.number().optional(),
     uncertainPaymentDate: yup.boolean().optional(),
+    eventTimestamp: yup.string().optional(),
   })
   .noUnknown(true);
 

--- a/packages/pn-personafisica-webapp/src/redux/notification/actions.ts
+++ b/packages/pn-personafisica-webapp/src/redux/notification/actions.ts
@@ -135,7 +135,7 @@ export const getNotificationPaymentInfo = createAsyncThunk<
             updatedPayment
           );
           setPaymentsInCache(payments, iun);
-          return paymentCache.payments;
+          return payments;
         }
 
         // If all the payments are already in cache i can return them

--- a/packages/pn-personagiuridica-webapp/src/redux/notification/actions.ts
+++ b/packages/pn-personagiuridica-webapp/src/redux/notification/actions.ts
@@ -130,7 +130,7 @@ export const getNotificationPaymentInfo = createAsyncThunk<
             updatedPayment
           );
           setPaymentsInCache(payments, iun);
-          return paymentCache.payments;
+          return payments;
         }
 
         // If all the payments are already in cache i can return them


### PR DESCRIPTION
## Short description
Added `eventTimestamp` to paymentCache validation schema. This property came from timeline.

## List of changes proposed in this pull request
- Changed validation schema
- Changed return statement on redux 

## How to test
When opening a notification you should't see warning about cache validation. 
To test the return, you should pay a notice and when you return on SEND you should see the notice updated