### PR TITLE
PN-12118 - Escape meta characters

### DIFF
--- a/packages/pn-commons/src/utility/string.utility.ts
+++ b/packages/pn-commons/src/utility/string.utility.ts
@@ -142,10 +142,7 @@ function clean(html: Document | Element) {
  * @param htmlStr
  * @returns escaped string
  */
-function escapeMetaCharacters(htmlStr: string | null) {
-  if (!htmlStr) {
-    return null;
-  }
+function escapeMetaCharacters(htmlStr: string) {
   return htmlStr
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
@@ -159,10 +156,10 @@ function escapeMetaCharacters(htmlStr: string | null) {
  * @param  {string} srt
  * @returns string
  */
-export function sanitizeString(srt: string, isUrl = false): string {
+export function sanitizeString(srt: string): string {
   // convert string to html without rendering it
   const parser = new DOMParser();
-  const html = parser.parseFromString(srt, 'text/html');
+  const html = parser.parseFromString(escapeMetaCharacters(srt), 'text/html');
   // remove script
   removeScripts(html);
   // remove malicious attributes
@@ -172,5 +169,5 @@ export function sanitizeString(srt: string, isUrl = false): string {
   // i18next by default converts string like the previous one in "&lt;p&gt;Hello&lt&#x2F;p&gt", so is not possible to have a result string with html tags
   // for this reason, this solution doesn't bring a loss of functionality, but instead it can increase the security against malicious code
   // Andrea Cimini, 2023.07.12
-  return (isUrl ? escapeMetaCharacters(html.body.textContent) : html.body.textContent) || '';
+  return html.body.textContent || '';
 }

--- a/packages/pn-commons/src/utility/string.utility.ts
+++ b/packages/pn-commons/src/utility/string.utility.ts
@@ -155,5 +155,5 @@ export function sanitizeString(srt: string): string {
   // i18next by default converts string like the previous one in "&lt;p&gt;Hello&lt&#x2F;p&gt", so is not possible to have a result string with html tags
   // for this reason, this solution doesn't bring a loss of functionality, but instead it can increase the security against malicious code
   // Andrea Cimini, 2023.07.12
-  return html.body.textContent || '';
+  return html.body.textContent ?? '';
 }

--- a/packages/pn-commons/src/utility/string.utility.ts
+++ b/packages/pn-commons/src/utility/string.utility.ts
@@ -142,17 +142,17 @@ function clean(html: Document | Element) {
  * @param htmlStr
  * @returns escaped string
  */
-// function escapeMetaCharacters(htmlStr: string | null) {
-//   if (!htmlStr) {
-//     return null;
-//   }
-//   return htmlStr
-//     .replace(/&/g, '&amp;')
-//     .replace(/</g, '&lt;')
-//     .replace(/>/g, '&gt;')
-//     .replace(/"/g, '&quot;')
-//     .replace(/'/g, '&#39;');
-// }
+function escapeMetaCharacters(htmlStr: string | null) {
+  if (!htmlStr) {
+    return null;
+  }
+  return htmlStr
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
 
 /**
  * Remove dangerous code from a string.
@@ -172,5 +172,5 @@ export function sanitizeString(srt: string): string {
   // i18next by default converts string like the previous one in "&lt;p&gt;Hello&lt&#x2F;p&gt", so is not possible to have a result string with html tags
   // for this reason, this solution doesn't bring a loss of functionality, but instead it can increase the security against malicious code
   // Andrea Cimini, 2023.07.12
-  return html.body.textContent ?? '';
+  return escapeMetaCharacters(html.body.textContent) ?? '';
 }

--- a/packages/pn-commons/src/utility/string.utility.ts
+++ b/packages/pn-commons/src/utility/string.utility.ts
@@ -138,20 +138,6 @@ function clean(html: Document | Element) {
 }
 
 /**
- * Escape html meta-characters
- * @param htmlStr
- * @returns escaped string
- */
-function escapeMetaCharacters(htmlStr: string) {
-  return htmlStr
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
-
-/**
  * Remove dangerous code from a string.
  * @param  {string} srt
  * @returns string
@@ -159,7 +145,7 @@ function escapeMetaCharacters(htmlStr: string) {
 export function sanitizeString(srt: string): string {
   // convert string to html without rendering it
   const parser = new DOMParser();
-  const html = parser.parseFromString(escapeMetaCharacters(srt), 'text/html');
+  const html = parser.parseFromString(srt, 'text/html');
   // remove script
   removeScripts(html);
   // remove malicious attributes

--- a/packages/pn-commons/src/utility/string.utility.ts
+++ b/packages/pn-commons/src/utility/string.utility.ts
@@ -159,7 +159,7 @@ function escapeMetaCharacters(htmlStr: string | null) {
  * @param  {string} srt
  * @returns string
  */
-export function sanitizeString(srt: string): string {
+export function sanitizeString(srt: string, isUrl = false): string {
   // convert string to html without rendering it
   const parser = new DOMParser();
   const html = parser.parseFromString(srt, 'text/html');
@@ -172,5 +172,5 @@ export function sanitizeString(srt: string): string {
   // i18next by default converts string like the previous one in "&lt;p&gt;Hello&lt&#x2F;p&gt", so is not possible to have a result string with html tags
   // for this reason, this solution doesn't bring a loss of functionality, but instead it can increase the security against malicious code
   // Andrea Cimini, 2023.07.12
-  return escapeMetaCharacters(html.body.textContent) ?? '';
+  return (isUrl ? escapeMetaCharacters(html.body.textContent) : html.body.textContent) || '';
 }

--- a/packages/pn-commons/src/utility/string.utility.ts
+++ b/packages/pn-commons/src/utility/string.utility.ts
@@ -142,17 +142,17 @@ function clean(html: Document | Element) {
  * @param htmlStr
  * @returns escaped string
  */
-function escapeMetaCharacters(htmlStr: string | null) {
-  if (!htmlStr) {
-    return null;
-  }
-  return htmlStr
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
+// function escapeMetaCharacters(htmlStr: string | null) {
+//   if (!htmlStr) {
+//     return null;
+//   }
+//   return htmlStr
+//     .replace(/&/g, '&amp;')
+//     .replace(/</g, '&lt;')
+//     .replace(/>/g, '&gt;')
+//     .replace(/"/g, '&quot;')
+//     .replace(/'/g, '&#39;');
+// }
 
 /**
  * Remove dangerous code from a string.
@@ -172,5 +172,5 @@ export function sanitizeString(srt: string): string {
   // i18next by default converts string like the previous one in "&lt;p&gt;Hello&lt&#x2F;p&gt", so is not possible to have a result string with html tags
   // for this reason, this solution doesn't bring a loss of functionality, but instead it can increase the security against malicious code
   // Andrea Cimini, 2023.07.12
-  return escapeMetaCharacters(html.body.textContent) ?? '';
+  return html.body.textContent ?? '';
 }

--- a/packages/pn-personafisica-login/src/pages/success/Success.tsx
+++ b/packages/pn-personafisica-login/src/pages/success/Success.tsx
@@ -30,7 +30,7 @@ const SuccessPage = () => {
     // the findIndex check is needed to prevent xss attacks
     if (redirectUrl && [PF_URL].findIndex((url) => url && redirectUrl.startsWith(url)) > -1) {
       window.location.replace(
-        `${redirectUrl}${sanitizeString(token)}&lang=${sanitizeString(lang)}`
+        `${redirectUrl}${sanitizeString(token)}${sanitizeString(`&lang=${lang}`)}`
       );
     }
   }, [aar, token, lang]);

--- a/packages/pn-personafisica-login/src/pages/success/Success.tsx
+++ b/packages/pn-personafisica-login/src/pages/success/Success.tsx
@@ -30,7 +30,7 @@ const SuccessPage = () => {
     // the findIndex check is needed to prevent xss attacks
     if (redirectUrl && [PF_URL].findIndex((url) => url && redirectUrl.startsWith(url)) > -1) {
       window.location.replace(
-        `${redirectUrl}${sanitizeString(token, true)}&lang=${sanitizeString(lang, true)}`
+        `${redirectUrl}${sanitizeString(token)}&lang=${sanitizeString(lang)}`
       );
     }
   }, [aar, token, lang]);

--- a/packages/pn-personafisica-login/src/pages/success/Success.tsx
+++ b/packages/pn-personafisica-login/src/pages/success/Success.tsx
@@ -17,6 +17,7 @@ const SuccessPage = () => {
   const calcRedirectUrl = useCallback(() => {
     // eslint-disable-next-line functional/no-let
     let redirectUrl = PF_URL ?? '';
+    const langParam = `&lang=${lang}`;
 
     // the includes check is needed to prevent xss attacks
     if (redirectUrl && [PF_URL].includes(redirectUrl) && aar) {
@@ -29,9 +30,7 @@ const SuccessPage = () => {
 
     // the findIndex check is needed to prevent xss attacks
     if (redirectUrl && [PF_URL].findIndex((url) => url && redirectUrl.startsWith(url)) > -1) {
-      window.location.replace(
-        `${redirectUrl}${sanitizeString(token)}${sanitizeString(`&lang=${lang}`)}`
-      );
+      window.location.replace(`${redirectUrl}${sanitizeString(token)}${sanitizeString(langParam)}`);
     }
   }, [aar, token, lang]);
 

--- a/packages/pn-personafisica-login/src/pages/success/Success.tsx
+++ b/packages/pn-personafisica-login/src/pages/success/Success.tsx
@@ -14,10 +14,14 @@ const SuccessPage = () => {
   const token = useMemo(() => window.location.hash, []);
   const lang = useMemo(() => getSessionLanguage(), []);
 
+  const encodeURIComponentSafe = (str: string) =>
+    encodeURIComponent(str).replace(/[!'()*]/g, function (c) {
+      return '%' + c.charCodeAt(0).toString(16);
+    });
+
   const calcRedirectUrl = useCallback(() => {
     // eslint-disable-next-line functional/no-let
     let redirectUrl = PF_URL ?? '';
-    const langParam = `&lang=${lang}`;
 
     // the includes check is needed to prevent xss attacks
     if (redirectUrl && [PF_URL].includes(redirectUrl) && aar) {
@@ -28,9 +32,17 @@ const SuccessPage = () => {
 
     console.log('redirectUrl', redirectUrl);
 
+    const sanitizedRedirectUrl = sanitizeString(redirectUrl);
+    const sanitizedToken = sanitizeString(token);
+    const sanitizedLang = sanitizeString(lang);
+
+    const safeRedirectUrl = encodeURIComponentSafe(sanitizedRedirectUrl);
+    const safeToken = encodeURIComponentSafe(sanitizedToken);
+    const safeLang = encodeURIComponentSafe(sanitizedLang);
+
     // the findIndex check is needed to prevent xss attacks
     if (redirectUrl && [PF_URL].findIndex((url) => url && redirectUrl.startsWith(url)) > -1) {
-      window.location.replace(`${redirectUrl}${sanitizeString(token)}${sanitizeString(langParam)}`);
+      window.location.replace(`${safeRedirectUrl}${safeToken}&lang=${safeLang}`);
     }
   }, [aar, token, lang]);
 

--- a/packages/pn-personafisica-login/src/pages/success/Success.tsx
+++ b/packages/pn-personafisica-login/src/pages/success/Success.tsx
@@ -30,7 +30,7 @@ const SuccessPage = () => {
     // the findIndex check is needed to prevent xss attacks
     if (redirectUrl && [PF_URL].findIndex((url) => url && redirectUrl.startsWith(url)) > -1) {
       window.location.replace(
-        `${redirectUrl}${sanitizeString(token)}&lang=${sanitizeString(lang)}`
+        `${redirectUrl}${sanitizeString(token, true)}&lang=${sanitizeString(lang, true)}`
       );
     }
   }, [aar, token, lang]);

--- a/packages/pn-personafisica-login/src/pages/success/Success.tsx
+++ b/packages/pn-personafisica-login/src/pages/success/Success.tsx
@@ -25,8 +25,6 @@ const SuccessPage = () => {
       redirectUrl += `?${AppRouteParams.AAR}=${sanitizeString(aar)}`;
     }
 
-    console.log('redirectUrl', redirectUrl);
-
     // the findIndex check is needed to prevent xss attacks
     if (redirectUrl && [PF_URL].findIndex((url) => url && redirectUrl.startsWith(url)) > -1) {
       window.location.replace(

--- a/packages/pn-personafisica-login/src/pages/success/Success.tsx
+++ b/packages/pn-personafisica-login/src/pages/success/Success.tsx
@@ -14,11 +14,6 @@ const SuccessPage = () => {
   const token = useMemo(() => window.location.hash, []);
   const lang = useMemo(() => getSessionLanguage(), []);
 
-  const encodeURIComponentSafe = (str: string) =>
-    encodeURIComponent(str).replace(/[!'()*]/g, function (c) {
-      return '%' + c.charCodeAt(0).toString(16);
-    });
-
   const calcRedirectUrl = useCallback(() => {
     // eslint-disable-next-line functional/no-let
     let redirectUrl = PF_URL ?? '';
@@ -32,17 +27,11 @@ const SuccessPage = () => {
 
     console.log('redirectUrl', redirectUrl);
 
-    const sanitizedRedirectUrl = sanitizeString(redirectUrl);
-    const sanitizedToken = sanitizeString(token);
-    const sanitizedLang = sanitizeString(lang);
-
-    const safeRedirectUrl = encodeURIComponentSafe(sanitizedRedirectUrl);
-    const safeToken = encodeURIComponentSafe(sanitizedToken);
-    const safeLang = encodeURIComponentSafe(sanitizedLang);
-
     // the findIndex check is needed to prevent xss attacks
     if (redirectUrl && [PF_URL].findIndex((url) => url && redirectUrl.startsWith(url)) > -1) {
-      window.location.replace(`${safeRedirectUrl}${safeToken}&lang=${safeLang}`);
+      window.location.replace(
+        `${redirectUrl}${sanitizeString(token)}&lang=${sanitizeString(lang)}`
+      );
     }
   }, [aar, token, lang]);
 

--- a/packages/pn-personafisica-login/src/pages/success/Success.tsx
+++ b/packages/pn-personafisica-login/src/pages/success/Success.tsx
@@ -25,6 +25,8 @@ const SuccessPage = () => {
       redirectUrl += `?${AppRouteParams.AAR}=${sanitizeString(aar)}`;
     }
 
+    console.log('redirectUrl', redirectUrl);
+
     // the findIndex check is needed to prevent xss attacks
     if (redirectUrl && [PF_URL].findIndex((url) => url && redirectUrl.startsWith(url)) > -1) {
       window.location.replace(


### PR DESCRIPTION
## Short description
Restore `sanitizeString` function without `escapeMetaCharacters`

## List of changes proposed in this pull request
- Edit `sanitizeString`

## How to test
On PG, edit the organization name in sessionStorage and add special characters (such as &, <, >, ...) to verify that they are displayed properly.