### PR TITLE
fix/PN-11562 - change default value and order for sender dashboard quick filters

### DIFF
--- a/packages/pn-pa-webapp/src/components/Statistics/FilterStatistics.tsx
+++ b/packages/pn-pa-webapp/src/components/Statistics/FilterStatistics.tsx
@@ -32,9 +32,9 @@ import { setStatisticsFilter } from '../../redux/statistics/reducers';
 const quickFilters = Object.values(SelectedStatisticsFilter).filter((value) => value !== 'custom');
 
 export const defaultValues = {
-  startDate: oneMonthAgo,
+  startDate: twelveMonthsAgo,
   endDate: today,
-  selected: SelectedStatisticsFilter.lastMonth,
+  selected: SelectedStatisticsFilter.last12Months,
 };
 
 type Props = {

--- a/packages/pn-pa-webapp/src/models/Statistics.ts
+++ b/packages/pn-pa-webapp/src/models/Statistics.ts
@@ -201,10 +201,10 @@ export enum WEEK_DAYS {
 }
 
 export const SelectedStatisticsFilter = {
-  lastMonth: 'lastMonth',
-  last3Months: 'last3Months',
-  last6Months: 'last6Months',
   last12Months: 'last12Months',
+  last6Months: 'last6Months',
+  last3Months: 'last3Months',
+  lastMonth: 'lastMonth',
   custom: 'custom',
 } as const;
 


### PR DESCRIPTION
## Short description
This PR changes the default value for sender dashboard filter to 12 months and rearrange quick choices in descending order

## How to test
- Go to Sender Dashboard and verify quick choices are in a descending order and the filter is set to "12 months" by default
- Make some changes, reset the filter and verify the value is set set again to default