### PR TITLE
PN-9835 - Clear name of attachment on remove document

### DIFF
--- a/packages/pn-pa-webapp/src/components/NewNotification/Attachments.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/Attachments.tsx
@@ -245,7 +245,10 @@ const Attachments: React.FC<Props> = ({
         key: '',
         versionToken: '',
       },
+      name: '',
     });
+
+    await formik.setFieldTouched(`${id}.name`, false, false);
   };
 
   const addDocumentHandler = async () => {

--- a/packages/pn-pa-webapp/src/components/NewNotification/__test__/Attachments.test.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/__test__/Attachments.test.tsx
@@ -188,9 +188,8 @@ describe('Attachments Component with payment enabled', async () => {
       expect(buttonSubmit).toBeDisabled();
     });
     await testInput(form!, `documents.0.name`, '');
-    const error = form!.querySelector(`[id="documents.0.name-helper-text"]`);
-    expect(error).toHaveTextContent('required-field');
     await testInput(form!, `documents.0.name`, ' text-with-spaces ');
+    const error = form!.querySelector(`[id="documents.0.name-helper-text"]`);
     expect(error).toHaveTextContent('no-spaces-at-edges');
   });
 


### PR DESCRIPTION
## Short description
Clear attachment name on remove document in order to re-enable CTA "Invia".

## List of changes proposed in this pull request
- Clear field

## How to test
Try to create a new notification. Upload a new attachment and then delete it. You should see the field "Nome dell'atto" cleared.