### PR TITLE
Fix/change sender dashboard download button

### DIFF
--- a/packages/pn-pa-webapp/src/components/Statistics/AggregateStatistics.tsx
+++ b/packages/pn-pa-webapp/src/components/Statistics/AggregateStatistics.tsx
@@ -1,8 +1,9 @@
 import { isArray } from 'lodash';
 import { CSSProperties } from 'react';
-import { useTranslation } from 'react-i18next';
 
 import { PnECharts, PnEChartsProps } from '@pagopa-pn/pn-data-viz';
+
+import { GraphColors } from '../../models/Statistics';
 
 export type AggregateDataItem = {
   title: string;
@@ -30,7 +31,6 @@ const AggregateStatistics: React.FC<Props> = ({
   options,
   sx,
 }) => {
-  const { t } = useTranslation(['statistics']);
   const data: Array<{ value: number; name: string }> = values.map((item) => ({
     value: item.value,
     name: item.title,
@@ -50,14 +50,16 @@ const AggregateStatistics: React.FC<Props> = ({
     toolbox: {
       feature: {
         saveAsImage: {
+          type: 'jpg',
           show: true,
-          title: t('save_as_image'),
+          title: '',
           name: 'chart',
           backgroundColor: 'white',
           pixelRatio: 2,
           iconStyle: {
-            borderColor: '#0055AA',
+            color: GraphColors.navy,
           },
+          icon: 'path://M4.16669 16.6667H15.8334V15H4.16669V16.6667ZM15.8334 7.5H12.5V2.5H7.50002V7.5H4.16669L10 13.3333L15.8334 7.5Z',
         },
       },
     },

--- a/packages/pn-pa-webapp/src/components/Statistics/DigitalMeanTimeStatistics.tsx
+++ b/packages/pn-pa-webapp/src/components/Statistics/DigitalMeanTimeStatistics.tsx
@@ -73,14 +73,16 @@ const DigitalMeanTimeStatistics: React.FC<Props> = (props) => {
     toolbox: {
       feature: {
         saveAsImage: {
+          type: 'jpg',
           show: true,
-          title: t('save_as_image'),
+          title: '',
           name: 'chart',
           backgroundColor: 'white',
           pixelRatio: 2,
           iconStyle: {
-            borderColor: GraphColors.navy,
+            color: GraphColors.navy,
           },
+          icon: 'path://M4.16669 16.6667H15.8334V15H4.16669V16.6667ZM15.8334 7.5H12.5V2.5H7.50002V7.5H4.16669L10 13.3333L15.8334 7.5Z',
         },
       },
     },

--- a/packages/pn-pa-webapp/src/components/Statistics/DigitalStateStatistics.tsx
+++ b/packages/pn-pa-webapp/src/components/Statistics/DigitalStateStatistics.tsx
@@ -73,14 +73,16 @@ const DigitalStateStatistics: React.FC<Props> = (props) => {
     toolbox: {
       feature: {
         saveAsImage: {
+          type: 'jpg',
           show: true,
-          title: t('save_as_image'),
+          title: '',
           name: 'chart',
           backgroundColor: 'white',
           pixelRatio: 2,
           iconStyle: {
-            borderColor: GraphColors.navy,
+            color: GraphColors.navy,
           },
+          icon: 'path://M4.16669 16.6667H15.8334V15H4.16669V16.6667ZM15.8334 7.5H12.5V2.5H7.50002V7.5H4.16669L10 13.3333L15.8334 7.5Z',
         },
       },
     },

--- a/packages/pn-pa-webapp/src/components/Statistics/FilterStatistics.tsx
+++ b/packages/pn-pa-webapp/src/components/Statistics/FilterStatistics.tsx
@@ -141,7 +141,7 @@ const FilterStatistics: React.FC<Props> = ({ filter }) => {
       <Chip
         key={elem}
         label={t(`filter.${elem}`)}
-        sx={{ mr: 1 }}
+        sx={{ mr: 1, mb: { xl: 0, xs: 1 } }}
         variant="outlined"
         component="button"
         color={elem === formik.values.selected ? 'primary' : 'default'}
@@ -154,7 +154,7 @@ const FilterStatistics: React.FC<Props> = ({ filter }) => {
   }, [filter]);
   return (
     <Stack
-      direction={{ lg: 'row', xs: 'column' }}
+      direction={{ xl: 'row', lg: 'column' }}
       mt={4}
       mb={1}
       display="flex"

--- a/packages/pn-pa-webapp/src/components/Statistics/LastStateStatistics.tsx
+++ b/packages/pn-pa-webapp/src/components/Statistics/LastStateStatistics.tsx
@@ -66,14 +66,16 @@ const LastStateStatistics: React.FC<Props> = (props) => {
     toolbox: {
       feature: {
         saveAsImage: {
+          type: 'jpg',
           show: true,
-          title: t('save_as_image'),
+          title: '',
           name: 'chart',
           backgroundColor: 'white',
           pixelRatio: 2,
           iconStyle: {
-            borderColor: GraphColors.navy,
+            color: GraphColors.navy,
           },
+          icon: 'path://M4.16669 16.6667H15.8334V15H4.16669V16.6667ZM15.8334 7.5H12.5V2.5H7.50002V7.5H4.16669L10 13.3333L15.8334 7.5Z',
         },
       },
     },

--- a/packages/pn-pa-webapp/src/components/Statistics/TrendStackedStatistics.tsx
+++ b/packages/pn-pa-webapp/src/components/Statistics/TrendStackedStatistics.tsx
@@ -3,7 +3,6 @@
 /* eslint-disable functional/immutable-data */
 import { add, compareAsc } from 'date-fns';
 import type { CSSProperties } from 'react';
-import { useTranslation } from 'react-i18next';
 
 import { formatDateSMonth, formatToSlicedISOString } from '@pagopa-pn/pn-commons';
 import { PnECharts, PnEChartsProps } from '@pagopa-pn/pn-data-viz';
@@ -51,8 +50,6 @@ const TrendStackedStatistics: React.FC<Props> = ({
   options,
   sx,
 }) => {
-  const { t } = useTranslation(['statistics']);
-
   /**
    * Returns all calendar days between startDate and endDate (included)
    *
@@ -189,14 +186,16 @@ const TrendStackedStatistics: React.FC<Props> = ({
     toolbox: {
       feature: {
         saveAsImage: {
+          type: 'jpg',
           show: true,
-          title: t('save_as_image'),
+          title: '',
           name: 'chart',
           backgroundColor: 'white',
           pixelRatio: 2,
           iconStyle: {
-            borderColor: GraphColors.navy,
+            color: GraphColors.navy,
           },
+          icon: 'path://M4.16669 16.6667H15.8334V15H4.16669V16.6667ZM15.8334 7.5H12.5V2.5H7.50002V7.5H4.16669L10 13.3333L15.8334 7.5Z',
         },
       },
     },


### PR DESCRIPTION
## Short description
This PR changes the download button icon for every sender dashboard component using mui icon instead of echart default one. It also removes the tooltip from the download button and sets the image type to jpg instead of default (png)

## List of changes proposed in this pull request
- change the saveAsImage feature inside the echart toolbox property of every statistics component

## How to test
Prerequisite: a IS_STATISTICS_ENABLED env var should be defined and set to true
- navigate to the sender dashboard page and verify the download icon on every chart is shown as expected