### PR TITLE
PN-11371 - Remove useless `aria-label` tags

### DIFF
--- a/packages/pn-commons/src/components/ApiError/ApiError.tsx
+++ b/packages/pn-commons/src/components/ApiError/ApiError.tsx
@@ -1,5 +1,5 @@
 import ReportGmailerrorredIcon from '@mui/icons-material/ReportGmailerrorred';
-import { Stack, Typography, styled } from '@mui/material';
+import { Link, Stack, Typography, styled } from '@mui/material';
 
 import { getLocalizedOrDefaultLabel } from '../../utility/localization.utility';
 
@@ -45,14 +45,15 @@ const ApiError: React.FC<ApiErrorProps> = ({ onClick, mt = 0, mainText, apiId })
         sx={{ verticalAlign: 'middle', margin: '0 20px' }}
       />
       <Typography sx={{ marginRight: '8px' }}>{text}</Typography>
-      <Typography
+      <Link
         color="primary"
         fontWeight="bold"
-        sx={{ cursor: 'pointer', textDecoration: 'underline' }}
+        component="button"
+        sx={{ cursor: 'pointer', textDecoration: 'underline', verticalAlign: 'inherit' }}
         onClick={onClick || (() => window.location.reload())}
       >
         {actionLaunchText}
-      </Typography>
+      </Link>
     </StyledStack>
   );
 };

--- a/packages/pn-commons/src/components/AppStatus/AppStatusBar.tsx
+++ b/packages/pn-commons/src/components/AppStatus/AppStatusBar.tsx
@@ -52,9 +52,7 @@ export const AppStatusBar = ({ status }: { status: AppCurrentStatus }) => {
           color: mainColor,
         }}
       />
-      <Typography aria-label={statusText} variant="body2">
-        {statusText}
-      </Typography>
+      <Typography variant="body2">{statusText}</Typography>
     </Stack>
   );
 };

