### PR TITLE
feat/PN-11563 - Add 'download jpeg' button to sender dashboard

### DIFF
--- a/packages/pn-commons/src/hooks/index.ts
+++ b/packages/pn-commons/src/hooks/index.ts
@@ -1,4 +1,4 @@
-import { downloadDocument, useDownloadDocument } from './useDownloadDocument';
+import { downloadDocument } from './useDownloadDocument';
 import { useErrors } from './useErrors';
 import { useHasPermissions } from './useHasPermissions';
 import { useIsCancelled } from './useIsCancelled';
@@ -16,7 +16,6 @@ export {
   useSessionCheck,
   useErrors,
   useTracking,
-  useDownloadDocument,
   useProcess,
   useHasPermissions,
   downloadDocument,

--- a/packages/pn-commons/src/hooks/useDownloadDocument.ts
+++ b/packages/pn-commons/src/hooks/useDownloadDocument.ts
@@ -1,32 +1,4 @@
-import { useEffect } from 'react';
-
 export function downloadDocument(url: string) {
   /* eslint-disable functional/immutable-data */
   window.location.href = url;
-}
-
-type Props = {
-  url?: string;
-  clearDownloadAction?: () => void;
-};
-
-// There are no tests for this hook, since for such a test either the document
-// or the downloadDocument action.
-// For the former, jest offers no simple way to do it.
-// For the latter, we were adding a parameter just for testing.
-// Hence the decision of not producing tests of this hook
-// -------------------------------
-// Carlos Lombardi and Andrea Cimini, 2022.11.17
-// -------------------------------
-export function useDownloadDocument({ url, clearDownloadAction }: Props) {
-  useEffect(() => {
-    if (url) {
-      downloadDocument(url);
-      if (clearDownloadAction) {
-        clearDownloadAction();
-      }
-    }
-  }, [url, clearDownloadAction]);
-
-  return null;
 }

--- a/packages/pn-commons/src/utility/Screenshot/apply-style.ts
+++ b/packages/pn-commons/src/utility/Screenshot/apply-style.ts
@@ -1,0 +1,27 @@
+/* eslint-disable functional/immutable-data */
+import { Options } from './types';
+
+export function applyStyle<T extends HTMLElement>(node: T, options: Options): T {
+  const { style } = node;
+
+  if (options.backgroundColor) {
+    style.backgroundColor = options.backgroundColor;
+  }
+
+  if (options.width) {
+    style.width = `${options.width}px`;
+  }
+
+  if (options.height) {
+    style.height = `${options.height}px`;
+  }
+
+  const manual = options.style;
+  if (manual != null) {
+    Object.keys(manual).forEach((key: any) => {
+      style[key] = manual[key] as string;
+    });
+  }
+
+  return node;
+}

--- a/packages/pn-commons/src/utility/Screenshot/apply-style.ts
+++ b/packages/pn-commons/src/utility/Screenshot/apply-style.ts
@@ -8,20 +8,5 @@ export function applyStyle<T extends HTMLElement>(node: T, options: Options): T 
     style.backgroundColor = options.backgroundColor;
   }
 
-  if (options.width) {
-    style.width = `${options.width}px`;
-  }
-
-  if (options.height) {
-    style.height = `${options.height}px`;
-  }
-
-  const manual = options.style;
-  if (manual != null) {
-    Object.keys(manual).forEach((key: any) => {
-      style[key] = manual[key] as string;
-    });
-  }
-
   return node;
 }

--- a/packages/pn-commons/src/utility/Screenshot/clone-node.ts
+++ b/packages/pn-commons/src/utility/Screenshot/clone-node.ts
@@ -99,16 +99,6 @@ function cloneCSSStyle<T extends HTMLElement>(nativeNode: T, clonedNode: T) {
   }
 }
 
