### PR TITLE
PN-11526 - Max length on physical address field of new notification form

### DIFF
--- a/packages/pn-pa-webapp/src/components/NewNotification/Recipient.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/Recipient.tsx
@@ -153,7 +153,7 @@ const Recipient: React.FC<Props> = ({
       showPhysicalAddress: yup.boolean().isTrue(),
       address: yup.string().when('showPhysicalAddress', {
         is: true,
-        then: requiredStringFieldValidation(tc, 1024),
+        then: requiredStringFieldValidation(tc, 44),
       }),
       houseNumber: yup.string().when('showPhysicalAddress', {
         is: true,


### PR DESCRIPTION
## Short description
Set max length to 44 on physical address field of new notification form

## List of changes proposed in this pull request
- Edit validation

## How to test
On PA, create a new notification and try to fill the physical address field with a string longer than 44 characters. You should see the error message: "Scrivi massimo 44 caratteri."