### PR TITLE
fix: added aria-label to button with IDP name

### DIFF
--- a/packages/pn-personafisica-login/src/pages/login/SpidSelect.tsx
+++ b/packages/pn-personafisica-login/src/pages/login/SpidSelect.tsx
@@ -76,6 +76,7 @@ const SpidSelect = ({ onBack }: { onBack: () => void }) => {
                   id={`spid-select-${IDP.entityId}`}
                   onClick={() => getSPID(IDP)}
                   sx={{ width: '100px', padding: '0' }}
+                  aria-label={IDP.name}
                 >
                   <Icon sx={{ width: '100px', height: '48px' }}>
                     <img width="100px" src={IDP.imageUrl} alt={IDP.name} />


### PR DESCRIPTION
## Short description
In login page for PF the list of IDPs name should be read correctly by voiceover.

## List of changes proposed in this pull request
- Added aria-label with IDP name to list of IDPs

## How to test
Go to login page and read the list of IDPs using voiceover: should read the name of the IDP instead of pulsante