### PR TITLE
feat/PN-9684: implemented alert in notificationDetail for alternative-RADD

### DIFF
--- a/packages/pn-commons/src/__mocks__/NotificationDetail.mock.ts
+++ b/packages/pn-commons/src/__mocks__/NotificationDetail.mock.ts
@@ -665,12 +665,59 @@ export const notificationDTOMultiRecipient: NotificationDetail = {
   timeline,
 };
 
+export const notificationDTORadd: NotificationDetail = {
+  abstract: 'Abstract della notifica',
+  paProtocolNumber: '302011692956029071',
+  subject: 'notifica analogica con cucumber',
+  recipients,
+  documents: [
+    {
+      title: 'Document 0',
+      digests: {
+        sha256: 'jezIVxlG1M1woCSUngM6KipUN3/p8cG5RMIPnuEanlE=',
+      },
+      contentType: 'application/pdf',
+      ref: {
+        key: 'PN_NOTIFICATION_ATTACHMENTS-abb7804b6e442c8b2223648af970cd1.pdf',
+        versionToken: 'v1',
+      },
+      docIdx: '0',
+    },
+  ],
+  notificationFeePolicy: NotificationFeePolicy.FLAT_RATE,
+  physicalCommunicationType: PhysicalCommunicationType.AR_REGISTERED_LETTER,
+  senderDenomination: 'Comune di palermo',
+  senderTaxId: '80016350821',
+  group: '000',
+  senderPaId: '5b994d4a-0fa8-47ac-9c7b-354f1d44a1ce',
+  iun: 'RTRD-UDGU-QTQY-202308-P-1',
+  sentAt: '2023-08-25T09:33:58.709695008Z',
+  documentsAvailable: true,
+  notificationStatus: NotificationStatus.EFFECTIVE_DATE,
+  notificationStatusHistory,
+  timeline: [
+    {
+      elementId: 'NOTIFICATION_RADD_RETRIEVED_mock',
+      timestamp: '2022-06-21T11:44:28Z',
+      legalFactsIds: [],
+      category: TimelineCategory.NOTIFICATION_RADD_RETRIEVED,
+      details: {
+        recIndex: 1,
+        eventTimestamp: '2022-06-21T11:44:28Z',
+        raddType: 'ALT',
+        raddTransactionId: '6',
+      },
+    },
+  ],
+};
+
 export const notificationDTO = getOneRecipientNotification();
 
 export const notificationToFe = parseNotificationDetail(_.cloneDeep(notificationDTO));
 export const notificationToFeMultiRecipient = parseNotificationDetail(
   _.cloneDeep(notificationDTOMultiRecipient)
 );
