### PR TITLE
fix/PN-11517 - not resetting the filter to its initial value

### DIFF
--- a/packages/pn-pa-webapp/src/components/Statistics/FilterStatistics.tsx
+++ b/packages/pn-pa-webapp/src/components/Statistics/FilterStatistics.tsx
@@ -78,20 +78,10 @@ const FilterStatistics: React.FC<Props> = ({ filter }) => {
     initialValues: initialValues(filter),
     validationSchema,
     /** onSubmit populates filter */
-    onSubmit: (values: FormikValues) => {
-      const currentFilter = {
-        startDate: values.startDate,
-        endDate: values.endDate,
-        selected: values.selected,
-      };
-      if (_.isEqual(filter, currentFilter)) {
-        return;
-      }
-      dispatch(setStatisticsFilter(currentFilter));
-    },
+    onSubmit: () => {},
   });
 
-  const getRangeDates = (range: SelectedStatisticsFilterKeys, loading: boolean): [Date, Date] => {
+  const getRangeDates = (range: SelectedStatisticsFilterKeys, loading: boolean = false): [Date, Date] => {
     switch (range) {
       case SelectedStatisticsFilter.lastMonth:
         return [oneMonthAgo, today];
@@ -124,12 +114,16 @@ const FilterStatistics: React.FC<Props> = ({ filter }) => {
   };
 
   const handleSelectFilter = (type: SelectedStatisticsFilterKeys) => {
-    setFilter(type);
-    formik.submitForm().catch((error) => console.log(`${error}`));
+    const [startDate, endDate] = getRangeDates(type);
+    dispatch(setStatisticsFilter({
+      startDate,
+      endDate,
+      selected: type
+    }));
   };
 
   const cleanFilter = () => {
-    dispatch(setStatisticsFilter(null));
+    handleSelectFilter(defaultValues.selected);
   };
 
   const filterChanged =


### PR DESCRIPTION
## Short description
This code fixes some bugs that were causing date filter not to properly reset to its initial value when the user specifies an invalid date right after the page reload (initial state).
This bug was also leading to not apply the immediately subsequent filter choice.

## List of changes proposed in this pull request
- change FilterStatistics component logic to solve issues including:
1.   filter reset
2.   set a new value right after point 1

## How to test
Prerequisite: a IS_STATISTICS_ENABLE env var should be defined and set to true
- using a previous version of the app (branch develop) replicate the user interaction available on the corresponding Jira task and go on following what described in the first comment of the same task for another issue connected with the one reported. Then test the component behaviour after applying the changes contained in this PR to verify everything works fine.