### PR TITLE
PN-12254 - Add mixpanel track of SEND_APPIO_STATUS super property

### DIFF
--- a/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/SendDisableIOStrategy.ts
+++ b/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/SendDisableIOStrategy.ts
@@ -10,6 +10,9 @@ export class SendDisableIOStrategy implements EventStrategy {
       [EventPropertyType.PROFILE]: {
         SEND_APPIO_STATUS: 'deactivated',
       },
+      [EventPropertyType.SUPER_PROPERTY]: {
+        SEND_APPIO_STATUS: 'deactivated',
+      },
     };
   }
 }

--- a/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/SendEnableIOStrategy.ts
+++ b/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/SendEnableIOStrategy.ts
@@ -10,6 +10,9 @@ export class SendEnableIOStrategy implements EventStrategy {
       [EventPropertyType.PROFILE]: {
         SEND_APPIO_STATUS: 'activated',
       },
+      [EventPropertyType.SUPER_PROPERTY]: {
+        SEND_APPIO_STATUS: 'activated',
+      },
     };
   }
 }

--- a/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/__test__/SendDisableIOStrategy.test.ts
+++ b/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/__test__/SendDisableIOStrategy.test.ts
@@ -11,6 +11,9 @@ describe('Mixpanel - Disable IO Strategy', () => {
       [EventPropertyType.PROFILE]: {
         SEND_APPIO_STATUS: 'deactivated',
       },
+      [EventPropertyType.SUPER_PROPERTY]: {
+        SEND_APPIO_STATUS: 'deactivated',
+      },
     });
   });
 });

--- a/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/__test__/SendEnableIOStrategy.test.ts
+++ b/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/__test__/SendEnableIOStrategy.test.ts
@@ -11,6 +11,9 @@ describe('Mixpanel - Enable IO Strategy', () => {
       [EventPropertyType.PROFILE]: {
         SEND_APPIO_STATUS: 'activated',
       },
+      [EventPropertyType.SUPER_PROPERTY]: {
+        SEND_APPIO_STATUS: 'activated',
+      },
     });
   });
 });


### PR DESCRIPTION
## Short description
Add track of SEND_APPIO_STATUS super property

## List of changes proposed in this pull request
- Add SEND_APPIO_STATUS super property

## How to test
To test this bug, you need to use the Netify Chrome extension.
Intercept the following URL with Netify: https://webapi.dev.notifichedigitali.it/bff/v1/addresses
Use this response body:
```json
[
   {
      "addressType":"COURTESY",
      "senderId":"default",
      "channelType":"APPIO",
      "value":"ENABLED"
   }
]
```
Then, try to deactivate AppIO. You should see two console logs:
`{SEND_APPIO_STATUS: 'deactivated'} profile` and `{SEND_APPIO_STATUS: 'deactivated'} superProperty`.