### PR TITLE
fix(PN-9711): reduce spaces between fields in NuovaDelega page

### DIFF
--- a/packages/pn-personafisica-webapp/src/pages/NuovaDelega.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/NuovaDelega.page.tsx
@@ -304,7 +304,7 @@ const NuovaDelega = () => {
                             alignItems="center"
                             direction={isMobile ? 'column' : 'row'}
                             spacing={1}
-                            flex={isMobile ? '1 0 100%' : '1 0 100px'}
+                            flex={isMobile ? '1 0' : '1 0 100px'}
                           >
                             {values.selectPersonaFisicaOrPersonaGiuridica === RecipientType.PF && (
                               <TextField
@@ -358,7 +358,7 @@ const NuovaDelega = () => {
                         </Stack>
                       </FormControl>
                       <TextField
-                        sx={{ marginTop: isMobile ? '8px' : '2rem' }}
+                        sx={{ marginTop: isMobile ? 1 : 4 }}
                         id="codiceFiscale"
                         value={values.codiceFiscale.toString()}
                         onChange={(event) => {

--- a/packages/pn-personafisica-webapp/src/pages/NuovaDelega.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/NuovaDelega.page.tsx
@@ -304,7 +304,7 @@ const NuovaDelega = () => {
                             alignItems="center"
                             direction={isMobile ? 'column' : 'row'}
                             spacing={1}
-                            flex={isMobile ? '1 0' : '1 0 100px'}
+                            flex="1 0"
                           >
                             {values.selectPersonaFisicaOrPersonaGiuridica === RecipientType.PF && (
                               <TextField

--- a/packages/pn-personafisica-webapp/src/pages/NuovaDelega.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/NuovaDelega.page.tsx
@@ -304,7 +304,7 @@ const NuovaDelega = () => {
                             alignItems="center"
                             direction={isMobile ? 'column' : 'row'}
                             spacing={1}
-                            flex="1 0 100px"
+                            flex={isMobile ? '1 0 100%' : '1 0 100px'}
                           >
                             {values.selectPersonaFisicaOrPersonaGiuridica === RecipientType.PF && (
                               <TextField
@@ -358,7 +358,7 @@ const NuovaDelega = () => {
                         </Stack>
                       </FormControl>
                       <TextField
-                        sx={{ marginTop: '2rem' }}
+                        sx={{ marginTop: isMobile ? '8px' : '2rem' }}
                         id="codiceFiscale"
                         value={values.codiceFiscale.toString()}
                         onChange={(event) => {

--- a/packages/pn-personagiuridica-webapp/src/pages/NuovaDelega.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/NuovaDelega.page.tsx
@@ -276,7 +276,7 @@ const NuovaDelega = () => {
                             alignItems="center"
                             direction={isMobile ? 'column' : 'row'}
                             spacing={1}
-                            flex={isMobile ? '1 0' : '1 0 100px'}
+                            flex="1 0"
                           >
                             {values.selectPersonaFisicaOrPersonaGiuridica === RecipientType.PF && (
                               <TextField

--- a/packages/pn-personagiuridica-webapp/src/pages/NuovaDelega.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/NuovaDelega.page.tsx
@@ -276,7 +276,7 @@ const NuovaDelega = () => {
                             alignItems="center"
                             direction={isMobile ? 'column' : 'row'}
                             spacing={1}
-                            flex={isMobile ? '1 0 100%' : '1 0 100px'}
+                            flex={isMobile ? '1 0' : '1 0 100px'}
                           >
                             {values.selectPersonaFisicaOrPersonaGiuridica === RecipientType.PF && (
                               <TextField
@@ -330,7 +330,7 @@ const NuovaDelega = () => {
                         </Stack>
                       </FormControl>
                       <TextField
-                        sx={{ marginTop: isMobile ? '8px' : '2rem' }}
+                        sx={{ marginTop: isMobile ? 1 : 4 }}
                         id="codiceFiscale"
                         value={values.codiceFiscale.toString()}
                         onChange={(event) => {

--- a/packages/pn-personagiuridica-webapp/src/pages/NuovaDelega.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/NuovaDelega.page.tsx
@@ -276,7 +276,7 @@ const NuovaDelega = () => {
                             alignItems="center"
                             direction={isMobile ? 'column' : 'row'}
                             spacing={1}
-                            flex="1 0 100px"
+                            flex={isMobile ? '1 0 100%' : '1 0 100px'}
                           >
                             {values.selectPersonaFisicaOrPersonaGiuridica === RecipientType.PF && (
                               <TextField
@@ -330,7 +330,7 @@ const NuovaDelega = () => {
                         </Stack>
                       </FormControl>
                       <TextField
-                        sx={{ marginTop: '2rem' }}
+                        sx={{ marginTop: isMobile ? '8px' : '2rem' }}
                         id="codiceFiscale"
                         value={values.codiceFiscale.toString()}
                         onChange={(event) => {


### PR DESCRIPTION
## Short description
Reduce spaces between fields in NuovaDelega page

## List of changes proposed in this pull request
- added condition to margin top and flex property in case of mobile/desktop in box for choosing PersonaFisica
- added condition to margin top and flex property in case of mobile/desktop in box for choosing PersonaGiuridica

## How to test
_As mobile_ login as PF, go to Deleghe section and go to Aggiungi nuova delega page. Check in new page the distance between Cognome and Codice fiscale and Ragione Sociale and Codice fiscale is normal.

_As mobile_ login as PG go to Deleghe section and go to Aggiungi nuova delega page. Check in new page the distance between Cognome and Codice fiscale and Ragione Sociale and Codice fiscale is normal.