### PR TITLE
Fix/PN-11513-11519 - Filter elements not aligned and too close one each other

### DIFF
--- a/packages/pn-pa-webapp/src/components/Statistics/FilterStatistics.tsx
+++ b/packages/pn-pa-webapp/src/components/Statistics/FilterStatistics.tsx
@@ -160,8 +160,9 @@ const FilterStatistics: React.FC<Props> = ({ filter }) => {
       justifyContent="space-between"
       alignItems="center"
     >
+      
       <Box flexGrow={0} flexShrink={0} >{quickFiltersJsx()}</Box>
-      <Box display="flex" >
+      <Box sx={{ display: isMobile ? 'flex-direction' : 'flex' }} >
         <CustomDatePicker
           language={i18n.language}
           label={t('filter.from_date')}
@@ -189,7 +190,8 @@ const FilterStatistics: React.FC<Props> = ({ filter }) => {
                 type: 'text',
                 'aria-label': t('filter.from_date-input-aria-label'),
               },
-              sx: { mb: isMobile ? 1 : 0, mr: 1 }
+              sx: { mb: isMobile ? 1 : 0, mr: 1 },
+              fullWidth: isMobile
             },
           }}
           disableFuture={true}
@@ -224,6 +226,7 @@ const FilterStatistics: React.FC<Props> = ({ filter }) => {
                 'aria-label': t('filter.to_date-input-aria-label'),
               },
               sx: { mb: isMobile ? 1 : 0, mr: 1 },
+              fullWidth: isMobile
             },
           }}
           disableFuture={true}

--- a/packages/pn-pa-webapp/src/components/Statistics/FilterStatistics.tsx
+++ b/packages/pn-pa-webapp/src/components/Statistics/FilterStatistics.tsx
@@ -160,8 +160,8 @@ const FilterStatistics: React.FC<Props> = ({ filter }) => {
       justifyContent="space-between"
       alignItems="center"
     >
-      <Box>{quickFiltersJsx()}</Box>
-      <Box>
+      <Box flexGrow={0} flexShrink={0} >{quickFiltersJsx()}</Box>
+      <Box display="flex" >
         <CustomDatePicker
           language={i18n.language}
           label={t('filter.from_date')}
@@ -189,7 +189,7 @@ const FilterStatistics: React.FC<Props> = ({ filter }) => {
                 type: 'text',
                 'aria-label': t('filter.from_date-input-aria-label'),
               },
-              sx: { mb: isMobile ? 1 : 0, mr: 1, width: { lg: '180px', xs: '100%' } },
+              sx: { mb: isMobile ? 1 : 0, mr: 1 }
             },
           }}
           disableFuture={true}
@@ -223,7 +223,7 @@ const FilterStatistics: React.FC<Props> = ({ filter }) => {
                 type: 'text',
                 'aria-label': t('filter.to_date-input-aria-label'),
               },
-              sx: { mb: isMobile ? 1 : 0, mr: 1, width: { lg: '180px', xs: '100%' } },
+              sx: { mb: isMobile ? 1 : 0, mr: 1 },
             },
           }}
           disableFuture={true}

--- a/packages/pn-pa-webapp/src/components/Statistics/FilterStatistics.tsx
+++ b/packages/pn-pa-webapp/src/components/Statistics/FilterStatistics.tsx
@@ -144,6 +144,7 @@ const FilterStatistics: React.FC<Props> = ({ filter }) => {
         label={t(`filter.${elem}`)}
         sx={{
           mr: 1,
+          my: { xl: 0, xs: 1 },
           background: elem === formik.values.selected ? GraphColors.lightBlue2 : 'none',
         }}
         variant="outlined"
@@ -158,9 +159,9 @@ const FilterStatistics: React.FC<Props> = ({ filter }) => {
   }, [filter]);
   return (
     <Stack
-      direction={{ xl: 'row', lg: 'column' }}
+      direction={{ xl: 'row', xs: 'column' }}
       mt={4}
-      mb={1}
+      spacing={1}
       display="flex"
       justifyContent="space-between"
       alignItems="center"
@@ -194,8 +195,7 @@ const FilterStatistics: React.FC<Props> = ({ filter }) => {
                 type: 'text',
                 'aria-label': t('filter.from_date-input-aria-label'),
               },
-              fullWidth: isMobile,
-              sx: { mb: isMobile ? '20px' : '0', mr: 1 },
+              sx: { mb: isMobile ? 1 : 0, mr: 1, width: { lg: '180px', xs: '100%' } },
             },
           }}
           disableFuture={true}
@@ -229,8 +229,7 @@ const FilterStatistics: React.FC<Props> = ({ filter }) => {
                 type: 'text',
                 'aria-label': t('filter.to_date-input-aria-label'),
               },
-              fullWidth: isMobile,
-              sx: { mb: isMobile ? '20px' : '0', mr: 1 },
+              sx: { mb: isMobile ? 1 : 0, mr: 1, width: { lg: '180px', xs: '100%' } },
             },
           }}
           disableFuture={true}

--- a/packages/pn-pa-webapp/src/components/Statistics/FilterStatistics.tsx
+++ b/packages/pn-pa-webapp/src/components/Statistics/FilterStatistics.tsx
@@ -162,7 +162,7 @@ const FilterStatistics: React.FC<Props> = ({ filter }) => {
     >
       
       <Box flexGrow={0} flexShrink={0} >{quickFiltersJsx()}</Box>
-      <Box sx={{ display: isMobile ? 'flex-direction' : 'flex' }} >
+      <Box sx={{ display: isMobile ? 'block' : 'flex' }} >
         <CustomDatePicker
           language={i18n.language}
           label={t('filter.from_date')}


### PR DESCRIPTION
## Short description
This PR resolves two layout bugs on the Sender Dashboard that were causing the elements belonging to the date filter
1. break their mutual alignement
2. getting too close one each other
reducing the windows horizontal resolution.

## How to test
Prerequisite: IS_STATISTICS_ENABLED env var should be declared and set to true in pa config.json
- Login into PA webapp and navigate to Sender Dashboard
- using the 'device mode' visualization on the browser verify what follows:
-   reducing the window width the quick filters move above the datepickers before their alignment breaks
-   there's a certain margin between every element of the component