### PR TITLE
PN-10685-fe-pa-link-invio-notifiche-e-accesso-alle-informazioni-non-rimanda-a-uno-nuovo-tab-sul-browser

### DIFF
--- a/packages/pn-pa-webapp/src/pages/ApiKeys.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/ApiKeys.page.tsx
@@ -31,7 +31,7 @@ import { getConfiguration } from '../services/configuration.service';
 
 const LinkApiB2b: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
   const { API_B2B_LINK } = getConfiguration();
-  return <Link href={API_B2B_LINK}>{children}</Link>;
+  return <Link href={API_B2B_LINK} target="_blank">{children}</Link>;
 };
 
 const TableGroupsId = ({ groups }: { groups?: Array<{ id: string; name: string }> }) => {


### PR DESCRIPTION
## Short description
The link on the ApiKeys page does not open in a new tab.

## List of changes proposed in this pull request
- added `target='_blank'` to ensure the link opens in a new browser tab

## How to test
Run PA and verify the link opens a new tab.