### PR TITLE
PN-10821 - Fix some Mixpanel regressions and track super profile properties

### DIFF
--- a/packages/pn-personafisica-login/src/pages/login/Login.tsx
+++ b/packages/pn-personafisica-login/src/pages/login/Login.tsx
@@ -50,6 +50,10 @@ const Login = () => {
       SPID_IDP_NAME: 'CIE',
       SPID_IDP_ID: SPID_CIE_ENTITY_ID,
     });
+
+    PFLoginEventStrategyFactory.triggerEvent(PFLoginEventsType.SEND_LOGIN_METHOD, {
+      entityID: 'cie',
+    });
   };
 
   if (showIDPS) {

--- a/packages/pn-personafisica-webapp/src/components/Contacts/DigitalContactElem.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/DigitalContactElem.tsx
@@ -174,9 +174,7 @@ const DigitalContactElem = forwardRef<{ editContact: () => void }, Props>(
           if (onDeleteCbk) {
             onDeleteCbk();
           }
-          PFEventStrategyFactory.triggerEvent(getEventByContactType(contactType), {
-            senderId,
-          });
+          PFEventStrategyFactory.triggerEvent(getEventByContactType(contactType), senderId);
         })
         .catch((error) => {
           console.error('Error occurred:', error);

--- a/packages/pn-personafisica-webapp/src/components/Contacts/DigitalContactsCodeVerification.context.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/DigitalContactsCodeVerification.context.tsx
@@ -65,8 +65,6 @@ const DigitalContactsCodeVerificationProvider: FC<{ children?: ReactNode }> = ({
   const [isConfirmationModalVisible, setIsConfirmationModalVisible] = useState(false);
   const [errorMessage, setErrorMessage] = useState<ErrorMessage>();
 
-  const [isSpecialContactMode, setIsSpecialContactMode] = useState(false);
-
   const initialProps = {
     labelRoot: '',
     labelType: '',
@@ -112,18 +110,17 @@ const DigitalContactsCodeVerificationProvider: FC<{ children?: ReactNode }> = ({
 
   const sendSuccessEvent = (type: LegalChannelType | CourtesyChannelType) => {
     if (type === LegalChannelType.PEC) {
-      PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_ADD_PEC_UX_SUCCESS, {
-        isSpecialContact: isSpecialContactMode,
-      });
+      PFEventStrategyFactory.triggerEvent(
+        PFEventsType.SEND_ADD_PEC_UX_SUCCESS,
+        modalProps.senderId
+      );
       return;
     }
     PFEventStrategyFactory.triggerEvent(
       type === CourtesyChannelType.SMS
         ? PFEventsType.SEND_ADD_SMS_UX_SUCCESS
         : PFEventsType.SEND_ADD_EMAIL_UX_SUCCESS,
-      {
-        isSpecialContact: isSpecialContactMode,
-      }
+      modalProps.senderId
     );
   };
   const handleCodeVerification = (verificationCode?: string, noCallback: boolean = false) => {
@@ -136,17 +133,20 @@ const DigitalContactsCodeVerificationProvider: FC<{ children?: ReactNode }> = ({
     }
     if (verificationCode) {
       if (modalProps.digitalDomicileType === LegalChannelType.PEC) {
-        PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_ADD_PEC_UX_CONVERSION, {
-          isSpecialContact: isSpecialContactMode,
-        });
+        PFEventStrategyFactory.triggerEvent(
+          PFEventsType.SEND_ADD_PEC_UX_CONVERSION,
+          modalProps.senderId
+        );
       } else if (modalProps.digitalDomicileType === CourtesyChannelType.SMS) {
-        PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_ADD_SMS_UX_CONVERSION, {
-          isSpecialContact: isSpecialContactMode,
-        });
+        PFEventStrategyFactory.triggerEvent(
+          PFEventsType.SEND_ADD_SMS_UX_CONVERSION,
+          modalProps.senderId
+        );
       } else if (modalProps.digitalDomicileType === CourtesyChannelType.EMAIL) {
-        PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_ADD_EMAIL_UX_CONVERSION, {
-          isSpecialContact: isSpecialContactMode,
-        });
+        PFEventStrategyFactory.triggerEvent(
+          PFEventsType.SEND_ADD_EMAIL_UX_CONVERSION,
+          modalProps.senderId
+        );
       }
     }
     if (!actionToBeDispatched) {
@@ -203,10 +203,8 @@ const DigitalContactsCodeVerificationProvider: FC<{ children?: ReactNode }> = ({
     recipientId: string,
     senderId: string,
     senderName?: string,
-    callbackOnValidation?: (status: 'validated' | 'cancelled') => void,
-    isSpecialContact?: boolean
+    callbackOnValidation?: (status: 'validated' | 'cancelled') => void
   ) => {
-    setIsSpecialContactMode(!!isSpecialContact);
     /* eslint-disable functional/no-let */
     let labelRoot = '';
     let labelType = '';
@@ -214,9 +212,7 @@ const DigitalContactsCodeVerificationProvider: FC<{ children?: ReactNode }> = ({
     if (digitalDomicileType === LegalChannelType.PEC) {
       labelRoot = 'legal-contacts';
       labelType = 'pec';
-      PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_ADD_PEC_START, {
-        isSpecialContact,
-      });
+      PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_ADD_PEC_START, senderId);
     } else {
       labelRoot = 'courtesy-contacts';
       labelType = digitalDomicileType === CourtesyChannelType.SMS ? 'phone' : 'email';
@@ -224,9 +220,7 @@ const DigitalContactsCodeVerificationProvider: FC<{ children?: ReactNode }> = ({
         digitalDomicileType === CourtesyChannelType.SMS
           ? PFEventsType.SEND_ADD_SMS_START
           : PFEventsType.SEND_ADD_EMAIL_START,
-        {
-          isSpecialContact,
-        }
+        senderId
       );
     }
     setModalProps({

--- a/packages/pn-personafisica-webapp/src/pages/AppStatus.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/AppStatus.page.tsx
@@ -53,9 +53,10 @@ const AppStatus = () => {
   };
 
   useEffect(() => {
-    PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_SERVICE_STATUS, {
-      service_status_OK: appStatus.currentStatus?.appIsFullyOperative,
-    });
+    PFEventStrategyFactory.triggerEvent(
+      PFEventsType.SEND_SERVICE_STATUS,
+      appStatus.currentStatus?.appIsFullyOperative
+    );
   }, [getCurrentAppStatus]);
 
   return (

--- a/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/SendAddContactActionStrategy.ts
+++ b/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/SendAddContactActionStrategy.ts
@@ -7,12 +7,12 @@ import {
 } from '@pagopa-pn/pn-commons';
 
 export class SendAddContactActionStrategy implements EventStrategy {
-  performComputations(isSpecialContact: boolean): TrackedEvent<{ other_contact: string }> {
+  performComputations(senderId: string): TrackedEvent<{ other_contact: string }> {
     return {
       [EventPropertyType.TRACK]: {
         event_category: EventCategory.UX,
         event_type: EventAction.ACTION,
-        other_contact: isSpecialContact ? 'yes' : 'no',
+        other_contact: senderId !== 'default' ? 'yes' : 'no',
       },
     };
   }

--- a/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/SendAddContactScreenViewStrategy.ts
+++ b/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/SendAddContactScreenViewStrategy.ts
@@ -7,12 +7,12 @@ import {
 } from '@pagopa-pn/pn-commons';
 
 export class SendAddContactScreenViewStrategy implements EventStrategy {
-  performComputations(isSpecialContact: boolean): TrackedEvent<{ other_contact: string }> {
+  performComputations(senderId: string): TrackedEvent<{ other_contact: string }> {
     return {
       [EventPropertyType.TRACK]: {
         event_category: EventCategory.UX,
         event_type: EventAction.SCREEN_VIEW,
-        other_contact: isSpecialContact ? 'yes' : 'no',
+        other_contact: senderId !== 'default' ? 'yes' : 'no',
       },
     };
   }

--- a/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/SendAddCourtesyAddressStrategy.ts
+++ b/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/SendAddCourtesyAddressStrategy.ts
@@ -32,11 +32,17 @@ export class SendAddCourtesyAddressStrategy implements EventStrategy {
         [EventPropertyType.PROFILE]: {
           SEND_HAS_EMAIL: 'yes',
         },
+        [EventPropertyType.SUPER_PROPERTY]: {
+          SEND_HAS_EMAIL: 'yes',
+        },
       };
     }
 
     return {
       [EventPropertyType.PROFILE]: {
+        SEND_HAS_SMS: 'yes',
+      },
+      [EventPropertyType.SUPER_PROPERTY]: {
         SEND_HAS_SMS: 'yes',
       },
     };

--- a/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/SendAddLegalAddressStrategy.ts
+++ b/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/SendAddLegalAddressStrategy.ts
@@ -18,6 +18,7 @@ export class SendAddLegalAddressStrategy implements EventStrategy {
 
     return {
       [EventPropertyType.PROFILE]: { SEND_HAS_PEC: 'yes' },
+      [EventPropertyType.SUPER_PROPERTY]: { SEND_HAS_PEC: 'yes' },
     };
   }
 }

--- a/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/SendHasAddressesStrategy.ts
+++ b/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/SendHasAddressesStrategy.ts
@@ -45,6 +45,12 @@ export class SendHasAddressesStrategy implements EventStrategy {
         SEND_HAS_SMS: hasCourtesySmsAddresses ? 'yes' : 'no',
         SEND_APPIO_STATUS: ioStatus,
       },
+      [EventPropertyType.SUPER_PROPERTY]: {
+        SEND_HAS_PEC: hasLegalAddresses ? 'yes' : 'no',
+        SEND_HAS_EMAIL: hasCourtesyEmailAddresses ? 'yes' : 'no',
+        SEND_HAS_SMS: hasCourtesySmsAddresses ? 'yes' : 'no',
+        SEND_APPIO_STATUS: ioStatus,
+      },
     };
   }
 }

--- a/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/SendRemoveCourtesyAddress.ts
+++ b/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/SendRemoveCourtesyAddress.ts
@@ -20,18 +20,29 @@ export class SendRemoveCourtesyAddressStrategy implements EventStrategy {
   performComputations({
     params,
   }: SendRemoveCourtesyAddressData): TrackedEvent<SendRemoveCourtesyAddressReturn> {
-    if (params.channelType === CourtesyChannelType.EMAIL) {
+    // If i'm removing a special contact (senderId !== 'default') I don't want to update the profile property
+    if (params.senderId === 'default') {
+      if (params.channelType === CourtesyChannelType.EMAIL) {
+        return {
+          [EventPropertyType.PROFILE]: {
+            SEND_HAS_EMAIL: 'no',
+          },
+          [EventPropertyType.SUPER_PROPERTY]: {
+            SEND_HAS_EMAIL: 'no',
+          },
+        };
+      }
+
       return {
         [EventPropertyType.PROFILE]: {
-          SEND_HAS_EMAIL: 'no',
+          SEND_HAS_SMS: 'no',
+        },
+        [EventPropertyType.SUPER_PROPERTY]: {
+          SEND_HAS_SMS: 'no',
         },
       };
+    } else {
+      return {};
     }
-
-    return {
-      [EventPropertyType.PROFILE]: {
-        SEND_HAS_SMS: 'no',
-      },
-    };
   }
 }

--- a/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/SendRemoveLegalAddress.ts
+++ b/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/SendRemoveLegalAddress.ts
@@ -1,15 +1,32 @@
 import { EventPropertyType, EventStrategy, TrackedEvent } from '@pagopa-pn/pn-commons';
 
+import { DeleteDigitalAddressParams } from '../../../redux/contact/types';
+
 type SendRemoveLegalAddress = {
   SEND_HAS_PEC: 'no';
 };
 
+type SendRemoveLegalAddressData = {
+  payload: string;
+  params: DeleteDigitalAddressParams;
+};
+
 export class SendRemoveLegalAddressStrategy implements EventStrategy {
-  performComputations(): TrackedEvent<SendRemoveLegalAddress> {
-    return {
-      [EventPropertyType.PROFILE]: {
-        SEND_HAS_PEC: 'no',
-      },
-    };
+  performComputations({
+    params,
+  }: SendRemoveLegalAddressData): TrackedEvent<SendRemoveLegalAddress> {
+    // If i'm removing a special contact (senderId !== 'default') I don't want to update the profile property
+    if (params.senderId === 'default') {
+      return {
+        [EventPropertyType.PROFILE]: {
+          SEND_HAS_PEC: 'no',
+        },
+        [EventPropertyType.SUPER_PROPERTY]: {
+          SEND_HAS_PEC: 'no',
+        },
+      };
+    } else {
+      return {};
+    }
   }
 }

--- a/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/__test__/SendAddContactActionStrategy.test.ts
+++ b/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/__test__/SendAddContactActionStrategy.test.ts
@@ -6,7 +6,7 @@ describe('Mixpanel - Add contact action Strategy', () => {
   it('should return add contact action event', () => {
     const strategy = new SendAddContactActionStrategy();
 
-    const isOtherContactEvent = strategy.performComputations(true);
+    const isOtherContactEvent = strategy.performComputations('1233456');
     expect(isOtherContactEvent).toEqual({
       [EventPropertyType.TRACK]: {
         event_category: EventCategory.UX,
@@ -15,7 +15,7 @@ describe('Mixpanel - Add contact action Strategy', () => {
       },
     });
 
-    const isNotOtherContactEvent = strategy.performComputations(false);
+    const isNotOtherContactEvent = strategy.performComputations('default');
     expect(isNotOtherContactEvent).toEqual({
       [EventPropertyType.TRACK]: {
         event_category: EventCategory.UX,

--- a/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/__test__/SendAddContactScreenViewStrategy.test.ts
+++ b/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/__test__/SendAddContactScreenViewStrategy.test.ts
@@ -6,7 +6,7 @@ describe('Mixpanel - Add contact screen view Strategy', () => {
   it('should return add contact screen view event', () => {
     const strategy = new SendAddContactScreenViewStrategy();
 
-    const isOtherContactEvent = strategy.performComputations(true);
+    const isOtherContactEvent = strategy.performComputations('123456');
     expect(isOtherContactEvent).toEqual({
       [EventPropertyType.TRACK]: {
         event_category: EventCategory.UX,
@@ -15,7 +15,7 @@ describe('Mixpanel - Add contact screen view Strategy', () => {
       },
     });
 
-    const isNotOtherContactEvent = strategy.performComputations(false);
+    const isNotOtherContactEvent = strategy.performComputations('default');
     expect(isNotOtherContactEvent).toEqual({
       [EventPropertyType.TRACK]: {
         event_category: EventCategory.UX,

--- a/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/__test__/SendAddCourtesyAddressStrategy.test.ts
+++ b/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/__test__/SendAddCourtesyAddressStrategy.test.ts
@@ -40,6 +40,9 @@ describe('Mixpanel - Add Courtesy Address Strategy', () => {
       [EventPropertyType.PROFILE]: {
         SEND_HAS_EMAIL: 'yes',
       },
+      [EventPropertyType.SUPER_PROPERTY]: {
+        SEND_HAS_EMAIL: 'yes',
+      },
     });
   });
 
@@ -61,6 +64,9 @@ describe('Mixpanel - Add Courtesy Address Strategy', () => {
 
     expect(event).toEqual({
       [EventPropertyType.PROFILE]: {
+        SEND_HAS_SMS: 'yes',
+      },
+      [EventPropertyType.SUPER_PROPERTY]: {
         SEND_HAS_SMS: 'yes',
       },
     });

--- a/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/__test__/SendAddLegalAddressStrategy.test.ts
+++ b/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/__test__/SendAddLegalAddressStrategy.test.ts
@@ -25,6 +25,9 @@ describe('Mixpanel - Add Legal Address Strategy', () => {
       [EventPropertyType.PROFILE]: {
         SEND_HAS_PEC: 'yes',
       },
+      [EventPropertyType.SUPER_PROPERTY]: {
+        SEND_HAS_PEC: 'yes',
+      },
     });
   });
 });

--- a/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/__test__/SendHasAddressesStrategy.test.ts
+++ b/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/__test__/SendHasAddressesStrategy.test.ts
@@ -17,6 +17,12 @@ describe('Mixpanel - Has Addresses Strategy', () => {
         SEND_HAS_PEC: 'yes',
         SEND_HAS_SMS: 'yes',
       },
+      [EventPropertyType.SUPER_PROPERTY]: {
+        SEND_APPIO_STATUS: 'deactivated',
+        SEND_HAS_EMAIL: 'yes',
+        SEND_HAS_PEC: 'yes',
+        SEND_HAS_SMS: 'yes',
+      },
     });
   });
 
@@ -31,6 +37,12 @@ describe('Mixpanel - Has Addresses Strategy', () => {
 
     expect(hasPecEvent).toEqual({
       [EventPropertyType.PROFILE]: {
+        SEND_APPIO_STATUS: 'deactivated',
+        SEND_HAS_EMAIL: 'yes',
+        SEND_HAS_PEC: 'no',
+        SEND_HAS_SMS: 'yes',
+      },
+      [EventPropertyType.SUPER_PROPERTY]: {
         SEND_APPIO_STATUS: 'deactivated',
         SEND_HAS_EMAIL: 'yes',
         SEND_HAS_PEC: 'no',
@@ -57,6 +69,12 @@ describe('Mixpanel - Has Addresses Strategy', () => {
         SEND_HAS_PEC: 'yes',
         SEND_HAS_SMS: 'yes',
       },
+      [EventPropertyType.SUPER_PROPERTY]: {
+        SEND_APPIO_STATUS: 'deactivated',
+        SEND_HAS_EMAIL: 'no',
+        SEND_HAS_PEC: 'yes',
+        SEND_HAS_SMS: 'yes',
+      },
     });
   });
 
@@ -78,6 +96,12 @@ describe('Mixpanel - Has Addresses Strategy', () => {
         SEND_HAS_PEC: 'yes',
         SEND_HAS_SMS: 'no',
       },
+      [EventPropertyType.SUPER_PROPERTY]: {
+        SEND_APPIO_STATUS: 'deactivated',
+        SEND_HAS_EMAIL: 'yes',
+        SEND_HAS_PEC: 'yes',
+        SEND_HAS_SMS: 'no',
+      },
     });
   });
 
@@ -94,6 +118,12 @@ describe('Mixpanel - Has Addresses Strategy', () => {
 
     expect(hasPecEvent).toEqual({
       [EventPropertyType.PROFILE]: {
+        SEND_APPIO_STATUS: 'nd',
+        SEND_HAS_EMAIL: 'yes',
+        SEND_HAS_PEC: 'yes',
+        SEND_HAS_SMS: 'yes',
+      },
+      [EventPropertyType.SUPER_PROPERTY]: {
         SEND_APPIO_STATUS: 'nd',
         SEND_HAS_EMAIL: 'yes',
         SEND_HAS_PEC: 'yes',
@@ -121,6 +151,12 @@ describe('Mixpanel - Has Addresses Strategy', () => {
 
     expect(hasPecEvent).toEqual({
       [EventPropertyType.PROFILE]: {
+        SEND_APPIO_STATUS: 'activated',
+        SEND_HAS_EMAIL: 'yes',
+        SEND_HAS_PEC: 'yes',
+        SEND_HAS_SMS: 'yes',
+      },
+      [EventPropertyType.SUPER_PROPERTY]: {
         SEND_APPIO_STATUS: 'activated',
         SEND_HAS_EMAIL: 'yes',
         SEND_HAS_PEC: 'yes',

--- a/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/__test__/SendRemoveCourtesyAddress.test.ts
+++ b/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/__test__/SendRemoveCourtesyAddress.test.ts
@@ -16,12 +16,15 @@ describe('Mixpanel - Remove Courtesy Address Strategy', () => {
       params: {
         channelType: address!.channelType,
         recipientId: address!.recipientId,
-        senderId: address!.senderId,
+        senderId: 'default',
       },
     });
 
     expect(event).toEqual({
       [EventPropertyType.PROFILE]: {
+        SEND_HAS_EMAIL: 'no',
+      },
+      [EventPropertyType.SUPER_PROPERTY]: {
         SEND_HAS_EMAIL: 'no',
       },
     });
@@ -38,7 +41,7 @@ describe('Mixpanel - Remove Courtesy Address Strategy', () => {
       params: {
         channelType: address!.channelType,
         recipientId: address!.recipientId,
-        senderId: address!.senderId,
+        senderId: 'default',
       },
     });
 
@@ -46,6 +49,27 @@ describe('Mixpanel - Remove Courtesy Address Strategy', () => {
       [EventPropertyType.PROFILE]: {
         SEND_HAS_SMS: 'no',
       },
+      [EventPropertyType.SUPER_PROPERTY]: {
+        SEND_HAS_SMS: 'no',
+      },
     });
+  });
+
+  it('should return empty object if senderId is not default', () => {
+    const strategy = new SendRemoveCourtesyAddressStrategy();
+    const address = digitalAddresses.courtesy.find(
+      (a) => a.channelType === CourtesyChannelType.SMS
+    );
+
+    const event = strategy.performComputations({
+      payload: 'not-default',
+      params: {
+        channelType: address!.channelType,
+        recipientId: address!.recipientId,
+        senderId: 'not-default',
+      },
+    });
+
+    expect(event).toEqual({});
   });
 });

--- a/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/__test__/SendRemoveLegalAddress.test.ts
+++ b/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/__test__/SendRemoveLegalAddress.test.ts
@@ -1,17 +1,48 @@
 import { EventPropertyType } from '@pagopa-pn/pn-commons';
 
+import { LegalChannelType } from '../../../../models/contacts';
+import { DeleteDigitalAddressParams } from '../../../../redux/contact/types';
 import { SendRemoveLegalAddressStrategy } from '../SendRemoveLegalAddress';
 
 describe('Mixpanel - Remove Legal Address Strategy', () => {
-  it('should return remove legal address event', () => {
+  it('should return remove legal address event if senderId is default', () => {
     const strategy = new SendRemoveLegalAddressStrategy();
 
-    const event = strategy.performComputations();
+    const params: { payload: string; params: DeleteDigitalAddressParams } = {
+      payload: 'OK',
+      params: {
+        senderId: 'default',
+        recipientId: 'default',
+        channelType: LegalChannelType.PEC,
+      },
+    };
+
+    const event = strategy.performComputations(params);
 
     expect(event).toEqual({
       [EventPropertyType.PROFILE]: {
         SEND_HAS_PEC: 'no',
       },
+      [EventPropertyType.SUPER_PROPERTY]: {
+        SEND_HAS_PEC: 'no',
+      },
     });
+  });
+
+  it('should return empty object if senderId is not default', () => {
+    const strategy = new SendRemoveLegalAddressStrategy();
+
+    const params: { payload: string; params: DeleteDigitalAddressParams } = {
+      payload: 'OK',
+      params: {
+        senderId: 'not-default',
+        recipientId: 'default',
+        channelType: LegalChannelType.PEC,
+      },
+    };
+
+    const event = strategy.performComputations(params);
+
+    expect(event).toEqual({});
   });
 });


### PR DESCRIPTION
## Short description
Fix some Mixpanel regressiona and add track of super profile properties

## List of changes proposed in this pull request
- Fix some events
- Add Super Profile Properties

## How to test
To test the super profile properties, start PF and verify that the `SEND_APPIO_STATUS`, `SEND_HAS_PEC`, `SEND_HAS_EMAIL`, `SEND_HAS_SMS` events are tracked after login and when removing/adding a contact.
To tests regression check [PN-10821](https://pagopa.atlassian.net/browse/PN-10821)