### PR TITLE
fix(PN-10232): remove link to pagopa bill when  not available attachment

### DIFF
--- a/packages/pn-pa-webapp/src/__mocks__/NotificationDetail.mock.ts
+++ b/packages/pn-pa-webapp/src/__mocks__/NotificationDetail.mock.ts
@@ -496,6 +496,13 @@ const paymentsPagoPa: Array<NotificationDetailPayment> = [
       },
     },
   },
+  {
+    pagoPa: {
+      creditorTaxId: '77777777777',
+      noticeCode: '302011689142547197',
+      applyCost: true,
+    },
+  },
 ];
 
 const paymentsPagoPaF24: Array<NotificationDetailPayment> = [

--- a/packages/pn-pa-webapp/src/components/Notifications/NotificationPaymentPagoPa.tsx
+++ b/packages/pn-pa-webapp/src/components/Notifications/NotificationPaymentPagoPa.tsx
@@ -25,7 +25,7 @@ const NotificationPaymentPagoPa: React.FC<Props> = ({ iun, payment }) => {
   const dispatch = useAppDispatch();
 
   const dowloadHandler = () => {
-    if (!_.isNil(payment.recIndex)) {
+    if (!_.isNil(payment.recIndex) && payment.attachment) {
       trackEventByType(TrackEventType.NOTIFICATION_DETAIL_PAYMENT_PAGOPA_FILE);
       dispatch(
         getPaymentAttachment({

--- a/packages/pn-pa-webapp/src/components/Notifications/NotificationPaymentPagoPa.tsx
+++ b/packages/pn-pa-webapp/src/components/Notifications/NotificationPaymentPagoPa.tsx
@@ -66,9 +66,11 @@ const NotificationPaymentPagoPa: React.FC<Props> = ({ iun, payment }) => {
           </Typography>
         </Grid>
         <Grid item xs={12}>
-          <ButtonNaked color="primary" onClick={dowloadHandler}>
-            {t('payment.pagopa-notice')}
-          </ButtonNaked>
+          {payment.attachment && (
+            <ButtonNaked color="primary" onClick={dowloadHandler}>
+              {t('payment.pagopa-notice')}
+            </ButtonNaked>
+          )}
         </Grid>
       </Grid>
       {payment.status === PaymentStatus.SUCCEEDED && (

--- a/packages/pn-pa-webapp/src/components/Notifications/__test__/NotificationPaymentPagoPa.test.tsx
+++ b/packages/pn-pa-webapp/src/components/Notifications/__test__/NotificationPaymentPagoPa.test.tsx
@@ -76,7 +76,7 @@ describe('NotificationPaymentPagoPa Component', async () => {
     expect(paymentChip).toBeInTheDocument();
   });
 
-  it('dowload payment attachment', async () => {
+  it('download payment attachment', async () => {
     const iun = notificationToFeMultiRecipient.iun;
     const attachmentName = PaymentAttachmentSName.PAGOPA;
     const paymentHistory = populatePaymentsPagoPaF24(
@@ -117,7 +117,7 @@ describe('NotificationPaymentPagoPa Component', async () => {
     });
   });
 
-  it('dowload payment attachment - no recIndex', async () => {
+  it('download payment attachment - no recIndex', async () => {
     const paymentHistory = populatePaymentsPagoPaF24(
       notificationToFeMultiRecipient.timeline,
       notificationToFeMultiRecipient.recipients[1].payments ?? [],
@@ -135,5 +135,21 @@ describe('NotificationPaymentPagoPa Component', async () => {
       expect(mock.history.get).toHaveLength(0);
       expect(downloadDocument).toBeCalledTimes(0);
     });
+  });
+
+  it('payment attachment not available', async () => {
+    const paymentHistory = populatePaymentsPagoPaF24(
+      notificationToFeMultiRecipient.timeline,
+      notificationToFeMultiRecipient.recipients[1].payments ?? [],
+      []
+    );
+    const indexItem = paymentHistory.findIndex((item) => !item.pagoPa?.attachment);
+    const { container } = render(
+      <NotificationPaymentPagoPa
+        iun={notificationToFeMultiRecipient.iun}
+        payment={paymentHistory[indexItem].pagoPa!}
+      />
+    );
+    expect(container).not.toHaveTextContent('payment.pagopa-notice');
   });
 });


### PR DESCRIPTION
## Short description
Remove link to pagopa bill when attachment is not available in notification detail

## How to test
Login as PA, open a notification (_AYTV-LVQL-QVJW-202403-W-1_ can be used in Comune di Palermo) and check link "Avviso PagoPA" is not there.