### PR TITLE
PN-11288 - Focusable elements on contacts page

### DIFF
--- a/packages/pn-commons/src/components/AppStatus/AppStatusBar.tsx
+++ b/packages/pn-commons/src/components/AppStatus/AppStatusBar.tsx
@@ -52,7 +52,7 @@ export const AppStatusBar = ({ status }: { status: AppCurrentStatus }) => {
           color: mainColor,
         }}
       />
-      <Typography tabIndex={0} aria-label={statusText} variant="body2">
+      <Typography aria-label={statusText} variant="body2">
         {statusText}
       </Typography>
     </Stack>

--- a/packages/pn-commons/src/components/AppStatus/AppStatusRender.tsx
+++ b/packages/pn-commons/src/components/AppStatus/AppStatusRender.tsx
@@ -141,7 +141,6 @@ export const AppStatusRender = (props: Props) => {
               <Typography
                 variant="caption"
                 sx={{ mt: 2, color: 'text.secondary' }}
-                tabIndex={0}
                 aria-label={lastCheckLegend}
               >
                 {lastCheckLegend}
@@ -151,12 +150,7 @@ export const AppStatusRender = (props: Props) => {
         </ApiErrorWrapper>
 
         {/* Titolo elenco di downtime */}
-        <Typography
-          variant="h6"
-          sx={{ mt: '36px', mb: 2 }}
-          tabIndex={0}
-          aria-label={downtimeListTitle}
-        >
+        <Typography variant="h6" sx={{ mt: '36px', mb: 2 }} aria-label={downtimeListTitle}>
           {downtimeListTitle}
         </Typography>
 

--- a/packages/pn-commons/src/components/TitleBox.tsx
+++ b/packages/pn-commons/src/components/TitleBox.tsx
@@ -51,7 +51,6 @@ const TitleBox: React.FC<Props> = ({
           data-testid="titleBox"
           role="heading"
           aria-label={ariaLabel}
-          aria-selected="true"
           variant={variantTitle}
           display="inline-block"
           sx={{ verticalAlign: 'middle' }}

--- a/packages/pn-commons/src/components/TitleBox.tsx
+++ b/packages/pn-commons/src/components/TitleBox.tsx
@@ -43,14 +43,7 @@ const TitleBox: React.FC<Props> = ({
   ariaLabel,
   children,
 }) => (
-  <Grid
-    id="page-header-container"
-    aria-orientation="horizontal"
-    tabIndex={0}
-    container
-    mt={mtGrid}
-    sx={sx}
-  >
+  <Grid id="page-header-container" aria-orientation="horizontal" container mt={mtGrid} sx={sx}>
     {title && (
       <Grid id="item" item xs={12} mb={mbTitle}>
         <Typography

--- a/packages/pn-personafisica-webapp/src/components/Contacts/CourtesyContacts.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/CourtesyContacts.tsx
@@ -28,7 +28,6 @@ const CourtesyContacts: React.FC<Props> = ({ contacts }) => {
         <CourtesyContactsList contacts={contacts} />
       </Box>
       <Alert
-        tabIndex={0}
         role="banner"
         aria-label={t('courtesy-contacts.disclaimer-message', { ns: 'recapiti' })}
         sx={{ mt: 4 }}

--- a/packages/pn-personafisica-webapp/src/components/Contacts/IOContact.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/IOContact.tsx
@@ -107,7 +107,6 @@ const IOContact: React.FC<Props> = ({ contact }) => {
     } else {
       return (
         <Alert
-          tabIndex={0}
           role="banner"
           sx={{ mt: 4 }}
           aria-label={

--- a/packages/pn-personafisica-webapp/src/components/Contacts/LegalContactsList.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/LegalContactsList.tsx
@@ -170,7 +170,6 @@ const LegalContactsList = ({ legalAddresses }: Props) => {
           </Box>
         )}
         <Alert
-          tabIndex={0}
           role="banner"
           aria-label={t('legal-contacts.disclaimer-message', { ns: 'recapiti' })}
           sx={{ mt: 4 }}

--- a/packages/pn-personafisica-webapp/src/pages/Contacts.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/Contacts.page.tsx
@@ -4,7 +4,6 @@ import { useNavigate } from 'react-router-dom';
 
 import { Box, Link, Stack, Typography } from '@mui/material';
 import { ApiErrorWrapper, TitleBox } from '@pagopa-pn/pn-commons';
-import { ButtonNaked } from '@pagopa/mui-italia';
 
 import CourtesyContacts from '../components/Contacts/CourtesyContacts';
 import { DigitalContactsCodeVerificationProvider } from '../components/Contacts/DigitalContactsCodeVerification.context';
@@ -113,15 +112,14 @@ const Contacts = () => {
         t('subtitle-link-2', { ns: 'recapiti' })
       )}
       {t('subtitle-text-3', { ns: 'recapiti' })}
-      <ButtonNaked
-        sx={{ verticalAlign: 'inherit' }}
+      <Link
         onClick={handleRedirectToProfilePage}
         aria-label={t('subtitle-link-3', { ns: 'recapiti' })}
+        component="button"
+        sx={{ verticalAlign: 'inherit' }}
       >
-        <Typography color="primary" sx={{ cursor: 'pointer', textDecoration: 'underline' }}>
-          {t('subtitle-link-3', { ns: 'recapiti' })}
-        </Typography>
-      </ButtonNaked>
+        {t('subtitle-link-3', { ns: 'recapiti' })}
+      </Link>
       {t('subtitle-text-4', { ns: 'recapiti' })}
     </>
   );

--- a/packages/pn-personafisica-webapp/src/pages/Contacts.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/Contacts.page.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { Box, Link, Stack, Typography } from '@mui/material';
 import { ApiErrorWrapper, TitleBox } from '@pagopa-pn/pn-commons';
+import { ButtonNaked } from '@pagopa/mui-italia';
 
 import CourtesyContacts from '../components/Contacts/CourtesyContacts';
 import { DigitalContactsCodeVerificationProvider } from '../components/Contacts/DigitalContactsCodeVerification.context';
@@ -112,13 +113,15 @@ const Contacts = () => {
         t('subtitle-link-2', { ns: 'recapiti' })
       )}
       {t('subtitle-text-3', { ns: 'recapiti' })}
-      <Link
+      <ButtonNaked
+        sx={{ verticalAlign: 'inherit' }}
         onClick={handleRedirectToProfilePage}
-        tabIndex={0}
         aria-label={t('subtitle-link-3', { ns: 'recapiti' })}
       >
-        {t('subtitle-link-3', { ns: 'recapiti' })}
-      </Link>
+        <Typography color="primary" sx={{ cursor: 'pointer', textDecoration: 'underline' }}>
+          {t('subtitle-link-3', { ns: 'recapiti' })}
+        </Typography>
+      </ButtonNaked>
       {t('subtitle-text-4', { ns: 'recapiti' })}
     </>
   );

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/CourtesyContacts.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/CourtesyContacts.tsx
@@ -28,7 +28,6 @@ const CourtesyContacts: React.FC<Props> = ({ contacts }) => {
         <CourtesyContactsList contacts={contacts} />
       </Box>
       <Alert
-        tabIndex={0}
         role="banner"
         aria-label={t('courtesy-contacts.disclaimer-message', { ns: 'recapiti' })}
         sx={{ mt: 4 }}

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/LegalContactsList.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/LegalContactsList.tsx
@@ -171,7 +171,6 @@ const LegalContactsList = ({ legalAddresses }: Props) => {
         )}
         <Alert
           role="banner"
-          tabIndex={0}
           aria-label={t('legal-contacts.disclaimer-message', { ns: 'recapiti' })}
           sx={{ mt: 4 }}
           severity="info"

--- a/packages/pn-personagiuridica-webapp/src/pages/Contacts.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/Contacts.page.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { Box, Link, Stack, Typography } from '@mui/material';
+import { Box, Stack, Typography } from '@mui/material';
 import { ApiErrorWrapper, TitleBox } from '@pagopa-pn/pn-commons';
+import { ButtonNaked } from '@pagopa/mui-italia';
 
 import CourtesyContacts from '../components/Contacts/CourtesyContacts';
 import { DigitalContactsCodeVerificationProvider } from '../components/Contacts/DigitalContactsCodeVerification.context';
@@ -53,15 +54,15 @@ const Contacts = () => {
   const subtitle = (
     <>
       {t('subtitle-1', { ns: 'recapiti', recipient: organization.name })}
-      <Link
-        color="primary"
-        fontWeight={'bold'}
+      <ButtonNaked
+        sx={{ verticalAlign: 'inherit' }}
         onClick={handleRedirectToProfilePage}
-        sx={{ cursor: 'pointer' }}
         aria-label={t('subtitle-link', { ns: 'recapiti' })}
       >
-        {t('subtitle-link', { ns: 'recapiti' })}
-      </Link>
+        <Typography color="primary" sx={{ cursor: 'pointer', textDecoration: 'underline' }}>
+          {t('subtitle-link', { ns: 'recapiti' })}
+        </Typography>
+      </ButtonNaked>
       {t('subtitle-2', { ns: 'recapiti' })}
     </>
   );

--- a/packages/pn-personagiuridica-webapp/src/pages/Contacts.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/Contacts.page.tsx
@@ -1,9 +1,8 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { Box, Stack, Typography } from '@mui/material';
+import { Box, Link, Stack, Typography } from '@mui/material';
 import { ApiErrorWrapper, TitleBox } from '@pagopa-pn/pn-commons';
-import { ButtonNaked } from '@pagopa/mui-italia';
 
 import CourtesyContacts from '../components/Contacts/CourtesyContacts';
 import { DigitalContactsCodeVerificationProvider } from '../components/Contacts/DigitalContactsCodeVerification.context';
@@ -54,15 +53,16 @@ const Contacts = () => {
   const subtitle = (
     <>
       {t('subtitle-1', { ns: 'recapiti', recipient: organization.name })}
-      <ButtonNaked
-        sx={{ verticalAlign: 'inherit' }}
+      <Link
+        color="primary"
+        fontWeight={'bold'}
         onClick={handleRedirectToProfilePage}
+        sx={{ verticalAlign: 'inherit' }}
         aria-label={t('subtitle-link', { ns: 'recapiti' })}
+        component="button"
       >
-        <Typography color="primary" sx={{ cursor: 'pointer', textDecoration: 'underline' }}>
-          {t('subtitle-link', { ns: 'recapiti' })}
-        </Typography>
-      </ButtonNaked>
+        {t('subtitle-link', { ns: 'recapiti' })}
+      </Link>
       {t('subtitle-2', { ns: 'recapiti' })}
     </>
   );


### PR DESCRIPTION
## Short description
Make the "Li trovi qui" link focusable and clickable with the `Enter` key. Also, removed `tabIndex` from all titles, subtitles and info box as only interactive elements should be focusable.

## List of changes proposed in this pull request
- Replaced `Link` with `ButtonNaked` components to enable `onClick` with the `Enter` key.
- Removed some `tabIndex` properties from text elements and info box

## How to test
On the Contacts page of PF and PG, try to navigate using the `Tab` key. You should only be able to navigate through interactive elements. Replicate the test on the `AppStatus` page as well.