-function cloneInputValue<T extends HTMLElement>(nativeNode: T, clonedNode: T) {
-  if (isInstanceOfElement(nativeNode, HTMLTextAreaElement)) {
-    clonedNode.innerHTML = nativeNode.value;
-  }
-
-  if (isInstanceOfElement(nativeNode, HTMLInputElement)) {
-    clonedNode.setAttribute('value', nativeNode.value);
-  }
-}
-
 function cloneSelectValue<T extends HTMLElement>(nativeNode: T, clonedNode: T) {
   if (isInstanceOfElement(nativeNode, HTMLSelectElement)) {
     const clonedSelect = clonedNode as any as HTMLSelectElement;
@@ -126,7 +116,6 @@ function decorate<T extends HTMLElement>(nativeNode: T, clonedNode: T): T {
   if (isInstanceOfElement(clonedNode, Element)) {
     cloneCSSStyle(nativeNode, clonedNode);
     clonePseudoElements(nativeNode, clonedNode);
-    cloneInputValue(nativeNode, clonedNode);
     cloneSelectValue(nativeNode, clonedNode);
   }
 

--- a/packages/pn-commons/src/utility/Screenshot/clone-node.ts
+++ b/packages/pn-commons/src/utility/Screenshot/clone-node.ts
@@ -2,8 +2,6 @@
 
 /* eslint-disable functional/immutable-data */
 import { clonePseudoElements } from './clone-pseudos';
-import { resourceToDataURL } from './dataurl';
-import { getMimeType } from './mimes';
 import type { Options } from './types';
 import { createImage, isInstanceOfElement, toArray } from './util';
 
@@ -15,49 +13,12 @@ async function cloneCanvasElement(canvas: HTMLCanvasElement) {
   return createImage(dataURL);
 }
 
-async function cloneVideoElement(video: HTMLVideoElement, options: Options) {
-  if (video.currentSrc) {
-    const canvas = document.createElement('canvas');
-    const ctx = canvas.getContext('2d');
-    canvas.width = video.clientWidth;
-    canvas.height = video.clientHeight;
-    ctx?.drawImage(video, 0, 0, canvas.width, canvas.height);
-    const dataURL = canvas.toDataURL();
-    return createImage(dataURL);
-  }
-
-  const poster = video.poster;
-  const contentType = getMimeType(poster);
-  const dataURL = await resourceToDataURL(poster, contentType, options);
-  return createImage(dataURL);
-}
-
-async function cloneIFrameElement(iframe: HTMLIFrameElement) {
-  try {
-    if (iframe?.contentDocument?.body) {
-      return (await cloneNode(iframe.contentDocument.body, {}, true)) as HTMLBodyElement;
-    }
-  } catch {
-    // Failed to clone iframe
-  }
-
-  return iframe.cloneNode(false) as HTMLIFrameElement;
-}
-
 async function cloneSingleNode<T extends HTMLElement>(
-  node: T,
-  options: Options
+  node: T
+  // options: Options
 ): Promise<HTMLElement> {
   if (isInstanceOfElement(node, HTMLCanvasElement)) {
     return cloneCanvasElement(node);
-  }
-
-  if (isInstanceOfElement(node, HTMLVideoElement)) {
-    return cloneVideoElement(node, options);
-  }
-
-  if (isInstanceOfElement(node, HTMLIFrameElement)) {
-    return cloneIFrameElement(node);
   }
 
   return node.cloneNode(false) as T;
@@ -224,7 +185,7 @@ export async function cloneNode<T extends HTMLElement>(
   }
 
   return Promise.resolve(node)
-    .then((clonedNode) => cloneSingleNode(clonedNode, options) as Promise<T>)
+    .then((clonedNode) => cloneSingleNode(clonedNode) as Promise<T>)
     .then((clonedNode) => cloneChildren(node, clonedNode, options))
     .then((clonedNode) => decorate(node, clonedNode))
     .then((clonedNode) => ensureSVGSymbols(clonedNode, options));

--- a/packages/pn-commons/src/utility/Screenshot/clone-node.ts
+++ b/packages/pn-commons/src/utility/Screenshot/clone-node.ts
@@ -1,0 +1,231 @@
+/* eslint-disable functional/no-let */
+
+/* eslint-disable functional/immutable-data */
+import { clonePseudoElements } from './clone-pseudos';
+import { resourceToDataURL } from './dataurl';
+import { getMimeType } from './mimes';
+import type { Options } from './types';
+import { createImage, isInstanceOfElement, toArray } from './util';
+
+async function cloneCanvasElement(canvas: HTMLCanvasElement) {
+  const dataURL = canvas.toDataURL();
+  if (dataURL === 'data:,') {
+    return canvas.cloneNode(false) as HTMLCanvasElement;
+  }
+  return createImage(dataURL);
+}
+
+async function cloneVideoElement(video: HTMLVideoElement, options: Options) {
+  if (video.currentSrc) {
+    const canvas = document.createElement('canvas');
+    const ctx = canvas.getContext('2d');
+    canvas.width = video.clientWidth;
+    canvas.height = video.clientHeight;
+    ctx?.drawImage(video, 0, 0, canvas.width, canvas.height);
+    const dataURL = canvas.toDataURL();
+    return createImage(dataURL);
+  }
+
+  const poster = video.poster;
+  const contentType = getMimeType(poster);
+  const dataURL = await resourceToDataURL(poster, contentType, options);
+  return createImage(dataURL);
+}
+
+async function cloneIFrameElement(iframe: HTMLIFrameElement) {
+  try {
+    if (iframe?.contentDocument?.body) {
+      return (await cloneNode(iframe.contentDocument.body, {}, true)) as HTMLBodyElement;
+    }
+  } catch {
+    // Failed to clone iframe
+  }
+
+  return iframe.cloneNode(false) as HTMLIFrameElement;
+}
+
+async function cloneSingleNode<T extends HTMLElement>(
+  node: T,
+  options: Options
+): Promise<HTMLElement> {
+  if (isInstanceOfElement(node, HTMLCanvasElement)) {
+    return cloneCanvasElement(node);
+  }
+
+  if (isInstanceOfElement(node, HTMLVideoElement)) {
+    return cloneVideoElement(node, options);
+  }
+
+  if (isInstanceOfElement(node, HTMLIFrameElement)) {
+    return cloneIFrameElement(node);
+  }
+
+  return node.cloneNode(false) as T;
+}
+
+const isSlotElement = (node: HTMLElement): node is HTMLSlotElement =>
+  node.tagName != null && node.tagName.toUpperCase() === 'SLOT';
+
+async function cloneChildren<T extends HTMLElement>(
+  nativeNode: T,
+  clonedNode: T,
+  options: Options
+): Promise<T> {
+  let children: Array<T> = [];
+
+  if (isSlotElement(nativeNode) && nativeNode.assignedNodes) {
+    children = toArray<T>(nativeNode.assignedNodes());
+  } else if (
+    isInstanceOfElement(nativeNode, HTMLIFrameElement) &&
+    nativeNode.contentDocument?.body
+  ) {
+    children = toArray<T>(nativeNode.contentDocument.body.childNodes);
+  } else {
+    children = toArray<T>((nativeNode.shadowRoot ?? nativeNode).childNodes);
+  }
+
+  if (children.length === 0 || isInstanceOfElement(nativeNode, HTMLVideoElement)) {
+    return clonedNode;
+  }
+
+  await children.reduce(
+    (deferred, child) =>
+      deferred
+        .then(() => cloneNode(child, options))
+        .then((clonedChild: HTMLElement | null) => {
+          if (clonedChild) {
+            clonedNode.appendChild(clonedChild);
+          }
+        }),
+    Promise.resolve()
+  );
+
+  return clonedNode;
+}
+
+function cloneCSSStyle<T extends HTMLElement>(nativeNode: T, clonedNode: T) {
+  const targetStyle = clonedNode.style;
+  if (!targetStyle) {
+    return;
+  }
+
+  const sourceStyle = window.getComputedStyle(nativeNode);
+  if (sourceStyle.cssText) {
+    targetStyle.cssText = sourceStyle.cssText;
+    targetStyle.transformOrigin = sourceStyle.transformOrigin;
+  } else {
+    toArray<string>(sourceStyle).forEach((name) => {
+      let value = sourceStyle.getPropertyValue(name);
+      if (name === 'font-size' && value.endsWith('px')) {
+        const reducedFont = Math.floor(parseFloat(value.substring(0, value.length - 2))) - 0.1;
+        value = `${reducedFont}px`;
+      }
+
+      if (
+        isInstanceOfElement(nativeNode, HTMLIFrameElement) &&
+        name === 'display' &&
+        value === 'inline'
+      ) {
+        value = 'block';
+      }
+
+      if (name === 'd' && clonedNode.getAttribute('d')) {
+        value = `path(${clonedNode.getAttribute('d')})`;
+      }
+
+      targetStyle.setProperty(name, value, sourceStyle.getPropertyPriority(name));
+    });
+  }
+}
+
+function cloneInputValue<T extends HTMLElement>(nativeNode: T, clonedNode: T) {
+  if (isInstanceOfElement(nativeNode, HTMLTextAreaElement)) {
+    clonedNode.innerHTML = nativeNode.value;
+  }
+
+  if (isInstanceOfElement(nativeNode, HTMLInputElement)) {
+    clonedNode.setAttribute('value', nativeNode.value);
+  }
+}
+
+function cloneSelectValue<T extends HTMLElement>(nativeNode: T, clonedNode: T) {
+  if (isInstanceOfElement(nativeNode, HTMLSelectElement)) {
+    const clonedSelect = clonedNode as any as HTMLSelectElement;
+    const selectedOption = Array.from(clonedSelect.children).find(
+      (child) => nativeNode.value === child.getAttribute('value')
+    );
+
+    if (selectedOption) {
+      selectedOption.setAttribute('selected', '');
+    }
+  }
+}
+
+function decorate<T extends HTMLElement>(nativeNode: T, clonedNode: T): T {
+  if (isInstanceOfElement(clonedNode, Element)) {
+    cloneCSSStyle(nativeNode, clonedNode);
+    clonePseudoElements(nativeNode, clonedNode);
+    cloneInputValue(nativeNode, clonedNode);
+    cloneSelectValue(nativeNode, clonedNode);
+  }
+
+  return clonedNode;
+}
+
+async function ensureSVGSymbols<T extends HTMLElement>(clone: T, options: Options) {
+  const uses = clone.querySelectorAll ? clone.querySelectorAll('use') : [];
+  if (uses.length === 0) {
+    return clone;
+  }
+
+  const processedDefs: { [key: string]: HTMLElement } = {};
+
+  uses.forEach(async (use) => {
+    const id = use.getAttribute('xlink:href');
+    if (id) {
+      const exist = clone.querySelector(id);
+      const definition = document.querySelector(id) as HTMLElement;
+      if (!exist && definition && !processedDefs[id]) {
+        // eslint-disable-next-line no-await-in-loop
+        processedDefs[id] = (await cloneNode(definition, options, true))!;
+      }
+    }
+  });
+
+  const nodes = Object.values(processedDefs);
+  if (nodes.length) {
+    const ns = 'http://www.w3.org/1999/xhtml';
+    const svg = document.createElementNS(ns, 'svg');
+    svg.setAttribute('xmlns', ns);
+    svg.style.position = 'absolute';
+    svg.style.width = '0';
+    svg.style.height = '0';
+    svg.style.overflow = 'hidden';
+    svg.style.display = 'none';
+
+    const defs = document.createElementNS(ns, 'defs');
+    svg.appendChild(defs);
+
+    nodes.forEach((node) => defs.appendChild(node));
+
+    clone.appendChild(svg);
+  }
+
+  return clone;
+}
+
+export async function cloneNode<T extends HTMLElement>(
+  node: T,
+  options: Options,
+  isRoot?: boolean
+): Promise<T | null> {
+  if (!isRoot && options.filter && !options.filter(node)) {
+    return null;
+  }
+
+  return Promise.resolve(node)
+    .then((clonedNode) => cloneSingleNode(clonedNode, options) as Promise<T>)
+    .then((clonedNode) => cloneChildren(node, clonedNode, options))
+    .then((clonedNode) => decorate(node, clonedNode))
+    .then((clonedNode) => ensureSVGSymbols(clonedNode, options));
+}

--- a/packages/pn-commons/src/utility/Screenshot/clone-pseudos.ts
+++ b/packages/pn-commons/src/utility/Screenshot/clone-pseudos.ts
@@ -1,0 +1,55 @@
+import { toArray, uuid } from './util';
+
+type Pseudo = ':before' | ':after';
+
+function formatCSSText(style: CSSStyleDeclaration) {
+  const content = style.getPropertyValue('content');
+  return `${style.cssText} content: '${content.replace(/'|"/g, '')}';`;
+}
+
+function formatCSSProperties(style: CSSStyleDeclaration) {
+  return toArray<string>(style)
+    .map((name) => {
+      const value = style.getPropertyValue(name);
+      const priority = style.getPropertyPriority(name);
+
+      return `${name}: ${value}${priority ? ' !important' : ''};`;
+    })
+    .join(' ');
+}
+
+function getPseudoElementStyle(
+  className: string,
+  pseudo: Pseudo,
+  style: CSSStyleDeclaration
+): Text {
+  const selector = `.${className}:${pseudo}`;
+  const cssText = style.cssText ? formatCSSText(style) : formatCSSProperties(style);
+
+  return document.createTextNode(`${selector}{${cssText}}`);
+}
+
+function clonePseudoElement<T extends HTMLElement>(nativeNode: T, clonedNode: T, pseudo: Pseudo) {
+  const style = window.getComputedStyle(nativeNode, pseudo);
+  const content = style.getPropertyValue('content');
+  if (content === '' || content === 'none') {
+    return;
+  }
+
+  const className = uuid();
+  try {
+    // eslint-disable-next-line functional/immutable-data
+    clonedNode.className = `${clonedNode.className} ${className}`;
+  } catch (err) {
+    return;
+  }
+
+  const styleElement = document.createElement('style');
+  styleElement.appendChild(getPseudoElementStyle(className, pseudo, style));
+  clonedNode.appendChild(styleElement);
+}
+
+export function clonePseudoElements<T extends HTMLElement>(nativeNode: T, clonedNode: T) {
+  clonePseudoElement(nativeNode, clonedNode, ':before');
+  clonePseudoElement(nativeNode, clonedNode, ':after');
+}

--- a/packages/pn-commons/src/utility/Screenshot/dataurl.ts
+++ b/packages/pn-commons/src/utility/Screenshot/dataurl.ts
@@ -1,0 +1,119 @@
+/* eslint-disable functional/immutable-data */
+
+/* eslint-disable functional/no-let */
+import { Options } from './types';
+
+function getContentFromDataUrl(dataURL: string) {
+  return dataURL.split(/,/)[1];
+}
+
+export function isDataUrl(url: string) {
+  return url.search(/^(data:)/) !== -1;
+}
+
+export function makeDataUrl(content: string, mimeType: string) {
+  return `data:${mimeType};base64,${content}`;
+}
+
+export async function fetchAsDataURL<T>(
+  url: string,
+  init: RequestInit | undefined,
+  process: (data: { result: string; res: Response }) => T
+): Promise<T> {
+  const res = await fetch(url, init);
+  if (res.status === 404) {
+    throw new Error(`Resource "${res.url}" not found`);
+  }
+  const blob = await res.blob();
+  return new Promise<T>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = reject;
+    reader.onloadend = () => {
+      try {
+        resolve(process({ res, result: reader.result as string }));
+      } catch (error) {
+        console.log(`${error}`);
+      }
+    };
+
+    reader.readAsDataURL(blob);
+  });
+}
+
+const cache: { [url: string]: string } = {};
+
+function getCacheKey(
+  url: string,
+  contentType: string | undefined,
+  includeQueryParams: boolean | undefined
+) {
+  let key = url.replace(/\?.*/, '');
+
+  if (includeQueryParams) {
+    key = url;
+  }
+
+  // font resource
+  if (/ttf|otf|eot|woff2?/i.test(key)) {
+    key = key.replace(/.*\//, '');
+  }
+
+  return contentType ? `[${contentType}]${key}` : key;
+}
+
+export async function resourceToDataURL(
+  resourceUrl: string,
+  contentType: string | undefined,
+  options: Options
+) {
+  const cacheKey = getCacheKey(resourceUrl, contentType, options.includeQueryParams);
+
+  if (cache[cacheKey] != null) {
+    return cache[cacheKey];
+  }
+
+  // ref: https://developer.mozilla.org/en/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#Bypassing_the_cache
+  if (options.cacheBust) {
+    // eslint-disable-next-line no-param-reassign
+    resourceUrl += (/\?/.test(resourceUrl) ? '&' : '?') + new Date().getTime();
+  }
+
+  return getDataUrl(resourceUrl, contentType, options, cacheKey);
+}
+
+async function getDataUrl(
+  resourceUrl: string,
+  contentType: string | undefined,
+  options: Options,
+  cacheKey: string
+): Promise<string> {
+  let dataURL: string;
+  try {
+    const content = await fetchAsDataURL(
+      resourceUrl,
+      options.fetchRequestInit,
+      ({ res, result }) => {
+        if (!contentType) {
+          // eslint-disable-next-line no-param-reassign
+          contentType = res.headers.get('Content-Type') ?? '';
+        }
+        return getContentFromDataUrl(result);
+      }
+    );
+    dataURL = makeDataUrl(content, contentType!);
+  } catch (error: any) {
+    dataURL = options.imagePlaceholder ?? '';
+
+    let msg = `Failed to fetch resource: ${resourceUrl}`;
+    if (error) {
+      msg = typeof error === 'string' ? error : error.message;
+    }
+
+    if (msg) {
+      console.warn(msg);
+    }
+  }
+
+  cache[cacheKey] = dataURL;
+  return dataURL;
+}

--- a/packages/pn-commons/src/utility/Screenshot/embed-images.ts
+++ b/packages/pn-commons/src/utility/Screenshot/embed-images.ts
@@ -1,0 +1,77 @@
+/* eslint-disable functional/immutable-data */
+import { isDataUrl, resourceToDataURL } from './dataurl';
+import { embedResources } from './embed-resources';
+import { getMimeType } from './mimes';
+import { Options } from './types';
+import { isInstanceOfElement, toArray } from './util';
+
+async function embedProp(propName: string, node: HTMLElement, options: Options) {
+  const propValue = node.style?.getPropertyValue(propName);
+  if (propValue) {
+    const cssString = await embedResources(propValue, null, options);
+    node.style.setProperty(propName, cssString, node.style.getPropertyPriority(propName));
+    return true;
+  }
+  return false;
+}
+
+async function embedBackground<T extends HTMLElement>(clonedNode: T, options: Options) {
+  if (!(await embedProp('background', clonedNode, options))) {
+    await embedProp('background-image', clonedNode, options);
+  }
+  if (!(await embedProp('mask', clonedNode, options))) {
+    await embedProp('mask-image', clonedNode, options);
+  }
+}
+
+async function embedImageNode<T extends HTMLElement | SVGImageElement>(
+  clonedNode: T,
+  options: Options
+) {
+  const isImageElement = isInstanceOfElement(clonedNode, HTMLImageElement);
+
+  if (
+    !(isImageElement && !isDataUrl(clonedNode.src)) &&
+    !(isInstanceOfElement(clonedNode, SVGImageElement) && !isDataUrl(clonedNode.href.baseVal))
+  ) {
+    return;
+  }
+
+  const url = isImageElement ? clonedNode.src : clonedNode.href.baseVal;
+
+  const dataURL = await resourceToDataURL(url, getMimeType(url), options);
+  await new Promise((resolve, reject) => {
+    clonedNode.onload = resolve;
+    clonedNode.onerror = reject;
+
+    const image = clonedNode as HTMLImageElement;
+    if (image.decode) {
+      image.decode = resolve as any;
+    }
+
+    if (image.loading === 'lazy') {
+      image.loading = 'eager';
+    }
+
+    if (isImageElement) {
+      clonedNode.srcset = '';
+      clonedNode.src = dataURL;
+    } else {
+      clonedNode.href.baseVal = dataURL;
+    }
+  });
+}
+
+async function embedChildren<T extends HTMLElement>(clonedNode: T, options: Options) {
+  const children = toArray<HTMLElement>(clonedNode.childNodes);
+  const deferreds = children.map((child) => embedImages(child, options));
+  await Promise.all(deferreds).then(() => clonedNode);
+}
+
+export async function embedImages<T extends HTMLElement>(clonedNode: T, options: Options) {
+  if (isInstanceOfElement(clonedNode, Element)) {
+    await embedBackground(clonedNode, options);
+    await embedImageNode(clonedNode, options);
+    await embedChildren(clonedNode, options);
+  }
+}

--- a/packages/pn-commons/src/utility/Screenshot/embed-resources.ts
+++ b/packages/pn-commons/src/utility/Screenshot/embed-resources.ts
@@ -5,8 +5,6 @@ import { Options } from './types';
 import { resolveUrl } from './util';
 
 const URL_REGEX = /url\((['"]?)([^'"]+?)\1\)/g;
-const URL_WITH_FORMAT_REGEX = /url\([^)]+\)\s*format\((["']?)([^"']+)\1\)/g;
-const FONT_SRC_REGEX = /src:\s*(?:url\([^)]+\)\s*format\([^)]+\)[,;]\s*)+/g;
 
 function toRegex(url: string): RegExp {
   // eslint-disable-next-line no-useless-escape
@@ -50,22 +48,8 @@ export async function embed(
   return cssText;
 }
 
-function filterPreferredFontFormat(str: string, { preferredFontFormat }: Options): string {
-  return !preferredFontFormat
-    ? str
-    : str.replace(FONT_SRC_REGEX, (match: string) => {
-        // eslint-disable-next-line no-constant-condition
-        while (true) {
-          const [src, , format] = URL_WITH_FORMAT_REGEX.exec(match) || [];
-          if (!format) {
-            return '';
-          }
-
-          if (format === preferredFontFormat) {
-            return `src: ${src};`;
-          }
-        }
-      });
+function filterPreferredFontFormat(str: string): string {
+  return str;
 }
 
 export function shouldEmbed(url: string): boolean {
@@ -81,7 +65,7 @@ export async function embedResources(
     return cssText;
   }
 
-  const filteredCSSText = filterPreferredFontFormat(cssText, options);
+  const filteredCSSText = filterPreferredFontFormat(cssText);
   const urls = parseURLs(filteredCSSText);
   return urls.reduce(
     (deferred, url) => deferred.then((css) => embed(css, url, baseUrl, options)),

--- a/packages/pn-commons/src/utility/Screenshot/embed-resources.ts
+++ b/packages/pn-commons/src/utility/Screenshot/embed-resources.ts
@@ -1,0 +1,90 @@
+/* eslint-disable functional/immutable-data */
+import { isDataUrl, makeDataUrl, resourceToDataURL } from './dataurl';
+import { getMimeType } from './mimes';
+import { Options } from './types';
+import { resolveUrl } from './util';
+
+const URL_REGEX = /url\((['"]?)([^'"]+?)\1\)/g;
+const URL_WITH_FORMAT_REGEX = /url\([^)]+\)\s*format\((["']?)([^"']+)\1\)/g;
+const FONT_SRC_REGEX = /src:\s*(?:url\([^)]+\)\s*format\([^)]+\)[,;]\s*)+/g;
+
+function toRegex(url: string): RegExp {
+  // eslint-disable-next-line no-useless-escape
+  const escaped = url.replace(/([.*+?^${}()|\[\]\/\\])/g, '\\$1');
+  return new RegExp(`(url\\(['"]?)(${escaped})(['"]?\\))`, 'g');
+}
+
+export function parseURLs(cssText: string): Array<string> {
+  const urls: Array<string> = [];
+
+  cssText.replace(URL_REGEX, (raw, url) => {
+    urls.push(url);
+    return raw;
+  });
+
+  return urls.filter((url) => !isDataUrl(url));
+}
+
+export async function embed(
+  cssText: string,
+  resourceURL: string,
+  baseURL: string | null,
+  options: Options,
+  getContentFromUrl?: (url: string) => Promise<string>
+): Promise<string> {
+  try {
+    const resolvedURL = baseURL ? resolveUrl(resourceURL, baseURL) : resourceURL;
+    const contentType = getMimeType(resourceURL);
+    // eslint-disable-next-line functional/no-let
+    let dataURL: string;
+    if (getContentFromUrl) {
+      const content = await getContentFromUrl(resolvedURL);
+      dataURL = makeDataUrl(content, contentType);
+    } else {
+      dataURL = await resourceToDataURL(resolvedURL, contentType, options);
+    }
+    return cssText.replace(toRegex(resourceURL), `$1${dataURL}$3`);
+  } catch (error) {
+    // pass
+  }
+  return cssText;
+}
+
+function filterPreferredFontFormat(str: string, { preferredFontFormat }: Options): string {
+  return !preferredFontFormat
+    ? str
+    : str.replace(FONT_SRC_REGEX, (match: string) => {
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+          const [src, , format] = URL_WITH_FORMAT_REGEX.exec(match) || [];
+          if (!format) {
+            return '';
+          }
+
+          if (format === preferredFontFormat) {
+            return `src: ${src};`;
+          }
+        }
+      });
+}
+
+export function shouldEmbed(url: string): boolean {
+  return url.search(URL_REGEX) !== -1;
+}
+
+export async function embedResources(
+  cssText: string,
+  baseUrl: string | null,
+  options: Options
+): Promise<string> {
+  if (!shouldEmbed(cssText)) {
+    return cssText;
+  }
+
+  const filteredCSSText = filterPreferredFontFormat(cssText, options);
+  const urls = parseURLs(filteredCSSText);
+  return urls.reduce(
+    (deferred, url) => deferred.then((css) => embed(css, url, baseUrl, options)),
+    Promise.resolve(filteredCSSText)
+  );
+}

--- a/packages/pn-commons/src/utility/Screenshot/embed-webfonts.ts
+++ b/packages/pn-commons/src/utility/Screenshot/embed-webfonts.ts
@@ -1,0 +1,226 @@
+/* eslint-disable functional/no-let */
+
+/* eslint-disable functional/immutable-data */
+import { fetchAsDataURL } from './dataurl';
+import { embedResources, shouldEmbed } from './embed-resources';
+import type { Options } from './types';
+import { toArray } from './util';
+
+interface Metadata {
+  url: string;
+  cssText: string;
+}
+
+const cssFetchCache: { [href: string]: Metadata } = {};
+
+async function fetchCSS(url: string) {
+  let cache = cssFetchCache[url];
+  if (cache != null) {
+    return cache;
+  }
+
+  const res = await fetch(url);
+  const cssText = await res.text();
+  cache = { url, cssText };
+
+  cssFetchCache[url] = cache;
+
+  return cache;
+}
+
+async function embedFonts(data: Metadata, options: Options): Promise<string> {
+  let cssText = data.cssText;
+  const regexUrl = /url\(["']?([^"')]+)["']?\)/g;
+  const fontLocs = cssText.match(/url\([^)]+\)/g) || [];
+  const loadFonts = fontLocs.map(async (loc: string) => {
+    let url = loc.replace(regexUrl, '$1');
+    if (!url.startsWith('https://')) {
+      url = new URL(url, data.url).href;
+    }
+
+    return fetchAsDataURL<[string, string]>(url, options.fetchRequestInit, ({ result }) => {
+      cssText = cssText.replace(loc, `url(${result})`);
+      return [loc, result];
+    });
+  });
+
+  return Promise.all(loadFonts).then(() => cssText);
+}
+
+function parseCSS(source: string) {
+  if (source == null) {
+    return [];
+  }
+
+  const result: Array<string> = [];
+  const commentsRegex = /(\/\*[\s\S]*?\*\/)/gi;
+  // strip out comments
+  let cssText = source.replace(commentsRegex, '');
+
+  // eslint-disable-next-line prefer-regex-literals
+  const keyframesRegex = /((@.*?keyframes [\s\S]*?){([\s\S]*?}\s*?)})/gi;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const matches = keyframesRegex.exec(cssText);
+    if (matches === null) {
+      break;
+    }
+    result.push(matches[0]);
+  }
+  cssText = cssText.replace(keyframesRegex, '');
+
+  const importRegex = /@import[\s\S]*?url\([^)]*\)[\s\S]*?;/gi;
+  // to match css & media queries together
+  const combinedCSSRegex =
+    '((\\s*?(?:\\/\\*[\\s\\S]*?\\*\\/)?\\s*?@media[\\s\\S]' +
+    '*?){([\\s\\S]*?)}\\s*?})|(([\\s\\S]*?){([\\s\\S]*?)})';
+  // unified regex
+  const unifiedRegex = new RegExp(combinedCSSRegex, 'gi');
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    let matches = importRegex.exec(cssText);
+    if (matches === null) {
+      matches = unifiedRegex.exec(cssText);
+      if (matches === null) {
+        break;
+      } else {
+        importRegex.lastIndex = unifiedRegex.lastIndex;
+      }
+    } else {
+      unifiedRegex.lastIndex = importRegex.lastIndex;
+    }
+    result.push(matches[0]);
+  }
+
+  return result;
+}
+
+async function getCSSRules(
+  styleSheets: Array<CSSStyleSheet>,
+  options: Options
+): Promise<Array<CSSStyleRule>> {
+  const ret: Array<CSSStyleRule> = [];
+  const deferreds: Array<Promise<number | void>> = [];
+
+  // First loop inlines imports
+  styleSheets.forEach((sheet) => {
+    if ('cssRules' in sheet) {
+      try {
+        toArray<CSSRule>(sheet.cssRules || []).forEach((item, index) => {
+          if (item.type === CSSRule.IMPORT_RULE) {
+            let importIndex = index + 1;
+            const url = (item as CSSImportRule).href;
+            const deferred = fetchCSS(url)
+              .then((metadata) => embedFonts(metadata, options))
+              .then((cssText) =>
+                parseCSS(cssText).forEach((rule) => {
+                  try {
+                    sheet.insertRule(
+                      rule,
+                      rule.startsWith('@import') ? (importIndex += 1) : sheet.cssRules.length
+                    );
+                  } catch (error) {
+                    console.error('Error inserting rule from remote css', {
+                      rule,
+                      error,
+                    });
+                  }
+                })
+              )
+              .catch((e) => {
+                console.error('Error loading remote css', e.toString());
+              });
+
+            deferreds.push(deferred);
+          }
+        });
+      } catch (e) {
+        const inline = styleSheets.find((a) => a.href == null) || document.styleSheets[0];
+        if (sheet.href != null) {
+          deferreds.push(
+            fetchCSS(sheet.href)
+              .then((metadata) => embedFonts(metadata, options))
+              .then((cssText) =>
+                parseCSS(cssText).forEach((rule) => {
+                  inline.insertRule(rule, sheet.cssRules.length);
+                })
+              )
+              .catch((err: unknown) => {
+                console.error('Error loading remote stylesheet', err);
+              })
+          );
+        }
+        console.error('Error inlining remote css file', e);
+      }
+    }
+  });
+
+  return Promise.all(deferreds).then(() => {
+    // Second loop parses rules
+    styleSheets.forEach((sheet) => {
+      if ('cssRules' in sheet) {
+        try {
+          toArray<CSSStyleRule>(sheet.cssRules || []).forEach((item) => {
+            ret.push(item);
+          });
+        } catch (e) {
+          console.error(`Error while reading CSS rules from ${sheet.href}`, e);
+        }
+      }
+    });
+
+    return ret;
+  });
+}
+
+function getWebFontRules(cssRules: Array<CSSStyleRule>): Array<CSSStyleRule> {
+  return cssRules
+    .filter((rule) => rule.type === CSSRule.FONT_FACE_RULE)
+    .filter((rule) => shouldEmbed(rule.style.getPropertyValue('src')));
+}
+
+async function parseWebFontRules<T extends HTMLElement>(node: T, options: Options) {
+  if (node.ownerDocument == null) {
+    throw new Error('Provided element is not within a Document');
+  }
+
+  const styleSheets = toArray<CSSStyleSheet>(node.ownerDocument.styleSheets);
+  const cssRules = await getCSSRules(styleSheets, options);
+
+  return getWebFontRules(cssRules);
+}
+
+export async function getWebFontCSS<T extends HTMLElement>(
+  node: T,
+  options: Options
+): Promise<string> {
+  const rules = await parseWebFontRules(node, options);
+  const cssTexts = await Promise.all(
+    rules.map((rule) => {
+      const baseUrl = rule.parentStyleSheet ? rule.parentStyleSheet.href : null;
+      return embedResources(rule.cssText, baseUrl, options);
+    })
+  );
+
+  return cssTexts.join('\n');
+}
+
+export async function embedWebFonts<T extends HTMLElement>(clonedNode: T, options: Options) {
+  const cssText =
+    options.fontEmbedCSS ?? options.skipFonts ? null : await getWebFontCSS(clonedNode, options);
+
+  if (cssText) {
+    const styleNode = document.createElement('style');
+    const sytleContent = document.createTextNode(cssText);
+
+    styleNode.appendChild(sytleContent);
+
+    if (clonedNode.firstChild) {
+      clonedNode.insertBefore(styleNode, clonedNode.firstChild);
+    } else {
+      clonedNode.appendChild(styleNode);
+    }
+  }
+}

--- a/packages/pn-commons/src/utility/Screenshot/index.ts
+++ b/packages/pn-commons/src/utility/Screenshot/index.ts
@@ -1,13 +1,18 @@
+/*
+The code into the folder Screenshot is taken from the library https://github.com/bubkoo/html-to-image/releases/tag/v1.11.11.
+We has removed all that code that useless, and we have added some custom code.
+The custom code has been targetted with the label CUSTOM.
+---------
+Andrea Cimini - 1/07/2024 
+*/
+
 /* eslint-disable functional/immutable-data */
 import { applyStyle } from './apply-style';
 import { cloneNode } from './clone-node';
 import { embedImages } from './embed-images';
-import {
-  embedWebFonts, // getWebFontCSS
-} from './embed-webfonts';
+import { embedWebFonts } from './embed-webfonts';
 import { Options } from './types';
 import {
-  // canvasToBlob,
   checkCanvasDimensions,
   createImage,
   getImageSize,
@@ -15,31 +20,32 @@ import {
   nodeToDataURL,
 } from './util';
 
-export async function toSvg<T extends HTMLElement>(
-  node: T,
-  options: Options = {}
-): Promise<string> {
-  const { width, height } = getImageSize(node, options);
-  const clonedNode = (await cloneNode(node, options, true)) as HTMLElement;
+async function toSvg<T extends HTMLElement>(node: T, options: Options = {}): Promise<string> {
+  const { width, height } = getImageSize(node);
+  const clonedNode = await cloneNode(node, options, true);
+  if (!clonedNode) {
+    console.debug('No node cloned');
+    return Promise.resolve('');
+  }
   await embedWebFonts(clonedNode, options);
   await embedImages(clonedNode, options);
   applyStyle(clonedNode, options);
   return await nodeToDataURL(clonedNode, width, height);
 }
 
-export async function toCanvas<T extends HTMLElement>(
+async function toCanvas<T extends HTMLElement>(
   node: T,
   options: Options = {}
 ): Promise<HTMLCanvasElement> {
-  const { width, height } = getImageSize(node, options);
+  const { width, height } = getImageSize(node);
   const svg = await toSvg(node, options);
   const img = await createImage(svg);
 
   const canvas = document.createElement('canvas');
   const context = canvas.getContext('2d')!;
-  const ratio = options.pixelRatio ?? getPixelRatio();
-  const canvasWidth = options.canvasWidth ?? width;
-  const canvasHeight = options.canvasHeight ?? height;
+  const ratio = getPixelRatio();
+  const canvasWidth = width;
+  const canvasHeight = height;
 
   canvas.width = canvasWidth * ratio;
   canvas.height = canvasHeight * ratio;

--- a/packages/pn-commons/src/utility/Screenshot/index.ts
+++ b/packages/pn-commons/src/utility/Screenshot/index.ts
@@ -1,0 +1,69 @@
+/* eslint-disable functional/immutable-data */
+import { applyStyle } from './apply-style';
+import { cloneNode } from './clone-node';
+import { embedImages } from './embed-images';
+import {
+  embedWebFonts, // getWebFontCSS
+} from './embed-webfonts';
+import { Options } from './types';
+import {
+  // canvasToBlob,
+  checkCanvasDimensions,
+  createImage,
+  getImageSize,
+  getPixelRatio,
+  nodeToDataURL,
+} from './util';
+
+export async function toSvg<T extends HTMLElement>(
+  node: T,
+  options: Options = {}
+): Promise<string> {
+  const { width, height } = getImageSize(node, options);
+  const clonedNode = (await cloneNode(node, options, true)) as HTMLElement;
+  await embedWebFonts(clonedNode, options);
+  await embedImages(clonedNode, options);
+  applyStyle(clonedNode, options);
+  return await nodeToDataURL(clonedNode, width, height);
+}
+
+export async function toCanvas<T extends HTMLElement>(
+  node: T,
+  options: Options = {}
+): Promise<HTMLCanvasElement> {
+  const { width, height } = getImageSize(node, options);
+  const svg = await toSvg(node, options);
+  const img = await createImage(svg);
+
+  const canvas = document.createElement('canvas');
+  const context = canvas.getContext('2d')!;
+  const ratio = options.pixelRatio ?? getPixelRatio();
+  const canvasWidth = options.canvasWidth ?? width;
+  const canvasHeight = options.canvasHeight ?? height;
+
+  canvas.width = canvasWidth * ratio;
+  canvas.height = canvasHeight * ratio;
+
+  if (!options.skipAutoScale) {
+    checkCanvasDimensions(canvas);
+  }
+  canvas.style.width = `${canvasWidth}`;
+  canvas.style.height = `${canvasHeight}`;
+
+  if (options.backgroundColor) {
+    context.fillStyle = options.backgroundColor;
+    context.fillRect(0, 0, canvas.width, canvas.height);
+  }
+
+  context.drawImage(img, 0, 0, canvas.width, canvas.height);
+
+  return canvas;
+}
+
+export async function toJpeg<T extends HTMLElement>(
+  node: T,
+  options: Options = {}
+): Promise<string> {
+  const canvas = await toCanvas(node, options);
+  return canvas.toDataURL('image/jpeg', options.quality ?? 1);
+}

--- a/packages/pn-commons/src/utility/Screenshot/mimes.ts
+++ b/packages/pn-commons/src/utility/Screenshot/mimes.ts
@@ -1,0 +1,25 @@
+const WOFF = 'application/font-woff';
+const JPEG = 'image/jpeg';
+const mimes: { [key: string]: string } = {
+  woff: WOFF,
+  woff2: WOFF,
+  ttf: 'application/font-truetype',
+  eot: 'application/vnd.ms-fontobject',
+  png: 'image/png',
+  jpg: JPEG,
+  jpeg: JPEG,
+  gif: 'image/gif',
+  tiff: 'image/tiff',
+  svg: 'image/svg+xml',
+  webp: 'image/webp',
+};
+
+function getExtension(url: string): string {
+  const match = /\.([^./]*?)$/g.exec(url);
+  return match ? match[1] : '';
+}
+
+export function getMimeType(url: string): string {
+  const extension = getExtension(url).toLowerCase();
+  return mimes[extension] || '';
+}

--- a/packages/pn-commons/src/utility/Screenshot/types.ts
+++ b/packages/pn-commons/src/utility/Screenshot/types.ts
@@ -1,28 +1,8 @@
 export interface Options {
   /**
-   * Width in pixels to be applied to node before rendering.
-   */
-  width?: number;
-  /**
-   * Height in pixels to be applied to node before rendering.
-   */
-  height?: number;
-  /**
    * A string value for the background color, any valid CSS color value.
    */
   backgroundColor?: string;
-  /**
-   * Width in pixels to be applied to canvas on export.
-   */
-  canvasWidth?: number;
-  /**
-   * Height in pixels to be applied to canvas on export.
-   */
-  canvasHeight?: number;
-  /**
-   * An object whose properties to be copied to node's style before rendering.
-   */
-  style?: Partial<CSSStyleDeclaration>;
   /**
    * A function taking DOM node as argument. Should return `true` if passed
    * node should be included in the output. Excluding node means excluding
@@ -35,47 +15,11 @@ export interface Options {
    */
   quality?: number;
   /**
-   * Set to `true` to append the current time as a query string to URL
-   * requests to enable cache busting.
-   */
-  cacheBust?: boolean;
-  /**
-   * Set false to use all URL as cache key.
-   * Default: false | undefined - which strips away the query parameters
-   */
-  includeQueryParams?: boolean;
-  /**
    * A data URL for a placeholder image that will be used when fetching
    * an image fails. Defaults to an empty string and will render empty
    * areas for failed images.
    */
   imagePlaceholder?: string;
-  /**
-   * The pixel ratio of captured image. Defalut is the actual pixel ratio of
-   * the device. Set 1 to use as initial-scale 1 for the image
-   */
-  pixelRatio?: number;
-  /**
-   * Option to skip the fonts download and embed.
-   */
-  skipFonts?: boolean;
-  /**
-   * The preferred font format. If specified all other font formats are ignored.
-   */
-  preferredFontFormat?:
-    | 'woff'
-    | 'woff2'
-    | 'truetype'
-    | 'opentype'
-    | 'embedded-opentype'
-    | 'svg'
-    | string;
-  /**
-   * A CSS string to specify for font embeds. If specified only this CSS will
-   * be present in the resulting image. Use with `getFontEmbedCSS()` to
-   * create embed CSS for use across multiple calls to library functions.
-   */
-  fontEmbedCSS?: string;
   /**
    * A boolean to turn off auto scaling for truly massive images..
    */
@@ -84,11 +28,4 @@ export interface Options {
    * A string indicating the image format. The default type is image/png; that type is also used if the given type isn't supported.
    */
   type?: string;
-
-  /**
-   *
-   *the second parameter of  window.fetch (Promise<Response> fetch(input[, init]))
-   *
-   */
-  fetchRequestInit?: RequestInit;
 }

--- a/packages/pn-commons/src/utility/Screenshot/types.ts
+++ b/packages/pn-commons/src/utility/Screenshot/types.ts
@@ -1,0 +1,94 @@
+export interface Options {
+  /**
+   * Width in pixels to be applied to node before rendering.
+   */
+  width?: number;
+  /**
+   * Height in pixels to be applied to node before rendering.
+   */
+  height?: number;
+  /**
+   * A string value for the background color, any valid CSS color value.
+   */
+  backgroundColor?: string;
+  /**
+   * Width in pixels to be applied to canvas on export.
+   */
+  canvasWidth?: number;
+  /**
+   * Height in pixels to be applied to canvas on export.
+   */
+  canvasHeight?: number;
+  /**
+   * An object whose properties to be copied to node's style before rendering.
+   */
+  style?: Partial<CSSStyleDeclaration>;
+  /**
+   * A function taking DOM node as argument. Should return `true` if passed
+   * node should be included in the output. Excluding node means excluding
+   * it's children as well.
+   */
+  filter?: (domNode: HTMLElement) => boolean;
+  /**
+   * A number between `0` and `1` indicating image quality (e.g. 0.92 => 92%)
+   * of the JPEG image.
+   */
+  quality?: number;
+  /**
+   * Set to `true` to append the current time as a query string to URL
+   * requests to enable cache busting.
+   */
+  cacheBust?: boolean;
+  /**
+   * Set false to use all URL as cache key.
+   * Default: false | undefined - which strips away the query parameters
+   */
+  includeQueryParams?: boolean;
+  /**
+   * A data URL for a placeholder image that will be used when fetching
+   * an image fails. Defaults to an empty string and will render empty
+   * areas for failed images.
+   */
+  imagePlaceholder?: string;
+  /**
+   * The pixel ratio of captured image. Defalut is the actual pixel ratio of
+   * the device. Set 1 to use as initial-scale 1 for the image
+   */
+  pixelRatio?: number;
+  /**
+   * Option to skip the fonts download and embed.
+   */
+  skipFonts?: boolean;
+  /**
+   * The preferred font format. If specified all other font formats are ignored.
+   */
+  preferredFontFormat?:
+    | 'woff'
+    | 'woff2'
+    | 'truetype'
+    | 'opentype'
+    | 'embedded-opentype'
+    | 'svg'
+    | string;
+  /**
+   * A CSS string to specify for font embeds. If specified only this CSS will
+   * be present in the resulting image. Use with `getFontEmbedCSS()` to
+   * create embed CSS for use across multiple calls to library functions.
+   */
+  fontEmbedCSS?: string;
+  /**
+   * A boolean to turn off auto scaling for truly massive images..
+   */
+  skipAutoScale?: boolean;
+  /**
+   * A string indicating the image format. The default type is image/png; that type is also used if the given type isn't supported.
+   */
+  type?: string;
+
+  /**
+   *
+   *the second parameter of  window.fetch (Promise<Response> fetch(input[, init]))
+   *
+   */
+  fetchRequestInit?: RequestInit;
+}

--- a/packages/pn-commons/src/utility/Screenshot/util.ts
+++ b/packages/pn-commons/src/utility/Screenshot/util.ts
@@ -50,13 +50,6 @@ export const uuid = (() => {
   };
 })();
 
-export function delay<T>(ms: number) {
-  return (args: T) =>
-    new Promise<T>((resolve) => {
-      setTimeout(() => resolve(args), ms);
-    });
-}
-
 export function toArray<T>(arrayLike: any): Array<T> {
   const arr: Array<T> = [];
 
@@ -86,9 +79,9 @@ function getNodeHeight(node: HTMLElement) {
   return node.clientHeight + topBorder + bottomBorder;
 }
 
-export function getImageSize(targetNode: HTMLElement, options: Options = {}) {
-  const width = options.width || getNodeWidth(targetNode);
-  const height = options.height || getNodeHeight(targetNode);
+export function getImageSize(targetNode: HTMLElement) {
+  const width = getNodeWidth(targetNode);
+  const height = getNodeHeight(targetNode);
 
   return { width, height };
 }
@@ -189,7 +182,7 @@ export function createImage(url: string): Promise<HTMLImageElement> {
   });
 }
 
-export async function svgToDataURL(svg: SVGElement): Promise<string> {
+async function svgToDataURL(svg: SVGElement): Promise<string> {
   return Promise.resolve()
     .then(() => new XMLSerializer().serializeToString(svg))
     .then(encodeURIComponent)

--- a/packages/pn-commons/src/utility/Screenshot/util.ts
+++ b/packages/pn-commons/src/utility/Screenshot/util.ts
@@ -1,0 +1,242 @@
+/* eslint-disable functional/immutable-data */
+import type { Options } from './types';
+
+export function resolveUrl(url: string, baseUrl: string | null): string {
+  // url is absolute already
+  if (url.match(/^[a-z]+:\/\//i)) {
+    return url;
+  }
+
+  // url is absolute already, without protocol
+  if (url.match(/^\/\//)) {
+    return window.location.protocol + url;
+  }
+
+  // dataURI, mailto:, tel:, etc.
+  if (url.match(/^[a-z]+:/i)) {
+    return url;
+  }
+
+  const doc = document.implementation.createHTMLDocument();
+  const base = doc.createElement('base');
+  const a = doc.createElement('a');
+
+  doc.head.appendChild(base);
+  doc.body.appendChild(a);
+
+  if (baseUrl) {
+    base.href = baseUrl;
+  }
+
+  a.href = url;
+
+  return a.href;
+}
+
+export const uuid = (() => {
+  // generate uuid for className of pseudo elements.
+  // We should not use GUIDs, otherwise pseudo elements sometimes cannot be captured.
+  // eslint-disable-next-line functional/no-let
+  let counter = 0;
+
+  // ref: http://stackoverflow.com/a/6248722/2519373
+  const random = () =>
+    // eslint-disable-next-line no-bitwise
+    `0000${((Math.random() * 36 ** 4) << 0).toString(36)}`.slice(-4);
+
+  return () => {
+    counter += 1;
+    return `u${random()}${counter}`;
+  };
+})();
+
+export function delay<T>(ms: number) {
+  return (args: T) =>
+    new Promise<T>((resolve) => {
+      setTimeout(() => resolve(args), ms);
+    });
+}
+
+export function toArray<T>(arrayLike: any): Array<T> {
+  const arr: Array<T> = [];
+
+  // eslint-disable-next-line functional/no-let
+  for (let i = 0, l = arrayLike.length; i < l; i++) {
+    arr.push(arrayLike[i]);
+  }
+
+  return arr;
+}
+
+function px(node: HTMLElement, styleProperty: string) {
+  const win = node.ownerDocument.defaultView || window;
+  const val = win.getComputedStyle(node).getPropertyValue(styleProperty);
+  return val ? parseFloat(val.replace('px', '')) : 0;
+}
+
+function getNodeWidth(node: HTMLElement) {
+  const leftBorder = px(node, 'border-left-width');
+  const rightBorder = px(node, 'border-right-width');
+  return node.clientWidth + leftBorder + rightBorder;
+}
+
+function getNodeHeight(node: HTMLElement) {
+  const topBorder = px(node, 'border-top-width');
+  const bottomBorder = px(node, 'border-bottom-width');
+  return node.clientHeight + topBorder + bottomBorder;
+}
+
+export function getImageSize(targetNode: HTMLElement, options: Options = {}) {
+  const width = options.width || getNodeWidth(targetNode);
+  const height = options.height || getNodeHeight(targetNode);
+
+  return { width, height };
+}
+
+export function getPixelRatio() {
+  // eslint-disable-next-line functional/no-let
+  let ratio;
+
+  // eslint-disable-next-line functional/no-let
+  let FINAL_PROCESS;
+  try {
+    FINAL_PROCESS = process;
+  } catch (e) {
+    // pass
+  }
+
+  const val = FINAL_PROCESS?.env ? FINAL_PROCESS.env.devicePixelRatio : null;
+  if (val) {
+    ratio = parseInt(val, 10);
+    if (Number.isNaN(ratio)) {
+      ratio = 1;
+    }
+  }
+  return ratio ?? window.devicePixelRatio ?? 1;
+}
+
+// @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas#maximum_canvas_size
+const canvasDimensionLimit = 16384;
+
+export function checkCanvasDimensions(canvas: HTMLCanvasElement) {
+  if (canvas.width > canvasDimensionLimit || canvas.height > canvasDimensionLimit) {
+    if (canvas.width > canvasDimensionLimit && canvas.height > canvasDimensionLimit) {
+      if (canvas.width > canvas.height) {
+        canvas.height *= canvasDimensionLimit / canvas.width;
+        canvas.width = canvasDimensionLimit;
+      } else {
+        canvas.width *= canvasDimensionLimit / canvas.height;
+        canvas.height = canvasDimensionLimit;
+      }
+    } else if (canvas.width > canvasDimensionLimit) {
+      canvas.height *= canvasDimensionLimit / canvas.width;
+      canvas.width = canvasDimensionLimit;
+    } else {
+      canvas.width *= canvasDimensionLimit / canvas.height;
+      canvas.height = canvasDimensionLimit;
+    }
+  }
+}
+
+export function canvasToBlob(
+  canvas: HTMLCanvasElement,
+  options: Options = {}
+): Promise<Blob | null> {
+  if (canvas.toBlob) {
+    return new Promise((resolve) => {
+      canvas.toBlob(
+        resolve,
+        options.type ? options.type : 'image/png',
+        options.quality ? options.quality : 1
+      );
+    });
+  }
+
+  return new Promise((resolve) => {
+    const binaryString = window.atob(
+      canvas
+        .toDataURL(
+          options.type ? options.type : undefined,
+          options.quality ? options.quality : undefined
+        )
+        .split(',')[1]
+    );
+    const len = binaryString.length;
+    const binaryArray = new Uint8Array(len);
+
+    // eslint-disable-next-line functional/no-let
+    for (let i = 0; i < len; i += 1) {
+      binaryArray[i] = binaryString.charCodeAt(i);
+    }
+
+    resolve(
+      new Blob([binaryArray], {
+        type: options.type ? options.type : 'image/png',
+      })
+    );
+  });
+}
+
+export function createImage(url: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.decode = () => resolve(img) as any;
+    img.onload = () => resolve(img);
+    img.onerror = reject;
+    img.crossOrigin = 'anonymous';
+    img.decoding = 'async';
+    img.src = url;
+  });
+}
+
+export async function svgToDataURL(svg: SVGElement): Promise<string> {
+  return Promise.resolve()
+    .then(() => new XMLSerializer().serializeToString(svg))
+    .then(encodeURIComponent)
+    .then((html) => `data:image/svg+xml;charset=utf-8,${html}`);
+}
+
+export async function nodeToDataURL(
+  node: HTMLElement,
+  width: number,
+  height: number
+): Promise<string> {
+  const xmlns = 'http://www.w3.org/2000/svg';
+  const svg = document.createElementNS(xmlns, 'svg');
+  const foreignObject = document.createElementNS(xmlns, 'foreignObject');
+
+  svg.setAttribute('width', `${width}`);
+  svg.setAttribute('height', `${height}`);
+  svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+
+  foreignObject.setAttribute('width', '100%');
+  foreignObject.setAttribute('height', '100%');
+  foreignObject.setAttribute('x', '0');
+  foreignObject.setAttribute('y', '0');
+  foreignObject.setAttribute('externalResourcesRequired', 'true');
+
+  svg.appendChild(foreignObject);
+  foreignObject.appendChild(node);
+  return svgToDataURL(svg);
+}
+
+export const isInstanceOfElement = <
+  T extends typeof Element | typeof HTMLElement | typeof SVGImageElement
+>(
+  node: Element | HTMLElement | SVGImageElement,
+  instance: T
+): node is T['prototype'] => {
+  if (node instanceof instance) {
+    return true;
+  }
+
+  const nodePrototype = Object.getPrototypeOf(node);
+
+  if (nodePrototype === null) {
+    return false;
+  }
+
+  return (
+    nodePrototype.constructor.name === instance.name || isInstanceOfElement(nodePrototype, instance)
+  );
+};

--- a/packages/pn-commons/src/utility/date.utility.ts
+++ b/packages/pn-commons/src/utility/date.utility.ts
@@ -87,7 +87,11 @@ export function isToday(date: DatePickerTypes): boolean {
   );
 }
 
-export function formatDate(dateString: string, todayLabelizzation: boolean = true): string {
+export function formatDate(
+  dateString: string,
+  todayLabelizzation: boolean = true,
+  separator: string = '/'
+): string {
   const date = new Date(dateString);
   const month = `0${date.getMonth() + 1}`.slice(-2);
   const day = `0${date.getDate()}`.slice(-2);
@@ -96,7 +100,9 @@ export function formatDate(dateString: string, todayLabelizzation: boolean = tru
     'date-time.today-uppercase-initial',
     'Oggi'
   );
-  return isToday(date) && todayLabelizzation ? todayLabel : `${day}/${month}/${date.getFullYear()}`;
+  return isToday(date) && todayLabelizzation
+    ? todayLabel
+    : `${day}${separator}${month}${separator}${date.getFullYear()}`;
 }
 
 export function formatDateTime(dateString: string): string {

--- a/packages/pn-commons/src/utility/index.ts
+++ b/packages/pn-commons/src/utility/index.ts
@@ -2,6 +2,7 @@ import { Configuration } from '../services/configuration.service';
 import EventStrategyFactory from '../utility/MixpanelUtils/EventStrategyFactory';
 import { AppError, AppErrorFactory, UnknownAppError, errorFactoryManager } from './AppError';
 import { AppResponsePublisher, ResponseEventDispatcher } from './AppResponse';
+import * as screenshot from './Screenshot';
 import { validateCurrentStatus, validateHistory, validateLegaFact } from './appStatus.utility';
 import { PRIVACY_LINK_RELATIVE_PATH, TOS_LINK_RELATIVE_PATH } from './costants';
 import { formatCurrency, formatEurocentToCurrency } from './currency.utility';
@@ -143,4 +144,5 @@ export {
   validateCurrentStatus,
   validateLegaFact,
   convertHoursToIntDays,
+  screenshot,
 };

--- a/packages/pn-pa-webapp/src/components/Statistics/AggregateStatistics.tsx
+++ b/packages/pn-pa-webapp/src/components/Statistics/AggregateStatistics.tsx
@@ -3,8 +3,6 @@ import { CSSProperties } from 'react';
 
 import { PnECharts, PnEChartsProps } from '@pagopa-pn/pn-data-viz';
 
-import { GraphColors } from '../../models/Statistics';
-
 export type AggregateDataItem = {
   title: string;
   value: number;
@@ -47,22 +45,6 @@ const AggregateStatistics: React.FC<Props> = ({
         </div>`;
       },
     },
-    toolbox: {
-      feature: {
-        saveAsImage: {
-          type: 'jpg',
-          show: true,
-          title: '',
-          name: 'chart',
-          backgroundColor: 'white',
-          pixelRatio: 2,
-          iconStyle: {
-            color: GraphColors.navy,
-          },
-          icon: 'path://M4.16669 16.6667H15.8334V15H4.16669V16.6667ZM15.8334 7.5H12.5V2.5H7.50002V7.5H4.16669L10 13.3333L15.8334 7.5Z',
-        },
-      },
-    },
     grid: {
       left: '3%',
       right: '4%',
@@ -81,11 +63,11 @@ const AggregateStatistics: React.FC<Props> = ({
     ],
     ...options,
   };
-  
+
   if (legend) {
     // eslint-disable-next-line functional/immutable-data
     option.legend = {
-      show: false
+      show: false,
     };
     return (
       <PnECharts

--- a/packages/pn-pa-webapp/src/components/Statistics/DigitalMeanTimeStatistics.tsx
+++ b/packages/pn-pa-webapp/src/components/Statistics/DigitalMeanTimeStatistics.tsx
@@ -70,22 +70,6 @@ const DigitalMeanTimeStatistics: React.FC<Props> = (props) => {
         } ${description} <b>${elem.data.value.toLocaleString()}</b></div>`;
       },
     },
-    toolbox: {
-      feature: {
-        saveAsImage: {
-          type: 'jpg',
-          show: true,
-          title: '',
-          name: 'chart',
-          backgroundColor: 'white',
-          pixelRatio: 2,
-          iconStyle: {
-            color: GraphColors.navy,
-          },
-          icon: 'path://M4.16669 16.6667H15.8334V15H4.16669V16.6667ZM15.8334 7.5H12.5V2.5H7.50002V7.5H4.16669L10 13.3333L15.8334 7.5Z',
-        },
-      },
-    },
     grid: {
       left: '3%',
       right: '4%',

--- a/packages/pn-pa-webapp/src/components/Statistics/DigitalStateStatistics.tsx
+++ b/packages/pn-pa-webapp/src/components/Statistics/DigitalStateStatistics.tsx
@@ -70,22 +70,6 @@ const DigitalStateStatistics: React.FC<Props> = (props) => {
         } <b>${title}: ${elem.data.value.toLocaleString()}</b><br />${description}</div>`;
       },
     },
-    toolbox: {
-      feature: {
-        saveAsImage: {
-          type: 'jpg',
-          show: true,
-          title: '',
-          name: 'chart',
-          backgroundColor: 'white',
-          pixelRatio: 2,
-          iconStyle: {
-            color: GraphColors.navy,
-          },
-          icon: 'path://M4.16669 16.6667H15.8334V15H4.16669V16.6667ZM15.8334 7.5H12.5V2.5H7.50002V7.5H4.16669L10 13.3333L15.8334 7.5Z',
-        },
-      },
-    },
     grid: {
       left: '3%',
       right: '4%',

--- a/packages/pn-pa-webapp/src/components/Statistics/FilterStatistics.tsx
+++ b/packages/pn-pa-webapp/src/components/Statistics/FilterStatistics.tsx
@@ -39,9 +39,10 @@ export const defaultValues = {
 
 type Props = {
   filter: StatisticsFilter | null;
+  className?: string;
 };
 
-const FilterStatistics: React.FC<Props> = ({ filter }) => {
+const FilterStatistics: React.FC<Props> = ({ filter, className }) => {
   const { t, i18n } = useTranslation(['statistics']);
   const isMobile = useIsMobile();
   const dispatch = useAppDispatch();
@@ -81,7 +82,10 @@ const FilterStatistics: React.FC<Props> = ({ filter }) => {
     onSubmit: () => {},
   });
 
-  const getRangeDates = (range: SelectedStatisticsFilterKeys, loading: boolean = false): [Date, Date] => {
+  const getRangeDates = (
+    range: SelectedStatisticsFilterKeys,
+    loading: boolean = false
+  ): [Date, Date] => {
     switch (range) {
       case SelectedStatisticsFilter.lastMonth:
         return [oneMonthAgo, today];
@@ -115,11 +119,13 @@ const FilterStatistics: React.FC<Props> = ({ filter }) => {
 
   const handleSelectFilter = (type: SelectedStatisticsFilterKeys) => {
     const [startDate, endDate] = getRangeDates(type);
-    dispatch(setStatisticsFilter({
-      startDate,
-      endDate,
-      selected: type
-    }));
+    dispatch(
+      setStatisticsFilter({
+        startDate,
+        endDate,
+        selected: type,
+      })
+    );
   };
 
   const cleanFilter = () => {
@@ -159,10 +165,12 @@ const FilterStatistics: React.FC<Props> = ({ filter }) => {
       display="flex"
       justifyContent="space-between"
       alignItems="center"
+      className={className}
     >
-      
-      <Box flexGrow={0} flexShrink={0} >{quickFiltersJsx()}</Box>
-      <Box sx={{ display: isMobile ? 'block' : 'flex' }} >
+      <Box flexGrow={0} flexShrink={0}>
+        {quickFiltersJsx()}
+      </Box>
+      <Box sx={{ display: isMobile ? 'block' : 'flex' }}>
         <CustomDatePicker
           language={i18n.language}
           label={t('filter.from_date')}
@@ -191,7 +199,7 @@ const FilterStatistics: React.FC<Props> = ({ filter }) => {
                 'aria-label': t('filter.from_date-input-aria-label'),
               },
               sx: { mb: isMobile ? 1 : 0, mr: 1 },
-              fullWidth: isMobile
+              fullWidth: isMobile,
             },
           }}
           disableFuture={true}
@@ -226,7 +234,7 @@ const FilterStatistics: React.FC<Props> = ({ filter }) => {
                 'aria-label': t('filter.to_date-input-aria-label'),
               },
               sx: { mb: isMobile ? 1 : 0, mr: 1 },
-              fullWidth: isMobile
+              fullWidth: isMobile,
             },
           }}
           disableFuture={true}

--- a/packages/pn-pa-webapp/src/components/Statistics/LastStateStatistics.tsx
+++ b/packages/pn-pa-webapp/src/components/Statistics/LastStateStatistics.tsx
@@ -63,22 +63,6 @@ const LastStateStatistics: React.FC<Props> = (props) => {
         </div>`;
       },
     },
-    toolbox: {
-      feature: {
-        saveAsImage: {
-          type: 'jpg',
-          show: true,
-          title: '',
-          name: 'chart',
-          backgroundColor: 'white',
-          pixelRatio: 2,
-          iconStyle: {
-            color: GraphColors.navy,
-          },
-          icon: 'path://M4.16669 16.6667H15.8334V15H4.16669V16.6667ZM15.8334 7.5H12.5V2.5H7.50002V7.5H4.16669L10 13.3333L15.8334 7.5Z',
-        },
-      },
-    },
     grid: {
       left: '3%',
       right: '4%',

--- a/packages/pn-pa-webapp/src/components/Statistics/TrendStackedStatistics.tsx
+++ b/packages/pn-pa-webapp/src/components/Statistics/TrendStackedStatistics.tsx
@@ -7,12 +7,7 @@ import type { CSSProperties } from 'react';
 import { formatDateSMonth, formatToSlicedISOString } from '@pagopa-pn/pn-commons';
 import { PnECharts, PnEChartsProps } from '@pagopa-pn/pn-data-viz';
 
-import {
-  GraphColors,
-  IStatisticsDailySummary,
-  Timeframe,
-  WEEK_DAYS,
-} from '../../models/Statistics';
+import { IStatisticsDailySummary, Timeframe, WEEK_DAYS } from '../../models/Statistics';
 
 const LAST_DAY_OF_THE_WEEK = WEEK_DAYS.SUNDAY;
 
@@ -183,22 +178,6 @@ const TrendStackedStatistics: React.FC<Props> = ({
       right: '4%',
       bottom: '8%',
       containLabel: true,
-    },
-    toolbox: {
-      feature: {
-        saveAsImage: {
-          type: 'jpg',
-          show: true,
-          title: '',
-          name: 'chart',
-          backgroundColor: 'white',
-          pixelRatio: 2,
-          iconStyle: {
-            color: GraphColors.navy,
-          },
-          icon: 'path://M4.16669 16.6667H15.8334V15H4.16669V16.6667ZM15.8334 7.5H12.5V2.5H7.50002V7.5H4.16669L10 13.3333L15.8334 7.5Z',
-        },
-      },
     },
     xAxis: {
       // axisLabel: {

--- a/packages/pn-pa-webapp/src/pages/Statistics.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/Statistics.page.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable functional/immutable-data */
 import { useCallback, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -37,16 +36,26 @@ const filter = (node: HTMLElement) => {
   return !exclusionClasses.some((classname) => node.classList?.contains(classname));
 };
 
-const handleDownloadJpeg = (elem: HTMLDivElement) =>
+const handleDownloadJpeg = (elem: HTMLDivElement | null) => {
+  if (!elem) {
+    return;
+  }
   screenshot
-    .toJpeg(elem, { quality: 0.95, backgroundColor: GraphColors.lightGrey, filter })
-    .then(function (dataUrl) {
-      // eslint-disable-next-line functional/no-let
+    .toJpeg(elem, {
+      quality: 0.95,
+      backgroundColor: GraphColors.lightGrey,
+      filter,
+    })
+    .then((dataUrl) => {
       const link = document.createElement('a');
+      // eslint-disable-next-line functional/immutable-data
       link.download = `statistiche-${formatDate(formatToSlicedISOString(today), false, '-')}.jpeg`;
+      // eslint-disable-next-line functional/immutable-data
       link.href = dataUrl;
       link.click();
-    });
+    })
+    .catch(() => {});
+};
 
 const getFilterDates = (filter: StatisticsFilter | null) =>
   filter
@@ -81,7 +90,7 @@ const Statistics = () => {
     <Stack direction={'row'} display="flex" justifyContent="space-between" alignItems="center">
       <Typography>{t('subtitle', { organization: loggedUserOrganizationParty?.name })}</Typography>
       <Button
-        onClick={() => handleDownloadJpeg(exportJpgNode.current as HTMLDivElement)}
+        onClick={() => handleDownloadJpeg(exportJpgNode.current)}
         variant="outlined"
         endIcon={<DownloadIcon />}
         sx={{ whiteSpace: 'nowrap' }}
@@ -153,9 +162,7 @@ const Statistics = () => {
                 <Typography variant="h6" component="h5" mt={6}>
                   {t('section_2')}
                 </Typography>
-                <Box className="filter">
-                  <FilterStatistics filter={statisticsFilter} />
-                </Box>
+                <FilterStatistics className="filter" filter={statisticsFilter} />
                 <Stack direction={{ lg: 'row', xs: 'column' }} spacing={3} mt={4}>
                   <Box sx={{ width: { xs: '100%', lg: '50%' } }}>
                     <DigitalStateStatistics

--- a/packages/pn-pa-webapp/src/pages/Statistics.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/Statistics.page.tsx
@@ -125,52 +125,54 @@ const Statistics = () => {
             <Typography variant="caption" sx={{ color: GraphColors.greyBlue }}>
               {lastUpdateTxt}
             </Typography>
-            <Typography variant="h6" component="h5" mt={7}>
-              {t('section_1')}
-            </Typography>
-            <FilterStatistics filter={statisticsFilter} />
-            <Stack ref={exportJpgNode} direction={'column'} spacing={3} pt={2}>
-              <FiledNotificationsStatistics
-                startDate={statisticsData.startDate ?? formatToSlicedISOString(oneYearAgo)}
-                endDate={statisticsData.endDate ?? formatToSlicedISOString(today)}
-                data={statisticsData.data[StatisticsDataTypes.FiledStatistics]}
-              />
-              <Stack direction={{ lg: 'row', xs: 'column' }} spacing={3} mt={4}>
-                <Box sx={{ width: { xs: '100%', lg: '50%' } }}>
-                  <LastStateStatistics
-                    data={statisticsData.data[StatisticsDataTypes.LastStateStatistics]}
-                  />
-                </Box>
-                <Box sx={{ width: { xs: '100%', lg: '50%' } }}>
-                  <DeliveryModeStatistics
-                    startDate={statisticsData.startDate ?? formatToSlicedISOString(oneYearAgo)}
-                    endDate={statisticsData.endDate ?? formatToSlicedISOString(today)}
-                    data={statisticsData.data[StatisticsDataTypes.DeliveryModeStatistics]}
-                  />
-                </Box>
-              </Stack>
-              <Box className="filter">
+            <Box ref={exportJpgNode}>
+              <Typography variant="h6" component="h5" mt={7}>
+                {t('section_1')}
+              </Typography>
+              <FilterStatistics filter={statisticsFilter} />
+              <Stack direction={'column'} spacing={3} pt={2}>
+                <FiledNotificationsStatistics
+                  startDate={statisticsData.startDate ?? formatToSlicedISOString(oneYearAgo)}
+                  endDate={statisticsData.endDate ?? formatToSlicedISOString(today)}
+                  data={statisticsData.data[StatisticsDataTypes.FiledStatistics]}
+                />
+                <Stack direction={{ lg: 'row', xs: 'column' }} spacing={3} mt={4}>
+                  <Box sx={{ width: { xs: '100%', lg: '50%' } }}>
+                    <LastStateStatistics
+                      data={statisticsData.data[StatisticsDataTypes.LastStateStatistics]}
+                    />
+                  </Box>
+                  <Box sx={{ width: { xs: '100%', lg: '50%' } }}>
+                    <DeliveryModeStatistics
+                      startDate={statisticsData.startDate ?? formatToSlicedISOString(oneYearAgo)}
+                      endDate={statisticsData.endDate ?? formatToSlicedISOString(today)}
+                      data={statisticsData.data[StatisticsDataTypes.DeliveryModeStatistics]}
+                    />
+                  </Box>
+                </Stack>
                 <Typography variant="h6" component="h5" mt={6}>
                   {t('section_2')}
                 </Typography>
-                <FilterStatistics filter={statisticsFilter} />
-              </Box>
-              <Stack direction={{ lg: 'row', xs: 'column' }} spacing={3} mt={4}>
-                <Box sx={{ width: { xs: '100%', lg: '50%' } }}>
-                  <DigitalStateStatistics
-                    data={statisticsData.data[StatisticsDataTypes.DigitalStateStatistics]}
-                  />
+                <Box className="filter">
+                  <FilterStatistics filter={statisticsFilter} />
                 </Box>
-                <Box sx={{ width: { xs: '100%', lg: '50%' } }}>
-                  <DigitalMeanTimeStatistics
-                    data={statisticsData.data[StatisticsDataTypes.DigitalMeanTimeStatistics]}
-                  />
-                </Box>
+                <Stack direction={{ lg: 'row', xs: 'column' }} spacing={3} mt={4}>
+                  <Box sx={{ width: { xs: '100%', lg: '50%' } }}>
+                    <DigitalStateStatistics
+                      data={statisticsData.data[StatisticsDataTypes.DigitalStateStatistics]}
+                    />
+                  </Box>
+                  <Box sx={{ width: { xs: '100%', lg: '50%' } }}>
+                    <DigitalMeanTimeStatistics
+                      data={statisticsData.data[StatisticsDataTypes.DigitalMeanTimeStatistics]}
+                    />
+                  </Box>
+                </Stack>
+                <DigitalErrorsDetailStatistics
+                  data={statisticsData.data[StatisticsDataTypes.DigitalErrorsDetailStatistics]}
+                />
               </Stack>
-              <DigitalErrorsDetailStatistics
-                data={statisticsData.data[StatisticsDataTypes.DigitalErrorsDetailStatistics]}
-              />
-            </Stack>
+            </Box>
           </>
         ) : (
           <>


### PR DESCRIPTION
## Short description
This code adds the Screenshot module to utility folder (pn-commons) to allow jpeg image generation starting from an html node.

## List of changes proposed in this pull request
- adds Screenshot module under pn-commons 'utility' folder
- changes Statistics.page adding a global 'export jpeg' button
- removes the download icon from every statistics component
- changes formatDate method in common date.utility to specify a custom separator

## How to test
- Go to sender dashboard and verify the 'download jpeg' button is visible and there's no download icon on statistics components
- Click on the 'download jpeg' button and verify a jpeg screenshot of every statistics component is generated and available to download.