### PR TITLE
Fix/PN-11403 - Manage api error for sender dashboard

### DIFF
--- a/packages/pn-pa-webapp/public/locales/it/statistics.json
+++ b/packages/pn-pa-webapp/public/locales/it/statistics.json
@@ -3,6 +3,7 @@
   "subtitle": "Esplora le statistiche relative alle notifiche del tuo ente su SEND - Servizio Notifiche Digitali",
   "section_1": "Panoramica delle notifiche",
   "section_2": "Dettaglio delle notifiche inviate digitalmente",
+  "error-fetch": "Non è stato possibile recuperare i dati relativi alle statistiche di invio delle notifiche dell'ente",
   "export_all": "Esporta JPEG",
   "last_update": "Ultimo aggiornamento {{dateTime}}",
   "aggregate_graph": "Aggregato",

--- a/packages/pn-pa-webapp/src/pages/Statistics.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/Statistics.page.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 
 import { Box, Stack, Typography } from '@mui/material';
 import {
+  ApiErrorWrapper,
   TitleBox,
   formatDateTime,
   formatToSlicedISOString,
@@ -22,7 +23,7 @@ import FilterStatistics, {
 import LastStateStatistics from '../components/Statistics/LastStateStatistics';
 import { CxType, StatisticsDataTypes, StatisticsFilter } from '../models/Statistics';
 import { useAppDispatch, useAppSelector } from '../redux/hooks';
-import { getStatistics } from '../redux/statistics/actions';
+import { STATISTICS_ACTIONS, getStatistics } from '../redux/statistics/actions';
 import { RootState } from '../redux/store';
 
 const cxType = CxType.PA;
@@ -78,70 +79,77 @@ const Statistics = () => {
 
   return (
     <Box p={3}>
-      {statisticsData ? (
-        <>
-          <TitleBox
-            title={t('title')}
-            variantTitle="h4"
-            subTitle={Subtitle}
-            variantSubTitle="subtitle1"
-          />
-          <Typography variant="caption" sx={{ color: '#5C6F82' }}>
-            {lastUpdateTxt}
-          </Typography>
-          <Typography variant="h6" component="h5" mt={7}>
-            {t('section_1')}
-          </Typography>
-          <FilterStatistics filter={statisticsFilter} />
-          <Stack direction={'column'} spacing={3} pt={2}>
-            <FiledNotificationsStatistics
-              startDate={statisticsData.startDate ?? formatToSlicedISOString(oneYearAgo)}
-              endDate={statisticsData.endDate ?? formatToSlicedISOString(today)}
-              data={statisticsData.data[StatisticsDataTypes.FiledStatistics]}
+      <ApiErrorWrapper
+        apiId={STATISTICS_ACTIONS.GET_STATISTICS}
+        reloadAction={() => fetchStatistics()}
+        mainText={t('error-fetch')}
+        mt={3}
+      >
+        {statisticsData ? (
+          <>
+            <TitleBox
+              title={t('title')}
+              variantTitle="h4"
+              subTitle={Subtitle}
+              variantSubTitle="subtitle1"
             />
-            <Stack direction={{ lg: 'row', xs: 'column' }} spacing={3} mt={4}>
-              <Box sx={{ width: { xs: '100%', lg: '50%' } }}>
-                <LastStateStatistics
-                  data={statisticsData.data[StatisticsDataTypes.LastStateStatistics]}
-                />
+            <Typography variant="caption" sx={{ color: '#5C6F82' }}>
+              {lastUpdateTxt}
+            </Typography>
+            <Typography variant="h6" component="h5" mt={7}>
+              {t('section_1')}
+            </Typography>
+            <FilterStatistics filter={statisticsFilter} />
+            <Stack direction={'column'} spacing={3} pt={2}>
+              <FiledNotificationsStatistics
+                startDate={statisticsData.startDate ?? formatToSlicedISOString(oneYearAgo)}
+                endDate={statisticsData.endDate ?? formatToSlicedISOString(today)}
+                data={statisticsData.data[StatisticsDataTypes.FiledStatistics]}
+              />
+              <Stack direction={{ lg: 'row', xs: 'column' }} spacing={3} mt={4}>
+                <Box sx={{ width: { xs: '100%', lg: '50%' } }}>
+                  <LastStateStatistics
+                    data={statisticsData.data[StatisticsDataTypes.LastStateStatistics]}
+                  />
+                </Box>
+                <Box sx={{ width: { xs: '100%', lg: '50%' } }}>
+                  <DeliveryModeStatistics
+                    startDate={statisticsData.startDate ?? formatToSlicedISOString(oneYearAgo)}
+                    endDate={statisticsData.endDate ?? formatToSlicedISOString(today)}
+                    data={statisticsData.data[StatisticsDataTypes.DeliveryModeStatistics]}
+                  />
+                </Box>
+              </Stack>
+              <Box>
+                <Typography variant="h6" component="h5" mt={6}>
+                  {t('section_2')}
+                </Typography>
+                <FilterStatistics filter={statisticsFilter} />
               </Box>
-              <Box sx={{ width: { xs: '100%', lg: '50%' } }}>
-                <DeliveryModeStatistics
-                  startDate={statisticsData.startDate ?? formatToSlicedISOString(oneYearAgo)}
-                  endDate={statisticsData.endDate ?? formatToSlicedISOString(today)}
-                  data={statisticsData.data[StatisticsDataTypes.DeliveryModeStatistics]}
-                />
-              </Box>
+              <Stack direction={{ lg: 'row', xs: 'column' }} spacing={3} mt={4}>
+                <Box sx={{ width: { xs: '100%', lg: '50%' } }}>
+                  <DigitalStateStatistics
+                    data={statisticsData.data[StatisticsDataTypes.DigitalStateStatistics]}
+                  />
+                </Box>
+                <Box sx={{ width: { xs: '100%', lg: '50%' } }}>
+                  <DigitalMeanTimeStatistics
+                    data={statisticsData.data[StatisticsDataTypes.DigitalMeanTimeStatistics]}
+                  />
+                </Box>
+              </Stack>
+              <DigitalErrorsDetailStatistics
+                data={statisticsData.data[StatisticsDataTypes.DigitalErrorsDetailStatistics]}
+              />
             </Stack>
-            <Box>
-              <Typography variant="h6" component="h5" mt={6}>
-                {t('section_2')}
-              </Typography>
-              <FilterStatistics filter={statisticsFilter} />
-            </Box>
-            <Stack direction={{ lg: 'row', xs: 'column' }} spacing={3} mt={4}>
-              <Box sx={{ width: { xs: '100%', lg: '50%' } }}>
-                <DigitalStateStatistics
-                  data={statisticsData.data[StatisticsDataTypes.DigitalStateStatistics]}
-                />
-              </Box>
-              <Box sx={{ width: { xs: '100%', lg: '50%' } }}>
-                <DigitalMeanTimeStatistics
-                  data={statisticsData.data[StatisticsDataTypes.DigitalMeanTimeStatistics]}
-                />
-              </Box>
-            </Stack>
-            <DigitalErrorsDetailStatistics
-              data={statisticsData.data[StatisticsDataTypes.DigitalErrorsDetailStatistics]}
-            />
-          </Stack>
-        </>
-      ) : (
-        <>
-          <TitleBox title={t('title')} variantTitle="h4" subTitle={''} variantSubTitle="body1" />
-          <EmptyStatistics sx={{ mt: 5 }} />
-        </>
-      )}
+          </>
+        ) : (
+          <>
+            <TitleBox title={t('title')} variantTitle="h4" subTitle={''} variantSubTitle="body1" />
+            <EmptyStatistics sx={{ mt: 5 }} />
+          </>
+        )}
+      </ApiErrorWrapper>
     </Box>
   );
 };


### PR DESCRIPTION
## Short description
Handle the case the server responds with a 4xx or 5xx response to a getStatistics api request using the ApiErrorWrapper

## List of changes proposed in this pull request
- use ApiErrorWrapper inside Statistics.page

## How to test
Prerequisite: IS_STATISTICS_ENABLED env var should be set to true
- In Statistics.page change the cxId at line 70 with any random string to simulate a bad request and force the server to respond with a 400.