### PR TITLE
fix(PN-10122): add useEffect to update value for active tab in Deleghe

### DIFF
--- a/packages/pn-personagiuridica-webapp/src/App.tsx
+++ b/packages/pn-personagiuridica-webapp/src/App.tsx
@@ -185,7 +185,7 @@ const ActualApp = () => {
     menuItems.splice(1, 0, {
       label: t('menu.deleghe'),
       icon: () => <AltRouteIcon />,
-      route: routes.DELEGHEACARICO,
+      route: routes.DELEGHE,
       rightBadgeNotification: pendingDelegators ? pendingDelegators : undefined,
     });
   }

--- a/packages/pn-personagiuridica-webapp/src/pages/Deleghe.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/Deleghe.page.tsx
@@ -53,8 +53,9 @@ const Deleghe = () => {
   }, []);
 
   useEffect(() => {
-    if (pathname === routes.DELEGHEACARICO) {
-      setValue(0);
+    const tabToBeSelected = pathname === routes.DELEGATI ? 1 : 0;
+    if (value !== tabToBeSelected) {
+      setValue(tabToBeSelected);
     }
   }, [pathname]);
   return (

--- a/packages/pn-personagiuridica-webapp/src/pages/Deleghe.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/Deleghe.page.tsx
@@ -52,6 +52,11 @@ const Deleghe = () => {
     };
   }, []);
 
+  useEffect(() => {
+    if (pathname === routes.DELEGHEACARICO) {
+      setValue(0);
+    }
+  }, [pathname]);
   return (
     <LoadingPageWrapper isInitialized={pageReady}>
       <Box
@@ -78,8 +83,8 @@ const Deleghe = () => {
                 centered
                 variant="fullWidth"
               >
-                <Tab id="tab-2" data-testid="tab2" label={t('deleghe.tab_deleghe')} />
-                <Tab id="tab-1" data-testid="tab1" label={t('deleghe.tab_delegati')} />
+                <Tab id="tab-2" value={0} data-testid="tab2" label={t('deleghe.tab_deleghe')} />
+                <Tab id="tab-1" value={1} data-testid="tab1" label={t('deleghe.tab_delegati')} />
               </Tabs>
             </Box>
             <TabPanel value={-1} index={-1}>


### PR DESCRIPTION
## List of changes proposed in this pull request
- add useEffect in Deleghe component
- update to DELEGHE the route of item in SideMenu component

## How to test
Login as PG, go to Deleghe page. Click on "Delegati dall'impresa" tab, then click on "Deleghe" in side menu. Check if page is updated to "Deleghe a carico dell'impresa"