### PR TITLE
fix/PN-11775 - resolve model error causing pa-webapp to crash

### DIFF
--- a/packages/pn-pa-webapp/src/models/Statistics.ts
+++ b/packages/pn-pa-webapp/src/models/Statistics.ts
@@ -49,7 +49,7 @@ export enum ResponseStatus { // EXPORT FROM pn-commons/../NotificationDetail.ts?
 }
 
 export enum DigitaErrorTypes {
-  INVALID_PEC = 'ERRORE DOMICILIO PEC NON VALIDO',
+  INVALID_PEC = 'ERRORE DOMINIO PEC NON VALIDO',
   DELIVERY_ERROR = 'ERRORE CONSEGNA',
   REJECTED = 'NON ACCETTAZIONE',
   UNKNOWN = '-',


### PR DESCRIPTION
## Short description
This code resolves an error on DeliveryMode model which was causing the FE to crash.

## List of changes proposed in this pull request
- changes DigitalErrorTypes.INVALID_PEC value to meet openapi specs

## How to test
Follow the steps to reproduce the error, available on the task description, and verify the application works fine.