### PR TITLE
chore: removed path params from mixpanel api url to allow tracking fo…

### DIFF
--- a/aws-cdn-templates/one-cdn.yaml
+++ b/aws-cdn-templates/one-cdn.yaml
@@ -486,7 +486,7 @@ Resources:
           ContentSecurityPolicy:
             ContentSecurityPolicy:
               "default-src 'self' https://pnpg.uat.selfcare.pagopa.it/ https://pnpg.selfcare.pagopa.it/ ; \
-              connect-src 'self' https://api-eu.mixpanel.com/track/ \
+              connect-src 'self' https://api-eu.mixpanel.com/ \
               https://uat.selfcare.pagopa.it/assets/ \
               https://selfcare.pagopa.it/assets/ \
               https://pnpg.uat.selfcare.pagopa.it/assets/ \
@@ -534,7 +534,7 @@ Resources:
               Fn::Join:
                 - " "
                 - - "default-src 'self'; object-src 'none';"
-                  - !Sub " connect-src 'self' https://api-eu.mixpanel.com/track/  \
+                  - !Sub " connect-src 'self' https://api-eu.mixpanel.com/  \
                     https://selfcare.pagopa.it/assets/ \
                     https://privacyportalde-cdn.onetrust.com/ \
                     ${WebApiUrl}; \


### PR DESCRIPTION
…r profile properties

## Short description
Removed "track" from mixpanel API path, in order to allow the usage of profile properties API from mixpanel.
[https://developer.mixpanel.com/reference/profile-set](https://developer.mixpanel.com/reference/profile-set)
[https://docs.mixpanel.com/docs/data-structure/user-profiles](https://docs.mixpanel.com/docs/data-structure/user-profiles)


## List of changes proposed in this pull request
- Modified connect-src policy in csp

## How to test
Copy the new policy directly in CloudFront DefaultHeaderPolicy and check in console that all mixpanel API are allowed.