### PR TITLE
use single contact compoent into SpecialContactElem - pn-12069

### DIFF
--- a/packages/pn-personafisica-webapp/src/components/Contacts/DigitalContactElem.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/DigitalContactElem.tsx
@@ -34,7 +34,7 @@ const DigitalContactElem = forwardRef<{ editContact: () => void; toggleEdit?: ()
       onConfirm,
       onEdit,
       onEditCancel,
-      editDisabled,
+      editDisabled = false,
       onDelete,
       editManagedFromOutside = false,
     },

--- a/packages/pn-personafisica-webapp/src/components/Contacts/DigitalContactElem.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/DigitalContactElem.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, forwardRef, useImperativeHandle, useState } from 'react';
+import { forwardRef, useImperativeHandle, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { InputAdornment, TextField, TextFieldProps, Typography } from '@mui/material';
@@ -15,11 +15,10 @@ type Props = {
   contactType: ChannelType;
   saveDisabled?: boolean;
   onConfirm?: (status: 'validated' | 'cancelled') => void;
+  onEdit?: (editFlag: boolean) => void;
   onEditCancel: () => void;
-  onEditConfirm?: () => void;
   onDelete: () => void;
   editDisabled?: boolean;
-  setContextEditMode?: Dispatch<SetStateAction<boolean>>;
   // this is a temporary property. it is needed until we remove the context
   editManagedFromOutside?: boolean;
 };
@@ -33,9 +32,9 @@ const DigitalContactElem = forwardRef<{ editContact: () => void; toggleEdit?: ()
       senderName,
       contactType,
       onConfirm,
+      onEdit,
       onEditCancel,
       editDisabled,
-      setContextEditMode,
       onDelete,
       editManagedFromOutside = false,
     },
@@ -44,10 +43,11 @@ const DigitalContactElem = forwardRef<{ editContact: () => void; toggleEdit?: ()
     const { t } = useTranslation(['common']);
     const [editMode, setEditMode] = useState(false);
     const { initValidation } = useDigitalContactsCodeVerificationContext(editManagedFromOutside);
+
     const toggleEdit = () => {
       setEditMode(!editMode);
-      if (setContextEditMode) {
-        setContextEditMode(!editMode);
+      if (onEdit) {
+        onEdit(!editMode);
       }
     };
 

--- a/packages/pn-personafisica-webapp/src/components/Contacts/EmailContactItem.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/EmailContactItem.tsx
@@ -28,7 +28,11 @@ import ExistingContactDialog from './ExistingContactDialog';
 
 interface Props {
   value: string;
+  senderId?: string;
+  senderName?: string;
   blockDelete?: boolean;
+  blockEdit?: boolean;
+  onEdit?: (editFlag: boolean) => void;
 }
 
 enum ModalType {
@@ -38,7 +42,14 @@ enum ModalType {
   DELETE = 'delete',
 }
 
-const EmailContactItem = ({ value, blockDelete }: Props) => {
+const EmailContactItem = ({
+  value,
+  senderId = 'default',
+  senderName,
+  blockDelete,
+  blockEdit,
+  onEdit,
+}: Props) => {
   const { t } = useTranslation(['common', 'recapiti']);
   const digitalAddresses =
     useAppSelector((state: RootState) => state.contactsState.digitalAddresses) ?? [];
@@ -52,11 +63,11 @@ const EmailContactItem = ({ value, blockDelete }: Props) => {
     useRef<{ updateError: (error: ErrorMessage, codeNotValid: boolean) => void }>(null);
 
   const validationSchema = yup.object().shape({
-    email: emailValidationSchema(t),
+    [`${senderId}_email`]: emailValidationSchema(t),
   });
 
   const initialValues = {
-    email: value ?? '',
+    [`${senderId}_email`]: value ?? '',
   };
 
   const formik = useFormik({
@@ -65,15 +76,25 @@ const EmailContactItem = ({ value, blockDelete }: Props) => {
     validateOnMount: true,
     enableReinitialize: true,
     onSubmit: () => {
-      PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_ADD_EMAIL_START, 'default');
+      PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_ADD_EMAIL_START, senderId);
       // first check if contact already exists
       if (
-        contactAlreadyExists(digitalAddresses, formik.values.email, 'default', ChannelType.EMAIL)
+        contactAlreadyExists(
+          digitalAddresses,
+          formik.values[`${senderId}_email`],
+          senderId,
+          ChannelType.EMAIL
+        )
       ) {
         setModalOpen(ModalType.EXISTING);
         return;
       }
-      setModalOpen(ModalType.DISCLAIMER);
+      // disclaimer modal must be opened only when we are adding a default address
+      if (senderId === 'default') {
+        setModalOpen(ModalType.DISCLAIMER);
+        return;
+      }
+      handleCodeVerification();
     },
   });
 
@@ -84,14 +105,15 @@ const EmailContactItem = ({ value, blockDelete }: Props) => {
 
   const handleCodeVerification = (verificationCode?: string) => {
     if (verificationCode) {
-      PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_ADD_EMAIL_UX_CONVERSION, 'default');
+      PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_ADD_EMAIL_UX_CONVERSION, senderId);
     }
 
     const digitalAddressParams: SaveDigitalAddressParams = {
       addressType: AddressType.COURTESY,
-      senderId: 'default',
+      senderId,
+      senderName,
       channelType: ChannelType.EMAIL,
-      value: formik.values.email,
+      value: formik.values[`${senderId}_email`],
       code: verificationCode,
     };
 
@@ -106,7 +128,7 @@ const EmailContactItem = ({ value, blockDelete }: Props) => {
           return;
         }
 
-        PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_ADD_EMAIL_UX_SUCCESS, 'default');
+        PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_ADD_EMAIL_UX_SUCCESS, senderId);
 
         // contact has already been verified
         // show success message
@@ -131,8 +153,8 @@ const EmailContactItem = ({ value, blockDelete }: Props) => {
     if (value) {
       digitalElemRef.current.toggleEdit();
     }
-    await formik.setFieldTouched('email', false, false);
-    await formik.setFieldValue('email', initialValues.email, true);
+    await formik.setFieldTouched(`${senderId}_email`, false, false);
+    await formik.setFieldValue(`${senderId}_email`, initialValues[`${senderId}_email`], true);
   };
 
   const deleteConfirmHandler = () => {
@@ -140,13 +162,13 @@ const EmailContactItem = ({ value, blockDelete }: Props) => {
     dispatch(
       deleteAddress({
         addressType: AddressType.COURTESY,
-        senderId: 'default',
+        senderId,
         channelType: ChannelType.EMAIL,
       })
     )
       .unwrap()
       .then(() => {
-        PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_REMOVE_EMAIL_SUCCESS, 'default');
+        PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_REMOVE_EMAIL_SUCCESS, senderId);
       })
       .catch(() => {});
   };
@@ -191,40 +213,47 @@ const EmailContactItem = ({ value, blockDelete }: Props) => {
    */
   return (
     <>
-      <form onSubmit={formik.handleSubmit} data-testid="courtesyContacts-email">
-        <Typography id="email-label" variant="body2" mb={1} sx={{ fontWeight: 'bold' }}>
-          {t(`courtesy-contacts.email-added`, { ns: 'recapiti' })}
-        </Typography>
+      <form onSubmit={formik.handleSubmit} data-testid={`${senderId}_emailContact`}>
+        {senderId === 'default' && (
+          <Typography id="email-label" variant="body2" mb={1} sx={{ fontWeight: 'bold' }}>
+            {t(`courtesy-contacts.email-added`, { ns: 'recapiti' })}
+          </Typography>
+        )}
         {value ? (
           <DigitalContactElem
-            senderId="default"
+            senderId={senderId}
             contactType={ChannelType.EMAIL}
             ref={digitalElemRef}
             inputProps={{
-              id: 'email',
-              name: 'email',
+              id: `${senderId}_email`,
+              name: `${senderId}_email`,
               label: t(`courtesy-contacts.link-email-placeholder`, {
                 ns: 'recapiti',
               }),
-              value: formik.values.email,
+              value: formik.values[`${senderId}_email`],
               onChange: (e) => void handleChangeTouched(e),
-              error: formik.touched.email && Boolean(formik.errors.email),
-              helperText: formik.touched.email && formik.errors.email,
+              error:
+                formik.touched[`${senderId}_email`] && Boolean(formik.errors[`${senderId}_email`]),
+              helperText: formik.touched[`${senderId}_email`] && formik.errors[`${senderId}_email`],
             }}
             saveDisabled={!formik.isValid}
+            editDisabled={blockEdit}
             onDelete={() => setModalOpen(ModalType.DELETE)}
             onEditCancel={() => formik.resetForm({ values: initialValues })}
+            onEdit={onEdit}
             editManagedFromOutside
           />
         ) : (
           <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
             <TextField
-              id="email"
-              name="email"
-              value={formik.values.email}
+              id={`${senderId}_email`}
+              name={`${senderId}_email`}
+              value={formik.values[`${senderId}_email`]}
               onChange={handleChangeTouched}
-              error={formik.touched.email && Boolean(formik.errors.email)}
-              helperText={formik.touched.email && formik.errors.email}
+              error={
+                formik.touched[`${senderId}_email`] && Boolean(formik.errors[`${senderId}_email`])
+              }
+              helperText={formik.touched[`${senderId}_email`] && formik.errors[`${senderId}_email`]}
               inputProps={{ sx: { height: '14px' } }}
               placeholder={t(`courtesy-contacts.link-email-placeholder`, { ns: 'recapiti' })}
               fullWidth
@@ -247,7 +276,7 @@ const EmailContactItem = ({ value, blockDelete }: Props) => {
       </form>
       <ExistingContactDialog
         open={modalOpen === ModalType.EXISTING}
-        value={formik.values.email}
+        value={formik.values[`${senderId}_email`]}
         handleDiscard={() => setModalOpen(null)}
         handleConfirm={() => handleCodeVerification()}
       />
@@ -263,7 +292,10 @@ const EmailContactItem = ({ value, blockDelete }: Props) => {
         content={t(`alert-dialog-email`, { ns: 'recapiti' })}
       />
       <CodeModal
-        title={t(`courtesy-contacts.email-verify`, { ns: 'recapiti' }) + ` ${formik.values.email}`}
+        title={
+          t(`courtesy-contacts.email-verify`, { ns: 'recapiti' }) +
+          ` ${formik.values[senderId + '_email']}`
+        }
         subtitle={<Trans i18nKey="courtesy-contacts.email-verify-descr" ns="recapiti" />}
         open={modalOpen === ModalType.CODE}
         initialValues={new Array(5).fill('')}
@@ -302,7 +334,7 @@ const EmailContactItem = ({ value, blockDelete }: Props) => {
           ns: 'recapiti',
         })}
         removeModalBody={t(`courtesy-contacts.${blockDelete ? 'block-' : ''}remove-email-message`, {
-          value: formik.values.email,
+          value: formik.values[`${senderId}_email`],
           ns: 'recapiti',
         })}
         handleModalClose={() => setModalOpen(null)}

--- a/packages/pn-personafisica-webapp/src/components/Contacts/EmailContactItem.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/EmailContactItem.tsx
@@ -42,14 +42,14 @@ enum ModalType {
   DELETE = 'delete',
 }
 
-const EmailContactItem = ({
+const EmailContactItem: React.FC<Props> = ({
   value,
   senderId = 'default',
   senderName,
   blockDelete,
   blockEdit,
   onEdit,
-}: Props) => {
+}) => {
   const { t } = useTranslation(['common', 'recapiti']);
   const digitalAddresses =
     useAppSelector((state: RootState) => state.contactsState.digitalAddresses) ?? [];

--- a/packages/pn-personafisica-webapp/src/components/Contacts/PecContactItem.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/PecContactItem.tsx
@@ -31,7 +31,11 @@ import PecVerificationDialog from './PecVerificationDialog';
 type Props = {
   value: string;
   verifyingAddress: boolean;
+  senderId?: string;
+  senderName?: string;
   blockDelete?: boolean;
+  blockEdit?: boolean;
+  onEdit?: (editFlag: boolean) => void;
 };
 
 enum ModalType {
@@ -42,7 +46,15 @@ enum ModalType {
   CODE = 'code',
 }
 
-const PecContactItem = ({ value, verifyingAddress, blockDelete }: Props) => {
+const PecContactItem = ({
+  value,
+  verifyingAddress,
+  blockDelete,
+  senderId = 'default',
+  senderName,
+  blockEdit,
+  onEdit,
+}: Props) => {
   const { t } = useTranslation(['common', 'recapiti']);
   const digitalAddresses =
     useAppSelector((state: RootState) => state.contactsState.digitalAddresses) ?? [];
@@ -56,11 +68,11 @@ const PecContactItem = ({ value, verifyingAddress, blockDelete }: Props) => {
     useRef<{ updateError: (error: ErrorMessage, codeNotValid: boolean) => void }>(null);
 
   const validationSchema = yup.object({
-    pec: pecValidationSchema(t),
+    [`${senderId}_pec`]: pecValidationSchema(t),
   });
 
   const initialValues = {
-    pec: value,
+    [`${senderId}_pec`]: value,
   };
 
   const formik = useFormik({
@@ -70,9 +82,16 @@ const PecContactItem = ({ value, verifyingAddress, blockDelete }: Props) => {
     enableReinitialize: true,
     /** onSubmit validate */
     onSubmit: () => {
-      PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_ADD_PEC_START, 'default');
+      PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_ADD_PEC_START, senderId);
       // first check if contact already exists
-      if (contactAlreadyExists(digitalAddresses, formik.values.pec, 'default', ChannelType.PEC)) {
+      if (
+        contactAlreadyExists(
+          digitalAddresses,
+          formik.values[`${senderId}_pec`],
+          senderId,
+          ChannelType.PEC
+        )
+      ) {
         setModalOpen(ModalType.EXISTING);
         return;
       }
@@ -87,14 +106,15 @@ const PecContactItem = ({ value, verifyingAddress, blockDelete }: Props) => {
 
   const handleCodeVerification = (verificationCode?: string) => {
     if (verificationCode) {
-      PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_ADD_PEC_UX_CONVERSION, 'default');
+      PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_ADD_PEC_UX_CONVERSION, senderId);
     }
 
     const digitalAddressParams: SaveDigitalAddressParams = {
       addressType: AddressType.LEGAL,
-      senderId: 'default',
+      senderId,
+      senderName,
       channelType: ChannelType.PEC,
-      value: formik.values.pec,
+      value: formik.values[`${senderId}_pec`],
       code: verificationCode,
     };
 
@@ -108,7 +128,7 @@ const PecContactItem = ({ value, verifyingAddress, blockDelete }: Props) => {
           return;
         }
 
-        PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_ADD_PEC_UX_SUCCESS, 'default');
+        PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_ADD_PEC_UX_SUCCESS, senderId);
 
         // contact has already been verified
         if (res.pecValid) {
@@ -137,8 +157,8 @@ const PecContactItem = ({ value, verifyingAddress, blockDelete }: Props) => {
     if (value) {
       digitalElemRef.current.toggleEdit();
     }
-    await formik.setFieldTouched('pec', false, false);
-    await formik.setFieldValue('pec', initialValues.pec, true);
+    await formik.setFieldTouched(`${senderId}_pec`, false, false);
+    await formik.setFieldValue(`${senderId}_pec`, initialValues[`${senderId}_pec`], true);
   };
 
   const deleteConfirmHandler = () => {
@@ -146,13 +166,13 @@ const PecContactItem = ({ value, verifyingAddress, blockDelete }: Props) => {
     dispatch(
       deleteAddress({
         addressType: AddressType.LEGAL,
-        senderId: 'default',
+        senderId,
         channelType: ChannelType.PEC,
       })
     )
       .unwrap()
       .then(() => {
-        PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_REMOVE_PEC_SUCCESS, 'default');
+        PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_REMOVE_PEC_SUCCESS, senderId);
       })
       .catch(() => {});
   };
@@ -199,37 +219,44 @@ const PecContactItem = ({ value, verifyingAddress, blockDelete }: Props) => {
    */
   return (
     <>
-      <form onSubmit={formik.handleSubmit} data-testid="pecContact">
+      <form onSubmit={formik.handleSubmit} data-testid={`${senderId}_pecContact`}>
         {value && (
           <>
-            <Typography mb={1} sx={{ fontWeight: 'bold' }} id="associatedPEC" mt={3}>
-              {t('legal-contacts.pec-added', { ns: 'recapiti' })}
-            </Typography>
+            {senderId === 'default' && (
+              <Typography mb={1} sx={{ fontWeight: 'bold' }} id="associatedPEC" mt={3}>
+                {t('legal-contacts.pec-added', { ns: 'recapiti' })}
+              </Typography>
+            )}
             <DigitalContactElem
-              senderId="default"
+              senderId={senderId}
               contactType={ChannelType.PEC}
               ref={digitalElemRef}
               inputProps={{
-                id: 'pec',
-                name: 'pec',
+                id: `${senderId}_pec`,
+                name: `${senderId}_pec`,
                 label: 'PEC',
-                value: formik.values.pec,
+                value: formik.values[`${senderId}_pec`],
                 onChange: (e) => void handleChangeTouched(e),
-                error: formik.touched.pec && Boolean(formik.errors.pec),
-                helperText: formik.touched.pec && formik.errors.pec,
+                error:
+                  formik.touched[`${senderId}_pec`] && Boolean(formik.errors[`${senderId}_pec`]),
+                helperText: formik.touched[`${senderId}_pec`] && formik.errors[`${senderId}_pec`],
               }}
               saveDisabled={!formik.isValid}
+              editDisabled={blockEdit}
               onDelete={() => setModalOpen(ModalType.DELETE)}
               onEditCancel={() => formik.resetForm({ values: initialValues })}
+              onEdit={onEdit}
               editManagedFromOutside
             />
           </>
         )}
         {verifyingAddress && (
           <>
-            <Typography mb={1} sx={{ fontWeight: 'bold' }} mt={3}>
-              {t('legal-contacts.pec-validating', { ns: 'recapiti' })}
-            </Typography>
+            {senderId === 'default' && (
+              <Typography mb={1} sx={{ fontWeight: 'bold' }} mt={3}>
+                {t('legal-contacts.pec-validating', { ns: 'recapiti' })}
+              </Typography>
+            )}
             <Stack direction="row" spacing={1}>
               <WatchLaterIcon fontSize="small" />
               <Typography id="validationPecProgress" fontWeight="bold" variant="body2">
@@ -248,14 +275,14 @@ const PecContactItem = ({ value, verifyingAddress, blockDelete }: Props) => {
         {!value && !verifyingAddress && (
           <Stack spacing={2} direction={{ sm: 'row', xs: 'column' }} mt={3}>
             <TextField
-              id="pec"
+              id={`${senderId}_pec`}
+              name={`${senderId}_pec`}
               placeholder={t('legal-contacts.link-pec-placeholder', { ns: 'recapiti' })}
               fullWidth
-              name="pec"
-              value={formik.values.pec}
+              value={formik.values[`${senderId}_pec`]}
               onChange={handleChangeTouched}
-              error={formik.touched.pec && Boolean(formik.errors.pec)}
-              helperText={formik.touched.pec && formik.errors.pec}
+              error={formik.touched[`${senderId}_pec`] && Boolean(formik.errors[`${senderId}_pec`])}
+              helperText={formik.touched[`${senderId}_pec`] && formik.errors[`${senderId}_pec`]}
               inputProps={{ sx: { height: '14px' } }}
               sx={{ flexBasis: { xs: 'unset', lg: '66.66%' } }}
             />
@@ -275,12 +302,15 @@ const PecContactItem = ({ value, verifyingAddress, blockDelete }: Props) => {
       </form>
       <ExistingContactDialog
         open={modalOpen === ModalType.EXISTING}
-        value={formik.values.pec}
+        value={formik.values[`${senderId}_pec`]}
         handleDiscard={() => setModalOpen(null)}
         handleConfirm={() => handleCodeVerification()}
       />
       <CodeModal
-        title={t(`legal-contacts.pec-verify`, { ns: 'recapiti' }) + ` ${formik.values.pec}`}
+        title={
+          t(`legal-contacts.pec-verify`, { ns: 'recapiti' }) +
+          ` ${formik.values[senderId + '_pec']}`
+        }
         subtitle={<Trans i18nKey={`legal-contacts.pec-verify-descr`} ns="recapiti" />}
         open={modalOpen === ModalType.CODE}
         initialValues={new Array(5).fill('')}
@@ -327,7 +357,7 @@ const PecContactItem = ({ value, verifyingAddress, blockDelete }: Props) => {
           ns: 'recapiti',
         })}
         removeModalBody={t(`legal-contacts.${blockDelete ? 'block-' : ''}remove-pec-message`, {
-          value: formik.values.pec,
+          value: formik.values[`${senderId}_pec`],
           ns: 'recapiti',
         })}
         handleModalClose={() => setModalOpen(null)}

--- a/packages/pn-personafisica-webapp/src/components/Contacts/PecContactItem.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/PecContactItem.tsx
@@ -46,7 +46,7 @@ enum ModalType {
   CODE = 'code',
 }
 
-const PecContactItem = ({
+const PecContactItem: React.FC<Props> = ({
   value,
   verifyingAddress,
   blockDelete,
@@ -54,7 +54,7 @@ const PecContactItem = ({
   senderName,
   blockEdit,
   onEdit,
-}: Props) => {
+}) => {
   const { t } = useTranslation(['common', 'recapiti']);
   const digitalAddresses =
     useAppSelector((state: RootState) => state.contactsState.digitalAddresses) ?? [];

--- a/packages/pn-personafisica-webapp/src/components/Contacts/SmsContactItem.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/SmsContactItem.tsx
@@ -46,14 +46,14 @@ enum ModalType {
   DELETE = 'delete',
 }
 
-const SmsContactItem = ({
+const SmsContactItem: React.FC<Props> = ({
   value,
   senderId = 'default',
   senderName,
   blockDelete,
   blockEdit,
   onEdit,
-}: Props) => {
+}) => {
   const { t } = useTranslation(['common', 'recapiti']);
   const digitalAddresses =
     useAppSelector((state: RootState) => state.contactsState.digitalAddresses) ?? [];

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/CourtesyContacts.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/CourtesyContacts.test.tsx
@@ -44,8 +44,8 @@ describe('CourtesyContacts Component', async () => {
     const disclaimer = getByTestId('contacts disclaimer');
     expect(disclaimer).toBeInTheDocument();
     // check inputs
-    const phoneInput = container.querySelector(`[name="sms"]`);
-    const emailInput = container.querySelector(`[name="email"]`);
+    const phoneInput = container.querySelector(`[name="default_sms"]`);
+    const emailInput = container.querySelector(`[name="default_email"]`);
     expect(phoneInput).toBeInTheDocument();
     expect(emailInput).toBeInTheDocument();
   });
@@ -60,8 +60,8 @@ describe('CourtesyContacts Component', async () => {
     const defaultEmail = digitalCourtesyAddresses.find(
       (addr) => addr.channelType === ChannelType.EMAIL && addr.senderId === 'default'
     );
-    const phoneInput = container.querySelector(`[name="sms"]`);
-    const emailInput = container.querySelector(`[name="email"]`);
+    const phoneInput = container.querySelector(`[name="default_sms"]`);
+    const emailInput = container.querySelector(`[name="default_email"]`);
     expect(phoneInput).not.toBeInTheDocument();
     expect(emailInput).not.toBeInTheDocument();
     const phoneNumber = getByText(defaultPhone!.value);

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/EmailContactItem.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/EmailContactItem.test.tsx
@@ -63,11 +63,11 @@ describe('testing EmailContactItem', () => {
     // render component
     const { container } = render(<EmailContactItem value="" />);
     const form = container.querySelector('form');
-    const input = form!.querySelector(`[name="email"]`);
+    const input = form!.querySelector(`[name="default_email"]`);
     // set invalid values
     fireEvent.change(input!, { target: { value: INVALID_EMAIL } });
     await waitFor(() => expect(input).toHaveValue(INVALID_EMAIL));
-    const errorMessage = form!.querySelector(`#email-helper-text`);
+    const errorMessage = form!.querySelector(`#default_email-helper-text`);
     expect(errorMessage).toBeInTheDocument();
     expect(errorMessage).toHaveTextContent('courtesy-contacts.valid-email');
     const buttons = form!.querySelectorAll('button');
@@ -81,11 +81,11 @@ describe('testing EmailContactItem', () => {
   it('type in an invalid email while in "edit mode"', async () => {
     const { container, getByRole } = render(<EmailContactItem value={VALID_EMAIL} />);
     const form = container.querySelector('form');
-    const phoneValue = getById(form!, 'email-typography');
+    const phoneValue = getById(form!, 'default_email-typography');
     expect(phoneValue).toHaveTextContent(VALID_EMAIL);
     const editButton = getByRole('button', { name: 'button.modifica' });
     fireEvent.click(editButton);
-    const input = container.querySelector(`[name="email"]`);
+    const input = container.querySelector(`[name="default_email"]`);
     const saveButton = getByRole('button', { name: 'button.salva' });
     expect(input).toHaveValue(VALID_EMAIL);
     expect(saveButton).toBeEnabled();
@@ -94,7 +94,7 @@ describe('testing EmailContactItem', () => {
       expect(input).toHaveValue(INVALID_EMAIL);
     });
     expect(saveButton).toBeDisabled();
-    const inputError = container.querySelector(`#email-helper-text`);
+    const inputError = container.querySelector(`#default_email-helper-text`);
     expect(inputError).toHaveTextContent('courtesy-contacts.valid-email');
   });
 
@@ -112,10 +112,10 @@ describe('testing EmailContactItem', () => {
     const result = render(<EmailContactItem value="" />);
     // insert new email
     const form = result.container.querySelector('form');
-    const input = form!.querySelector(`[name="email"]`);
+    const input = form!.querySelector(`[name="default_email"]`);
     fireEvent.change(input!, { target: { value: mailValue } });
     await waitFor(() => expect(input!).toHaveValue(mailValue));
-    const errorMessage = form?.querySelector('#sms-helper-text');
+    const errorMessage = form?.querySelector('#default_email-helper-text');
     expect(errorMessage).not.toBeInTheDocument();
     const button = result.getByTestId('courtesy-email-button');
     expect(button).toBeEnabled();
@@ -160,7 +160,7 @@ describe('testing EmailContactItem', () => {
     await waitFor(() => {
       expect(input).not.toBeInTheDocument();
     });
-    const emailValue = getById(form!, 'email-typography');
+    const emailValue = getById(form!, 'default_email-typography');
     expect(emailValue).toBeInTheDocument();
     expect(emailValue).toHaveTextContent(mailValue);
     const editButton = getById(form!, 'modifyContact-default');
@@ -188,11 +188,11 @@ describe('testing EmailContactItem', () => {
     const result = render(<EmailContactItem value={defaultEmailAddress!.value} />);
     // edit value
     const form = result.container.querySelector('form');
-    let mailValue = getById(form!, 'email-typography');
+    let mailValue = getById(form!, 'default_email-typography');
     expect(mailValue).toHaveTextContent(defaultEmailAddress!.value);
     let editButton = result.getByRole('button', { name: 'button.modifica' });
     fireEvent.click(editButton);
-    const input = result.container.querySelector(`[name="email"]`);
+    const input = result.container.querySelector(`[name="default_email"]`);
     const saveButton = result.getByRole('button', { name: 'button.salva' });
     expect(input).toHaveValue(defaultEmailAddress!.value);
     expect(saveButton).toBeEnabled();
@@ -244,7 +244,7 @@ describe('testing EmailContactItem', () => {
     await waitFor(() => {
       expect(input).not.toBeInTheDocument();
     });
-    mailValue = getById(form!, 'email-typography');
+    mailValue = getById(form!, 'default_email-typography');
     expect(mailValue).toBeInTheDocument();
     expect(mailValue).toHaveTextContent(emailValue);
     editButton = getById(form!, 'modifyContact-default');
@@ -288,7 +288,7 @@ describe('testing EmailContactItem', () => {
     // simulate rerendering due to redux changes
     result.rerender(<EmailContactItem value="" />);
     await waitFor(() => {
-      const input = result.container.querySelector(`[name="email"]`);
+      const input = result.container.querySelector(`[name="default_email"]`);
       expect(input).toBeInTheDocument();
       expect(result.container).not.toHaveTextContent('');
     });

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/LegalContacts.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/LegalContacts.test.tsx
@@ -59,7 +59,7 @@ describe('LegalContacts Component', async () => {
     expect(container).toHaveTextContent('legal-contacts.subtitle');
     expect(container).toHaveTextContent('legal-contacts.description');
     const form = container.querySelector('form');
-    const pecInput = form?.querySelector('input[id="pec"]');
+    const pecInput = form?.querySelector('input[id="default_pec"]');
     expect(pecInput!).toHaveValue('');
     const button = await waitFor(() => getByRole('button', { name: 'button.conferma' }));
     expect(button).toBeDisabled();

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/PecContactItem.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/PecContactItem.test.tsx
@@ -62,11 +62,11 @@ describe('PecContactItem component', () => {
     // render component
     const { container } = render(<PecContactItem value="" verifyingAddress={false} />);
     const form = container.querySelector('form');
-    const input = form!.querySelector('input[name="pec"]');
+    const input = form!.querySelector('input[name="default_pec"]');
     // add invalid values
     fireEvent.change(input!, { target: { value: 'invalid-pec' } });
     await waitFor(() => expect(input).toHaveValue('invalid-pec'));
-    const errorMessage = form!.querySelector('#pec-helper-text');
+    const errorMessage = form!.querySelector('#default_pec-helper-text');
     expect(errorMessage).toBeInTheDocument();
     expect(errorMessage).toHaveTextContent('legal-contacts.valid-pec');
     const buttons = form!.querySelectorAll('button');
@@ -94,10 +94,10 @@ describe('PecContactItem component', () => {
     const result = render(<PecContactItem value="" verifyingAddress={false} />);
     // insert new pec
     const form = result.container.querySelector('form');
-    let input = form!.querySelector('input[name="pec"]');
+    let input = form!.querySelector('input[name="default_pec"]');
     fireEvent.change(input!, { target: { value: VALID_PEC } });
     await waitFor(() => expect(input!).toHaveValue(VALID_PEC));
-    const errorMessage = form?.querySelector('#pec-helper-text');
+    const errorMessage = form?.querySelector('#default_pec-helper-text');
     expect(errorMessage).not.toBeInTheDocument();
     const button = result.getByTestId('addContact');
     expect(button).toBeEnabled();
@@ -159,7 +159,7 @@ describe('PecContactItem component', () => {
     await waitFor(() => {
       expect(result.container).not.toHaveTextContent('legal-contacts.pec-validating');
       expect(result.container).not.toHaveTextContent('legal-contacts.validation-in-progress');
-      input = result.container.querySelector('input[name="pec"]');
+      input = result.container.querySelector('input[name="default_pec"]');
       expect(input).toBeInTheDocument();
     });
   });
@@ -181,10 +181,10 @@ describe('PecContactItem component', () => {
     const result = render(<PecContactItem value="" verifyingAddress={false} />);
     // insert new pec
     const form = result.container.querySelector('form');
-    const input = form!.querySelector('input[name="pec"]');
+    const input = form!.querySelector('input[name="default_pec"]');
     fireEvent.change(input!, { target: { value: VALID_PEC } });
     await waitFor(() => expect(input!).toHaveValue(VALID_PEC));
-    const errorMessage = form?.querySelector('#pec-helper-text');
+    const errorMessage = form?.querySelector('#default_pec-helper-text');
     expect(errorMessage).not.toBeInTheDocument();
     const button = result.getByTestId('addContact');
     expect(button).toBeEnabled();
@@ -218,7 +218,7 @@ describe('PecContactItem component', () => {
     await waitFor(() => {
       expect(input).not.toBeInTheDocument();
     });
-    const pecValue = getById(form!, 'pec-typography');
+    const pecValue = getById(form!, 'default_pec-typography');
     expect(pecValue).toBeInTheDocument();
     expect(pecValue).toHaveTextContent(VALID_PEC);
     const editButton = getById(form!, 'modifyContact-default');
@@ -233,11 +233,11 @@ describe('PecContactItem component', () => {
       <PecContactItem value={defaultAddress!.value} verifyingAddress={false} />
     );
     const form = container.querySelector('form');
-    const pecValue = getById(form!, 'pec-typography');
+    const pecValue = getById(form!, 'default_pec-typography');
     expect(pecValue).toHaveTextContent(defaultAddress!.value);
     const editButton = getByRole('button', { name: 'button.modifica' });
     fireEvent.click(editButton);
-    const input = container.querySelector('[name="pec"]');
+    const input = container.querySelector('[name="default_pec"]');
     const saveButton = getByRole('button', { name: 'button.salva' });
     expect(input).toHaveValue(defaultAddress!.value);
     expect(saveButton).toBeEnabled();
@@ -246,7 +246,7 @@ describe('PecContactItem component', () => {
       expect(input).toHaveValue('invalid-pec');
     });
     expect(saveButton).toBeDisabled();
-    const inputError = container.querySelector('#pec-helper-text');
+    const inputError = container.querySelector('#default_pec-helper-text');
     expect(inputError).toHaveTextContent('legal-contacts.valid-pec');
   });
 
@@ -270,11 +270,11 @@ describe('PecContactItem component', () => {
     );
     // edit value
     const form = result.container.querySelector('form');
-    let pecValue = getById(form!, 'pec-typography');
+    let pecValue = getById(form!, 'default_pec-typography');
     expect(pecValue).toHaveTextContent(defaultAddress!.value);
     let editButton = result.getByRole('button', { name: 'button.modifica' });
     fireEvent.click(editButton);
-    const input = result.container.querySelector('[name="pec"]');
+    const input = result.container.querySelector('[name="default_pec"]');
     const saveButton = result.getByRole('button', { name: 'button.salva' });
     expect(input).toHaveValue(defaultAddress!.value);
     expect(saveButton).toBeEnabled();
@@ -313,7 +313,7 @@ describe('PecContactItem component', () => {
     await waitFor(() => {
       expect(input).not.toBeInTheDocument();
     });
-    pecValue = getById(form!, 'pec-typography');
+    pecValue = getById(form!, 'default_pec-typography');
     expect(pecValue).toBeInTheDocument();
     expect(pecValue).toHaveTextContent(VALID_PEC);
     editButton = getById(form!, 'modifyContact-default');
@@ -360,7 +360,7 @@ describe('PecContactItem component', () => {
     // simulate rerendering due to redux changes
     result.rerender(<PecContactItem value="" verifyingAddress={false} />);
     await waitFor(() => {
-      const input = result.container.querySelector('input[name="pec"]');
+      const input = result.container.querySelector('input[name="default_pec"]');
       expect(input).toBeInTheDocument();
       expect(result.container).not.toHaveTextContent('');
     });

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/SmsContactItem.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/SmsContactItem.test.tsx
@@ -64,13 +64,13 @@ describe('test SmsContactItem', () => {
     // render component
     const { container } = render(<SmsContactItem value="" />);
     const form = container.querySelector('form');
-    const input = form!.querySelector(`[name="sms"]`);
+    const input = form!.querySelector(`[name="default_sms"]`);
     // add invalid values
     fireEvent.change(input!, { target: { value: INPUT_INVALID_PHONE } });
     await waitFor(() => {
       expect(input!).toHaveValue(INPUT_INVALID_PHONE);
     });
-    const errorMessage = form!.querySelector(`#sms-helper-text`);
+    const errorMessage = form!.querySelector(`#default_sms-helper-text`);
     expect(errorMessage).toBeInTheDocument();
     expect(errorMessage).toHaveTextContent('courtesy-contacts.valid-sms');
     const buttons = form!.querySelectorAll('button');
@@ -86,11 +86,11 @@ describe('test SmsContactItem', () => {
   it('type in an invalid number while in "edit mode"', async () => {
     const { container, getByRole } = render(<SmsContactItem value={INPUT_VALID_PHONE} />);
     const form = container.querySelector('form');
-    const phoneValue = getById(form!, 'sms-typography');
+    const phoneValue = getById(form!, 'default_sms-typography');
     expect(phoneValue).toHaveTextContent(INPUT_VALID_PHONE);
     const editButton = getByRole('button', { name: 'button.modifica' });
     fireEvent.click(editButton);
-    const input = container.querySelector(`[name="sms"]`);
+    const input = container.querySelector(`[name="default_sms"]`);
     const saveButton = getByRole('button', { name: 'button.salva' });
     expect(input).toHaveValue(INPUT_VALID_PHONE);
     expect(saveButton).toBeEnabled();
@@ -99,7 +99,7 @@ describe('test SmsContactItem', () => {
       expect(input).toHaveValue(INPUT_INVALID_PHONE);
     });
     expect(saveButton).toBeDisabled();
-    const inputError = container.querySelector(`#sms-helper-text`);
+    const inputError = container.querySelector(`#default_sms-helper-text`);
     expect(inputError).toHaveTextContent('courtesy-contacts.valid-sms');
   });
 
@@ -121,10 +121,10 @@ describe('test SmsContactItem', () => {
     const result = render(<SmsContactItem value="" />);
     // insert new phone
     const form = result.container.querySelector('form');
-    const input = form!.querySelector(`[name="sms"]`);
+    const input = form!.querySelector(`[name="default_sms"]`);
     fireEvent.change(input!, { target: { value: phoneValue } });
     await waitFor(() => expect(input!).toHaveValue(phoneValue));
-    const errorMessage = form?.querySelector('#phone-helper-text');
+    const errorMessage = form?.querySelector('#default_sms-helper-text');
     expect(errorMessage).not.toBeInTheDocument();
     const button = result.getByTestId('courtesy-sms-button');
     expect(button).toBeEnabled();
@@ -167,7 +167,7 @@ describe('test SmsContactItem', () => {
     await waitFor(() => {
       expect(input).not.toBeInTheDocument();
     });
-    const smsValue = getById(form!, 'sms-typography');
+    const smsValue = getById(form!, 'default_sms-typography');
     expect(smsValue).toBeInTheDocument();
     expect(smsValue).toHaveTextContent(internationalPhonePrefix + phoneValue);
     const editButton = getById(form!, 'modifyContact-default');
@@ -195,11 +195,11 @@ describe('test SmsContactItem', () => {
     const result = render(<SmsContactItem value={defaultPhoneAddress!.value} />);
     // edit value
     const form = result.container.querySelector('form');
-    let smsValue = getById(form!, 'sms-typography');
+    let smsValue = getById(form!, 'default_sms-typography');
     expect(smsValue).toHaveTextContent(defaultPhoneAddress!.value);
     let editButton = result.getByRole('button', { name: 'button.modifica' });
     fireEvent.click(editButton);
-    const input = result.container.querySelector(`[name="sms"]`);
+    const input = result.container.querySelector(`[name="default_sms"]`);
     const saveButton = result.getByRole('button', { name: 'button.salva' });
     expect(input).toHaveValue(defaultPhoneAddress!.value.replace(internationalPhonePrefix, ''));
     expect(saveButton).toBeEnabled();
@@ -253,7 +253,7 @@ describe('test SmsContactItem', () => {
     await waitFor(() => {
       expect(input).not.toBeInTheDocument();
     });
-    smsValue = getById(form!, 'sms-typography');
+    smsValue = getById(form!, 'default_sms-typography');
     expect(smsValue).toBeInTheDocument();
     expect(smsValue).toHaveTextContent(internationalPhonePrefix + phoneValue);
     editButton = getById(form!, 'modifyContact-default');
@@ -298,7 +298,7 @@ describe('test SmsContactItem', () => {
     // simulate rerendering due to redux changes
     result.rerender(<SmsContactItem value="" />);
     await waitFor(() => {
-      const input = result.container.querySelector(`[name="sms"]`);
+      const input = result.container.querySelector(`[name="default_sms"]`);
       expect(input).toBeInTheDocument();
       expect(result.container).not.toHaveTextContent('');
     });

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/SpecialContactElem.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/SpecialContactElem.test.tsx
@@ -3,17 +3,9 @@ import { vi } from 'vitest';
 
 import { SpecialContactsProvider } from '@pagopa-pn/pn-commons';
 
-import {
-  RenderResult,
-  act,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '../../../__test__/test-utils';
+import { fireEvent, render, waitFor } from '../../../__test__/test-utils';
 import { apiClient } from '../../../api/apiClients';
 import { AddressType, ChannelType } from '../../../models/contacts';
-import { DigitalContactsCodeVerificationProvider } from '../DigitalContactsCodeVerification.context';
 import SpecialContactElem from '../SpecialContactElem';
 
 vi.mock('react-i18next', () => ({
@@ -24,14 +16,7 @@ vi.mock('react-i18next', () => ({
   Trans: (props: { i18nKey: string }) => props.i18nKey,
 }));
 
-/*
-In questo test viene testato solo il rendering dei componenti e non il flusso.
-Il flusso completo viene testato nella pagina dei contatti, dove si può testare anche il cambio di stato di redux e le api
-
-Andrea Cimini - 6/09/2023
-*/
 describe('SpecialContactElem Component', () => {
-  let result: RenderResult;
   let mock: MockAdapter;
 
   const pecAddress = {
@@ -40,6 +25,7 @@ describe('SpecialContactElem Component', () => {
     senderName: 'Mocked Sender',
     channelType: ChannelType.PEC,
     value: 'mocked@pec.it',
+    pecValid: true,
   };
 
   const emailAddress = {
@@ -70,281 +56,82 @@ describe('SpecialContactElem Component', () => {
     mock.restore();
   });
 
-  it('renders SpecialContactElem', async () => {
+  it('renders SpecialContactElem', () => {
     // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContactsProvider>
-            <SpecialContactElem addresses={[pecAddress, emailAddress]} />
-          </SpecialContactsProvider>
-        </DigitalContactsCodeVerificationProvider>
-      );
-    });
+    const { container, getAllByTestId } = render(
+      <SpecialContactsProvider>
+        <SpecialContactElem addresses={[pecAddress, emailAddress]} />
+      </SpecialContactsProvider>
+    );
 
-    expect(result.container).toHaveTextContent('Mocked Sender');
-    const specialContactForms = result.getAllByTestId('specialContactForm');
+    expect(container).toHaveTextContent('Mocked Sender');
+    const specialContactForms = getAllByTestId(
+      /^[a-zA-Z0-9\-]+(?:_pecContact|_emailContact|_smsContact)$/
+    );
     expect(specialContactForms).toHaveLength(2);
-    expect(specialContactForms![0]).toHaveTextContent('mocked@pec.it');
-    expect(specialContactForms![1]).toHaveTextContent('mocked@mail.it');
-    const firstFormButtons = specialContactForms![0].querySelectorAll('button');
+    expect(specialContactForms[0]).toHaveTextContent('mocked@pec.it');
+    expect(specialContactForms[1]).toHaveTextContent('mocked@mail.it');
+    const firstFormButtons = specialContactForms[0].querySelectorAll('button');
     expect(firstFormButtons).toHaveLength(2);
     expect(firstFormButtons[0]).toHaveTextContent('button.modifica');
     expect(firstFormButtons[1]).toHaveTextContent('button.elimina');
-    const secondFormButtons = specialContactForms![1].querySelectorAll('button');
+    const secondFormButtons = specialContactForms[1].querySelectorAll('button');
     expect(secondFormButtons).toHaveLength(2);
     expect(secondFormButtons[0]).toHaveTextContent('button.modifica');
     expect(secondFormButtons[1]).toHaveTextContent('button.elimina');
-    expect(result.container).toHaveTextContent('-');
-  });
-
-  it('changes a pec - new value valid', async () => {
-    // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContactsProvider>
-            <SpecialContactElem addresses={[pecAddress]} />
-          </SpecialContactsProvider>
-        </DigitalContactsCodeVerificationProvider>
-      );
-    });
-
-    expect(result.container).toHaveTextContent('Mocked Sender');
-    const specialContactForm = result.getByTestId('specialContactForm');
-    const firstFormButtons = specialContactForm!.querySelectorAll('button');
-    fireEvent.click(firstFormButtons[0]);
-    const input = await waitFor(() => specialContactForm!.querySelector('input'));
-    expect(input).toBeInTheDocument();
-    expect(input).toHaveValue('mocked@pec.it');
-    const newButtons = specialContactForm!.querySelectorAll('button');
-    expect(newButtons!).toHaveLength(2);
-    expect(newButtons![0]).toHaveTextContent('button.salva');
-    expect(newButtons![0]).toBeEnabled();
-    fireEvent.change(input!, { target: { value: 'new.long-pec-123@456.it' } });
-    await waitFor(() => expect(input!).toHaveValue('new.long-pec-123@456.it'));
-    expect(newButtons![0]).toBeEnabled();
-    const inputError = result.container.querySelector(`#mocked-senderId_pec-helper-text`);
-    expect(inputError).not.toBeInTheDocument();
-  });
-
-  it('changes a pec - new value invalid', async () => {
-    // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContactsProvider>
-            <SpecialContactElem addresses={[pecAddress]} />
-          </SpecialContactsProvider>
-        </DigitalContactsCodeVerificationProvider>
-      );
-    });
-
-    expect(result.container).toHaveTextContent('Mocked Sender');
-    const specialContactForm = result.getByTestId('specialContactForm');
-    const firstFormButtons = specialContactForm!.querySelectorAll('button');
-    fireEvent.click(firstFormButtons[0]);
-    const input = await waitFor(() => specialContactForm!.querySelector('input'));
-    expect(input).toBeInTheDocument();
-    expect(input).toHaveValue('mocked@pec.it');
-    const newButtons = specialContactForm!.querySelectorAll('button');
-    expect(newButtons!).toHaveLength(2);
-    expect(newButtons![0]).toHaveTextContent('button.salva');
-    expect(newButtons![0]).toBeEnabled();
-    fireEvent.change(input!, { target: { value: 'new.bad.-pec-123]@456.it' } });
-    await waitFor(() => expect(input!).toHaveValue('new.bad.-pec-123]@456.it'));
-    expect(newButtons![0]).toBeDisabled();
-    let inputError = result.container.querySelector(`#mocked-senderId_pec-helper-text`);
-    expect(inputError).toBeInTheDocument();
-    expect(inputError).toHaveTextContent('legal-contacts.valid-pec');
-    fireEvent.change(input!, { target: { value: '' } });
-    await waitFor(() => expect(input!).toHaveValue(''));
-    inputError = result.container.querySelector(`#mocked-senderId_pec-helper-text`);
-    expect(inputError).toHaveTextContent('legal-contacts.valid-pec');
-  });
-
-  it('changes a mail - new value valid', async () => {
-    // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContactsProvider>
-            <SpecialContactElem addresses={[emailAddress]} />
-          </SpecialContactsProvider>
-        </DigitalContactsCodeVerificationProvider>
-      );
-    });
-
-    expect(result.container).toHaveTextContent('Mocked Sender');
-    const specialContactForm = result.getByTestId('specialContactForm');
-    const firstFormButtons = specialContactForm!.querySelectorAll('button');
-    fireEvent.click(firstFormButtons[0]);
-    const input = await waitFor(() => specialContactForm!.querySelector('input'));
-    expect(input).toBeInTheDocument();
-    expect(input).toHaveValue('mocked@mail.it');
-    const newButtons = specialContactForm!.querySelectorAll('button');
-    expect(newButtons!).toHaveLength(2);
-    expect(newButtons![0]).toHaveTextContent('button.salva');
-    expect(newButtons![0]).toBeEnabled();
-    fireEvent.change(input!, { target: { value: 'new.long-mail-123@456.it' } });
-    await waitFor(() => expect(input!).toHaveValue('new.long-mail-123@456.it'));
-    expect(newButtons![0]).toBeEnabled();
-    const inputError = result.container.querySelector(`#mocked-senderId_mail-helper-text`);
-    expect(inputError).not.toBeInTheDocument();
-  });
-
-  it('changes a mail - new value invalid', async () => {
-    // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContactsProvider>
-            <SpecialContactElem addresses={[emailAddress]} />
-          </SpecialContactsProvider>
-        </DigitalContactsCodeVerificationProvider>
-      );
-    });
-
-    expect(result.container).toHaveTextContent('Mocked Sender');
-    const specialContactForm = result.getByTestId('specialContactForm');
-    const firstFormButtons = specialContactForm!.querySelectorAll('button');
-    fireEvent.click(firstFormButtons[0]);
-    const input = await waitFor(() => specialContactForm!.querySelector('input'));
-    expect(input).toBeInTheDocument();
-    expect(input).toHaveValue('mocked@mail.it');
-    const newButtons = specialContactForm!.querySelectorAll('button');
-    expect(newButtons!).toHaveLength(2);
-    expect(newButtons![0]).toHaveTextContent('button.salva');
-    expect(newButtons![0]).toBeEnabled();
-    fireEvent.change(input!, { target: { value: 'new.bad.-mail-123]@456.it' } });
-    await waitFor(() => expect(input!).toHaveValue('new.bad.-mail-123]@456.it'));
-    expect(newButtons![0]).toBeDisabled();
-    let inputError = result.container.querySelector(`#mocked-senderId_email-helper-text`);
-    expect(inputError).toBeInTheDocument();
-    expect(inputError).toHaveTextContent('courtesy-contacts.valid-email');
-    fireEvent.change(input!, { target: { value: '' } });
-    await waitFor(() => expect(input!).toHaveValue(''));
-    inputError = result.container.querySelector(`#mocked-senderId_email-helper-text`);
-    expect(inputError).toHaveTextContent('courtesy-contacts.valid-email');
-  });
-
-  it('changes a phone number - new value valid', async () => {
-    // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContactsProvider>
-            <SpecialContactElem addresses={[phoneAddress]} />
-          </SpecialContactsProvider>
-        </DigitalContactsCodeVerificationProvider>
-      );
-    });
-
-    expect(result.container).toHaveTextContent('Mocked Sender');
-    const specialContactForm = result.getByTestId('specialContactForm');
-    const firstFormButtons = specialContactForm!.querySelectorAll('button');
-    fireEvent.click(firstFormButtons[0]);
-    const input = await waitFor(() => specialContactForm!.querySelector('input'));
-    expect(input).toBeInTheDocument();
-    expect(input).toHaveValue('+39333333333');
-    const newButtons = specialContactForm!.querySelectorAll('button');
-    expect(newButtons!).toHaveLength(2);
-    expect(newButtons![0]).toHaveTextContent('button.salva');
-    expect(newButtons![0]).toBeEnabled();
-    fireEvent.change(input!, { target: { value: '+39333333334' } });
-    await waitFor(() => expect(input!).toHaveValue('+39333333334'));
-    expect(newButtons![0]).toBeEnabled();
-    const inputError = result.container.querySelector(`#mocked-senderId_sms-helper-text`);
-    expect(inputError).not.toBeInTheDocument();
-  });
-
-  it('changes a phone number - new value invalid', async () => {
-    // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContactsProvider>
-            <SpecialContactElem addresses={[phoneAddress]} />
-          </SpecialContactsProvider>
-        </DigitalContactsCodeVerificationProvider>
-      );
-    });
-
-    expect(result.container).toHaveTextContent('Mocked Sender');
-    const specialContactForm = result.getByTestId('specialContactForm');
-    const firstFormButtons = specialContactForm!.querySelectorAll('button');
-    fireEvent.click(firstFormButtons[0]);
-    const input = await waitFor(() => specialContactForm!.querySelector('input'));
-    expect(input).toBeInTheDocument();
-    expect(input).toHaveValue('+39333333333');
-    const newButtons = specialContactForm!.querySelectorAll('button');
-    expect(newButtons!).toHaveLength(2);
-    expect(newButtons![0]).toHaveTextContent('button.salva');
-    expect(newButtons![0]).toBeEnabled();
-    fireEvent.change(input!, { target: { value: '123456789' } });
-    await waitFor(() => expect(input!).toHaveValue('123456789'));
-    expect(newButtons![0]).toBeDisabled();
-    let inputError = result.container.querySelector(`#mocked-senderId_sms-helper-text`);
-    expect(inputError).toBeInTheDocument();
-    expect(inputError).toHaveTextContent('courtesy-contacts.valid-sms');
-    fireEvent.change(input!, { target: { value: '' } });
-    await waitFor(() => expect(input!).toHaveValue(''));
-    inputError = result.container.querySelector(`#mocked-senderId_sms-helper-text`);
-    expect(inputError).toHaveTextContent('courtesy-contacts.valid-sms');
+    expect(container).toHaveTextContent('-');
   });
 
   it('Edits one contacts and checks that others are disabled', async () => {
     // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContactsProvider>
-            <SpecialContactElem addresses={[pecAddress, phoneAddress]} />
-            <SpecialContactElem
-              addresses={[
-                {
-                  addressType: AddressType.COURTESY,
-                  senderId: 'another-mocked-senderId',
-                  senderName: 'Another mocked Sender',
-                  channelType: ChannelType.EMAIL,
-                  value: 'mocked@mail.it',
-                },
-                {
-                  addressType: AddressType.COURTESY,
-                  senderId: 'another-mocked-senderId',
-                  senderName: 'Another mocked Sender',
-                  channelType: ChannelType.SMS,
-                  value: '+39333333334',
-                },
-              ]}
-            />
-          </SpecialContactsProvider>
-        </DigitalContactsCodeVerificationProvider>
-      );
-    });
+    const { getAllByTestId } = render(
+      <SpecialContactsProvider>
+        <SpecialContactElem addresses={[pecAddress, phoneAddress]} />
+        <SpecialContactElem
+          addresses={[
+            {
+              addressType: AddressType.COURTESY,
+              senderId: 'another-mocked-senderId',
+              senderName: 'Another mocked Sender',
+              channelType: ChannelType.EMAIL,
+              value: 'mocked@mail.it',
+            },
+            {
+              addressType: AddressType.COURTESY,
+              senderId: 'another-mocked-senderId',
+              senderName: 'Another mocked Sender',
+              channelType: ChannelType.SMS,
+              value: '+39333333334',
+            },
+          ]}
+        />
+      </SpecialContactsProvider>
+    );
     // edit the first contact of the first row
-    const specialContactForms = result.getAllByTestId('specialContactForm');
-    let firstFormButtons = specialContactForms![0].querySelectorAll('button');
+    const specialContactForms = getAllByTestId(
+      /^[a-zA-Z0-9\-]+(?:_pecContact|_emailContact|_smsContact)$/
+    );
+    let firstFormButtons = specialContactForms[0].querySelectorAll('button');
     fireEvent.click(firstFormButtons[0]);
-    let input = await waitFor(() => specialContactForms![0].querySelector('input'));
-    firstFormButtons = specialContactForms![0].querySelectorAll('button');
+    let input = await waitFor(() => specialContactForms[0].querySelector('input'));
+    firstFormButtons = specialContactForms[0].querySelectorAll('button');
     expect(input).toBeInTheDocument();
     // check the disabled status of the others button
-    const secondFormButtons = specialContactForms![1].querySelectorAll('button');
+    const secondFormButtons = specialContactForms[1].querySelectorAll('button');
     for (const button of secondFormButtons) {
       expect(button).toBeDisabled();
     }
-    const thirdFormButtons = specialContactForms![2].querySelectorAll('button');
+    const thirdFormButtons = specialContactForms[2].querySelectorAll('button');
     for (const button of thirdFormButtons) {
       expect(button).toBeDisabled();
     }
-    const fourthFormButtons = specialContactForms![3].querySelectorAll('button');
+    const fourthFormButtons = specialContactForms[3].querySelectorAll('button');
     for (const button of fourthFormButtons) {
       expect(button).toBeDisabled();
     }
     // exit from edit
     fireEvent.click(firstFormButtons[1]);
-    input = await waitFor(() => specialContactForms![0].querySelector('input'));
+    input = await waitFor(() => specialContactForms[0].querySelector('input'));
     expect(input).not.toBeInTheDocument();
     // check the disabled status of the others button
     for (const button of secondFormButtons) {
@@ -356,40 +143,5 @@ describe('SpecialContactElem Component', () => {
     for (const button of fourthFormButtons) {
       expect(button).toBeEnabled();
     }
-  });
-  it('remove contact', async () => {
-    mock.onDelete('/bff/v1/addresses/LEGAL/mocked-senderId/PEC').reply(204);
-    // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContactsProvider>
-            <SpecialContactElem addresses={[pecAddress]} />
-          </SpecialContactsProvider>
-        </DigitalContactsCodeVerificationProvider>
-      );
-    });
-    const buttons = result?.container.querySelectorAll('button');
-    // click on cancel
-    fireEvent.click(buttons![1]);
-    let dialog = await waitFor(() => screen.getByRole('dialog'));
-    expect(dialog).toBeInTheDocument();
-    let dialogButtons = dialog?.querySelectorAll('button');
-    // cancel remove operation
-    fireEvent.click(dialogButtons![0]);
-    await waitFor(() => {
-      expect(dialog).not.toBeInTheDocument();
-    });
-    // click on confirm
-    fireEvent.click(buttons![1]);
-    dialog = await waitFor(() => screen.getByRole('dialog'));
-    dialogButtons = dialog?.querySelectorAll('button');
-    fireEvent.click(dialogButtons![1]);
-    await waitFor(() => {
-      expect(dialog).not.toBeInTheDocument();
-    });
-    await waitFor(() => {
-      expect(mock.history.delete).toHaveLength(1);
-    });
   });
 });

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/SpecialContacts.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/SpecialContacts.test.tsx
@@ -77,7 +77,6 @@ const fillCodeDialog = async (result: RenderResult) => {
 };
 
 describe('SpecialContacts Component', async () => {
-  let result: RenderResult;
   let mock: MockAdapter;
 
   beforeAll(() => {
@@ -92,18 +91,16 @@ describe('SpecialContacts Component', async () => {
     mock.restore();
   });
 
-  it('renders component', async () => {
+  it('renders component', () => {
     mock.onGet('/bff/v1/pa-list').reply(200, parties);
     // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContacts digitalAddresses={digitalAddresses} />
-        </DigitalContactsCodeVerificationProvider>
-      );
-    });
-    expect(result.container).toHaveTextContent('special-contacts.subtitle');
-    const form = result.container.querySelector('form');
+    const { container, getAllByTestId } = render(
+      <DigitalContactsCodeVerificationProvider>
+        <SpecialContacts digitalAddresses={digitalAddresses} />
+      </DigitalContactsCodeVerificationProvider>
+    );
+    expect(container).toHaveTextContent('special-contacts.subtitle');
+    const form = container.querySelector('form');
     testFormElements(form!, 'sender', 'special-contacts.sender');
     testFormElements(form!, 'addressType', 'special-contacts.address-type');
     testFormElements(form!, 's_value', 'special-contacts.pec');
@@ -111,21 +108,21 @@ describe('SpecialContacts Component', async () => {
     expect(button).toHaveTextContent('button.associa');
     expect(button).toBeDisabled();
     // contacts list
-    const specialContactForms = result.getAllByTestId('specialContactForm');
+    const specialContactForms = getAllByTestId(
+      /^[a-zA-Z0-9\-]+(?:_pecContact|_emailContact|_smsContact)$/
+    );
     expect(specialContactForms).toHaveLength(specialAddressesCount);
   });
 
   it('check valid pec', async () => {
     mock.onGet('/bff/v1/pa-list').reply(200, parties);
     // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContacts digitalAddresses={digitalAddresses} />
-        </DigitalContactsCodeVerificationProvider>
-      );
-    });
-    const form = result.container.querySelector('form');
+    const { container, getByTestId } = render(
+      <DigitalContactsCodeVerificationProvider>
+        <SpecialContacts digitalAddresses={digitalAddresses} />
+      </DigitalContactsCodeVerificationProvider>
+    );
+    const form = container.querySelector('form');
     // change sender
     await testAutocomplete(form!, 'sender', parties, true, 1, true);
     // change pec
@@ -133,21 +130,19 @@ describe('SpecialContacts Component', async () => {
     // check if valid
     testValidFiled(form!, 's_value');
     // check already exists alert
-    const alreadyExistsAlert = result.getByTestId('alreadyExistsAlert');
+    const alreadyExistsAlert = getByTestId('alreadyExistsAlert');
     expect(alreadyExistsAlert).toHaveTextContent('special-contacts.pec-already-exists');
   });
 
   it('check invalid pec', async () => {
     mock.onGet('/bff/v1/pa-list').reply(200, parties);
     // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContacts digitalAddresses={digitalAddresses} />
-        </DigitalContactsCodeVerificationProvider>
-      );
-    });
-    const form = result.container.querySelector('form');
+    const { container } = render(
+      <DigitalContactsCodeVerificationProvider>
+        <SpecialContacts digitalAddresses={digitalAddresses} />
+      </DigitalContactsCodeVerificationProvider>
+    );
+    const form = container.querySelector('form');
     // change sender
     await testAutocomplete(form!, 'sender', parties, true, 1, true);
     // change pec
@@ -163,14 +158,12 @@ describe('SpecialContacts Component', async () => {
   it('checks invalid mail', async () => {
     mock.onGet('/bff/v1/pa-list').reply(200, parties);
     // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContacts digitalAddresses={digitalAddresses} />
-        </DigitalContactsCodeVerificationProvider>
-      );
-    });
-    const form = result.container.querySelector('form');
+    const { container } = render(
+      <DigitalContactsCodeVerificationProvider>
+        <SpecialContacts digitalAddresses={digitalAddresses} />
+      </DigitalContactsCodeVerificationProvider>
+    );
+    const form = container.querySelector('form');
     // change sender
     await testAutocomplete(form!, 'sender', parties, true, 1, true);
     // change addressType
@@ -197,14 +190,12 @@ describe('SpecialContacts Component', async () => {
   it('checks valid mail', async () => {
     mock.onGet('/bff/v1/pa-list').reply(200, parties);
     // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContacts digitalAddresses={digitalAddresses} />
-        </DigitalContactsCodeVerificationProvider>
-      );
-    });
-    const form = result.container.querySelector('form');
+    const { container, getByTestId } = render(
+      <DigitalContactsCodeVerificationProvider>
+        <SpecialContacts digitalAddresses={digitalAddresses} />
+      </DigitalContactsCodeVerificationProvider>
+    );
+    const form = container.querySelector('form');
     // change sender
     await testAutocomplete(form!, 'sender', parties, true, 0, true);
     // change addressType
@@ -223,21 +214,19 @@ describe('SpecialContacts Component', async () => {
     // check if valid
     testValidFiled(form!, 's_value');
     // check already exists alert
-    const alreadyExistsAlert = result.getByTestId('alreadyExistsAlert');
+    const alreadyExistsAlert = getByTestId('alreadyExistsAlert');
     expect(alreadyExistsAlert).toHaveTextContent('special-contacts.email-already-exists');
   });
 
   it('checks invalid phone', async () => {
     mock.onGet('/bff/v1/pa-list').reply(200, parties);
     // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContacts digitalAddresses={digitalAddresses} />
-        </DigitalContactsCodeVerificationProvider>
-      );
-    });
-    const form = result.container.querySelector('form');
+    const { container } = render(
+      <DigitalContactsCodeVerificationProvider>
+        <SpecialContacts digitalAddresses={digitalAddresses} />
+      </DigitalContactsCodeVerificationProvider>
+    );
+    const form = container.querySelector('form');
     // change sender
     await testAutocomplete(form!, 'sender', parties, true, 1, true);
     // change addressType
@@ -264,14 +253,12 @@ describe('SpecialContacts Component', async () => {
   it('checks valid phone', async () => {
     mock.onGet('/bff/v1/pa-list').reply(200, parties);
     // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContacts digitalAddresses={digitalAddresses} />
-        </DigitalContactsCodeVerificationProvider>
-      );
-    });
-    const form = result.container.querySelector('form');
+    const { container, getByTestId } = render(
+      <DigitalContactsCodeVerificationProvider>
+        <SpecialContacts digitalAddresses={digitalAddresses} />
+      </DigitalContactsCodeVerificationProvider>
+    );
+    const form = container.querySelector('form');
     // change sender
     await testAutocomplete(form!, 'sender', parties, true, 1, true);
     // change addressType
@@ -290,7 +277,7 @@ describe('SpecialContacts Component', async () => {
     // check if valid
     testValidFiled(form!, 's_value');
     // check already exists alert
-    const alreadyExistsAlert = result.getByTestId('alreadyExistsAlert');
+    const alreadyExistsAlert = getByTestId('alreadyExistsAlert');
     expect(alreadyExistsAlert).toHaveTextContent('special-contacts.sms-already-exists');
   });
 
@@ -311,14 +298,12 @@ describe('SpecialContacts Component', async () => {
       })
       .reply(204);
     // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContacts digitalAddresses={digitalAddresses} />
-        </DigitalContactsCodeVerificationProvider>,
-        { preloadedState: { contactsState: { digitalAddresses } } }
-      );
-    });
+    const result = render(
+      <DigitalContactsCodeVerificationProvider>
+        <SpecialContacts digitalAddresses={digitalAddresses} />
+      </DigitalContactsCodeVerificationProvider>,
+      { preloadedState: { contactsState: { digitalAddresses } } }
+    );
     const form = result.container.querySelector('form');
     // change sender
     await testAutocomplete(form!, 'sender', parties, true, 2, true);
@@ -374,7 +359,9 @@ describe('SpecialContacts Component', async () => {
     );
     await waitFor(() => {
       // contacts list
-      const specialContactForms = result.getAllByTestId('specialContactForm');
+      const specialContactForms = result.getAllByTestId(
+        /^[a-zA-Z0-9\-]+(?:_pecContact|_emailContact|_smsContact)$/
+      );
       expect(specialContactForms).toHaveLength(specialAddressesCount + 1);
     });
   });
@@ -396,17 +383,17 @@ describe('SpecialContacts Component', async () => {
       })
       .replyOnce(204);
     // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContacts digitalAddresses={digitalAddresses} />
-        </DigitalContactsCodeVerificationProvider>,
-        { preloadedState: { contactsState: { digitalAddresses } } }
-      );
-    });
+    const result = render(
+      <DigitalContactsCodeVerificationProvider>
+        <SpecialContacts digitalAddresses={digitalAddresses} />
+      </DigitalContactsCodeVerificationProvider>,
+      { preloadedState: { contactsState: { digitalAddresses } } }
+    );
     // ATTENTION: the order in the mock is very important
     // change mail
-    const specialContactForms = result.getAllByTestId('specialContactForm');
+    const specialContactForms = result.getAllByTestId(
+      /^[a-zA-Z0-9\-]+(?:_pecContact|_emailContact|_smsContact)$/
+    );
     const emailEditButton = within(specialContactForms[1]).getByRole('button', {
       name: 'button.modifica',
     });
@@ -431,7 +418,9 @@ describe('SpecialContacts Component', async () => {
         verificationCode: '01234',
       });
     });
-    expect(dialog).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(dialog).not.toBeInTheDocument();
+    });
     const addresses = [
       ...digitalLegalAddresses,
       {
@@ -451,7 +440,9 @@ describe('SpecialContacts Component', async () => {
     );
     await waitFor(() => {
       // contacts list
-      const specialContactForms = result.getAllByTestId('specialContactForm');
+      const specialContactForms = result.getAllByTestId(
+        /^[a-zA-Z0-9\-]+(?:_pecContact|_emailContact|_smsContact)$/
+      );
       expect(specialContactForms[1]).toHaveTextContent(mailValue);
     });
   });
@@ -460,22 +451,22 @@ describe('SpecialContacts Component', async () => {
     mock.onGet('/bff/v1/pa-list').reply(200, parties);
     mock.onDelete(`/bff/v1/addresses/COURTESY/${parties[0].id}/EMAIL`).reply(200);
     // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContacts digitalAddresses={digitalAddresses} />
-        </DigitalContactsCodeVerificationProvider>,
-        { preloadedState: { contactsState: { digitalAddresses } } }
-      );
-    });
+    const { rerender, getAllByTestId, getByRole } = render(
+      <DigitalContactsCodeVerificationProvider>
+        <SpecialContacts digitalAddresses={digitalAddresses} />
+      </DigitalContactsCodeVerificationProvider>,
+      { preloadedState: { contactsState: { digitalAddresses } } }
+    );
     // ATTENTION: the order in the mock is very important
     // delete mail
-    const specialContactForms = result.getAllByTestId('specialContactForm');
+    const specialContactForms = getAllByTestId(
+      /^[a-zA-Z0-9\-]+(?:_pecContact|_emailContact|_smsContact)$/
+    );
     const emailDeleteButton = within(specialContactForms[1]).getByRole('button', {
       name: 'button.elimina',
     });
     fireEvent.click(emailDeleteButton);
-    const dialogBox = result.getByRole('dialog', { name: /courtesy-contacts.remove\b/ });
+    const dialogBox = getByRole('dialog', { name: /courtesy-contacts.remove\b/ });
     expect(dialogBox).toBeVisible();
     const confirmButton = within(dialogBox).getByRole('button', { name: 'button.conferma' });
     fireEvent.click(confirmButton);
@@ -486,14 +477,16 @@ describe('SpecialContacts Component', async () => {
     const addresses = [...digitalLegalAddresses, ...digitalCourtesyAddresses.slice(1)];
     expect(testStore.getState().contactsState.digitalAddresses).toStrictEqual(addresses);
     // simulate rerendering due to redux changes
-    result.rerender(
+    rerender(
       <DigitalContactsCodeVerificationProvider>
         <SpecialContacts digitalAddresses={addresses} />
       </DigitalContactsCodeVerificationProvider>
     );
     await waitFor(() => {
       // contacts list
-      const specialContactForms = result.getAllByTestId('specialContactForm');
+      const specialContactForms = getAllByTestId(
+        /^[a-zA-Z0-9\-]+(?:_pecContact|_emailContact|_smsContact)$/
+      );
       expect(specialContactForms).toHaveLength(specialAddressesCount - 1);
     });
   });

--- a/packages/pn-personafisica-webapp/src/pages/__test__/Contacts.page.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/Contacts.page.test.tsx
@@ -57,8 +57,8 @@ describe('Contacts page', async () => {
     });
     expect(result.container).toHaveTextContent(/title/i);
     expect(result.container).toHaveTextContent(/subtitle/i);
-    const pecContact = result.getByTestId('pecContact');
-    expect(pecContact).toBeInTheDocument();
+    const legalContacts = result.getByTestId('legalContacts');
+    expect(legalContacts).toBeInTheDocument();
     const courtesyContacts = result.getByTestId('courtesyContacts');
     expect(courtesyContacts).toBeInTheDocument();
     const specialContact = result.queryByTestId('specialContact');
@@ -73,8 +73,8 @@ describe('Contacts page', async () => {
     await act(async () => {
       result = render(<Contacts />);
     });
-    const pecContact = result.getByTestId('pecContact');
-    expect(pecContact).toBeInTheDocument();
+    const legalContacts = result.getByTestId('legalContacts');
+    expect(legalContacts).toBeInTheDocument();
     const courtesyContacts = result.getByTestId('courtesyContacts');
     expect(courtesyContacts).toBeInTheDocument();
     const specialContact = result.queryByTestId('specialContact');
@@ -86,8 +86,8 @@ describe('Contacts page', async () => {
     await act(async () => {
       result = render(<Contacts />);
     });
-    const pecContact = result.queryByTestId('pecContact');
-    expect(pecContact).toBeInTheDocument();
+    const legalContacts = result.queryByTestId('legalContacts');
+    expect(legalContacts).toBeInTheDocument();
     const courtesyContacts = result.getByTestId('courtesyContacts');
     expect(courtesyContacts).toBeInTheDocument();
     const specialContact = result.getByTestId('specialContact');
@@ -99,8 +99,8 @@ describe('Contacts page', async () => {
     await act(async () => {
       result = render(<Contacts />);
     });
-    const pecContact = result.getByTestId('pecContact');
-    expect(pecContact).toBeInTheDocument();
+    const legalContacts = result.getByTestId('legalContacts');
+    expect(legalContacts).toBeInTheDocument();
     const courtesyContacts = result.getByTestId('courtesyContacts');
     expect(courtesyContacts).toBeInTheDocument();
     const specialContact = result.getByTestId('specialContact');
@@ -112,8 +112,8 @@ describe('Contacts page', async () => {
     await act(async () => {
       result = render(<Contacts />);
     });
-    const pecContact = result.queryByTestId('pecContact');
-    expect(pecContact).toBeInTheDocument();
+    const legalContacts = result.queryByTestId('legalContacts');
+    expect(legalContacts).toBeInTheDocument();
     const courtesyContacts = result.getByTestId('courtesyContacts');
     expect(courtesyContacts).toBeInTheDocument();
     const specialContact = result.getByTestId('specialContact');

--- a/packages/pn-personafisica-webapp/src/utility/contacts.utility.ts
+++ b/packages/pn-personafisica-webapp/src/utility/contacts.utility.ts
@@ -3,7 +3,6 @@ import * as yup from 'yup';
 
 import { dataRegex } from '@pagopa-pn/pn-commons';
 
-import { PFEventsType } from '../models/PFEventsType';
 import { ChannelType, DigitalAddress } from '../models/contacts';
 
 export const internationalPhonePrefix = '+39';
@@ -13,15 +12,6 @@ export const allowedAddressTypes = [ChannelType.PEC, ChannelType.EMAIL, ChannelT
 export function countContactsByType(contacts: Array<DigitalAddress>, type: ChannelType) {
   return contacts.reduce((total, contact) => (contact.channelType === type ? total + 1 : total), 0);
 }
-
-export const getEventByContactType = (contactType: ChannelType): PFEventsType => {
-  if (contactType === ChannelType.PEC) {
-    return PFEventsType.SEND_REMOVE_PEC_SUCCESS;
-  } else if (contactType === ChannelType.EMAIL) {
-    return PFEventsType.SEND_REMOVE_EMAIL_SUCCESS;
-  }
-  return PFEventsType.SEND_REMOVE_SMS_SUCCESS;
-};
 
 export const contactAlreadyExists = (
   digitalAddresses: Array<DigitalAddress>,

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/DigitalContactElem.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/DigitalContactElem.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, forwardRef, useImperativeHandle, useState } from 'react';
+import { forwardRef, useImperativeHandle, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { InputAdornment, TextField, TextFieldProps, Typography } from '@mui/material';
@@ -15,11 +15,10 @@ type Props = {
   contactType: ChannelType;
   saveDisabled?: boolean;
   onConfirm?: (status: 'validated' | 'cancelled') => void;
+  onEdit?: (editFlag: boolean) => void;
   onEditCancel: () => void;
-  onEditConfirm?: () => void;
   onDelete: () => void;
   editDisabled?: boolean;
-  setContextEditMode?: Dispatch<SetStateAction<boolean>>;
   // this is a temporary property. it is needed until we remove the context
   editManagedFromOutside?: boolean;
 };
@@ -33,9 +32,9 @@ const DigitalContactElem = forwardRef<{ editContact: () => void; toggleEdit?: ()
       senderName,
       contactType,
       onConfirm,
+      onEdit,
       onEditCancel,
-      editDisabled,
-      setContextEditMode,
+      editDisabled = false,
       onDelete,
       editManagedFromOutside = false,
     },
@@ -44,10 +43,11 @@ const DigitalContactElem = forwardRef<{ editContact: () => void; toggleEdit?: ()
     const { t } = useTranslation(['common']);
     const [editMode, setEditMode] = useState(false);
     const { initValidation } = useDigitalContactsCodeVerificationContext(editManagedFromOutside);
+
     const toggleEdit = () => {
       setEditMode(!editMode);
-      if (setContextEditMode) {
-        setContextEditMode(!editMode);
+      if (onEdit) {
+        onEdit(!editMode);
       }
     };
 
@@ -57,6 +57,9 @@ const DigitalContactElem = forwardRef<{ editContact: () => void; toggleEdit?: ()
     };
 
     const editHandler = () => {
+      if (editManagedFromOutside) {
+        return;
+      }
       initValidation(
         contactType,
         inputProps.value as string,

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/PecContactItem.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/PecContactItem.tsx
@@ -29,7 +29,11 @@ import PecVerificationDialog from './PecVerificationDialog';
 type Props = {
   value: string;
   verifyingAddress: boolean;
+  senderId?: string;
+  senderName?: string;
   blockDelete?: boolean;
+  blockEdit?: boolean;
+  onEdit?: (editFlag: boolean) => void;
 };
 
 enum ModalType {
@@ -40,7 +44,15 @@ enum ModalType {
   CODE = 'code',
 }
 
-const PecContactItem = ({ value, verifyingAddress, blockDelete }: Props) => {
+const PecContactItem: React.FC<Props> = ({
+  value,
+  verifyingAddress,
+  blockDelete,
+  senderId = 'default',
+  senderName,
+  blockEdit,
+  onEdit,
+}) => {
   const { t } = useTranslation(['common', 'recapiti']);
   const digitalAddresses =
     useAppSelector((state: RootState) => state.contactsState.digitalAddresses) ?? [];
@@ -54,11 +66,11 @@ const PecContactItem = ({ value, verifyingAddress, blockDelete }: Props) => {
     useRef<{ updateError: (error: ErrorMessage, codeNotValid: boolean) => void }>(null);
 
   const validationSchema = yup.object({
-    pec: pecValidationSchema(t),
+    [`${senderId}_pec`]: pecValidationSchema(t),
   });
 
   const initialValues = {
-    pec: value,
+    [`${senderId}_pec`]: value,
   };
 
   const formik = useFormik({
@@ -69,7 +81,14 @@ const PecContactItem = ({ value, verifyingAddress, blockDelete }: Props) => {
     /** onSubmit validate */
     onSubmit: () => {
       // first check if contact already exists
-      if (contactAlreadyExists(digitalAddresses, formik.values.pec, 'default', ChannelType.PEC)) {
+      if (
+        contactAlreadyExists(
+          digitalAddresses,
+          formik.values[`${senderId}_pec`],
+          senderId,
+          ChannelType.PEC
+        )
+      ) {
         setModalOpen(ModalType.EXISTING);
         return;
       }
@@ -85,9 +104,10 @@ const PecContactItem = ({ value, verifyingAddress, blockDelete }: Props) => {
   const handleCodeVerification = (verificationCode?: string) => {
     const digitalAddressParams: SaveDigitalAddressParams = {
       addressType: AddressType.LEGAL,
-      senderId: 'default',
+      senderId,
+      senderName,
       channelType: ChannelType.PEC,
-      value: formik.values.pec,
+      value: formik.values[`${senderId}_pec`],
       code: verificationCode,
     };
 
@@ -128,8 +148,8 @@ const PecContactItem = ({ value, verifyingAddress, blockDelete }: Props) => {
     if (value) {
       digitalElemRef.current.toggleEdit();
     }
-    await formik.setFieldTouched('pec', false, false);
-    await formik.setFieldValue('pec', initialValues.pec, true);
+    await formik.setFieldTouched(`${senderId}_pec`, false, false);
+    await formik.setFieldValue(`${senderId}_pec`, initialValues[`${senderId}_pec`], true);
   };
 
   const deleteConfirmHandler = () => {
@@ -137,7 +157,7 @@ const PecContactItem = ({ value, verifyingAddress, blockDelete }: Props) => {
     void dispatch(
       deleteAddress({
         addressType: AddressType.LEGAL,
-        senderId: 'default',
+        senderId,
         channelType: ChannelType.PEC,
       })
     );
@@ -174,37 +194,44 @@ const PecContactItem = ({ value, verifyingAddress, blockDelete }: Props) => {
 
   return (
     <>
-      <form onSubmit={formik.handleSubmit} data-testid="pecContact">
+      <form onSubmit={formik.handleSubmit} data-testid={`${senderId}_pecContact`}>
         {value && (
           <>
-            <Typography mb={1} sx={{ fontWeight: 'bold' }} id="associatedPEC" mt={3}>
-              {t('legal-contacts.pec-added', { ns: 'recapiti' })}
-            </Typography>
+            {senderId === 'default' && (
+              <Typography mb={1} sx={{ fontWeight: 'bold' }} id="associatedPEC" mt={3}>
+                {t('legal-contacts.pec-added', { ns: 'recapiti' })}
+              </Typography>
+            )}
             <DigitalContactElem
-              senderId="default"
+              senderId={senderId}
               contactType={ChannelType.PEC}
               ref={digitalElemRef}
               inputProps={{
-                id: 'pec',
-                name: 'pec',
+                id: `${senderId}_pec`,
+                name: `${senderId}_pec`,
                 label: 'PEC',
-                value: formik.values.pec,
+                value: formik.values[`${senderId}_pec`],
                 onChange: (e) => void handleChangeTouched(e),
-                error: formik.touched.pec && Boolean(formik.errors.pec),
-                helperText: formik.touched.pec && formik.errors.pec,
+                error:
+                  formik.touched[`${senderId}_pec`] && Boolean(formik.errors[`${senderId}_pec`]),
+                helperText: formik.touched[`${senderId}_pec`] && formik.errors[`${senderId}_pec`],
               }}
               saveDisabled={!formik.isValid}
+              editDisabled={blockEdit}
               onDelete={() => setModalOpen(ModalType.DELETE)}
               onEditCancel={() => formik.resetForm({ values: initialValues })}
+              onEdit={onEdit}
               editManagedFromOutside
             />
           </>
         )}
         {verifyingAddress && (
           <>
-            <Typography mb={1} sx={{ fontWeight: 'bold' }} mt={3}>
-              {t('legal-contacts.pec-validating', { ns: 'recapiti' })}
-            </Typography>
+            {senderId === 'default' && (
+              <Typography mb={1} sx={{ fontWeight: 'bold' }} mt={3}>
+                {t('legal-contacts.pec-validating', { ns: 'recapiti' })}
+              </Typography>
+            )}
             <Stack direction="row" spacing={1}>
               <WatchLaterIcon fontSize="small" />
               <Typography id="validationPecProgress" fontWeight="bold" variant="body2">
@@ -223,14 +250,14 @@ const PecContactItem = ({ value, verifyingAddress, blockDelete }: Props) => {
         {!value && !verifyingAddress && (
           <Stack spacing={2} direction={{ sm: 'row', xs: 'column' }} mt={3}>
             <TextField
-              id="pec"
+              id={`${senderId}_pec`}
+              name={`${senderId}_pec`}
               placeholder={t('legal-contacts.link-pec-placeholder', { ns: 'recapiti' })}
               fullWidth
-              name="pec"
-              value={formik.values.pec}
+              value={formik.values[`${senderId}_pec`]}
               onChange={handleChangeTouched}
-              error={formik.touched.pec && Boolean(formik.errors.pec)}
-              helperText={formik.touched.pec && formik.errors.pec}
+              error={formik.touched[`${senderId}_pec`] && Boolean(formik.errors[`${senderId}_pec`])}
+              helperText={formik.touched[`${senderId}_pec`] && formik.errors[`${senderId}_pec`]}
               inputProps={{ sx: { height: '14px' } }}
               sx={{ flexBasis: { xs: 'unset', lg: '66.66%' } }}
             />
@@ -250,12 +277,15 @@ const PecContactItem = ({ value, verifyingAddress, blockDelete }: Props) => {
       </form>
       <ExistingContactDialog
         open={modalOpen === ModalType.EXISTING}
-        value={formik.values.pec}
+        value={formik.values[`${senderId}_pec`]}
         handleDiscard={() => setModalOpen(null)}
         handleConfirm={() => handleCodeVerification()}
       />
       <CodeModal
-        title={t(`legal-contacts.pec-verify`, { ns: 'recapiti' }) + ` ${formik.values.pec}`}
+        title={
+          t(`legal-contacts.pec-verify`, { ns: 'recapiti' }) +
+          ` ${formik.values[senderId + '_pec']}`
+        }
         subtitle={<Trans i18nKey={`legal-contacts.pec-verify-descr`} ns="recapiti" />}
         open={modalOpen === ModalType.CODE}
         initialValues={new Array(5).fill('')}
@@ -302,7 +332,7 @@ const PecContactItem = ({ value, verifyingAddress, blockDelete }: Props) => {
           ns: 'recapiti',
         })}
         removeModalBody={t(`legal-contacts.${blockDelete ? 'block-' : ''}remove-pec-message`, {
-          value: formik.values.pec,
+          value: formik.values[`${senderId}_pec`],
           ns: 'recapiti',
         })}
         handleModalClose={() => setModalOpen(null)}

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/SpecialContactElem.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/SpecialContactElem.tsx
@@ -1,22 +1,14 @@
-import { useFormik } from 'formik';
-import { ChangeEvent, Fragment, useRef, useState } from 'react';
+import { Fragment } from 'react';
 import { useTranslation } from 'react-i18next';
-import * as yup from 'yup';
 
 import { TableCell, TableRow, Typography } from '@mui/material';
 import { useIsMobile, useSpecialContactsContext } from '@pagopa-pn/pn-commons';
 
 import { ChannelType, DigitalAddress } from '../../models/contacts';
-import { deleteAddress } from '../../redux/contact/actions';
-import { useAppDispatch } from '../../redux/hooks';
-import {
-  allowedAddressTypes,
-  emailValidationSchema,
-  pecValidationSchema,
-  phoneValidationSchema,
-} from '../../utility/contacts.utility';
-import DeleteDialog from './DeleteDialog';
-import DigitalContactElem from './DigitalContactElem';
+import { allowedAddressTypes } from '../../utility/contacts.utility';
+import EmailContactItem from './EmailContactItem';
+import PecContactItem from './PecContactItem';
+import SmsContactItem from './SmsContactItem';
 
 type Props = {
   addresses: Array<DigitalAddress>;
@@ -29,31 +21,10 @@ type Field = {
   address?: DigitalAddress;
 };
 
-const reduceAddresses = <TValue,>(senderId: string, value: (type: string) => TValue) =>
-  allowedAddressTypes.reduce((obj, type) => {
-    // eslint-disable-next-line functional/immutable-data
-    obj[`${senderId}_${type.toLowerCase()}`] = value(type);
-    return obj;
-  }, {} as { [key: string]: TValue });
-
 const SpecialContactElem: React.FC<Props> = ({ addresses }) => {
   const { t } = useTranslation(['recapiti']);
   const isMobile = useIsMobile();
   const { contextEditMode, setContextEditMode } = useSpecialContactsContext();
-  const dispatch = useAppDispatch();
-
-  const digitalElemRef = useRef<{
-    [key: string]: { editContact: () => void };
-  }>(reduceAddresses(addresses[0].senderId, () => ({ editContact: () => {} })));
-
-  const [showDeleteModal, setShowDeleteModal] = useState(
-    reduceAddresses(addresses[0].senderId, () => false)
-  );
-
-  const initialValues = reduceAddresses(
-    addresses[0].senderId,
-    (type) => addresses.find((a) => a.channelType === type)?.value ?? ''
-  );
 
   const fields: Array<Field> = allowedAddressTypes.map((type) => ({
     id: `${addresses[0].senderId}_${type.toLowerCase()}`,
@@ -62,104 +33,38 @@ const SpecialContactElem: React.FC<Props> = ({ addresses }) => {
     address: addresses.find((a) => a.channelType === type),
   }));
 
-  const validationSchema = yup.object({
-    [`${addresses[0].senderId}_pec`]: pecValidationSchema(t),
-    [`${addresses[0].senderId}_sms`]: phoneValidationSchema(t, true),
-    [`${addresses[0].senderId}_email`]: emailValidationSchema(t),
-  });
-
-  const updateContact = async (status: 'validated' | 'cancelled', id: string) => {
-    if (status === 'cancelled') {
-      await formik.setFieldValue(id, initialValues[id], true);
-    }
-  };
-
-  const formik = useFormik({
-    initialValues,
-    validationSchema,
-    enableReinitialize: true,
-    /** onSubmit validate */
-    onSubmit: () => {},
-  });
-
-  const handleChangeTouched = async (e: ChangeEvent) => {
-    formik.handleChange(e);
-    await formik.setFieldTouched(e.target.id, true, false);
-  };
-
-  const toggleDeleteModal = (key: string) => {
-    setShowDeleteModal((oldValue) => ({ ...oldValue, [key]: !oldValue[key] }));
-  };
-
-  const deleteConfirmHandler = (f: Field) => {
-    if (!f.address) {
-      return;
-    }
-    toggleDeleteModal(f.id);
-    void dispatch(
-      deleteAddress({
-        addressType: f.address.addressType,
-        senderId: addresses[0].senderId,
-        channelType: f.address.channelType,
-      })
-    );
-  };
-
   const jsxField = (f: Field) => (
     <>
       {f.address ? (
         <>
-          <DeleteDialog
-            showModal={showDeleteModal[f.id]}
-            removeModalTitle={t(
-              `${f.labelRoot}.remove-${f.address.channelType.toLowerCase()}-title`,
-              {
-                ns: 'recapiti',
-              }
-            )}
-            removeModalBody={t(
-              `${f.labelRoot}.remove-${f.address.channelType.toLowerCase()}-message`,
-              {
-                value: formik.values[f.id],
-                ns: 'recapiti',
-              }
-            )}
-            handleModalClose={() => toggleDeleteModal(f.id)}
-            confirmHandler={() => deleteConfirmHandler(f)}
-          />
-          <form
-            data-testid="specialContactForm"
-            onSubmit={(e) => {
-              e.preventDefault();
-              digitalElemRef.current[f.id].editContact();
-            }}
-          >
-            <DigitalContactElem
-              senderId={addresses[0].senderId}
+          {f.address?.channelType === ChannelType.PEC && (
+            <PecContactItem
+              value={f.address.value}
+              verifyingAddress={!f.address.pecValid}
+              senderId={f.address.senderId}
               senderName={f.address.senderName}
-              contactType={f.address.channelType}
-              inputProps={{
-                id: f.id,
-                name: f.id,
-                label: f.label,
-                value: formik.values[f.id],
-                onChange: handleChangeTouched,
-                error:
-                  (formik.touched[f.id] || formik.values[f.id].length > 0) &&
-                  Boolean(formik.errors[f.id]),
-                helperText:
-                  (formik.touched[f.id] || formik.values[f.id].length > 0) && formik.errors[f.id],
-              }}
-              saveDisabled={!!formik.errors[f.id]}
-              onConfirm={(status) => updateContact(status, f.id)}
-              onEditCancel={() => updateContact('cancelled', f.id)}
-              // eslint-disable-next-line functional/immutable-data
-              ref={(node: { editContact: () => void }) => (digitalElemRef.current[f.id] = node)}
-              editDisabled={contextEditMode}
-              setContextEditMode={setContextEditMode}
-              onDelete={() => toggleDeleteModal(f.id)}
+              blockEdit={contextEditMode}
+              onEdit={(editFlag) => setContextEditMode(editFlag)}
             />
-          </form>
+          )}
+          {f.address?.channelType === ChannelType.EMAIL && (
+            <EmailContactItem
+              value={f.address.value}
+              senderId={f.address.senderId}
+              senderName={f.address.senderName}
+              blockEdit={contextEditMode}
+              onEdit={(editFlag) => setContextEditMode(editFlag)}
+            />
+          )}
+          {f.address?.channelType === ChannelType.SMS && (
+            <SmsContactItem
+              value={f.address.value}
+              senderId={f.address.senderId}
+              senderName={f.address.senderName}
+              blockEdit={contextEditMode}
+              onEdit={(editFlag) => setContextEditMode(editFlag)}
+            />
+          )}
         </>
       ) : (
         '-'

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/__test__/CourtesyContacts.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/__test__/CourtesyContacts.test.tsx
@@ -44,8 +44,8 @@ describe('CourtesyContacts Component', async () => {
     const disclaimer = getByTestId('contacts disclaimer');
     expect(disclaimer).toBeInTheDocument();
     // check inputs
-    const phoneInput = container.querySelector(`[name="sms"]`);
-    const emailInput = container.querySelector(`[name="email"]`);
+    const phoneInput = container.querySelector(`[name="default_sms"]`);
+    const emailInput = container.querySelector(`[name="default_email"]`);
     expect(phoneInput).toBeInTheDocument();
     expect(emailInput).toBeInTheDocument();
   });
@@ -60,8 +60,8 @@ describe('CourtesyContacts Component', async () => {
     const defaultEmail = digitalCourtesyAddresses.find(
       (addr) => addr.channelType === ChannelType.EMAIL && addr.senderId === 'default'
     );
-    const phoneInput = container.querySelector(`[name="sms"]`);
-    const emailInput = container.querySelector(`[name="email"]`);
+    const phoneInput = container.querySelector(`[name="default_sms"]`);
+    const emailInput = container.querySelector(`[name="default_email"]`);
     expect(phoneInput).not.toBeInTheDocument();
     expect(emailInput).not.toBeInTheDocument();
     const phoneNumber = getByText(defaultPhone!.value);

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/__test__/EmailContactItem.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/__test__/EmailContactItem.test.tsx
@@ -63,11 +63,11 @@ describe('testing EmailContactItem', () => {
     // render component
     const { container } = render(<EmailContactItem value="" />);
     const form = container.querySelector('form');
-    const input = form!.querySelector(`[name="email"]`);
+    const input = form!.querySelector(`[name="default_email"]`);
     // set invalid values
     fireEvent.change(input!, { target: { value: INVALID_EMAIL } });
     await waitFor(() => expect(input).toHaveValue(INVALID_EMAIL));
-    const errorMessage = form!.querySelector(`#email-helper-text`);
+    const errorMessage = form!.querySelector(`#default_email-helper-text`);
     expect(errorMessage).toBeInTheDocument();
     expect(errorMessage).toHaveTextContent('courtesy-contacts.valid-email');
     const buttons = form!.querySelectorAll('button');
@@ -81,11 +81,11 @@ describe('testing EmailContactItem', () => {
   it('type in an invalid email while in "edit mode"', async () => {
     const { container, getByRole } = render(<EmailContactItem value={VALID_EMAIL} />);
     const form = container.querySelector('form');
-    const phoneValue = getById(form!, 'email-typography');
+    const phoneValue = getById(form!, 'default_email-typography');
     expect(phoneValue).toHaveTextContent(VALID_EMAIL);
     const editButton = getByRole('button', { name: 'button.modifica' });
     fireEvent.click(editButton);
-    const input = container.querySelector(`[name="email"]`);
+    const input = container.querySelector(`[name="default_email"]`);
     const saveButton = getByRole('button', { name: 'button.salva' });
     expect(input).toHaveValue(VALID_EMAIL);
     expect(saveButton).toBeEnabled();
@@ -94,7 +94,7 @@ describe('testing EmailContactItem', () => {
       expect(input).toHaveValue(INVALID_EMAIL);
     });
     expect(saveButton).toBeDisabled();
-    const inputError = container.querySelector(`#email-helper-text`);
+    const inputError = container.querySelector(`#default_email-helper-text`);
     expect(inputError).toHaveTextContent('courtesy-contacts.valid-email');
   });
 
@@ -112,10 +112,10 @@ describe('testing EmailContactItem', () => {
     const result = render(<EmailContactItem value="" />);
     // insert new email
     const form = result.container.querySelector('form');
-    const input = form!.querySelector(`[name="email"]`);
+    const input = form!.querySelector(`[name="default_email"]`);
     fireEvent.change(input!, { target: { value: mailValue } });
     await waitFor(() => expect(input!).toHaveValue(mailValue));
-    const errorMessage = form?.querySelector('#sms-helper-text');
+    const errorMessage = form?.querySelector('#default_email-helper-text');
     expect(errorMessage).not.toBeInTheDocument();
     const button = result.getByTestId('courtesy-email-button');
     expect(button).toBeEnabled();
@@ -160,7 +160,7 @@ describe('testing EmailContactItem', () => {
     await waitFor(() => {
       expect(input).not.toBeInTheDocument();
     });
-    const emailValue = getById(form!, 'email-typography');
+    const emailValue = getById(form!, 'default_email-typography');
     expect(emailValue).toBeInTheDocument();
     expect(emailValue).toHaveTextContent(mailValue);
     const editButton = getById(form!, 'modifyContact-default');
@@ -188,11 +188,11 @@ describe('testing EmailContactItem', () => {
     const result = render(<EmailContactItem value={defaultEmailAddress!.value} />);
     // edit value
     const form = result.container.querySelector('form');
-    let mailValue = getById(form!, 'email-typography');
+    let mailValue = getById(form!, 'default_email-typography');
     expect(mailValue).toHaveTextContent(defaultEmailAddress!.value);
     let editButton = result.getByRole('button', { name: 'button.modifica' });
     fireEvent.click(editButton);
-    const input = result.container.querySelector(`[name="email"]`);
+    const input = result.container.querySelector(`[name="default_email"]`);
     const saveButton = result.getByRole('button', { name: 'button.salva' });
     expect(input).toHaveValue(defaultEmailAddress!.value);
     expect(saveButton).toBeEnabled();
@@ -244,7 +244,7 @@ describe('testing EmailContactItem', () => {
     await waitFor(() => {
       expect(input).not.toBeInTheDocument();
     });
-    mailValue = getById(form!, 'email-typography');
+    mailValue = getById(form!, 'default_email-typography');
     expect(mailValue).toBeInTheDocument();
     expect(mailValue).toHaveTextContent(emailValue);
     editButton = getById(form!, 'modifyContact-default');
@@ -288,7 +288,7 @@ describe('testing EmailContactItem', () => {
     // simulate rerendering due to redux changes
     result.rerender(<EmailContactItem value="" />);
     await waitFor(() => {
-      const input = result.container.querySelector(`[name="email"]`);
+      const input = result.container.querySelector(`[name="default_email"]`);
       expect(input).toBeInTheDocument();
       expect(result.container).not.toHaveTextContent('');
     });

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/__test__/LegalContacts.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/__test__/LegalContacts.test.tsx
@@ -59,7 +59,7 @@ describe('LegalContacts Component', async () => {
     expect(container).toHaveTextContent('legal-contacts.subtitle');
     expect(container).toHaveTextContent('legal-contacts.description');
     const form = container.querySelector('form');
-    const pecInput = form?.querySelector('input[id="pec"]');
+    const pecInput = form?.querySelector('input[id="default_pec"]');
     expect(pecInput!).toHaveValue('');
     const button = await waitFor(() => getByRole('button', { name: 'button.conferma' }));
     expect(button).toBeDisabled();

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/__test__/PecContactItem.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/__test__/PecContactItem.test.tsx
@@ -62,11 +62,11 @@ describe('PecContactItem component', () => {
     // render component
     const { container } = render(<PecContactItem value="" verifyingAddress={false} />);
     const form = container.querySelector('form');
-    const input = form!.querySelector('input[name="pec"]');
+    const input = form!.querySelector('input[name="default_pec"]');
     // add invalid values
     fireEvent.change(input!, { target: { value: 'invalid-pec' } });
     await waitFor(() => expect(input).toHaveValue('invalid-pec'));
-    const errorMessage = form!.querySelector('#pec-helper-text');
+    const errorMessage = form!.querySelector('#default_pec-helper-text');
     expect(errorMessage).toBeInTheDocument();
     expect(errorMessage).toHaveTextContent('legal-contacts.valid-pec');
     const buttons = form!.querySelectorAll('button');
@@ -94,10 +94,10 @@ describe('PecContactItem component', () => {
     const result = render(<PecContactItem value="" verifyingAddress={false} />);
     // insert new pec
     const form = result.container.querySelector('form');
-    let input = form!.querySelector('input[name="pec"]');
+    let input = form!.querySelector('input[name="default_pec"]');
     fireEvent.change(input!, { target: { value: VALID_PEC } });
     await waitFor(() => expect(input!).toHaveValue(VALID_PEC));
-    const errorMessage = form?.querySelector('#pec-helper-text');
+    const errorMessage = form?.querySelector('#default_pec-helper-text');
     expect(errorMessage).not.toBeInTheDocument();
     const button = result.getByTestId('addContact');
     expect(button).toBeEnabled();
@@ -159,7 +159,7 @@ describe('PecContactItem component', () => {
     await waitFor(() => {
       expect(result.container).not.toHaveTextContent('legal-contacts.pec-validating');
       expect(result.container).not.toHaveTextContent('legal-contacts.validation-in-progress');
-      input = result.container.querySelector('input[name="pec"]');
+      input = result.container.querySelector('input[name="default_pec"]');
       expect(input).toBeInTheDocument();
     });
   });
@@ -181,10 +181,10 @@ describe('PecContactItem component', () => {
     const result = render(<PecContactItem value="" verifyingAddress={false} />);
     // insert new pec
     const form = result.container.querySelector('form');
-    const input = form!.querySelector('input[name="pec"]');
+    const input = form!.querySelector('input[name="default_pec"]');
     fireEvent.change(input!, { target: { value: VALID_PEC } });
     await waitFor(() => expect(input!).toHaveValue(VALID_PEC));
-    const errorMessage = form?.querySelector('#pec-helper-text');
+    const errorMessage = form?.querySelector('#default_pec-helper-text');
     expect(errorMessage).not.toBeInTheDocument();
     const button = result.getByTestId('addContact');
     expect(button).toBeEnabled();
@@ -218,7 +218,7 @@ describe('PecContactItem component', () => {
     await waitFor(() => {
       expect(input).not.toBeInTheDocument();
     });
-    const pecValue = getById(form!, 'pec-typography');
+    const pecValue = getById(form!, 'default_pec-typography');
     expect(pecValue).toBeInTheDocument();
     expect(pecValue).toHaveTextContent(VALID_PEC);
     const editButton = getById(form!, 'modifyContact-default');
@@ -233,11 +233,11 @@ describe('PecContactItem component', () => {
       <PecContactItem value={defaultAddress!.value} verifyingAddress={false} />
     );
     const form = container.querySelector('form');
-    const pecValue = getById(form!, 'pec-typography');
+    const pecValue = getById(form!, 'default_pec-typography');
     expect(pecValue).toHaveTextContent(defaultAddress!.value);
     const editButton = getByRole('button', { name: 'button.modifica' });
     fireEvent.click(editButton);
-    const input = container.querySelector('[name="pec"]');
+    const input = container.querySelector('[name="default_pec"]');
     const saveButton = getByRole('button', { name: 'button.salva' });
     expect(input).toHaveValue(defaultAddress!.value);
     expect(saveButton).toBeEnabled();
@@ -246,7 +246,7 @@ describe('PecContactItem component', () => {
       expect(input).toHaveValue('invalid-pec');
     });
     expect(saveButton).toBeDisabled();
-    const inputError = container.querySelector('#pec-helper-text');
+    const inputError = container.querySelector('#default_pec-helper-text');
     expect(inputError).toHaveTextContent('legal-contacts.valid-pec');
   });
 
@@ -270,11 +270,11 @@ describe('PecContactItem component', () => {
     );
     // edit value
     const form = result.container.querySelector('form');
-    let pecValue = getById(form!, 'pec-typography');
+    let pecValue = getById(form!, 'default_pec-typography');
     expect(pecValue).toHaveTextContent(defaultAddress!.value);
     let editButton = result.getByRole('button', { name: 'button.modifica' });
     fireEvent.click(editButton);
-    const input = result.container.querySelector('[name="pec"]');
+    const input = result.container.querySelector('[name="default_pec"]');
     const saveButton = result.getByRole('button', { name: 'button.salva' });
     expect(input).toHaveValue(defaultAddress!.value);
     expect(saveButton).toBeEnabled();
@@ -313,7 +313,7 @@ describe('PecContactItem component', () => {
     await waitFor(() => {
       expect(input).not.toBeInTheDocument();
     });
-    pecValue = getById(form!, 'pec-typography');
+    pecValue = getById(form!, 'default_pec-typography');
     expect(pecValue).toBeInTheDocument();
     expect(pecValue).toHaveTextContent(VALID_PEC);
     editButton = getById(form!, 'modifyContact-default');
@@ -360,7 +360,7 @@ describe('PecContactItem component', () => {
     // simulate rerendering due to redux changes
     result.rerender(<PecContactItem value="" verifyingAddress={false} />);
     await waitFor(() => {
-      const input = result.container.querySelector('input[name="pec"]');
+      const input = result.container.querySelector('input[name="default_pec"]');
       expect(input).toBeInTheDocument();
       expect(result.container).not.toHaveTextContent('');
     });

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/__test__/SmsContactItem.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/__test__/SmsContactItem.test.tsx
@@ -64,13 +64,13 @@ describe('test SmsContactItem', () => {
     // render component
     const { container } = render(<SmsContactItem value="" />);
     const form = container.querySelector('form');
-    const input = form!.querySelector(`[name="sms"]`);
+    const input = form!.querySelector(`[name="default_sms"]`);
     // add invalid values
     fireEvent.change(input!, { target: { value: INPUT_INVALID_PHONE } });
     await waitFor(() => {
       expect(input!).toHaveValue(INPUT_INVALID_PHONE);
     });
-    const errorMessage = form!.querySelector(`#sms-helper-text`);
+    const errorMessage = form!.querySelector(`#default_sms-helper-text`);
     expect(errorMessage).toBeInTheDocument();
     expect(errorMessage).toHaveTextContent('courtesy-contacts.valid-sms');
     const buttons = form!.querySelectorAll('button');
@@ -86,11 +86,11 @@ describe('test SmsContactItem', () => {
   it('type in an invalid number while in "edit mode"', async () => {
     const { container, getByRole } = render(<SmsContactItem value={INPUT_VALID_PHONE} />);
     const form = container.querySelector('form');
-    const phoneValue = getById(form!, 'sms-typography');
+    const phoneValue = getById(form!, 'default_sms-typography');
     expect(phoneValue).toHaveTextContent(INPUT_VALID_PHONE);
     const editButton = getByRole('button', { name: 'button.modifica' });
     fireEvent.click(editButton);
-    const input = container.querySelector(`[name="sms"]`);
+    const input = container.querySelector(`[name="default_sms"]`);
     const saveButton = getByRole('button', { name: 'button.salva' });
     expect(input).toHaveValue(INPUT_VALID_PHONE);
     expect(saveButton).toBeEnabled();
@@ -99,7 +99,7 @@ describe('test SmsContactItem', () => {
       expect(input).toHaveValue(INPUT_INVALID_PHONE);
     });
     expect(saveButton).toBeDisabled();
-    const inputError = container.querySelector(`#sms-helper-text`);
+    const inputError = container.querySelector(`#default_sms-helper-text`);
     expect(inputError).toHaveTextContent('courtesy-contacts.valid-sms');
   });
 
@@ -121,10 +121,10 @@ describe('test SmsContactItem', () => {
     const result = render(<SmsContactItem value="" />);
     // insert new phone
     const form = result.container.querySelector('form');
-    const input = form!.querySelector(`[name="sms"]`);
+    const input = form!.querySelector(`[name="default_sms"]`);
     fireEvent.change(input!, { target: { value: phoneValue } });
     await waitFor(() => expect(input!).toHaveValue(phoneValue));
-    const errorMessage = form?.querySelector('#phone-helper-text');
+    const errorMessage = form?.querySelector('#default_sms-helper-text');
     expect(errorMessage).not.toBeInTheDocument();
     const button = result.getByTestId('courtesy-sms-button');
     expect(button).toBeEnabled();
@@ -167,7 +167,7 @@ describe('test SmsContactItem', () => {
     await waitFor(() => {
       expect(input).not.toBeInTheDocument();
     });
-    const smsValue = getById(form!, 'sms-typography');
+    const smsValue = getById(form!, 'default_sms-typography');
     expect(smsValue).toBeInTheDocument();
     expect(smsValue).toHaveTextContent(internationalPhonePrefix + phoneValue);
     const editButton = getById(form!, 'modifyContact-default');
@@ -195,11 +195,11 @@ describe('test SmsContactItem', () => {
     const result = render(<SmsContactItem value={defaultPhoneAddress!.value} />);
     // edit value
     const form = result.container.querySelector('form');
-    let smsValue = getById(form!, 'sms-typography');
+    let smsValue = getById(form!, 'default_sms-typography');
     expect(smsValue).toHaveTextContent(defaultPhoneAddress!.value);
     let editButton = result.getByRole('button', { name: 'button.modifica' });
     fireEvent.click(editButton);
-    const input = result.container.querySelector(`[name="sms"]`);
+    const input = result.container.querySelector(`[name="default_sms"]`);
     const saveButton = result.getByRole('button', { name: 'button.salva' });
     expect(input).toHaveValue(defaultPhoneAddress!.value.replace(internationalPhonePrefix, ''));
     expect(saveButton).toBeEnabled();
@@ -253,7 +253,7 @@ describe('test SmsContactItem', () => {
     await waitFor(() => {
       expect(input).not.toBeInTheDocument();
     });
-    smsValue = getById(form!, 'sms-typography');
+    smsValue = getById(form!, 'default_sms-typography');
     expect(smsValue).toBeInTheDocument();
     expect(smsValue).toHaveTextContent(internationalPhonePrefix + phoneValue);
     editButton = getById(form!, 'modifyContact-default');
@@ -298,7 +298,7 @@ describe('test SmsContactItem', () => {
     // simulate rerendering due to redux changes
     result.rerender(<SmsContactItem value="" />);
     await waitFor(() => {
-      const input = result.container.querySelector(`[name="sms"]`);
+      const input = result.container.querySelector(`[name="default_sms"]`);
       expect(input).toBeInTheDocument();
       expect(result.container).not.toHaveTextContent('');
     });

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/__test__/SpecialContactElem.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/__test__/SpecialContactElem.test.tsx
@@ -3,17 +3,9 @@ import { vi } from 'vitest';
 
 import { SpecialContactsProvider } from '@pagopa-pn/pn-commons';
 
-import {
-  RenderResult,
-  act,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '../../../__test__/test-utils';
+import { fireEvent, render, waitFor } from '../../../__test__/test-utils';
 import { apiClient } from '../../../api/apiClients';
 import { AddressType, ChannelType } from '../../../models/contacts';
-import { DigitalContactsCodeVerificationProvider } from '../DigitalContactsCodeVerification.context';
 import SpecialContactElem from '../SpecialContactElem';
 
 vi.mock('react-i18next', () => ({
@@ -24,14 +16,7 @@ vi.mock('react-i18next', () => ({
   Trans: (props: { i18nKey: string }) => props.i18nKey,
 }));
 
-/*
-In questo test viene testato solo il rendering dei componenti e non il flusso.
-Il flusso completo viene testato nella pagina dei contatti, dove si può testare anche il cambio di stato di redux e le api
-
-Andrea Cimini - 11/09/2023
-*/
 describe('SpecialContactElem Component', () => {
-  let result: RenderResult | undefined;
   let mock: MockAdapter;
 
   const pecAddress = {
@@ -40,6 +25,7 @@ describe('SpecialContactElem Component', () => {
     senderName: 'Mocked Sender',
     channelType: ChannelType.PEC,
     value: 'mocked@pec.it',
+    pecValid: true,
   };
 
   const emailAddress = {
@@ -70,281 +56,82 @@ describe('SpecialContactElem Component', () => {
     mock.restore();
   });
 
-  it('renders SpecialContactElem', async () => {
+  it('renders SpecialContactElem', () => {
     // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContactsProvider>
-            <SpecialContactElem addresses={[pecAddress, emailAddress]} />
-          </SpecialContactsProvider>
-        </DigitalContactsCodeVerificationProvider>
-      );
-    });
+    const { container, getAllByTestId } = render(
+      <SpecialContactsProvider>
+        <SpecialContactElem addresses={[pecAddress, emailAddress]} />
+      </SpecialContactsProvider>
+    );
 
-    expect(result?.container).toHaveTextContent('Mocked Sender');
-    const specialContactForms = result?.getAllByTestId('specialContactForm');
+    expect(container).toHaveTextContent('Mocked Sender');
+    const specialContactForms = getAllByTestId(
+      /^[a-zA-Z0-9\-]+(?:_pecContact|_emailContact|_smsContact)$/
+    );
     expect(specialContactForms).toHaveLength(2);
-    expect(specialContactForms![0]).toHaveTextContent('mocked@pec.it');
-    expect(specialContactForms![1]).toHaveTextContent('mocked@mail.it');
-    const firstFormButtons = specialContactForms![0].querySelectorAll('button');
+    expect(specialContactForms[0]).toHaveTextContent('mocked@pec.it');
+    expect(specialContactForms[1]).toHaveTextContent('mocked@mail.it');
+    const firstFormButtons = specialContactForms[0].querySelectorAll('button');
     expect(firstFormButtons).toHaveLength(2);
     expect(firstFormButtons[0]).toHaveTextContent('button.modifica');
     expect(firstFormButtons[1]).toHaveTextContent('button.elimina');
-    const secondFormButtons = specialContactForms![1].querySelectorAll('button');
+    const secondFormButtons = specialContactForms[1].querySelectorAll('button');
     expect(secondFormButtons).toHaveLength(2);
     expect(secondFormButtons[0]).toHaveTextContent('button.modifica');
     expect(secondFormButtons[1]).toHaveTextContent('button.elimina');
-    expect(result?.container).toHaveTextContent('-');
-  });
-
-  it('changes a pec - new value valid', async () => {
-    // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContactsProvider>
-            <SpecialContactElem addresses={[pecAddress]} />
-          </SpecialContactsProvider>
-        </DigitalContactsCodeVerificationProvider>
-      );
-    });
-
-    expect(result?.container).toHaveTextContent('Mocked Sender');
-    const specialContactForm = result?.getByTestId('specialContactForm');
-    const firstFormButtons = specialContactForm!.querySelectorAll('button');
-    fireEvent.click(firstFormButtons[0]);
-    const input = await waitFor(() => specialContactForm!.querySelector('input'));
-    expect(input).toBeInTheDocument();
-    expect(input).toHaveValue('mocked@pec.it');
-    const newButtons = specialContactForm!.querySelectorAll('button');
-    expect(newButtons!).toHaveLength(2);
-    expect(newButtons![0]).toHaveTextContent('button.salva');
-    expect(newButtons![0]).toBeEnabled();
-    fireEvent.change(input!, { target: { value: 'new.long-pec-123@456.it' } });
-    await waitFor(() => expect(input!).toHaveValue('new.long-pec-123@456.it'));
-    expect(newButtons![0]).toBeEnabled();
-    const inputError = result?.container.querySelector(`#mocked-senderId_pec-helper-text`);
-    expect(inputError).not.toBeInTheDocument();
-  });
-
-  it('changes a pec - new value invalid', async () => {
-    // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContactsProvider>
-            <SpecialContactElem addresses={[pecAddress]} />
-          </SpecialContactsProvider>
-        </DigitalContactsCodeVerificationProvider>
-      );
-    });
-
-    expect(result?.container).toHaveTextContent('Mocked Sender');
-    const specialContactForm = result?.getByTestId('specialContactForm');
-    const firstFormButtons = specialContactForm!.querySelectorAll('button');
-    fireEvent.click(firstFormButtons[0]);
-    const input = await waitFor(() => specialContactForm!.querySelector('input'));
-    expect(input).toBeInTheDocument();
-    expect(input).toHaveValue('mocked@pec.it');
-    const newButtons = specialContactForm!.querySelectorAll('button');
-    expect(newButtons!).toHaveLength(2);
-    expect(newButtons![0]).toHaveTextContent('button.salva');
-    expect(newButtons![0]).toBeEnabled();
-    fireEvent.change(input!, { target: { value: 'new.bad.-pec-[123@456.it' } });
-    await waitFor(() => expect(input!).toHaveValue('new.bad.-pec-[123@456.it'));
-    expect(newButtons![0]).toBeDisabled();
-    let inputError = result?.container.querySelector(`#mocked-senderId_pec-helper-text`);
-    expect(inputError).toBeInTheDocument();
-    expect(inputError).toHaveTextContent('legal-contacts.valid-pec');
-    fireEvent.change(input!, { target: { value: '' } });
-    await waitFor(() => expect(input!).toHaveValue(''));
-    inputError = result?.container.querySelector(`#mocked-senderId_pec-helper-text`);
-    expect(inputError).toHaveTextContent('legal-contacts.valid-pec');
-  });
-
-  it('changes a mail - new value valid', async () => {
-    // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContactsProvider>
-            <SpecialContactElem addresses={[emailAddress]} />
-          </SpecialContactsProvider>
-        </DigitalContactsCodeVerificationProvider>
-      );
-    });
-
-    expect(result?.container).toHaveTextContent('Mocked Sender');
-    const specialContactForm = result?.getByTestId('specialContactForm');
-    const firstFormButtons = specialContactForm!.querySelectorAll('button');
-    fireEvent.click(firstFormButtons[0]);
-    const input = await waitFor(() => specialContactForm!.querySelector('input'));
-    expect(input).toBeInTheDocument();
-    expect(input).toHaveValue('mocked@mail.it');
-    const newButtons = specialContactForm!.querySelectorAll('button');
-    expect(newButtons!).toHaveLength(2);
-    expect(newButtons![0]).toHaveTextContent('button.salva');
-    expect(newButtons![0]).toBeEnabled();
-    fireEvent.change(input!, { target: { value: 'new.long-mail-123@456.it' } });
-    await waitFor(() => expect(input!).toHaveValue('new.long-mail-123@456.it'));
-    expect(newButtons![0]).toBeEnabled();
-    const inputError = result?.container.querySelector(`#mocked-senderId_mail-helper-text`);
-    expect(inputError).not.toBeInTheDocument();
-  });
-
-  it('changes a mail - new value invalid', async () => {
-    // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContactsProvider>
-            <SpecialContactElem addresses={[emailAddress]} />
-          </SpecialContactsProvider>
-        </DigitalContactsCodeVerificationProvider>
-      );
-    });
-
-    expect(result?.container).toHaveTextContent('Mocked Sender');
-    const specialContactForm = result?.getByTestId('specialContactForm');
-    const firstFormButtons = specialContactForm!.querySelectorAll('button');
-    fireEvent.click(firstFormButtons[0]);
-    const input = await waitFor(() => specialContactForm!.querySelector('input'));
-    expect(input).toBeInTheDocument();
-    expect(input).toHaveValue('mocked@mail.it');
-    const newButtons = specialContactForm!.querySelectorAll('button');
-    expect(newButtons!).toHaveLength(2);
-    expect(newButtons![0]).toHaveTextContent('button.salva');
-    expect(newButtons![0]).toBeEnabled();
-    fireEvent.change(input!, { target: { value: 'new.bad.-mail-[123@456.it' } });
-    await waitFor(() => expect(input!).toHaveValue('new.bad.-mail-[123@456.it'));
-    expect(newButtons![0]).toBeDisabled();
-    let inputError = result?.container.querySelector(`#mocked-senderId_email-helper-text`);
-    expect(inputError).toBeInTheDocument();
-    expect(inputError).toHaveTextContent('courtesy-contacts.valid-email');
-    fireEvent.change(input!, { target: { value: '' } });
-    await waitFor(() => expect(input!).toHaveValue(''));
-    inputError = result?.container.querySelector(`#mocked-senderId_email-helper-text`);
-    expect(inputError).toHaveTextContent('courtesy-contacts.valid-email');
-  });
-
-  it('changes a phone number - new value valid', async () => {
-    // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContactsProvider>
-            <SpecialContactElem addresses={[phoneAddress]} />
-          </SpecialContactsProvider>
-        </DigitalContactsCodeVerificationProvider>
-      );
-    });
-
-    expect(result?.container).toHaveTextContent('Mocked Sender');
-    const specialContactForm = result?.getByTestId('specialContactForm');
-    const firstFormButtons = specialContactForm!.querySelectorAll('button');
-    fireEvent.click(firstFormButtons[0]);
-    const input = await waitFor(() => specialContactForm!.querySelector('input'));
-    expect(input).toBeInTheDocument();
-    expect(input).toHaveValue('+39333333333');
-    const newButtons = specialContactForm!.querySelectorAll('button');
-    expect(newButtons!).toHaveLength(2);
-    expect(newButtons![0]).toHaveTextContent('button.salva');
-    expect(newButtons![0]).toBeEnabled();
-    fireEvent.change(input!, { target: { value: '+39333333334' } });
-    await waitFor(() => expect(input!).toHaveValue('+39333333334'));
-    expect(newButtons![0]).toBeEnabled();
-    const inputError = result?.container.querySelector(`#mocked-senderId_sms-helper-text`);
-    expect(inputError).not.toBeInTheDocument();
-  });
-
-  it('changes a phone number - new value invalid', async () => {
-    // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContactsProvider>
-            <SpecialContactElem addresses={[phoneAddress]} />
-          </SpecialContactsProvider>
-        </DigitalContactsCodeVerificationProvider>
-      );
-    });
-
-    expect(result?.container).toHaveTextContent('Mocked Sender');
-    const specialContactForm = result?.getByTestId('specialContactForm');
-    const firstFormButtons = specialContactForm!.querySelectorAll('button');
-    fireEvent.click(firstFormButtons[0]);
-    const input = await waitFor(() => specialContactForm!.querySelector('input'));
-    expect(input).toBeInTheDocument();
-    expect(input).toHaveValue('+39333333333');
-    const newButtons = specialContactForm!.querySelectorAll('button');
-    expect(newButtons!).toHaveLength(2);
-    expect(newButtons![0]).toHaveTextContent('button.salva');
-    expect(newButtons![0]).toBeEnabled();
-    fireEvent.change(input!, { target: { value: '123456789' } });
-    await waitFor(() => expect(input!).toHaveValue('123456789'));
-    expect(newButtons![0]).toBeDisabled();
-    let inputError = result?.container.querySelector(`#mocked-senderId_sms-helper-text`);
-    expect(inputError).toBeInTheDocument();
-    expect(inputError).toHaveTextContent('courtesy-contacts.valid-sms');
-    fireEvent.change(input!, { target: { value: '' } });
-    await waitFor(() => expect(input!).toHaveValue(''));
-    inputError = result?.container.querySelector(`#mocked-senderId_sms-helper-text`);
-    expect(inputError).toHaveTextContent('courtesy-contacts.valid-sms');
+    expect(container).toHaveTextContent('-');
   });
 
   it('Edits one contacts and checks that others are disabled', async () => {
     // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContactsProvider>
-            <SpecialContactElem addresses={[pecAddress, phoneAddress]} />
-            <SpecialContactElem
-              addresses={[
-                {
-                  addressType: AddressType.COURTESY,
-                  senderId: 'another-mocked-senderId',
-                  senderName: 'Another mocked Sender',
-                  channelType: ChannelType.EMAIL,
-                  value: 'mocked@mail.it',
-                },
-                {
-                  addressType: AddressType.COURTESY,
-                  senderId: 'another-mocked-senderId',
-                  senderName: 'Another mocked Sender',
-                  channelType: ChannelType.SMS,
-                  value: '+39333333334',
-                },
-              ]}
-            />
-          </SpecialContactsProvider>
-        </DigitalContactsCodeVerificationProvider>
-      );
-    });
+    const { getAllByTestId } = render(
+      <SpecialContactsProvider>
+        <SpecialContactElem addresses={[pecAddress, phoneAddress]} />
+        <SpecialContactElem
+          addresses={[
+            {
+              addressType: AddressType.COURTESY,
+              senderId: 'another-mocked-senderId',
+              senderName: 'Another mocked Sender',
+              channelType: ChannelType.EMAIL,
+              value: 'mocked@mail.it',
+            },
+            {
+              addressType: AddressType.COURTESY,
+              senderId: 'another-mocked-senderId',
+              senderName: 'Another mocked Sender',
+              channelType: ChannelType.SMS,
+              value: '+39333333334',
+            },
+          ]}
+        />
+      </SpecialContactsProvider>
+    );
     // edit the first contact of the first row
-    const specialContactForms = result?.getAllByTestId('specialContactForm');
-    let firstFormButtons = specialContactForms![0].querySelectorAll('button');
+    const specialContactForms = getAllByTestId(
+      /^[a-zA-Z0-9\-]+(?:_pecContact|_emailContact|_smsContact)$/
+    );
+    let firstFormButtons = specialContactForms[0].querySelectorAll('button');
     fireEvent.click(firstFormButtons[0]);
-    let input = await waitFor(() => specialContactForms![0].querySelector('input'));
-    firstFormButtons = specialContactForms![0].querySelectorAll('button');
+    let input = await waitFor(() => specialContactForms[0].querySelector('input'));
+    firstFormButtons = specialContactForms[0].querySelectorAll('button');
     expect(input).toBeInTheDocument();
     // check the disabled status of the others button
-    const secondFormButtons = specialContactForms![1].querySelectorAll('button');
+    const secondFormButtons = specialContactForms[1].querySelectorAll('button');
     for (const button of secondFormButtons) {
       expect(button).toBeDisabled();
     }
-    const thirdFormButtons = specialContactForms![2].querySelectorAll('button');
+    const thirdFormButtons = specialContactForms[2].querySelectorAll('button');
     for (const button of thirdFormButtons) {
       expect(button).toBeDisabled();
     }
-    const fourthFormButtons = specialContactForms![3].querySelectorAll('button');
+    const fourthFormButtons = specialContactForms[3].querySelectorAll('button');
     for (const button of fourthFormButtons) {
       expect(button).toBeDisabled();
     }
     // exit from edit
     fireEvent.click(firstFormButtons[1]);
-    input = await waitFor(() => specialContactForms![0].querySelector('input'));
+    input = await waitFor(() => specialContactForms[0].querySelector('input'));
     expect(input).not.toBeInTheDocument();
     // check the disabled status of the others button
     for (const button of secondFormButtons) {
@@ -356,41 +143,5 @@ describe('SpecialContactElem Component', () => {
     for (const button of fourthFormButtons) {
       expect(button).toBeEnabled();
     }
-  });
-
-  it('remove contact', async () => {
-    mock.onDelete('/bff/v1/addresses/LEGAL/mocked-senderId/PEC').reply(204);
-    // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContactsProvider>
-            <SpecialContactElem addresses={[pecAddress]} />
-          </SpecialContactsProvider>
-        </DigitalContactsCodeVerificationProvider>
-      );
-    });
-    const buttons = result?.container.querySelectorAll('button');
-    // click on cancel
-    fireEvent.click(buttons![1]);
-    let dialog = await waitFor(() => screen.getByRole('dialog'));
-    expect(dialog).toBeInTheDocument();
-    let dialogButtons = dialog?.querySelectorAll('button');
-    // cancel remove operation
-    fireEvent.click(dialogButtons![0]);
-    await waitFor(() => {
-      expect(dialog).not.toBeInTheDocument();
-    });
-    // click on confirm
-    fireEvent.click(buttons![1]);
-    dialog = await waitFor(() => screen.getByRole('dialog'));
-    dialogButtons = dialog?.querySelectorAll('button');
-    fireEvent.click(dialogButtons![1]);
-    await waitFor(() => {
-      expect(dialog).not.toBeInTheDocument();
-    });
-    await waitFor(() => {
-      expect(mock.history.delete).toHaveLength(1);
-    });
   });
 });

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/__test__/SpecialContacts.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/__test__/SpecialContacts.test.tsx
@@ -50,7 +50,7 @@ const specialAddressesCount = digitalAddresses.reduce((count, elem) => {
 function testValidFiled(form: HTMLFormElement, elementName: string) {
   const errorMessage = form.querySelector(`#${elementName}-helper-text`);
   expect(errorMessage).not.toBeInTheDocument();
-  const button = within(form!).getByTestId('addSpecialButton');
+  const button = within(form).getByTestId('addSpecialButton');
   expect(button).toBeEnabled();
 }
 
@@ -58,7 +58,7 @@ function testInvalidField(form: HTMLFormElement, elementName: string, errorMessa
   const errorMessage = form.querySelector(`#${elementName}-helper-text`);
   expect(errorMessage).toBeInTheDocument();
   expect(errorMessage).toHaveTextContent(errorMessageString);
-  const button = within(form!).getByTestId('addSpecialButton');
+  const button = within(form).getByTestId('addSpecialButton');
   expect(button).toBeDisabled();
 }
 
@@ -72,12 +72,11 @@ const fillCodeDialog = async (result: RenderResult) => {
   });
   // confirm the addition
   const dialogButtons = dialog?.querySelectorAll('button');
-  fireEvent.click(dialogButtons![1]);
+  fireEvent.click(dialogButtons[1]);
   return dialog;
 };
 
 describe('SpecialContacts Component', async () => {
-  let result: RenderResult;
   let mock: MockAdapter;
 
   beforeAll(() => {
@@ -92,18 +91,16 @@ describe('SpecialContacts Component', async () => {
     mock.restore();
   });
 
-  it('renders component', async () => {
+  it('renders component', () => {
     mock.onGet('/bff/v1/pa-list').reply(200, parties);
     // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContacts digitalAddresses={digitalAddresses} />
-        </DigitalContactsCodeVerificationProvider>
-      );
-    });
-    expect(result.container).toHaveTextContent('special-contacts.subtitle');
-    const form = result.container.querySelector('form');
+    const { container, getAllByTestId } = render(
+      <DigitalContactsCodeVerificationProvider>
+        <SpecialContacts digitalAddresses={digitalAddresses} />
+      </DigitalContactsCodeVerificationProvider>
+    );
+    expect(container).toHaveTextContent('special-contacts.subtitle');
+    const form = container.querySelector('form');
     testFormElements(form!, 'sender', 'special-contacts.sender');
     testFormElements(form!, 'addressType', 'special-contacts.address-type');
     testFormElements(form!, 's_value', 'special-contacts.pec');
@@ -111,21 +108,21 @@ describe('SpecialContacts Component', async () => {
     expect(button).toHaveTextContent('button.associa');
     expect(button).toBeDisabled();
     // contacts list
-    const specialContactForms = result.getAllByTestId('specialContactForm');
+    const specialContactForms = getAllByTestId(
+      /^[a-zA-Z0-9\-]+(?:_pecContact|_emailContact|_smsContact)$/
+    );
     expect(specialContactForms).toHaveLength(specialAddressesCount);
   });
 
   it('check valid pec', async () => {
     mock.onGet('/bff/v1/pa-list').reply(200, parties);
     // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContacts digitalAddresses={digitalAddresses} />
-        </DigitalContactsCodeVerificationProvider>
-      );
-    });
-    const form = result.container.querySelector('form');
+    const { container, getByTestId } = render(
+      <DigitalContactsCodeVerificationProvider>
+        <SpecialContacts digitalAddresses={digitalAddresses} />
+      </DigitalContactsCodeVerificationProvider>
+    );
+    const form = container.querySelector('form');
     // change sender
     await testAutocomplete(form!, 'sender', parties, true, 1, true);
     // change pec
@@ -133,21 +130,19 @@ describe('SpecialContacts Component', async () => {
     // check if valid
     testValidFiled(form!, 's_value');
     // check already exists alert
-    const alreadyExistsAlert = result.getByTestId('alreadyExistsAlert');
+    const alreadyExistsAlert = getByTestId('alreadyExistsAlert');
     expect(alreadyExistsAlert).toHaveTextContent('special-contacts.pec-already-exists');
   });
 
   it('check invalid pec', async () => {
     mock.onGet('/bff/v1/pa-list').reply(200, parties);
     // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContacts digitalAddresses={digitalAddresses} />
-        </DigitalContactsCodeVerificationProvider>
-      );
-    });
-    const form = result.container.querySelector('form');
+    const { container } = render(
+      <DigitalContactsCodeVerificationProvider>
+        <SpecialContacts digitalAddresses={digitalAddresses} />
+      </DigitalContactsCodeVerificationProvider>
+    );
+    const form = container.querySelector('form');
     // change sender
     await testAutocomplete(form!, 'sender', parties, true, 1, true);
     // change pec
@@ -163,14 +158,12 @@ describe('SpecialContacts Component', async () => {
   it('checks invalid mail', async () => {
     mock.onGet('/bff/v1/pa-list').reply(200, parties);
     // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContacts digitalAddresses={digitalAddresses} />
-        </DigitalContactsCodeVerificationProvider>
-      );
-    });
-    const form = result.container.querySelector('form');
+    const { container } = render(
+      <DigitalContactsCodeVerificationProvider>
+        <SpecialContacts digitalAddresses={digitalAddresses} />
+      </DigitalContactsCodeVerificationProvider>
+    );
+    const form = container.querySelector('form');
     // change sender
     await testAutocomplete(form!, 'sender', parties, true, 1, true);
     // change addressType
@@ -197,14 +190,12 @@ describe('SpecialContacts Component', async () => {
   it('checks valid mail', async () => {
     mock.onGet('/bff/v1/pa-list').reply(200, parties);
     // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContacts digitalAddresses={digitalAddresses} />
-        </DigitalContactsCodeVerificationProvider>
-      );
-    });
-    const form = result.container.querySelector('form');
+    const { container, getByTestId } = render(
+      <DigitalContactsCodeVerificationProvider>
+        <SpecialContacts digitalAddresses={digitalAddresses} />
+      </DigitalContactsCodeVerificationProvider>
+    );
+    const form = container.querySelector('form');
     // change sender
     await testAutocomplete(form!, 'sender', parties, true, 0, true);
     // change addressType
@@ -223,21 +214,19 @@ describe('SpecialContacts Component', async () => {
     // check if valid
     testValidFiled(form!, 's_value');
     // check already exists alert
-    const alreadyExistsAlert = result.getByTestId('alreadyExistsAlert');
+    const alreadyExistsAlert = getByTestId('alreadyExistsAlert');
     expect(alreadyExistsAlert).toHaveTextContent('special-contacts.email-already-exists');
   });
 
   it('checks invalid phone', async () => {
     mock.onGet('/bff/v1/pa-list').reply(200, parties);
     // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContacts digitalAddresses={digitalAddresses} />
-        </DigitalContactsCodeVerificationProvider>
-      );
-    });
-    const form = result.container.querySelector('form');
+    const { container } = render(
+      <DigitalContactsCodeVerificationProvider>
+        <SpecialContacts digitalAddresses={digitalAddresses} />
+      </DigitalContactsCodeVerificationProvider>
+    );
+    const form = container.querySelector('form');
     // change sender
     await testAutocomplete(form!, 'sender', parties, true, 1, true);
     // change addressType
@@ -264,14 +253,12 @@ describe('SpecialContacts Component', async () => {
   it('checks valid phone', async () => {
     mock.onGet('/bff/v1/pa-list').reply(200, parties);
     // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContacts digitalAddresses={digitalAddresses} />
-        </DigitalContactsCodeVerificationProvider>
-      );
-    });
-    const form = result.container.querySelector('form');
+    const { container, getByTestId } = render(
+      <DigitalContactsCodeVerificationProvider>
+        <SpecialContacts digitalAddresses={digitalAddresses} />
+      </DigitalContactsCodeVerificationProvider>
+    );
+    const form = container.querySelector('form');
     // change sender
     await testAutocomplete(form!, 'sender', parties, true, 1, true);
     // change addressType
@@ -290,7 +277,7 @@ describe('SpecialContacts Component', async () => {
     // check if valid
     testValidFiled(form!, 's_value');
     // check already exists alert
-    const alreadyExistsAlert = result.getByTestId('alreadyExistsAlert');
+    const alreadyExistsAlert = getByTestId('alreadyExistsAlert');
     expect(alreadyExistsAlert).toHaveTextContent('special-contacts.sms-already-exists');
   });
 
@@ -311,14 +298,12 @@ describe('SpecialContacts Component', async () => {
       })
       .reply(204);
     // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContacts digitalAddresses={digitalAddresses} />
-        </DigitalContactsCodeVerificationProvider>,
-        { preloadedState: { contactsState: { digitalAddresses } } }
-      );
-    });
+    const result = render(
+      <DigitalContactsCodeVerificationProvider>
+        <SpecialContacts digitalAddresses={digitalAddresses} />
+      </DigitalContactsCodeVerificationProvider>,
+      { preloadedState: { contactsState: { digitalAddresses } } }
+    );
     const form = result.container.querySelector('form');
     // change sender
     await testAutocomplete(form!, 'sender', parties, true, 2, true);
@@ -374,7 +359,9 @@ describe('SpecialContacts Component', async () => {
     );
     await waitFor(() => {
       // contacts list
-      const specialContactForms = result.getAllByTestId('specialContactForm');
+      const specialContactForms = result.getAllByTestId(
+        /^[a-zA-Z0-9\-]+(?:_pecContact|_emailContact|_smsContact)$/
+      );
       expect(specialContactForms).toHaveLength(specialAddressesCount + 1);
     });
   });
@@ -396,24 +383,24 @@ describe('SpecialContacts Component', async () => {
       })
       .replyOnce(204);
     // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContacts digitalAddresses={digitalAddresses} />
-        </DigitalContactsCodeVerificationProvider>,
-        { preloadedState: { contactsState: { digitalAddresses } } }
-      );
-    });
+    const result = render(
+      <DigitalContactsCodeVerificationProvider>
+        <SpecialContacts digitalAddresses={digitalAddresses} />
+      </DigitalContactsCodeVerificationProvider>,
+      { preloadedState: { contactsState: { digitalAddresses } } }
+    );
     // ATTENTION: the order in the mock is very important
     // change mail
-    const specialContactForms = result.getAllByTestId('specialContactForm');
-    const emailEditButton = within(specialContactForms![1]).getByRole('button', {
+    const specialContactForms = result.getAllByTestId(
+      /^[a-zA-Z0-9\-]+(?:_pecContact|_emailContact|_smsContact)$/
+    );
+    const emailEditButton = within(specialContactForms[1]).getByRole('button', {
       name: 'button.modifica',
     });
     fireEvent.click(emailEditButton);
-    const input = await waitFor(() => specialContactForms![1].querySelector('input'));
+    const input = await waitFor(() => specialContactForms[1].querySelector('input'));
     fireEvent.change(input!, { target: { value: mailValue } });
-    const emailSaveButton = within(specialContactForms![1]).getByRole('button', {
+    const emailSaveButton = within(specialContactForms[1]).getByRole('button', {
       name: 'button.salva',
     });
     fireEvent.click(emailSaveButton);
@@ -431,7 +418,9 @@ describe('SpecialContacts Component', async () => {
         verificationCode: '01234',
       });
     });
-    expect(dialog).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(dialog).not.toBeInTheDocument();
+    });
     const addresses = [
       ...digitalLegalAddresses,
       {
@@ -441,7 +430,6 @@ describe('SpecialContacts Component', async () => {
       },
       ...digitalCourtesyAddresses.slice(1),
     ];
-
     expect(testStore.getState().contactsState.digitalAddresses).toStrictEqual(addresses);
     expect(input).not.toBeInTheDocument();
     // simulate rerendering due to redux changes
@@ -452,8 +440,10 @@ describe('SpecialContacts Component', async () => {
     );
     await waitFor(() => {
       // contacts list
-      const specialContactForms = result.getAllByTestId('specialContactForm');
-      expect(specialContactForms![1]).toHaveTextContent(mailValue);
+      const specialContactForms = result.getAllByTestId(
+        /^[a-zA-Z0-9\-]+(?:_pecContact|_emailContact|_smsContact)$/
+      );
+      expect(specialContactForms[1]).toHaveTextContent(mailValue);
     });
   });
 
@@ -461,24 +451,24 @@ describe('SpecialContacts Component', async () => {
     mock.onGet('/bff/v1/pa-list').reply(200, parties);
     mock.onDelete(`/bff/v1/addresses/COURTESY/${parties[0].id}/EMAIL`).reply(200);
     // render component
-    await act(async () => {
-      result = render(
-        <DigitalContactsCodeVerificationProvider>
-          <SpecialContacts digitalAddresses={digitalAddresses} />
-        </DigitalContactsCodeVerificationProvider>,
-        { preloadedState: { contactsState: { digitalAddresses } } }
-      );
-    });
+    const { rerender, getAllByTestId, getByRole } = render(
+      <DigitalContactsCodeVerificationProvider>
+        <SpecialContacts digitalAddresses={digitalAddresses} />
+      </DigitalContactsCodeVerificationProvider>,
+      { preloadedState: { contactsState: { digitalAddresses } } }
+    );
     // ATTENTION: the order in the mock is very important
     // delete mail
-    const specialContactForms = result.getAllByTestId('specialContactForm');
-    const emailDeleteButton = within(specialContactForms![1]).getByRole('button', {
+    const specialContactForms = getAllByTestId(
+      /^[a-zA-Z0-9\-]+(?:_pecContact|_emailContact|_smsContact)$/
+    );
+    const emailDeleteButton = within(specialContactForms[1]).getByRole('button', {
       name: 'button.elimina',
     });
     fireEvent.click(emailDeleteButton);
-    const dialogBox = result.getByRole('dialog', { name: /courtesy-contacts.remove\b/ });
+    const dialogBox = getByRole('dialog', { name: /courtesy-contacts.remove\b/ });
     expect(dialogBox).toBeVisible();
-    const confirmButton = within(dialogBox!).getByRole('button', { name: 'button.conferma' });
+    const confirmButton = within(dialogBox).getByRole('button', { name: 'button.conferma' });
     fireEvent.click(confirmButton);
     await waitFor(() => {
       expect(dialogBox).not.toBeVisible();
@@ -487,14 +477,16 @@ describe('SpecialContacts Component', async () => {
     const addresses = [...digitalLegalAddresses, ...digitalCourtesyAddresses.slice(1)];
     expect(testStore.getState().contactsState.digitalAddresses).toStrictEqual(addresses);
     // simulate rerendering due to redux changes
-    result.rerender(
+    rerender(
       <DigitalContactsCodeVerificationProvider>
         <SpecialContacts digitalAddresses={addresses} />
       </DigitalContactsCodeVerificationProvider>
     );
     await waitFor(() => {
       // contacts list
-      const specialContactForms = result.getAllByTestId('specialContactForm');
+      const specialContactForms = getAllByTestId(
+        /^[a-zA-Z0-9\-]+(?:_pecContact|_emailContact|_smsContact)$/
+      );
       expect(specialContactForms).toHaveLength(specialAddressesCount - 1);
     });
   });

--- a/packages/pn-personagiuridica-webapp/src/pages/__test__/Contacts.page.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/__test__/Contacts.page.test.tsx
@@ -56,8 +56,8 @@ describe('Contacts page', async () => {
     });
     expect(result.container).toHaveTextContent(/title/i);
     expect(result.container).toHaveTextContent(/subtitle/i);
-    const pecContact = result?.getByTestId('pecContact');
-    expect(pecContact).toBeInTheDocument();
+    const legalContacts = result?.getByTestId('legalContacts');
+    expect(legalContacts).toBeInTheDocument();
     const courtesyContacts = result?.getByTestId('courtesyContacts');
     expect(courtesyContacts).toBeInTheDocument();
     const specialContact = result?.queryByTestId('specialContact');
@@ -71,8 +71,8 @@ describe('Contacts page', async () => {
     await act(async () => {
       result = await render(<Contacts />);
     });
-    const pecContact = result?.queryByTestId('pecContact');
-    expect(pecContact).toBeInTheDocument();
+    const legalContacts = result?.queryByTestId('legalContacts');
+    expect(legalContacts).toBeInTheDocument();
     const courtesyContacts = result?.getByTestId('courtesyContacts');
     expect(courtesyContacts).toBeInTheDocument();
     const specialContact = result?.getByTestId('specialContact');
@@ -84,8 +84,8 @@ describe('Contacts page', async () => {
     await act(async () => {
       result = await render(<Contacts />);
     });
-    const pecContact = result?.getByTestId('pecContact');
-    expect(pecContact).toBeInTheDocument();
+    const legalContacts = result?.getByTestId('legalContacts');
+    expect(legalContacts).toBeInTheDocument();
     const courtesyContacts = result?.getByTestId('courtesyContacts');
     expect(courtesyContacts).toBeInTheDocument();
     const specialContact = result?.getByTestId('specialContact');
@@ -97,8 +97,8 @@ describe('Contacts page', async () => {
     await act(async () => {
       result = await render(<Contacts />);
     });
-    const pecContact = result?.queryByTestId('pecContact');
-    expect(pecContact).toBeInTheDocument();
+    const legalContacts = result?.queryByTestId('legalContacts');
+    expect(legalContacts).toBeInTheDocument();
     const courtesyContacts = result?.getByTestId('courtesyContacts');
     expect(courtesyContacts).toBeInTheDocument();
     const specialContact = result?.getByTestId('specialContact');


### PR DESCRIPTION
## Short description
Use single contact compoent into SpecialContactElem

## List of changes proposed in this pull request
- Updated PecContactItem, EmailContactItem, SmsContactItem to manage special contact case
- Integrated into SpecialContactElem single contact components
- Updated tests

## How to test
Login with pf/pg -> go to Recapiti page -> add/edit/remove special contacts and check that everything is ok