--- a/packages/pn-commons/src/components/AppStatus/AppStatusRender.tsx
+++ b/packages/pn-commons/src/components/AppStatus/AppStatusRender.tsx
@@ -138,11 +138,7 @@ export const AppStatusRender = (props: Props) => {
               data-testid="appStatus-lastCheck"
               id="appStatusLastCheck"
             >
-              <Typography
-                variant="caption"
-                sx={{ mt: 2, color: 'text.secondary' }}
-                aria-label={lastCheckLegend}
-              >
+              <Typography variant="caption" sx={{ mt: 2, color: 'text.secondary' }}>
                 {lastCheckLegend}
               </Typography>
             </Stack>
@@ -150,7 +146,7 @@ export const AppStatusRender = (props: Props) => {
         </ApiErrorWrapper>
 
         {/* Titolo elenco di downtime */}
-        <Typography variant="h6" sx={{ mt: '36px', mb: 2 }} aria-label={downtimeListTitle}>
+        <Typography variant="h6" sx={{ mt: '36px', mb: 2 }}>
           {downtimeListTitle}
         </Typography>
 

--- a/packages/pn-commons/src/components/TitleBox.tsx
+++ b/packages/pn-commons/src/components/TitleBox.tsx
@@ -21,8 +21,6 @@ type Props = {
   variantSubTitle?: Variant;
   /** style to apply */
   sx?: SxProps<Theme>;
-  /** a11y for component */
-  ariaLabel?: string;
   /** paragraph component */
   children?: React.ReactNode;
 };
@@ -40,7 +38,6 @@ const TitleBox: React.FC<Props> = ({
   variantTitle = 'h1',
   variantSubTitle = 'h5',
   sx,
-  ariaLabel,
   children,
 }) => (
   <Grid id="page-header-container" aria-orientation="horizontal" container mt={mtGrid} sx={sx}>
@@ -50,7 +47,6 @@ const TitleBox: React.FC<Props> = ({
           id={`${title}-page`}
           data-testid="titleBox"
           role="heading"
-          aria-label={ariaLabel}
           variant={variantTitle}
           display="inline-block"
           sx={{ verticalAlign: 'middle' }}

--- a/packages/pn-pa-webapp/src/components/ApiKeys/DesktopApiKeys.tsx
+++ b/packages/pn-pa-webapp/src/components/ApiKeys/DesktopApiKeys.tsx
@@ -26,13 +26,11 @@ type Props = {
 
 const LinkNewApiKey: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
   const navigate = useNavigate();
-  const { t } = useTranslation(['apikeys']);
   return (
     <Link
       component={'button'}
       variant="body1"
       id="call-to-action-first"
-      aria-label={t('empty-action-label')}
       key="new-api-key"
       data-testid="link-new-api-key"
       onClick={() => navigate(routes.NUOVA_API_KEY)}

--- a/packages/pn-pa-webapp/src/components/Notifications/DesktopNotifications.tsx
+++ b/packages/pn-pa-webapp/src/components/Notifications/DesktopNotifications.tsx
@@ -49,59 +49,47 @@ type LinkCreateNotificationProps = {
   children?: React.ReactNode;
 };
 
-const LinkRemoveFilters: React.FC<LinkRemoveFiltersProps> = ({ children, cleanFilters }) => {
-  const { t } = useTranslation(['notifiche']);
-  return (
-    <Link
-      component={'button'}
-      variant="body1"
-      id="call-to-action-first"
-      aria-label={t('empty-state.aria-label-remove-filters')}
-      key="remove-filters"
-      data-testid="link-remove-filters"
-      onClick={cleanFilters}
-    >
-      {children}
-    </Link>
-  );
-};
+const LinkRemoveFilters: React.FC<LinkRemoveFiltersProps> = ({ children, cleanFilters }) => (
+  <Link
+    component={'button'}
+    variant="body1"
+    id="call-to-action-first"
+    key="remove-filters"
+    data-testid="link-remove-filters"
+    onClick={cleanFilters}
+  >
+    {children}
+  </Link>
+);
 
-const LinkApiKey: React.FC<LinkApiKeyProps> = ({ children, onApiKeys }) => {
-  const { t } = useTranslation(['notifiche']);
-  return (
-    <Link
-      component={'button'}
-      variant="body1"
-      id="call-to-action-first"
-      aria-label={t('empty-state.aria-label-api-keys')}
-      key="api-keys"
-      data-testid="link-api-keys"
-      onClick={onApiKeys}
-    >
-      {children}
-    </Link>
-  );
-};
+const LinkApiKey: React.FC<LinkApiKeyProps> = ({ children, onApiKeys }) => (
+  <Link
+    component={'button'}
+    variant="body1"
+    id="call-to-action-first"
+    key="api-keys"
+    data-testid="link-api-keys"
+    onClick={onApiKeys}
+  >
+    {children}
+  </Link>
+);
 
 const LinkCreateNotification: React.FC<LinkCreateNotificationProps> = ({
   children,
   onManualSend,
-}) => {
-  const { t } = useTranslation(['notifiche']);
-  return (
-    <Link
-      component={'button'}
-      variant="body1"
-      id="call-to-action-second"
-      aria-label={t('empty-state.aria-label-create-notification')}
-      key="create-notification"
-      data-testid="link-create-notification"
-      onClick={onManualSend}
-    >
-      {children}
-    </Link>
-  );
-};
+}) => (
+  <Link
+    component={'button'}
+    variant="body1"
+    id="call-to-action-second"
+    key="create-notification"
+    data-testid="link-create-notification"
+    onClick={onManualSend}
+  >
+    {children}
+  </Link>
+);
 
 const DesktopNotifications = ({
   notifications,

--- a/packages/pn-pa-webapp/src/components/Notifications/MobileNotifications.tsx
+++ b/packages/pn-pa-webapp/src/components/Notifications/MobileNotifications.tsx
@@ -55,59 +55,47 @@ type LinkCreateNotificationProps = {
   children?: React.ReactNode;
 };
 
-const LinkRemoveFilters: React.FC<LinkRemoveFiltersProps> = ({ children, cleanFilters }) => {
-  const { t } = useTranslation(['notifiche']);
-  return (
-    <Link
-      component={'button'}
-      variant="body1"
-      id="call-to-action-first"
-      aria-label={t('empty-state.aria-label-remove-filters')}
-      key="remove-filters"
-      data-testid="link-remove-filters"
-      onClick={cleanFilters}
-    >
-      {children}
-    </Link>
-  );
-};
+const LinkRemoveFilters: React.FC<LinkRemoveFiltersProps> = ({ children, cleanFilters }) => (
+  <Link
+    component={'button'}
+    variant="body1"
+    id="call-to-action-first"
+    key="remove-filters"
+    data-testid="link-remove-filters"
+    onClick={cleanFilters}
+  >
+    {children}
+  </Link>
+);
 
-const LinkApiKey: React.FC<LinkApiKeyProps> = ({ children, onApiKeys }) => {
-  const { t } = useTranslation(['notifiche']);
-  return (
-    <Link
-      component={'button'}
-      variant="body1"
-      id="call-to-action-first"
-      aria-label={t('empty-state.aria-label-api-keys')}
-      key="api-keys"
-      data-testid="link-api-keys"
-      onClick={onApiKeys}
-    >
-      {children}
-    </Link>
-  );
-};
+const LinkApiKey: React.FC<LinkApiKeyProps> = ({ children, onApiKeys }) => (
+  <Link
+    component={'button'}
+    variant="body1"
+    id="call-to-action-first"
+    key="api-keys"
+    data-testid="link-api-keys"
+    onClick={onApiKeys}
+  >
+    {children}
+  </Link>
+);
 
 const LinkCreateNotification: React.FC<LinkCreateNotificationProps> = ({
   children,
   onManualSend,
-}) => {
-  const { t } = useTranslation(['notifiche']);
-  return (
-    <Link
-      component={'button'}
-      variant="body1"
-      id="call-to-action-second"
-      aria-label={t('empty-state.aria-label-create-notification')}
-      key="create-notification"
-      data-testid="link-create-notification"
-      onClick={onManualSend}
-    >
-      {children}
-    </Link>
-  );
-};
+}) => (
+  <Link
+    component={'button'}
+    variant="body1"
+    id="call-to-action-second"
+    key="create-notification"
+    data-testid="link-create-notification"
+    onClick={onManualSend}
+  >
+    {children}
+  </Link>
+);
 
 const MobileNotifications = ({
   notifications,

--- a/packages/pn-pa-webapp/src/components/Notifications/NotificationPaymentF24.tsx
+++ b/packages/pn-pa-webapp/src/components/Notifications/NotificationPaymentF24.tsx
@@ -75,13 +75,7 @@ const NotificationPaymentF24: React.FC<Props> = ({ iun, payments }) => {
                 data-testid="show-all-attachments"
                 onClick={() => setOpen(true)}
               >
-                <Typography
-                  color="primary"
-                  variant="body2"
-                  tabIndex={0}
-                  aria-label={t('detail.show-all')}
-                  fontWeight={'bold'}
-                >
+                <Typography color="primary" variant="body2" tabIndex={0} fontWeight={'bold'}>
                   {t('detail.show-all')}
                 </Typography>
               </ButtonNaked>

--- a/packages/pn-pa-webapp/src/components/Notifications/NotificationRecipientsDetail.tsx
+++ b/packages/pn-pa-webapp/src/components/Notifications/NotificationRecipientsDetail.tsx
@@ -82,13 +82,7 @@ const NotificationRecipientsDetail: React.FC<Props> = ({ recipients, iun }) => {
                 onClick={() => setOpen(true)}
                 data-testid="show-all-recipients"
               >
-                <Typography
-                  color="primary"
-                  variant="body2"
-                  tabIndex={0}
-                  aria-label={t('detail.show-all')}
-                  fontWeight={'bold'}
-                >
+                <Typography color="primary" variant="body2" tabIndex={0} fontWeight={'bold'}>
                   {t('detail.show-all')}
                 </Typography>
               </ButtonNaked>

--- a/packages/pn-pa-webapp/src/pages/ApiKeys.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/ApiKeys.page.tsx
@@ -31,7 +31,11 @@ import { getConfiguration } from '../services/configuration.service';
 
 const LinkApiB2b: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
   const { API_B2B_LINK } = getConfiguration();
-  return <Link href={API_B2B_LINK} target="_blank">{children}</Link>;
+  return (
+    <Link href={API_B2B_LINK} target="_blank">
+      {children}
+    </Link>
+  );
 };
 
 const TableGroupsId = ({ groups }: { groups?: Array<{ id: string; name: string }> }) => {
@@ -172,12 +176,7 @@ const ApiKeys = () => {
           marginTop: isMobile ? 3 : 10,
         }}
       >
-        <Typography
-          tabIndex={0}
-          aria-label={t('generated-api-keys')}
-          variant="h5"
-          sx={{ marginBottom: isMobile ? 3 : undefined }}
-        >
+        <Typography variant="h5" sx={{ marginBottom: isMobile ? 3 : undefined }}>
           {t('generated-api-keys')}
         </Typography>
         <Button

--- a/packages/pn-pa-webapp/src/pages/Dashboard.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/Dashboard.page.tsx
@@ -96,7 +96,6 @@ const Dashboard = () => {
                 id="new-notification-btn"
                 variant="contained"
                 onClick={handleRouteManualSend}
-                aria-label={t('new-notification-button')}
                 data-testid="newNotificationBtn"
                 sx={{ marginBottom: isMobile ? 3 : undefined }}
               >

--- a/packages/pn-pa-webapp/src/pages/NewNotification.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/NewNotification.page.tsx
@@ -129,12 +129,7 @@ const NewNotification = () => {
               {t('required-fields')}
             </Typography>
             {!IS_PAYMENT_ENABLED && (
-              <Alert
-                aria-label={t('new-notification.warning-payment-disabled', { ns: 'notifiche' })}
-                data-testid="alert"
-                sx={{ mt: 4 }}
-                severity={'warning'}
-              >
+              <Alert role="alert" data-testid="alert" sx={{ mt: 4 }} severity={'warning'}>
                 <Typography component="span" variant="body1">
                   {t('new-notification.warning-payment-disabled', { ns: 'notifiche' })}
                 </Typography>

--- a/packages/pn-personafisica-webapp/src/components/Contacts/CourtesyContacts.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/CourtesyContacts.tsx
@@ -27,14 +27,8 @@ const CourtesyContacts: React.FC<Props> = ({ contacts }) => {
       <Box sx={{ width: { xs: '100%', lg: '50%' } }} data-testid="courtesyContacts">
         <CourtesyContactsList contacts={contacts} />
       </Box>
-      <Alert
-        role="banner"
-        aria-label={t('courtesy-contacts.disclaimer-message', { ns: 'recapiti' })}
-        sx={{ mt: 4 }}
-        severity="info"
-        data-testid="contacts disclaimer"
-      >
-        <Typography role="banner" component="span" variant="body1">
+      <Alert role="banner" sx={{ mt: 4 }} severity="info" data-testid="contacts disclaimer">
+        <Typography component="span" variant="body1">
           {t('courtesy-contacts.disclaimer-message', { ns: 'recapiti' })}
         </Typography>
         {/** 

--- a/packages/pn-personafisica-webapp/src/components/Contacts/IOContact.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/IOContact.tsx
@@ -109,15 +109,10 @@ const IOContact: React.FC<Props> = ({ contact }) => {
         <Alert
           role="banner"
           sx={{ mt: 4 }}
-          aria-label={
-            status === IOContactStatus.UNAVAILABLE
-              ? t('io-contact.disclaimer-message-unavailable', { ns: 'recapiti' })
-              : t('io-contact.disclaimer-message', { ns: 'recapiti' })
-          }
           severity={status !== IOContactStatus.UNAVAILABLE ? 'info' : 'warning'}
           data-testid="appIO-contact-disclaimer"
         >
-          <Typography component="span" variant="body1" role="banner">
+          <Typography component="span" variant="body1">
             {status === IOContactStatus.UNAVAILABLE
               ? t('io-contact.disclaimer-message-unavailable', { ns: 'recapiti' })
               : t('io-contact.disclaimer-message', { ns: 'recapiti' })}{' '}

--- a/packages/pn-personafisica-webapp/src/components/Contacts/InsertLegalContact.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/InsertLegalContact.tsx
@@ -82,19 +82,8 @@ const InsertLegalContact: React.FC = () => {
             </Button>
           </Grid>
         </Grid>
-        <Alert
-          tabIndex={0}
-          role="banner"
-          aria-label={t('legal-contacts.disclaimer-message', { ns: 'recapiti' })}
-          sx={{ mt: 4 }}
-          severity="info"
-        >
-          <Typography
-            role="banner"
-            component="span"
-            variant="body1"
-            data-testid="legal-contact-disclaimer"
-          >
+        <Alert tabIndex={0} role="banner" sx={{ mt: 4 }} severity="info">
+          <Typography component="span" variant="body1" data-testid="legal-contact-disclaimer">
             {t('legal-contacts.disclaimer-message', { ns: 'recapiti' })}{' '}
           </Typography>
           {/** 

--- a/packages/pn-personafisica-webapp/src/components/Contacts/LegalContactsList.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/LegalContactsList.tsx
@@ -169,18 +169,8 @@ const LegalContactsList = ({ legalAddresses }: Props) => {
             </Box>
           </Box>
         )}
-        <Alert
-          role="banner"
-          aria-label={t('legal-contacts.disclaimer-message', { ns: 'recapiti' })}
-          sx={{ mt: 4 }}
-          severity="info"
-        >
-          <Typography
-            role="banner"
-            component="span"
-            variant="body1"
-            data-testid="legal-contact-disclaimer"
-          >
+        <Alert role="banner" sx={{ mt: 4 }} severity="info">
+          <Typography component="span" variant="body1" data-testid="legal-contact-disclaimer">
             {t('legal-contacts.disclaimer-message', { ns: 'recapiti' })}{' '}
           </Typography>
           {/**

--- a/packages/pn-personafisica-webapp/src/components/Contacts/SpecialContacts.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/SpecialContacts.tsx
@@ -456,7 +456,7 @@ const SpecialContacts = ({ legalAddresses, courtesyAddresses }: Props) => {
                 {t('special-contacts.associated', { ns: 'recapiti' })}
               </Typography>
               {!isMobile && (
-                <Table aria-label={t('special-contacts.associated', { ns: 'recapiti' })}>
+                <Table>
                   <TableHead>
                     <TableRow>
                       {listHeaders.map((h) => (

--- a/packages/pn-personafisica-webapp/src/components/Deleghe/Delegates.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Deleghe/Delegates.tsx
@@ -35,22 +35,18 @@ type Props = {
   children?: React.ReactNode;
 };
 
-const LinkAddDelegate: React.FC<Props> = ({ children, handleAddDelegationClick }) => {
-  const { t } = useTranslation(['deleghe']);
-  return (
-    <Link
-      component={'button'}
-      variant="body1"
-      id="call-to-action-first"
-      aria-label={t('deleghe.add')}
-      key="add-delegate"
-      data-testid="link-add-delegate"
-      onClick={(_e, source = 'empty_state') => handleAddDelegationClick(source)}
-    >
-      {children}
-    </Link>
-  );
-};
+const LinkAddDelegate: React.FC<Props> = ({ children, handleAddDelegationClick }) => (
+  <Link
+    component={'button'}
+    variant="body1"
+    id="call-to-action-first"
+    key="add-delegate"
+    data-testid="link-add-delegate"
+    onClick={(_e, source = 'empty_state') => handleAddDelegationClick(source)}
+  >
+    {children}
+  </Link>
+);
 
 const Delegates = () => {
   const { t } = useTranslation(['deleghe']);

--- a/packages/pn-personafisica-webapp/src/components/Deleghe/MobileDelegates.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Deleghe/MobileDelegates.tsx
@@ -33,22 +33,18 @@ type Props = {
   children?: React.ReactNode;
 };
 
-const LinkAddDelegate: React.FC<Props> = ({ children, handleAddDelegationClick }) => {
-  const { t } = useTranslation(['deleghe']);
-  return (
-    <Link
-      component={'button'}
-      variant="body1"
-      id="call-to-action-first"
-      aria-label={t('deleghe.add')}
-      key="add-delegate"
-      data-testid="link-add-delegate"
-      onClick={(_e, source = 'empty_state') => handleAddDelegationClick(source)}
-    >
-      {children}
-    </Link>
-  );
-};
+const LinkAddDelegate: React.FC<Props> = ({ children, handleAddDelegationClick }) => (
+  <Link
+    component={'button'}
+    variant="body1"
+    id="call-to-action-first"
+    key="add-delegate"
+    data-testid="link-add-delegate"
+    onClick={(_e, source = 'empty_state') => handleAddDelegationClick(source)}
+  >
+    {children}
+  </Link>
+);
 
 const MobileDelegates = () => {
   const { t } = useTranslation(['deleghe']);

--- a/packages/pn-personafisica-webapp/src/components/Notifications/DesktopNotifications.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Notifications/DesktopNotifications.tsx
@@ -41,25 +41,20 @@ type LinkRemoveFiltersProps = {
   children?: React.ReactNode;
 };
 
-const LinkRemoveFilters: React.FC<LinkRemoveFiltersProps> = ({ children, cleanFilters }) => {
-  const { t } = useTranslation('notifiche');
-  return (
-    <Link
-      component={'button'}
-      variant="body1"
-      id="call-to-action-first"
-      aria-label={t('empty-state.aria-label-remove-filters')}
-      key="remove-filters"
-      data-testid="link-remove-filters"
-      onClick={cleanFilters}
-    >
-      {children}
-    </Link>
-  );
-};
+const LinkRemoveFilters: React.FC<LinkRemoveFiltersProps> = ({ children, cleanFilters }) => (
+  <Link
+    component={'button'}
+    variant="body1"
+    id="call-to-action-first"
+    key="remove-filters"
+    data-testid="link-remove-filters"
+    onClick={cleanFilters}
+  >
+    {children}
+  </Link>
+);
 
 const LinkRouteContacts: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
-  const { t } = useTranslation('notifiche');
   const navigate = useNavigate();
   const goToContactsPage = () => {
     PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_VIEW_CONTACT_DETAILS, {
@@ -72,7 +67,6 @@ const LinkRouteContacts: React.FC<{ children?: React.ReactNode }> = ({ children 
       component={'button'}
       variant="body1"
       id="call-to-action-first"
-      aria-label={t('empty-state.aria-label-route-contacts')}
       key="route-contacts"
       data-testid="link-route-contacts"
       onClick={goToContactsPage}

--- a/packages/pn-personafisica-webapp/src/components/Notifications/MobileNotifications.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Notifications/MobileNotifications.tsx
@@ -58,25 +58,20 @@ type LinkRemoveFiltersProps = {
  */
 const IS_SORT_ENABLED = false;
 
-const LinkRemoveFilters: React.FC<LinkRemoveFiltersProps> = ({ children, cleanFilters }) => {
-  const { t } = useTranslation('notifiche');
-  return (
-    <Link
-      component={'button'}
-      variant="body1"
-      id="call-to-action-first"
-      aria-label={t('empty-state.aria-label-remove-filters')}
-      key="remove-filters"
-      data-testid="link-remove-filters"
-      onClick={cleanFilters}
-    >
-      {children}
-    </Link>
-  );
-};
+const LinkRemoveFilters: React.FC<LinkRemoveFiltersProps> = ({ children, cleanFilters }) => (
+  <Link
+    component={'button'}
+    variant="body1"
+    id="call-to-action-first"
+    key="remove-filters"
+    data-testid="link-remove-filters"
+    onClick={cleanFilters}
+  >
+    {children}
+  </Link>
+);
 
 const LinkRouteContacts: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
-  const { t } = useTranslation('notifiche');
   const navigate = useNavigate();
   const goToContactsPage = () => {
     PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_VIEW_CONTACT_DETAILS, {
@@ -89,7 +84,6 @@ const LinkRouteContacts: React.FC<{ children?: React.ReactNode }> = ({ children 
       component={'button'}
       variant="body1"
       id="call-to-action-first"
-      aria-label={t('empty-state.aria-label-route-contacts')}
       key="route-contacts"
       data-testid="link-route-contacts"
       onClick={goToContactsPage}

--- a/packages/pn-personafisica-webapp/src/pages/Contacts.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/Contacts.page.tsx
@@ -89,11 +89,7 @@ const Contacts = () => {
     <>
       {t('subtitle-text-1', { ns: 'recapiti' })}
       {faqWhatIsAarCompleteLink ? (
-        <Link
-          href={faqWhatIsAarCompleteLink}
-          target="_blank"
-          aria-label={t('subtitle-link-1', { ns: 'recapiti' })}
-        >
+        <Link href={faqWhatIsAarCompleteLink} target="_blank">
           {t('subtitle-link-1', { ns: 'recapiti' })}
         </Link>
       ) : (
@@ -101,11 +97,7 @@ const Contacts = () => {
       )}
       {t('subtitle-text-2', { ns: 'recapiti' })}
       {faqWhatIsCourtesyMessageCompleteLink ? (
-        <Link
-          href={faqWhatIsCourtesyMessageCompleteLink}
-          target="_blank"
-          aria-label={t('subtitle-link-2', { ns: 'recapiti' })}
-        >
+        <Link href={faqWhatIsCourtesyMessageCompleteLink} target="_blank">
           {t('subtitle-link-2', { ns: 'recapiti' })}
         </Link>
       ) : (
@@ -114,7 +106,6 @@ const Contacts = () => {
       {t('subtitle-text-3', { ns: 'recapiti' })}
       <Link
         onClick={handleRedirectToProfilePage}
-        aria-label={t('subtitle-link-3', { ns: 'recapiti' })}
         component="button"
         sx={{ verticalAlign: 'inherit' }}
       >
@@ -139,7 +130,6 @@ const Contacts = () => {
             title={t('title')}
             subTitle={subtitle}
             variantSubTitle={'body1'}
-            ariaLabel={t('title')}
           />
           <ApiErrorWrapper
             apiId={CONTACT_ACTIONS.GET_DIGITAL_ADDRESSES}

--- a/packages/pn-personafisica-webapp/src/pages/Profile.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/Profile.page.tsx
@@ -93,7 +93,6 @@ const Profile = () => {
 
         <Grid item lg={8} xs={12}>
           <Alert
-            severity="info"
             aria-label="contacts-redirect"
             action={
               <Button

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/CourtesyContacts.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/CourtesyContacts.tsx
@@ -27,14 +27,8 @@ const CourtesyContacts: React.FC<Props> = ({ contacts }) => {
       <Box sx={{ width: { xs: '100%', lg: '50%' } }} data-testid="courtesyContacts">
         <CourtesyContactsList contacts={contacts} />
       </Box>
-      <Alert
-        role="banner"
-        aria-label={t('courtesy-contacts.disclaimer-message', { ns: 'recapiti' })}
-        sx={{ mt: 4 }}
-        severity="info"
-        data-testid="contacts disclaimer"
-      >
-        <Typography role="banner" component="span" variant="body1">
+      <Alert role="banner" sx={{ mt: 4 }} severity="info" data-testid="contacts disclaimer">
+        <Typography component="span" variant="body1">
           {t('courtesy-contacts.disclaimer-message', { ns: 'recapiti' })}
         </Typography>
         {/** 

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/InsertLegalContact.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/InsertLegalContact.tsx
@@ -84,7 +84,6 @@ const InsertLegalContact: React.FC = () => {
         </Grid>
         <Alert
           role="banner"
-          tabIndex={0}
           aria-label={t('legal-contacts.disclaimer-message', { ns: 'recapiti' })}
           sx={{ mt: 4 }}
           severity="info"

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/LegalContactsList.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/LegalContactsList.tsx
@@ -169,18 +169,8 @@ const LegalContactsList = ({ legalAddresses }: Props) => {
             </Box>
           </Box>
         )}
-        <Alert
-          role="banner"
-          aria-label={t('legal-contacts.disclaimer-message', { ns: 'recapiti' })}
-          sx={{ mt: 4 }}
-          severity="info"
-        >
-          <Typography
-            role="banner"
-            component="span"
-            variant="body1"
-            data-testid="legal-contact-disclaimer"
-          >
+        <Alert role="banner" sx={{ mt: 4 }} severity="info">
+          <Typography component="span" variant="body1" data-testid="legal-contact-disclaimer">
             {t('legal-contacts.disclaimer-message', { ns: 'recapiti' })}{' '}
           </Typography>
           {/**

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/SpecialContacts.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/SpecialContacts.tsx
@@ -455,7 +455,7 @@ const SpecialContacts = ({ legalAddresses, courtesyAddresses }: Props) => {
                 {t('special-contacts.associated', { ns: 'recapiti' })}
               </Typography>
               {!isMobile && (
-                <Table aria-label={t('special-contacts.associated', { ns: 'recapiti' })}>
+                <Table>
                   <TableHead>
                     <TableRow>
                       {listHeaders.map((h) => (

--- a/packages/pn-personagiuridica-webapp/src/components/Deleghe/DelegatesByCompany.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Deleghe/DelegatesByCompany.tsx
@@ -33,22 +33,18 @@ type Props = {
   children?: React.ReactNode;
 };
 
-const LinkAddDelegate: React.FC<Props> = ({ children, handleAddDelegationClick }) => {
-  const { t } = useTranslation(['deleghe']);
-  return (
-    <Link
-      component={'button'}
-      variant="body1"
-      id="call-to-action-first"
-      aria-label={t('deleghe.add')}
-      key="add-delegate"
-      data-testid="link-add-delegate"
-      onClick={(_e, source = 'empty_state') => handleAddDelegationClick(source)}
-    >
-      {children}
-    </Link>
-  );
-};
+const LinkAddDelegate: React.FC<Props> = ({ children, handleAddDelegationClick }) => (
+  <Link
+    component={'button'}
+    variant="body1"
+    id="call-to-action-first"
+    key="add-delegate"
+    data-testid="link-add-delegate"
+    onClick={(_e, source = 'empty_state') => handleAddDelegationClick(source)}
+  >
+    {children}
+  </Link>
+);
 
 const DelegatesByCompany = () => {
   const isMobile = useIsMobile();

--- a/packages/pn-personagiuridica-webapp/src/components/Deleghe/DelegationsElements.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Deleghe/DelegationsElements.tsx
@@ -271,7 +271,7 @@ export const Menu: React.FC<Props> = ({ menuType, id, userLogged, row, onAction 
         id={`delegation-menu-icon-${id}`}
         onClick={handleClick}
         data-testid="delegationMenuIcon"
-        aria-label="menu-aria-label"
+        aria-label={t('deleghe.table.menu-aria-label')}
       >
         <MoreVertIcon fontSize={'small'} />
       </IconButton>

--- a/packages/pn-personagiuridica-webapp/src/components/Deleghe/DelegationsOfTheCompany.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Deleghe/DelegationsOfTheCompany.tsx
@@ -67,22 +67,18 @@ type Props = {
   children?: React.ReactNode;
 };
 
-const LinkRemoveFilters: React.FC<Props> = ({ children, clearFiltersHandler }) => {
-  const { t } = useTranslation(['deleghe']);
-  return (
-    <Link
-      component={'button'}
-      variant="body1"
-      id="call-to-action-first"
-      aria-label={t('empty-state.aria-label-remove-filters')}
-      key="remove-filters"
-      data-testid="link-remove-filters"
-      onClick={clearFiltersHandler}
-    >
-      {children}
-    </Link>
-  );
-};
+const LinkRemoveFilters: React.FC<Props> = ({ children, clearFiltersHandler }) => (
+  <Link
+    component={'button'}
+    variant="body1"
+    id="call-to-action-first"
+    key="remove-filters"
+    data-testid="link-remove-filters"
+    onClick={clearFiltersHandler}
+  >
+    {children}
+  </Link>
+);
 
 const DelegationsOfTheCompany = () => {
   const { t } = useTranslation(['deleghe', 'common']);

--- a/packages/pn-personagiuridica-webapp/src/components/Notifications/DesktopNotifications.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Notifications/DesktopNotifications.tsx
@@ -40,22 +40,18 @@ type LinkRemoveFiltersProps = {
   children?: React.ReactNode;
 };
 
-const LinkRemoveFilters: React.FC<LinkRemoveFiltersProps> = ({ children, cleanFilters }) => {
-  const { t } = useTranslation(['notifiche']);
-  return (
-    <Link
-      component={'button'}
-      variant="body1"
-      id="call-to-action-first"
-      aria-label={t('empty-state.aria-label-remove-filters')}
-      key="remove-filters"
-      data-testid="link-remove-filters"
-      onClick={cleanFilters}
-    >
-      {children}
-    </Link>
-  );
-};
+const LinkRemoveFilters: React.FC<LinkRemoveFiltersProps> = ({ children, cleanFilters }) => (
+  <Link
+    component={'button'}
+    variant="body1"
+    id="call-to-action-first"
+    key="remove-filters"
+    data-testid="link-remove-filters"
+    onClick={cleanFilters}
+  >
+    {children}
+  </Link>
+);
 
 const DesktopNotifications = ({
   notifications,

--- a/packages/pn-personagiuridica-webapp/src/components/Notifications/MobileNotifications.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Notifications/MobileNotifications.tsx
@@ -57,22 +57,18 @@ type LinkRemoveFiltersProps = {
  */
 const IS_SORT_ENABLED = false;
 
-const LinkRemoveFilters: React.FC<LinkRemoveFiltersProps> = ({ children, cleanFilters }) => {
-  const { t } = useTranslation(['notifiche']);
-  return (
-    <Link
-      component={'button'}
-      variant="body1"
-      id="call-to-action-first"
-      aria-label={t('empty-state.aria-label-remove-filters')}
-      key="remove-filters"
-      data-testid="link-remove-filters"
-      onClick={cleanFilters}
-    >
-      {children}
-    </Link>
-  );
-};
+const LinkRemoveFilters: React.FC<LinkRemoveFiltersProps> = ({ children, cleanFilters }) => (
+  <Link
+    component={'button'}
+    variant="body1"
+    id="call-to-action-first"
+    key="remove-filters"
+    data-testid="link-remove-filters"
+    onClick={cleanFilters}
+  >
+    {children}
+  </Link>
+);
 
 const MobileNotifications = ({
   notifications,

--- a/packages/pn-personagiuridica-webapp/src/pages/Contacts.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/Contacts.page.tsx
@@ -58,7 +58,6 @@ const Contacts = () => {
         fontWeight={'bold'}
         onClick={handleRedirectToProfilePage}
         sx={{ verticalAlign: 'inherit' }}
-        aria-label={t('subtitle-link', { ns: 'recapiti' })}
         component="button"
       >
         {t('subtitle-link', { ns: 'recapiti' })}
@@ -76,7 +75,6 @@ const Contacts = () => {
             title={t('title')}
             subTitle={subtitle}
             variantSubTitle={'body1'}
-            ariaLabel={t('title')}
           />
           <ApiErrorWrapper
             apiId={CONTACT_ACTIONS.GET_DIGITAL_ADDRESSES}


### PR DESCRIPTION
## Short description
Remove useless `aria-label` tags and improve accessibility on `Alert` component

## List of changes proposed in this pull request
- Remove `aria-label` from `Typography` and `Link` components
- Remove `role="banner"` from `Typography` of `Alert` components

## How to test
Start PA, PF and PG and check that screen reader reads all texts