+export const notificationToFeRadd = parseNotificationDetail(_.cloneDeep(notificationDTORadd));
 
 export const getTimelineElem = (
   category: TimelineCategory,

--- a/packages/pn-commons/src/__mocks__/NotificationDetail.mock.ts
+++ b/packages/pn-commons/src/__mocks__/NotificationDetail.mock.ts
@@ -696,6 +696,7 @@ export const notificationDTORadd: NotificationDetail = {
   notificationStatus: NotificationStatus.EFFECTIVE_DATE,
   notificationStatusHistory,
   timeline: [
+    ...timeline,
     {
       elementId: 'NOTIFICATION_RADD_RETRIEVED_mock',
       timestamp: '2022-06-21T11:44:28Z',

--- a/packages/pn-commons/src/models/NotificationDetail.ts
+++ b/packages/pn-commons/src/models/NotificationDetail.ts
@@ -26,7 +26,7 @@ export interface NotificationDetail {
   notificationStatusHistory: Array<NotificationStatusHistory>;
   timeline: Array<INotificationDetailTimeline>;
   amount?: number;
-  radd: boolean; // da definire
+  radd?: boolean; // da definire
 
   // only fe
   otherDocuments?: Array<NotificationDetailDocument>;

--- a/packages/pn-commons/src/models/NotificationDetail.ts
+++ b/packages/pn-commons/src/models/NotificationDetail.ts
@@ -26,6 +26,8 @@ export interface NotificationDetail {
   notificationStatusHistory: Array<NotificationStatusHistory>;
   timeline: Array<INotificationDetailTimeline>;
   amount?: number;
+  radd: boolean; // da definire
+
   // only fe
   otherDocuments?: Array<NotificationDetailDocument>;
 }

--- a/packages/pn-commons/src/models/NotificationDetail.ts
+++ b/packages/pn-commons/src/models/NotificationDetail.ts
@@ -26,7 +26,7 @@ export interface NotificationDetail {
   notificationStatusHistory: Array<NotificationStatusHistory>;
   timeline: Array<INotificationDetailTimeline>;
   amount?: number;
-  radd?: boolean; // da definire
+  radd?: INotificationDetailTimeline;
 
   // only fe
   otherDocuments?: Array<NotificationDetailDocument>;
@@ -62,6 +62,7 @@ export type NotificationDetailTimelineDetails =
   | SendDigitalDetails
   | SendPaperDetails
   | PaidDetails
+  | RaddDetails
   // PN-1647
   | NotHandledDetails;
 
@@ -224,6 +225,13 @@ export interface PaidDetails extends BaseDetails {
   uncertainPaymentDate?: boolean;
 }
 
+export interface RaddDetails extends BaseDetails {
+  recIndex?: number;
+  eventTimestamp?: string;
+  raddType?: string;
+  raddTransactionId?: string;
+}
+
 // PN-1647
 export interface NotHandledDetails extends BaseDetails {
   reasonCode: string;
@@ -359,6 +367,8 @@ export enum TimelineCategory {
   AAR_GENERATION = 'AAR_GENERATION',
   NOTIFICATION_CANCELLATION_REQUEST = 'NOTIFICATION_CANCELLATION_REQUEST',
   NOTIFICATION_CANCELLED = 'NOTIFICATION_CANCELLED',
+  // PN-9684
+  NOTIFICATION_RADD_RETRIEVED = 'NOTIFICATION_RADD_RETRIEVED',
 }
 
 interface DigitalAddress {

--- a/packages/pn-commons/src/utility/__test__/notification.utility.test.ts
+++ b/packages/pn-commons/src/utility/__test__/notification.utility.test.ts
@@ -7,6 +7,7 @@ import {
   notificationDTOMultiRecipient,
   notificationToFe,
   notificationToFeMultiRecipient,
+  notificationToFeRadd,
   payments,
 } from '../../__mocks__/NotificationDetail.mock';
 import {
@@ -34,6 +35,7 @@ import { initLocalizationForTest } from '../../test-utils';
 import { initLocalization } from '../../utility';
 import { TimelineStepFactory } from '../TimelineUtils/TimelineStepFactory';
 import {
+  checkRaddInTimeline,
   getF24Payments,
   getLegalFactLabel,
   getNotificationStatusInfos,
@@ -1040,6 +1042,29 @@ describe('parse notification & filters', () => {
         (viewedElement.details as ViewedDetails).delegateInfo!.taxId
       })`
     );
+  });
+
+  it.only('return radd timeline element when radd is present in timeline', () => {
+    const raddElement = {
+      elementId: 'NOTIFICATION_RADD_RETRIEVED_mock',
+      timestamp: '2022-06-21T11:44:28Z',
+      legalFactsIds: [],
+      category: TimelineCategory.NOTIFICATION_RADD_RETRIEVED,
+      details: {
+        recIndex: 1,
+        eventTimestamp: '2022-06-21T11:44:28Z',
+        raddType: 'ALT',
+        raddTransactionId: '6',
+      },
+    };
+    const raddFromTimeline = checkRaddInTimeline(notificationToFeRadd);
+    console.log('........................................');
+    console.log(raddElement);
+    console.log('........................................');
+    console.log(raddFromTimeline);
+    console.log('........................................');
+    expect(raddElement).toStrictEqual(raddFromTimeline);
+    // expect(raddFromTimeline).toStrictEqual(raddElement);
   });
 });
 

--- a/packages/pn-commons/src/utility/__test__/notification.utility.test.ts
+++ b/packages/pn-commons/src/utility/__test__/notification.utility.test.ts
@@ -7,6 +7,7 @@ import {
   notificationDTOMultiRecipient,
   notificationToFe,
   notificationToFeMultiRecipient,
+  notificationToFeRadd,
   payments,
 } from '../../__mocks__/NotificationDetail.mock';
 import {
@@ -1042,22 +1043,22 @@ describe('parse notification & filters', () => {
     );
   });
 
-  // it('return radd timeline element when radd is present in timeline', () => {
-  //   const raddElement = {
-  //     elementId: 'NOTIFICATION_RADD_RETRIEVED_mock',
-  //     timestamp: '2022-06-21T11:44:28Z',
-  //     legalFactsIds: [],
-  //     category: TimelineCategory.NOTIFICATION_RADD_RETRIEVED,
-  //     details: {
-  //       recIndex: 1,
-  //       eventTimestamp: '2022-06-21T11:44:28Z',
-  //       raddType: 'ALT',
-  //       raddTransactionId: '6',
-  //     },
-  //   };
-  //   const raddFromTimeline = checkRaddInTimeline(notificationToFeRadd);
-  //   expect(raddElement).toStrictEqual(raddFromTimeline);
-  // });
+  it('return radd timeline element when radd is present in timeline', () => {
+    const raddElement = {
+      elementId: 'NOTIFICATION_RADD_RETRIEVED_mock',
+      timestamp: '2022-06-21T11:44:28Z',
+      legalFactsIds: [],
+      category: TimelineCategory.NOTIFICATION_RADD_RETRIEVED,
+      details: {
+        recIndex: 1,
+        eventTimestamp: '2022-06-21T11:44:28Z',
+        raddType: 'ALT',
+        raddTransactionId: '6',
+      },
+    };
+    const raddFromTimeline = notificationToFeRadd.radd;
+    expect(raddElement).toStrictEqual(raddFromTimeline);
+  });
 });
 
 describe('Populate pagoPA and F24 payments', () => {

--- a/packages/pn-commons/src/utility/__test__/notification.utility.test.ts
+++ b/packages/pn-commons/src/utility/__test__/notification.utility.test.ts
@@ -7,7 +7,6 @@ import {
   notificationDTOMultiRecipient,
   notificationToFe,
   notificationToFeMultiRecipient,
-  notificationToFeRadd,
   payments,
 } from '../../__mocks__/NotificationDetail.mock';
 import {
@@ -35,7 +34,6 @@ import { initLocalizationForTest } from '../../test-utils';
 import { initLocalization } from '../../utility';
 import { TimelineStepFactory } from '../TimelineUtils/TimelineStepFactory';
 import {
-  checkRaddInTimeline,
   getF24Payments,
   getLegalFactLabel,
   getNotificationStatusInfos,
@@ -1044,28 +1042,22 @@ describe('parse notification & filters', () => {
     );
   });
 
-  it.only('return radd timeline element when radd is present in timeline', () => {
-    const raddElement = {
-      elementId: 'NOTIFICATION_RADD_RETRIEVED_mock',
-      timestamp: '2022-06-21T11:44:28Z',
-      legalFactsIds: [],
-      category: TimelineCategory.NOTIFICATION_RADD_RETRIEVED,
-      details: {
-        recIndex: 1,
-        eventTimestamp: '2022-06-21T11:44:28Z',
-        raddType: 'ALT',
-        raddTransactionId: '6',
-      },
-    };
-    const raddFromTimeline = checkRaddInTimeline(notificationToFeRadd);
-    console.log('........................................');
-    console.log(raddElement);
-    console.log('........................................');
-    console.log(raddFromTimeline);
-    console.log('........................................');
-    expect(raddElement).toStrictEqual(raddFromTimeline);
-    // expect(raddFromTimeline).toStrictEqual(raddElement);
-  });
+  // it('return radd timeline element when radd is present in timeline', () => {
+  //   const raddElement = {
+  //     elementId: 'NOTIFICATION_RADD_RETRIEVED_mock',
+  //     timestamp: '2022-06-21T11:44:28Z',
+  //     legalFactsIds: [],
+  //     category: TimelineCategory.NOTIFICATION_RADD_RETRIEVED,
+  //     details: {
+  //       recIndex: 1,
+  //       eventTimestamp: '2022-06-21T11:44:28Z',
+  //       raddType: 'ALT',
+  //       raddTransactionId: '6',
+  //     },
+  //   };
+  //   const raddFromTimeline = checkRaddInTimeline(notificationToFeRadd);
+  //   expect(raddElement).toStrictEqual(raddFromTimeline);
+  // });
 });
 
 describe('Populate pagoPA and F24 payments', () => {

--- a/packages/pn-commons/src/utility/index.ts
+++ b/packages/pn-commons/src/utility/index.ts
@@ -28,6 +28,7 @@ import { IUN_regex, formatIun } from './iun.utility';
 import { lazyRetry } from './lazyRetry.utility';
 import { initLocalization } from './localization.utility';
 import {
+  checkRaddInTimeline,
   getF24Payments,
   getLegalFactLabel,
   getNotificationAllowedStatus,
@@ -124,4 +125,5 @@ export {
   PAYMENT_CACHE_KEY,
   rewriteLinks,
   dateIsLessThan10Years,
+  checkRaddInTimeline,
 };

--- a/packages/pn-commons/src/utility/notification.utility.ts
+++ b/packages/pn-commons/src/utility/notification.utility.ts
@@ -866,6 +866,11 @@ const populateOtherDocuments = (
   return [];
 };
 
+export const checkRaddInTimeline = (notificationDetail: NotificationDetail) =>
+  notificationDetail.timeline.find(
+    (element) => element.category === TimelineCategory.NOTIFICATION_RADD_RETRIEVED
+  );
+
 export const getF24Payments = (
   payments: Array<NotificationDetailPayment>,
   recIndex: number,
@@ -1021,14 +1026,13 @@ const insertCancelledStatusInTimeline = (notificationDetail: NotificationDetail)
     }
   }
 };
-
 export function parseNotificationDetail(
   notificationDetail: NotificationDetail
 ): NotificationDetail {
   const parsedNotification = {
     ...notificationDetail,
     otherDocuments: populateOtherDocuments(notificationDetail),
-    radd: true,
+    radd: checkRaddInTimeline(notificationDetail),
   };
   insertCancelledStatusInTimeline(parsedNotification);
   /* eslint-disable functional/immutable-data */

--- a/packages/pn-commons/src/utility/notification.utility.ts
+++ b/packages/pn-commons/src/utility/notification.utility.ts
@@ -1034,6 +1034,7 @@ export function parseNotificationDetail(
     otherDocuments: populateOtherDocuments(notificationDetail),
     radd: checkRaddInTimeline(notificationDetail),
   };
+
   insertCancelledStatusInTimeline(parsedNotification);
   /* eslint-disable functional/immutable-data */
   /* eslint-disable functional/no-let */

--- a/packages/pn-commons/src/utility/notification.utility.ts
+++ b/packages/pn-commons/src/utility/notification.utility.ts
@@ -1028,6 +1028,7 @@ export function parseNotificationDetail(
   const parsedNotification = {
     ...notificationDetail,
     otherDocuments: populateOtherDocuments(notificationDetail),
+    radd: true,
   };
   insertCancelledStatusInTimeline(parsedNotification);
   /* eslint-disable functional/immutable-data */

--- a/packages/pn-pa-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/it/notifiche.json
@@ -306,7 +306,8 @@
       },
       "radd": {
         "title": "I documenti sono stati ritirati",
-        "description": "Il destinatario o un suo delegato ha ritirato i documenti notificati presso un operatore abilitato alla consegna degli stessi."
+        "description-mono-recipient": "Il destinatario o un suo delegato ha ritirato i documenti notificati presso un operatore abilitato alla consegna degli stessi.",
+        "description-multi-recipients": "Uno dei destinatari o un suo delegato ha ritirato i documenti notificati presso un operatore abilitato alla consegna degli stessi."
       }
     },
     "downtimes": {

--- a/packages/pn-pa-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/it/notifiche.json
@@ -303,6 +303,10 @@
         "F02": "per smarrimento della busta",
         "F03": "per deterioramento della busta",
         "F04": "per rapina della busta"
+      },
+      "radd": {
+        "title": "I documenti sono stati ritirati",
+        "description": "Il destinatario o un suo delegato ha ritirato i documenti notificati presso un operatore abilitato alla consegna degli stessi."
       }
     },
     "downtimes": {

--- a/packages/pn-pa-webapp/src/__mocks__/NotificationDetail.mock.ts
+++ b/packages/pn-pa-webapp/src/__mocks__/NotificationDetail.mock.ts
@@ -645,3 +645,22 @@ export const notificationToFe = parseNotificationDetail(_.cloneDeep(notification
 export const notificationToFeMultiRecipient = parseNotificationDetail(
   _.cloneDeep(notificationDTOMultiRecipient)
 );
+
+export const raddNotificationDTO: NotificationDetail = {
+  ...notificationDTO,
+  timeline: [
+    ...notificationDTO.timeline,
+    {
+      elementId: 'NOTIFICATION_RADD_RETRIEVED_mock',
+      timestamp: '2022-06-21T11:44:28Z',
+      legalFactsIds: [],
+      category: TimelineCategory.NOTIFICATION_RADD_RETRIEVED,
+      details: {
+        recIndex: 1,
+        eventTimestamp: '2022-06-21T11:44:28Z',
+        raddType: 'ALT',
+        raddTransactionId: '6',
+      },
+    },
+  ],
+};

--- a/packages/pn-pa-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/NotificationDetail.page.tsx
@@ -314,12 +314,20 @@ const NotificationDetail: React.FC = () => {
                     downloadFilesMessage={getDownloadFilesMessage('attachments')}
                     downloadFilesLink={t('detail.download-files-link', { ns: 'notifiche' })}
                   />
-                  {notification.radd && (
+                  {notification.radd && notification.recipients.length === 1 && (
                     <Alert severity={'success'} sx={{ mb: 3, mt: 2 }} data-testid="raddAlert">
                       <AlertTitle>
                         {t('detail.timeline.radd.title', { ns: 'notifiche' })}
                       </AlertTitle>
                       {t('detail.timeline.radd.description-mono-recipient', { ns: 'notifiche' })}
+                    </Alert>
+                  )}
+                  {notification.radd && notification.recipients.length > 1 && (
+                    <Alert severity={'success'} sx={{ mb: 3, mt: 2 }} data-testid="raddAlert">
+                      <AlertTitle>
+                        {t('detail.timeline.radd.title', { ns: 'notifiche' })}
+                      </AlertTitle>
+                      {t('detail.timeline.radd.description-multi-recipients', { ns: 'notifiche' })}
                     </Alert>
                   )}
                 </Paper>

--- a/packages/pn-pa-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/NotificationDetail.page.tsx
@@ -319,7 +319,7 @@ const NotificationDetail: React.FC = () => {
                       <AlertTitle>
                         {t('detail.timeline.radd.title', { ns: 'notifiche' })}
                       </AlertTitle>
-                      {t('detail.timeline.radd.description', { ns: 'notifiche' })}
+                      {t('detail.timeline.radd.description-mono-recipient', { ns: 'notifiche' })}
                     </Alert>
                   )}
                 </Paper>

--- a/packages/pn-pa-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/NotificationDetail.page.tsx
@@ -3,7 +3,7 @@ import React, { Fragment, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 
-import { Alert, Box, Grid, Paper, Stack, Typography } from '@mui/material';
+import { Alert, AlertTitle, Box, Grid, Paper, Stack, Typography } from '@mui/material';
 import {
   ApiError,
   AppResponse,
@@ -305,6 +305,14 @@ const NotificationDetail: React.FC = () => {
                     downloadFilesMessage={getDownloadFilesMessage('attachments')}
                     downloadFilesLink={t('detail.download-files-link', { ns: 'notifiche' })}
                   />
+                  {notification.radd && (
+                    <Alert severity={'success'} sx={{ mb: 3, mt: 2 }} data-testid="raddAlert">
+                      <AlertTitle>
+                        {t('detail.timeline.radd.title', { ns: 'notifiche' })}
+                      </AlertTitle>
+                      {t('detail.timeline.radd.description', { ns: 'notifiche' })}
+                    </Alert>
+                  )}
                 </Paper>
                 <Paper sx={{ p: 3, mb: 3 }} elevation={0}>
                   <NotificationDetailDocuments

--- a/packages/pn-pa-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/NotificationDetail.page.tsx
@@ -314,20 +314,16 @@ const NotificationDetail: React.FC = () => {
                     downloadFilesMessage={getDownloadFilesMessage('attachments')}
                     downloadFilesLink={t('detail.download-files-link', { ns: 'notifiche' })}
                   />
-                  {notification.radd && notification.recipients.length === 1 && (
+                  {notification.radd && (
                     <Alert severity={'success'} sx={{ mb: 3, mt: 2 }} data-testid="raddAlert">
                       <AlertTitle>
                         {t('detail.timeline.radd.title', { ns: 'notifiche' })}
                       </AlertTitle>
-                      {t('detail.timeline.radd.description-mono-recipient', { ns: 'notifiche' })}
-                    </Alert>
-                  )}
-                  {notification.radd && notification.recipients.length > 1 && (
-                    <Alert severity={'success'} sx={{ mb: 3, mt: 2 }} data-testid="raddAlert">
-                      <AlertTitle>
-                        {t('detail.timeline.radd.title', { ns: 'notifiche' })}
-                      </AlertTitle>
-                      {t('detail.timeline.radd.description-multi-recipients', { ns: 'notifiche' })}
+                      {notification.recipients.length === 1
+                        ? t('detail.timeline.radd.description-mono-recipient', { ns: 'notifiche' })
+                        : t('detail.timeline.radd.description-multi-recipients', {
+                            ns: 'notifiche',
+                          })}
                     </Alert>
                   )}
                 </Paper>

--- a/packages/pn-pa-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
+++ b/packages/pn-pa-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
@@ -23,15 +23,7 @@ import {
   notificationDTOMultiRecipient,
   notificationToFe,
 } from '../../__mocks__/NotificationDetail.mock';
-import {
-  RenderResult,
-  act,
-  fireEvent,
-  prettyDOM,
-  render,
-  waitFor,
-  within,
-} from '../../__test__/test-utils';
+import { RenderResult, act, fireEvent, render, waitFor, within } from '../../__test__/test-utils';
 import {
   CANCEL_NOTIFICATION,
   NOTIFICATION_DETAIL,

--- a/packages/pn-pa-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
+++ b/packages/pn-pa-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
@@ -22,6 +22,7 @@ import {
   notificationDTO,
   notificationDTOMultiRecipient,
   notificationToFe,
+  raddNotificationDTO,
 } from '../../__mocks__/NotificationDetail.mock';
 import { RenderResult, act, fireEvent, render, waitFor, within } from '../../__test__/test-utils';
 import {
@@ -552,6 +553,21 @@ describe('NotificationDetail Page', async () => {
     });
     await act(async () => {
       result = render(<NotificationDetail />);
+    });
+
+    const alertRadd = result.getAllByTestId('raddAlert')[0];
+    expect(alertRadd).toBeInTheDocument();
+    expect(alertRadd).toHaveTextContent('detail.timeline.radd.title');
+  });
+
+  it('render success alert when documents have been retrieved', async () => {
+    mock.onGet(NOTIFICATION_DETAIL(raddNotificationDTO.iun)).reply(200, raddNotificationDTO);
+    await act(async () => {
+      result = render(<NotificationDetail />, {
+        preloadedState: {
+          userState: { user: { fiscal_number: raddNotificationDTO.recipients[2].taxId } },
+        },
+      });
     });
 
     const alertRadd = result.getAllByTestId('raddAlert')[0];

--- a/packages/pn-pa-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
+++ b/packages/pn-pa-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
@@ -534,8 +534,8 @@ describe('NotificationDetail Page', async () => {
 
   it('render success alert when documents have been picked up - monorecipient', async () => {
     mock
-      .onGet(NOTIFICATION_DETAIL(notificationDTO.iun))
-      .reply(200, { ...notificationDTO, radd: true });
+      .onGet(NOTIFICATION_DETAIL(raddNotificationDTO.iun))
+      .reply(200, { ...raddNotificationDTO, radd: true });
     await act(async () => {
       result = render(<NotificationDetail />);
     });
@@ -543,11 +543,12 @@ describe('NotificationDetail Page', async () => {
     const alertRadd = result.getAllByTestId('raddAlert')[0];
     expect(alertRadd).toBeInTheDocument();
     expect(alertRadd).toHaveTextContent('detail.timeline.radd.title');
+    expect(alertRadd).toHaveTextContent('detail.timeline.radd.description-mono-recipient');
   });
 
   it('render success alert when documents have been picked up - multirecipient', async () => {
-    mock.onGet(NOTIFICATION_DETAIL(notificationDTO.iun)).reply(200, {
-      ...notificationDTO,
+    mock.onGet(NOTIFICATION_DETAIL(raddNotificationDTO.iun)).reply(200, {
+      ...raddNotificationDTO,
       radd: true,
       recipients: ['CLMCST42R12D969Z', '20517490320'],
     });
@@ -558,20 +559,6 @@ describe('NotificationDetail Page', async () => {
     const alertRadd = result.getAllByTestId('raddAlert')[0];
     expect(alertRadd).toBeInTheDocument();
     expect(alertRadd).toHaveTextContent('detail.timeline.radd.title');
-  });
-
-  it('render success alert when documents have been retrieved', async () => {
-    mock.onGet(NOTIFICATION_DETAIL(raddNotificationDTO.iun)).reply(200, raddNotificationDTO);
-    await act(async () => {
-      result = render(<NotificationDetail />, {
-        preloadedState: {
-          userState: { user: { fiscal_number: raddNotificationDTO.recipients[2].taxId } },
-        },
-      });
-    });
-
-    const alertRadd = result.getAllByTestId('raddAlert')[0];
-    expect(alertRadd).toBeInTheDocument();
-    expect(alertRadd).toHaveTextContent('detail.timeline.radd.title');
+    expect(alertRadd).toHaveTextContent('detail.timeline.radd.description-multi-recipients');
   });
 });

--- a/packages/pn-pa-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
+++ b/packages/pn-pa-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
@@ -544,7 +544,7 @@ describe('NotificationDetail Page', async () => {
     expect(alertRadd).toHaveTextContent('detail.timeline.radd.title');
   });
 
-  it.only('render success alert when documents have been picked up - multirecipient', async () => {
+  it('render success alert when documents have been picked up - multirecipient', async () => {
     mock.onGet(NOTIFICATION_DETAIL(notificationDTO.iun)).reply(200, {
       ...notificationDTO,
       radd: true,

--- a/packages/pn-pa-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
+++ b/packages/pn-pa-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
@@ -23,7 +23,15 @@ import {
   notificationDTOMultiRecipient,
   notificationToFe,
 } from '../../__mocks__/NotificationDetail.mock';
-import { RenderResult, act, fireEvent, render, waitFor, within } from '../../__test__/test-utils';
+import {
+  RenderResult,
+  act,
+  fireEvent,
+  prettyDOM,
+  render,
+  waitFor,
+  within,
+} from '../../__test__/test-utils';
 import {
   CANCEL_NOTIFICATION,
   NOTIFICATION_DETAIL,
@@ -529,5 +537,33 @@ describe('NotificationDetail Page', async () => {
     });
     const paymentsTable = result.queryByTestId('paymentInfoBox');
     expect(paymentsTable).not.toBeInTheDocument();
+  });
+
+  it('render success alert when documents have been picked up - monorecipient', async () => {
+    mock
+      .onGet(NOTIFICATION_DETAIL(notificationDTO.iun))
+      .reply(200, { ...notificationDTO, radd: true });
+    await act(async () => {
+      result = render(<NotificationDetail />);
+    });
+
+    const alertRadd = result.getAllByTestId('raddAlert')[0];
+    expect(alertRadd).toBeInTheDocument();
+    expect(alertRadd).toHaveTextContent('detail.timeline.radd.title');
+  });
+
+  it.only('render success alert when documents have been picked up - multirecipient', async () => {
+    mock.onGet(NOTIFICATION_DETAIL(notificationDTO.iun)).reply(200, {
+      ...notificationDTO,
+      radd: true,
+      recipients: ['CLMCST42R12D969Z', '20517490320'],
+    });
+    await act(async () => {
+      result = render(<NotificationDetail />);
+    });
+
+    const alertRadd = result.getAllByTestId('raddAlert')[0];
+    expect(alertRadd).toBeInTheDocument();
+    expect(alertRadd).toHaveTextContent('detail.timeline.radd.title');
   });
 });

--- a/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
@@ -324,6 +324,10 @@
         "F02": "per smarrimento della busta",
         "F03": "per deterioramento della busta",
         "F04": "per rapina della busta"
+      },
+      "radd": {
+        "title": "I documenti sono stati ritirati",
+        "description": "Il destinatario o un suo delegato ha ritirato i documenti notificati presso un operatore abilitato alla consegna degli stessi."
       }
     },
     "downtimes": {

--- a/packages/pn-personafisica-webapp/src/__mocks__/NotificationDetail.mock.ts
+++ b/packages/pn-personafisica-webapp/src/__mocks__/NotificationDetail.mock.ts
@@ -546,6 +546,25 @@ export const cancelledNotificationDTO: NotificationDetail = {
   ],
 };
 
+export const raddNotificationDTO: NotificationDetail = {
+  ...notificationDTO,
+  timeline: [
+    ...notificationDTO.timeline,
+    {
+      elementId: 'NOTIFICATION_RADD_RETRIEVED_mock',
+      timestamp: '2022-06-21T11:44:28Z',
+      legalFactsIds: [],
+      category: TimelineCategory.NOTIFICATION_RADD_RETRIEVED,
+      details: {
+        recIndex: 1,
+        eventTimestamp: '2022-06-21T11:44:28Z',
+        raddType: 'ALT',
+        raddTransactionId: '6',
+      },
+    },
+  ],
+};
+
 export const paymentsData: PaymentsData = {
   pagoPaF24: getPagoPaF24Payments(payments, 2),
   f24Only: getF24Payments(payments, 2),

--- a/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
@@ -3,7 +3,7 @@ import { Fragment, ReactNode, useCallback, useEffect, useMemo, useState } from '
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
-import { Alert, Box, Grid, Paper, Stack, Typography } from '@mui/material';
+import { Alert, AlertTitle, Box, Grid, Paper, Stack, Typography } from '@mui/material';
 import {
   ApiError,
   ApiErrorWrapper,
@@ -510,6 +510,14 @@ const NotificationDetail = () => {
                     disableDownloads={isCancelled.cancellationInTimeline}
                     titleVariant="h6"
                   />
+                  {notification.radd && (
+                    <Alert severity={'success'} sx={{ mb: 3, mt: 2 }} data-testid="raddAlert">
+                      <AlertTitle>
+                        {t('detail.timeline.radd.title', { ns: 'notifiche' })}
+                      </AlertTitle>
+                      {t('detail.timeline.radd.description', { ns: 'notifiche' })}
+                    </Alert>
+                  )}
                 </Paper>
 
                 {checkIfUserHasPayments && (

--- a/packages/pn-personafisica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
@@ -804,7 +804,7 @@ describe('NotificationDetail Page', async () => {
     expect(paymentCache?.currentPayment).toBeUndefined();
   });
 
-  it('render success alert when documents have been picked up', async () => {
+  it('render success alert when documents have been retrieved', async () => {
     mock.onGet(NOTIFICATION_DETAIL(raddNotificationDTO.iun)).reply(200, raddNotificationDTO);
     await act(async () => {
       result = render(<NotificationDetail />, {

--- a/packages/pn-personafisica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
@@ -27,6 +27,7 @@ import {
   notificationDTO,
   notificationToFe,
   paymentsData,
+  raddNotificationDTO,
 } from '../../__mocks__/NotificationDetail.mock';
 import {
   RenderResult,
@@ -804,11 +805,13 @@ describe('NotificationDetail Page', async () => {
   });
 
   it('render success alert when documents have been picked up', async () => {
-    mock
-      .onGet(NOTIFICATION_DETAIL(notificationDTO.iun))
-      .reply(200, { ...notificationDTO, radd: true });
+    mock.onGet(NOTIFICATION_DETAIL(raddNotificationDTO.iun)).reply(200, raddNotificationDTO);
     await act(async () => {
-      result = render(<NotificationDetail />);
+      result = render(<NotificationDetail />, {
+        preloadedState: {
+          userState: { user: { fiscal_number: raddNotificationDTO.recipients[2].taxId } },
+        },
+      });
     });
 
     const alertRadd = result.getAllByTestId('raddAlert')[0];

--- a/packages/pn-personafisica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
@@ -802,4 +802,17 @@ describe('NotificationDetail Page', async () => {
     const paymentCache = getPaymentCache(notificationDTO.iun);
     expect(paymentCache?.currentPayment).toBeUndefined();
   });
+
+  it('render success alert when documents have been picked up', async () => {
+    mock
+      .onGet(NOTIFICATION_DETAIL(notificationDTO.iun))
+      .reply(200, { ...notificationDTO, radd: true });
+    await act(async () => {
+      result = render(<NotificationDetail />);
+    });
+
+    const alertRadd = result.getAllByTestId('raddAlert')[0];
+    expect(alertRadd).toBeInTheDocument();
+    expect(alertRadd).toHaveTextContent('detail.timeline.radd.title');
+  });
 });

--- a/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
@@ -326,6 +326,10 @@
         "F02": "per smarrimento della busta",
         "F03": "per deterioramento della busta",
         "F04": "per rapina della busta"
+      },
+      "radd": {
+        "title": "I documenti sono stati ritirati",
+        "description": "Il destinatario o un suo delegato ha ritirato i documenti notificati presso un operatore abilitato alla consegna degli stessi."
       }
     },
     "downtimes": {

--- a/packages/pn-personagiuridica-webapp/src/__mocks__/NotificationDetail.mock.ts
+++ b/packages/pn-personagiuridica-webapp/src/__mocks__/NotificationDetail.mock.ts
@@ -521,3 +521,22 @@ export const cachedPayments: PaymentCache = {
     paymentInfo
   ),
 };
+
+export const raddNotificationDTO: NotificationDetail = {
+  ...notificationDTO,
+  timeline: [
+    ...notificationDTO.timeline,
+    {
+      elementId: 'NOTIFICATION_RADD_RETRIEVED_mock',
+      timestamp: '2022-06-21T11:44:28Z',
+      legalFactsIds: [],
+      category: TimelineCategory.NOTIFICATION_RADD_RETRIEVED,
+      details: {
+        recIndex: 1,
+        eventTimestamp: '2022-06-21T11:44:28Z',
+        raddType: 'ALT',
+        raddTransactionId: '6',
+      },
+    },
+  ],
+};

--- a/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
@@ -3,7 +3,7 @@ import { Fragment, ReactNode, useCallback, useEffect, useMemo, useState } from '
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
-import { Alert, Box, Grid, Paper, Stack, Typography } from '@mui/material';
+import { Alert, AlertTitle, Box, Grid, Paper, Stack, Typography } from '@mui/material';
 import {
   ApiError,
   ApiErrorWrapper,
@@ -414,6 +414,14 @@ const NotificationDetail = () => {
                     disableDownloads={isCancelled.cancellationInTimeline}
                     titleVariant="h6"
                   />
+                  {notification.radd && (
+                    <Alert severity={'success'} sx={{ mb: 3, mt: 2 }} data-testid="raddAlert">
+                      <AlertTitle>
+                        {t('detail.timeline.radd.title', { ns: 'notifiche' })}
+                      </AlertTitle>
+                      {t('detail.timeline.radd.description', { ns: 'notifiche' })}
+                    </Alert>
+                  )}
                 </Paper>
 
                 {checkIfUserHasPayments && (

--- a/packages/pn-personagiuridica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
@@ -875,7 +875,7 @@ describe('NotificationDetail Page', async () => {
     expect(paymentCache?.currentPayment).toBeUndefined();
   });
 
-  it('render success alert when documents have been picked up', async () => {
+  it('render success alert when documents have been retrieved', async () => {
     mock
       .onGet(NOTIFICATION_DETAIL(notificationDTO.iun))
       .reply(200, { ...notificationDTO, radd: true });

--- a/packages/pn-personagiuridica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
@@ -28,6 +28,7 @@ import {
   notificationDTO,
   notificationToFe,
   paymentsData,
+  raddNotificationDTO,
 } from '../../__mocks__/NotificationDetail.mock';
 import {
   RenderResult,
@@ -876,11 +877,13 @@ describe('NotificationDetail Page', async () => {
   });
 
   it('render success alert when documents have been retrieved', async () => {
-    mock
-      .onGet(NOTIFICATION_DETAIL(notificationDTO.iun))
-      .reply(200, { ...notificationDTO, radd: true });
+    mock.onGet(NOTIFICATION_DETAIL(raddNotificationDTO.iun)).reply(200, raddNotificationDTO);
     await act(async () => {
-      result = render(<NotificationDetail />);
+      result = render(<NotificationDetail />, {
+        preloadedState: {
+          userState: { user: { fiscal_number: raddNotificationDTO.recipients[2].taxId } },
+        },
+      });
     });
 
     const alertRadd = result.getAllByTestId('raddAlert')[0];

--- a/packages/pn-personagiuridica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
@@ -874,4 +874,17 @@ describe('NotificationDetail Page', async () => {
     const paymentCache = getPaymentCache(notificationDTO.iun);
     expect(paymentCache?.currentPayment).toBeUndefined();
   });
+
+  it('render success alert when documents have been picked up', async () => {
+    mock
+      .onGet(NOTIFICATION_DETAIL(notificationDTO.iun))
+      .reply(200, { ...notificationDTO, radd: true });
+    await act(async () => {
+      result = render(<NotificationDetail />);
+    });
+
+    const alertRadd = result.getAllByTestId('raddAlert')[0];
+    expect(alertRadd).toBeInTheDocument();
+    expect(alertRadd).toHaveTextContent('detail.timeline.radd.title');
+  });
 });


### PR DESCRIPTION
## Short description
Implemented alert in notificationDetail for alternative-RADD for pg/pf/pa when documents are withdrawn by recipients.

## List of changes proposed in this pull request
- added radd property in NotificationDetail.ts
- populated radd property in notification.utility.ts
- added Alert component with title in DOCUMENTI ALLEGATI box in pg/pf/pa

## How to test
- Login as PF, go to notification a notification (es. VHYJ-LJWY-QWEG-202402-E-1 in Cristoforo Colombo from Comune di Palermo) and check DOCUMENTI ALLEGATI box has the success alert
- Login as PG, go to a notification and check DOCUMENTI ALLEGATI box has the success alert
- Login as PA, go to notification (es. THYR-YRDN-ULPE-202402-E-1 Convivio Spa from Comune di Palermo) and check DOCUMENTI ALLEGATI box has the success alert
