### PR TITLE
PN-11747 - Handle multi language on PF

### DIFF
--- a/packages/pn-commons/src/utility/string.utility.ts
+++ b/packages/pn-commons/src/utility/string.utility.ts
@@ -138,6 +138,23 @@ function clean(html: Document | Element) {
 }
 
 /**
+ * Escape html meta-characters
+ * @param htmlStr
+ * @returns escaped string
+ */
+function escapeMetaCharacters(htmlStr: string | null) {
+  if (!htmlStr) {
+    return null;
+  }
+  return htmlStr
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
  * Remove dangerous code from a string.
  * @param  {string} srt
  * @returns string
@@ -155,5 +172,5 @@ export function sanitizeString(srt: string): string {
   // i18next by default converts string like the previous one in "&lt;p&gt;Hello&lt&#x2F;p&gt", so is not possible to have a result string with html tags
   // for this reason, this solution doesn't bring a loss of functionality, but instead it can increase the security against malicious code
   // Andrea Cimini, 2023.07.12
-  return html.body.textContent ?? '';
+  return escapeMetaCharacters(html.body.textContent) ?? '';
 }

--- a/packages/pn-pa-webapp/src/App.tsx
+++ b/packages/pn-pa-webapp/src/App.tsx
@@ -186,6 +186,9 @@ const ActualApp = () => {
     if (sessionToken) {
       void dispatch(getCurrentAppStatus());
       void dispatch(getInstitutions());
+      // Temporary fix for multi-language support
+      // Remove lang from sessionStorage in order to makes Footer works properly
+      sessionStorage.removeItem('lang');
     }
     if (idOrganization) {
       void dispatch(getProductsOfInstitution());

--- a/packages/pn-pa-webapp/src/App.tsx
+++ b/packages/pn-pa-webapp/src/App.tsx
@@ -19,6 +19,7 @@ import {
   SideMenuItem,
   appStateActions,
   errorFactoryManager,
+  getSessionLanguage,
   initLocalization,
   setSessionLanguage,
   useMultiEvent,
@@ -186,9 +187,7 @@ const ActualApp = () => {
     if (sessionToken) {
       void dispatch(getCurrentAppStatus());
       void dispatch(getInstitutions());
-      // Temporary fix for multi-language support
-      // Remove lang from sessionStorage in order to makes Footer works properly
-      sessionStorage.removeItem('lang');
+      handleSetUserLanguage();
     }
     if (idOrganization) {
       void dispatch(getProductsOfInstitution());
@@ -208,6 +207,11 @@ const ActualApp = () => {
     window.location.href = sessionToken
       ? `${SELFCARE_BASE_URL}/assistenza?productId=${productId}`
       : `mailto:${configuration.PAGOPA_HELP_EMAIL}`;
+  };
+
+  const handleSetUserLanguage = () => {
+    const language = getSessionLanguage() || 'it';
+    void changeLanguageHandler(language);
   };
 
   const changeLanguageHandler = async (langCode: string) => {

--- a/packages/pn-pa-webapp/src/App.tsx
+++ b/packages/pn-pa-webapp/src/App.tsx
@@ -20,6 +20,7 @@ import {
   appStateActions,
   errorFactoryManager,
   initLocalization,
+  setSessionLanguage,
   useMultiEvent,
   useTracking,
 } from '@pagopa-pn/pn-commons';
@@ -207,6 +208,7 @@ const ActualApp = () => {
   };
 
   const changeLanguageHandler = async (langCode: string) => {
+    setSessionLanguage(langCode);
     await i18n.changeLanguage(langCode);
   };
 

--- a/packages/pn-personafisica-login/src/__test__/App.test.tsx
+++ b/packages/pn-personafisica-login/src/__test__/App.test.tsx
@@ -11,6 +11,10 @@ vi.mock('react-i18next', () => ({
   // this mock makes sure any components using the translation hook can use it without a warning being shown
   useTranslation: () => ({
     t: (str: string) => str,
+    i18n: {
+      language: 'it',
+      changeLanguage: () => new Promise(() => {}),
+    },
   }),
   Trans: (props: { i18nKey: string }) => props.i18nKey,
 }));

--- a/packages/pn-personafisica-login/src/pages/login/Login.tsx
+++ b/packages/pn-personafisica-login/src/pages/login/Login.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router-dom';
 
@@ -43,10 +43,10 @@ const Login = () => {
     storageAarOps.write(aar);
   }
 
-  const handleSetUserLanguage = useCallback(() => {
+  const handleSetUserLanguage = () => {
     const language = getSessionLanguage() || 'it';
     void changeLanguageHandler(language);
-  }, [location]);
+  };
 
   useEffect(() => {
     PFLoginEventStrategyFactory.triggerEvent(PFLoginEventsType.SEND_LOGIN);

--- a/packages/pn-personafisica-login/src/pages/login/Login.tsx
+++ b/packages/pn-personafisica-login/src/pages/login/Login.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router-dom';
 
@@ -7,7 +7,13 @@ import Button from '@mui/material/Button';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import { styled } from '@mui/material/styles';
-import { AppRouteParams, Layout, useIsMobile } from '@pagopa-pn/pn-commons';
+import {
+  AppRouteParams,
+  Layout,
+  getSessionLanguage,
+  setSessionLanguage,
+  useIsMobile,
+} from '@pagopa-pn/pn-commons';
 import { CieIcon, SpidIcon } from '@pagopa/mui-italia/dist/icons';
 
 import { PFLoginEventsType } from '../../models/PFLoginEventsType';
@@ -37,8 +43,14 @@ const Login = () => {
     storageAarOps.write(aar);
   }
 
+  const handleSetUserLanguage = useCallback(() => {
+    const language = getSessionLanguage() || 'it';
+    void changeLanguageHandler(language);
+  }, [location]);
+
   useEffect(() => {
     PFLoginEventStrategyFactory.triggerEvent(PFLoginEventsType.SEND_LOGIN);
+    handleSetUserLanguage();
   }, []);
 
   const goCIE = () => {
@@ -61,6 +73,7 @@ const Login = () => {
   }
 
   const changeLanguageHandler = async (langCode: string) => {
+    setSessionLanguage(langCode);
     await i18n.changeLanguage(langCode);
   };
 

--- a/packages/pn-personafisica-login/src/pages/login/__test__/Login.test.tsx
+++ b/packages/pn-personafisica-login/src/pages/login/__test__/Login.test.tsx
@@ -26,6 +26,10 @@ vi.mock('react-i18next', () => ({
   // this mock makes sure any components using the translation hook can use it without a warning being shown
   useTranslation: () => ({
     t: (str: string) => str,
+    i18n: {
+      language: 'it',
+      changeLanguage: () => new Promise(() => {}),
+    },
   }),
   Trans: (props: { i18nKey: string }) => props.i18nKey,
 }));

--- a/packages/pn-personafisica-login/src/pages/success/Success.tsx
+++ b/packages/pn-personafisica-login/src/pages/success/Success.tsx
@@ -27,7 +27,7 @@ const SuccessPage = () => {
     // the findIndex check is needed to prevent xss attacks
     if (redirectUrl && [PF_URL].findIndex((url) => url && redirectUrl.startsWith(url)) > -1) {
       window.location.replace(
-        `${redirectUrl}${sanitizeString(token)}&lang=${getSessionLanguage()}`
+        `${redirectUrl}${sanitizeString(token)}&lang=${sanitizeString(getSessionLanguage())}`
       );
     }
   }, [aar, token]);

--- a/packages/pn-personafisica-login/src/pages/success/Success.tsx
+++ b/packages/pn-personafisica-login/src/pages/success/Success.tsx
@@ -12,6 +12,7 @@ const SuccessPage = () => {
 
   const aar = useMemo(() => storageAarOps.read(), []);
   const token = useMemo(() => window.location.hash, []);
+  const lang = useMemo(() => getSessionLanguage(), []);
 
   const calcRedirectUrl = useCallback(() => {
     // eslint-disable-next-line functional/no-let
@@ -27,10 +28,10 @@ const SuccessPage = () => {
     // the findIndex check is needed to prevent xss attacks
     if (redirectUrl && [PF_URL].findIndex((url) => url && redirectUrl.startsWith(url)) > -1) {
       window.location.replace(
-        `${redirectUrl}${sanitizeString(token)}&lang=${sanitizeString(getSessionLanguage())}`
+        `${redirectUrl}${sanitizeString(token)}&lang=${sanitizeString(lang)}`
       );
     }
-  }, [aar, token]);
+  }, [aar, token, lang]);
 
   useEffect(() => {
     calcRedirectUrl();

--- a/packages/pn-personafisica-login/src/pages/success/Success.tsx
+++ b/packages/pn-personafisica-login/src/pages/success/Success.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo } from 'react';
 
-import { AppRouteParams, sanitizeString } from '@pagopa-pn/pn-commons';
+import { AppRouteParams, getSessionLanguage, sanitizeString } from '@pagopa-pn/pn-commons';
 
 import { PFLoginEventsType } from '../../models/PFLoginEventsType';
 import { getConfiguration } from '../../services/configuration.service';
@@ -26,7 +26,9 @@ const SuccessPage = () => {
 
     // the findIndex check is needed to prevent xss attacks
     if (redirectUrl && [PF_URL].findIndex((url) => url && redirectUrl.startsWith(url)) > -1) {
-      window.location.replace(`${redirectUrl}${sanitizeString(token)}`);
+      window.location.replace(
+        `${redirectUrl}${sanitizeString(token)}&lang=${getSessionLanguage()}`
+      );
     }
   }, [aar, token]);
 

--- a/packages/pn-personafisica-login/src/pages/success/__test__/Success.test.tsx
+++ b/packages/pn-personafisica-login/src/pages/success/__test__/Success.test.tsx
@@ -37,7 +37,9 @@ describe('test login page', () => {
       </BrowserRouter>
     );
     expect(mockLocationAssign).toBeCalled();
-    expect(mockLocationAssign).toBeCalledWith(getConfiguration().PF_URL + '#token=fake-token');
+    expect(mockLocationAssign).toBeCalledWith(
+      getConfiguration().PF_URL + '#token=fake-token&lang=it'
+    );
   });
 
   it('test redirect - aar', () => {
@@ -50,7 +52,7 @@ describe('test login page', () => {
 
     expect(mockLocationAssign).toBeCalled();
     expect(mockLocationAssign).toBeCalledWith(
-      getConfiguration().PF_URL + '?aar=aar-token#token=fake-token'
+      getConfiguration().PF_URL + '?aar=aar-token#token=fake-token&lang=it'
     );
   });
 
@@ -64,7 +66,7 @@ describe('test login page', () => {
 
     expect(mockLocationAssign).toBeCalled();
     expect(mockLocationAssign).toBeCalledWith(
-      getConfiguration().PF_URL + '?aar=aar-malicious-token#token=fake-token'
+      getConfiguration().PF_URL + '?aar=aar-malicious-token#token=fake-token&lang=it'
     );
   });
 });

--- a/packages/pn-personafisica-webapp/src/App.tsx
+++ b/packages/pn-personafisica-webapp/src/App.tsx
@@ -1,4 +1,4 @@
-import { ErrorInfo, useEffect, useMemo, useState } from 'react';
+import { ErrorInfo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 
@@ -22,7 +22,9 @@ import {
   SideMenuItem,
   appStateActions,
   errorFactoryManager,
+  getSessionLanguage,
   initLocalization,
+  setSessionLanguage,
   useMultiEvent,
   useTracking,
 } from '@pagopa-pn/pn-commons';
@@ -77,7 +79,7 @@ const App = () => {
   );
   const currentStatus = useAppSelector((state: RootState) => state.appStatus.currentStatus);
   const navigate = useNavigate();
-  const { pathname } = useLocation();
+  const { pathname, hash } = useLocation();
   const path = pathname.split('/');
   const { MIXPANEL_TOKEN, PAGOPA_HELP_EMAIL, VERSION } = getConfiguration();
 
@@ -199,7 +201,14 @@ const App = () => {
     },
   ];
 
+  const handleSetUserLanguage = useCallback(() => {
+    const langParam = new URLSearchParams(hash).get('lang');
+    const language = langParam || getSessionLanguage() || 'it';
+    void changeLanguageHandler(language);
+  }, [location]);
+
   const changeLanguageHandler = async (langCode: string) => {
+    setSessionLanguage(langCode);
     await i18n.changeLanguage(langCode);
   };
 
@@ -262,6 +271,7 @@ const App = () => {
       void dispatch(getDomicileInfo());
       void dispatch(getSidemenuInformation());
       void dispatch(getCurrentAppStatus());
+      handleSetUserLanguage();
     }
   }, [sessionToken]);
 

--- a/packages/pn-personafisica-webapp/src/App.tsx
+++ b/packages/pn-personafisica-webapp/src/App.tsx
@@ -1,4 +1,4 @@
-import { ErrorInfo, useCallback, useEffect, useMemo, useState } from 'react';
+import { ErrorInfo, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 
@@ -201,11 +201,11 @@ const App = () => {
     },
   ];
 
-  const handleSetUserLanguage = useCallback(() => {
+  const handleSetUserLanguage = () => {
     const langParam = new URLSearchParams(hash).get('lang');
     const language = langParam || getSessionLanguage() || 'it';
     void changeLanguageHandler(language);
-  }, [location]);
+  };
 
   const changeLanguageHandler = async (langCode: string) => {
     setSessionLanguage(langCode);

--- a/packages/pn-personafisica-webapp/src/__test__/App.test.tsx
+++ b/packages/pn-personafisica-webapp/src/__test__/App.test.tsx
@@ -30,7 +30,10 @@ vi.mock('react-i18next', () => ({
   Trans: (props: { i18nKey: string }) => props.i18nKey,
   useTranslation: () => ({
     t: (str: string) => str,
-    i18n: { language: 'it' },
+    i18n: {
+      language: 'it',
+      changeLanguage: () => new Promise(() => {}),
+    },
   }),
 }));
 


### PR DESCRIPTION
## Short description
Handle multi language on PF and PF Login. Also store lang on session storage of PA in order to make footer works properly

## List of changes proposed in this pull request
- Add lang on success URL of PF Login
- Read lang from URL on PF
- Store lang on session storage of PA

## How to test
On PF, use a direct access link and append a lang query parameter with a language (e.g. &lang=en) to it. Verify that the page is translated into the selected language. Also, try refreshing the page and check that the selected language is retained