### PR TITLE
fix/PN-11520 - IllusStatistics component not scaling reducing screen resolution

### DIFF
--- a/packages/pn-commons/src/components/Illustrations/IllusStatistics.tsx
+++ b/packages/pn-commons/src/components/Illustrations/IllusStatistics.tsx
@@ -10,7 +10,7 @@ export const IllusStatistics = ({
   gridColor = '#E0E0E0',
   barColor = '#E8EBF1',
 }: IllusStatisticsProps) => (
-  <Illustration name={title} viewBox="0 0 342 130" sx={{ width: 342, height: 130 }}>
+  <Illustration name={title} viewBox="0 0 342 130" sx={{ width: 342, height: 130, maxWidth: '100%', maxHeight: '100%' }}>
     <path
       fillRule="evenodd"
       clipRule="evenodd"


### PR DESCRIPTION
## Short description
This PR fixes a bug causing the IllusStatistics component not to scale down and the subsequent overflowing beyond its container limits on low resolution screens.

## List of changes proposed in this pull request
- set max-width and max-height css properties inside the IllusStatistics component to its container size

## How to test
Prerequisite: IS_STATISTICS_ENABLE env var should be defined and set to true
- Start pa-webapp
- navigate to Statistics page and apply a date filter which causes no data to be available into at least one of the page components or login using a PA which has less than 100 notifications in order to force the empty state
- Reduce the screen resolution and verify the image in question is reduced accordingly