### PR TITLE
Fixed lateral scroll when title of F24 is too much long

### DIFF
--- a/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentF24Item.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentF24Item.tsx
@@ -170,13 +170,13 @@ const NotificationPaymentF24Item: React.FC<Props> = ({
         backgroundColor: isPagoPaAttachment ? 'transparent' : 'grey.50',
         borderRadius: '6px',
       }}
+      spacing={1}
     >
       <Stack
         justifyContent={{ sm: 'flex-start', lg: 'inherit' }}
         gap={0.5}
         direction="column"
         flexGrow="1"
-        mb={{ sm: '8px', lg: 0 }}
       >
         {isPagoPaAttachment ? (
           <Typography variant="body2">

--- a/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentF24Item.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentF24Item.tsx
@@ -164,7 +164,7 @@ const NotificationPaymentF24Item: React.FC<Props> = ({
     <Stack
       py={isPagoPaAttachment ? 0 : 1}
       px={isPagoPaAttachment ? 0 : 2}
-      alignItems={{ sm: 'flex-start', lg: 'center' }}
+      alignItems={{ sm: 'flex-start', lg: 'center', xs: 'flex-start' }}
       direction={{ sm: 'column', lg: 'row' }}
       sx={{
         backgroundColor: isPagoPaAttachment ? 'transparent' : 'grey.50',

--- a/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentF24Item.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentF24Item.tsx
@@ -4,7 +4,7 @@ import { Download, InfoRounded } from '@mui/icons-material';
 import { CircularProgress, Stack, Typography } from '@mui/material';
 import { ButtonNaked } from '@pagopa/mui-italia';
 
-import { downloadDocument, useIsMobile } from '../../hooks';
+import { downloadDocument } from '../../hooks';
 import { F24PaymentDetails, PaymentAttachment, PaymentAttachmentSName } from '../../models';
 import { getLocalizedOrDefaultLabel } from '../../utility/localization.utility';
 
@@ -37,7 +37,6 @@ const NotificationPaymentF24Item: React.FC<Props> = ({
   disableDownload,
   handleDownload,
 }) => {
-  const isMobile = useIsMobile('sm');
   const [maxTimeError, setMaxTimeError] = useState<string | null>(null);
   const timer = useRef<NodeJS.Timeout>();
   const interval = useRef<NodeJS.Timeout>();
@@ -165,19 +164,19 @@ const NotificationPaymentF24Item: React.FC<Props> = ({
     <Stack
       py={isPagoPaAttachment ? 0 : 1}
       px={isPagoPaAttachment ? 0 : 2}
-      alignItems={isMobile ? 'flex-start' : 'center'}
-      direction={isMobile ? 'column' : 'row'}
+      alignItems={{ sm: 'flex-start', lg: 'center' }}
+      direction={{ sm: 'column', lg: 'row' }}
       sx={{
         backgroundColor: isPagoPaAttachment ? 'transparent' : 'grey.50',
         borderRadius: '6px',
       }}
     >
       <Stack
-        justifyContent={isMobile ? 'flex-start' : 'inherit'}
+        justifyContent={{ sm: 'flex-start', lg: 'inherit' }}
         gap={0.5}
         direction="column"
         flexGrow="1"
-        mb={isMobile ? '8px' : 0}
+        mb={{ sm: '8px', lg: 0 }}
       >
         {isPagoPaAttachment ? (
           <Typography variant="body2">

--- a/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentF24Item.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentF24Item.tsx
@@ -48,17 +48,6 @@ const NotificationPaymentF24Item: React.FC<Props> = ({
 
   const [downloadingMessage, setDownloadingMessage] = useState<string | null>(null);
 
-  /* const handleTitle = (title: string) => {
-    const mid = Math.floor(title.length / 2);
-
-    // Non ci sono spazi, quindi dividiamo esattamente a metà
-    const firstPart = title.slice(0, mid);
-    const secondPart = title.slice(mid);
-
-    // Inserisce l'interruzione di riga
-    return firstPart + '\n' + secondPart;
-  }; */
-
   const getDownloadF24Status = useCallback(async (f24Item: F24PaymentDetails, attempt: number) => {
     try {
       // eslint-disable-next-line functional/immutable-data

--- a/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentF24Item.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentF24Item.tsx
@@ -144,7 +144,7 @@ const NotificationPaymentF24Item: React.FC<Props> = ({
           disabled={disableDownload}
           data-testid="download-f24-button"
         >
-          <Download fontSize="small" sx={{ mr: 1 }} />
+          <Download fontSize="small" sx={{ mr: 0.5, ml: -0.5 }} />
           {getLocalizedOrDefaultLabel('notifications', 'detail.payment.download-f24')}
         </ButtonNaked>
       );
@@ -201,7 +201,12 @@ const NotificationPaymentF24Item: React.FC<Props> = ({
           </>
         )}
         {maxTimeError && (
-          <Stack alignItems="center" gap={0.5} data-testid="f24-maxTime-error">
+          <Stack
+            direction={'row'}
+            alignItems={{ sm: 'center' }}
+            gap={0.5}
+            data-testid="f24-maxTime-error"
+          >
             <InfoRounded
               sx={{
                 color: 'error.dark',

--- a/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentF24Item.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentF24Item.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { Download, InfoRounded } from '@mui/icons-material';
-import { Box, CircularProgress, Stack, Typography } from '@mui/material';
+import { CircularProgress, Stack, Typography } from '@mui/material';
 import { ButtonNaked } from '@pagopa/mui-italia';
 
 import { downloadDocument, useIsMobile } from '../../hooks';
@@ -172,12 +172,11 @@ const NotificationPaymentF24Item: React.FC<Props> = ({
         borderRadius: '6px',
       }}
     >
-      <Box
-        display="flex"
+      <Stack
         justifyContent={isMobile ? 'flex-start' : 'inherit'}
         gap={0.5}
-        flexDirection="column"
-        flex="1 0 0"
+        direction="column"
+        flexGrow="1"
         mb={isMobile ? '8px' : 0}
       >
         {isPagoPaAttachment ? (
@@ -203,7 +202,7 @@ const NotificationPaymentF24Item: React.FC<Props> = ({
           </>
         )}
         {maxTimeError && (
-          <Box display="flex" alignItems="center" gap={0.5} data-testid="f24-maxTime-error">
+          <Stack alignItems="center" gap={0.5} data-testid="f24-maxTime-error">
             <InfoRounded
               sx={{
                 color: 'error.dark',
@@ -213,10 +212,10 @@ const NotificationPaymentF24Item: React.FC<Props> = ({
             <Typography fontSize="12px" lineHeight="12px" fontWeight="600" color="error.dark">
               {getLocalizedOrDefaultLabel('notifications', maxTimeError)}
             </Typography>
-          </Box>
+          </Stack>
         )}
-      </Box>
-      <Box>{getElement()}</Box>
+      </Stack>
+      {getElement()}
     </Stack>
   );
 };

--- a/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentF24Item.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentF24Item.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { Download, InfoRounded } from '@mui/icons-material';
-import { Box, CircularProgress, Typography } from '@mui/material';
+import { Box, CircularProgress, Stack, Typography } from '@mui/material';
 import { ButtonNaked } from '@pagopa/mui-italia';
 
 import { downloadDocument, useIsMobile } from '../../hooks';
@@ -152,22 +152,21 @@ const NotificationPaymentF24Item: React.FC<Props> = ({
     }
 
     return (
-      <Box display="flex" alignItems="center" justifyContent="center" gap={0.5}>
+      <Stack alignItems="center" justifyContent="center" gap={0.5}>
         <Typography variant="caption" color="text.secondary" data-testid="f24-download-message">
           {getLocalizedOrDefaultLabel('notifications', downloadingMessage)}
         </Typography>
         <CircularProgress size="1.125rem" role="loadingSpinner" sx={{ color: 'text.secondary' }} />
-      </Box>
+      </Stack>
     );
   };
 
   return (
-    <Box
+    <Stack
       py={isPagoPaAttachment ? 0 : 1}
       px={isPagoPaAttachment ? 0 : 2}
-      display="flex"
-      alignItems="center"
-      alignSelf="stretch"
+      alignItems={isMobile ? 'flex-start' : 'center'}
+      direction={isMobile ? 'column' : 'row'}
       sx={{
         backgroundColor: isPagoPaAttachment ? 'transparent' : 'grey.50',
         borderRadius: '6px',
@@ -179,6 +178,7 @@ const NotificationPaymentF24Item: React.FC<Props> = ({
         gap={0.5}
         flexDirection="column"
         flex="1 0 0"
+        mb={isMobile ? '8px' : 0}
       >
         {isPagoPaAttachment ? (
           <Typography variant="body2">
@@ -217,7 +217,7 @@ const NotificationPaymentF24Item: React.FC<Props> = ({
         )}
       </Box>
       <Box>{getElement()}</Box>
-    </Box>
+    </Stack>
   );
 };
 

--- a/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentF24Item.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentF24Item.tsx
@@ -143,15 +143,22 @@ const NotificationPaymentF24Item: React.FC<Props> = ({
           onClick={downloadF24}
           disabled={disableDownload}
           data-testid="download-f24-button"
+          sx={{ mt: { xs: 1, sm: 0 } }}
         >
-          <Download fontSize="small" sx={{ mr: 0.5, ml: -0.5 }} />
+          <Download fontSize="small" sx={{ mr: 0.5 }} />
           {getLocalizedOrDefaultLabel('notifications', 'detail.payment.download-f24')}
         </ButtonNaked>
       );
     }
 
     return (
-      <Stack alignItems="center" justifyContent="center" gap={0.5}>
+      <Stack
+        alignItems="center"
+        justifyContent="center"
+        gap={0.5}
+        direction="row"
+        sx={{ mt: { xs: 1, sm: 0 } }}
+      >
         <Typography variant="caption" color="text.secondary" data-testid="f24-download-message">
           {getLocalizedOrDefaultLabel('notifications', downloadingMessage)}
         </Typography>
@@ -164,8 +171,8 @@ const NotificationPaymentF24Item: React.FC<Props> = ({
     <Stack
       py={isPagoPaAttachment ? 0 : 1}
       px={isPagoPaAttachment ? 0 : 2}
-      alignItems={{ sm: 'flex-start', lg: 'center', xs: 'flex-start' }}
-      direction={{ sm: 'column', lg: 'row' }}
+      alignItems={{ xs: 'flex-start', sm: 'center' }}
+      direction={{ xs: 'column', sm: 'row' }}
       sx={{
         backgroundColor: isPagoPaAttachment ? 'transparent' : 'grey.50',
         borderRadius: '6px',
@@ -173,7 +180,7 @@ const NotificationPaymentF24Item: React.FC<Props> = ({
       spacing={1}
     >
       <Stack
-        justifyContent={{ sm: 'flex-start', lg: 'inherit' }}
+        justifyContent={{ xs: 'flex-start', sm: 'inherit' }}
         gap={0.5}
         direction="column"
         flexGrow="1"
@@ -202,8 +209,8 @@ const NotificationPaymentF24Item: React.FC<Props> = ({
         )}
         {maxTimeError && (
           <Stack
-            direction={'row'}
-            alignItems={{ sm: 'center' }}
+            direction="row"
+            alignItems={{ xs: 'center' }}
             gap={0.5}
             data-testid="f24-maxTime-error"
           >

--- a/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentF24Item.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentF24Item.tsx
@@ -48,6 +48,17 @@ const NotificationPaymentF24Item: React.FC<Props> = ({
 
   const [downloadingMessage, setDownloadingMessage] = useState<string | null>(null);
 
+  /* const handleTitle = (title: string) => {
+    const mid = Math.floor(title.length / 2);
+
+    // Non ci sono spazi, quindi dividiamo esattamente a metà
+    const firstPart = title.slice(0, mid);
+    const secondPart = title.slice(mid);
+
+    // Inserisce l'interruzione di riga
+    return firstPart + '\n' + secondPart;
+  }; */
+
   const getDownloadF24Status = useCallback(async (f24Item: F24PaymentDetails, attempt: number) => {
     try {
       // eslint-disable-next-line functional/immutable-data
@@ -186,7 +197,7 @@ const NotificationPaymentF24Item: React.FC<Props> = ({
           </Typography>
         ) : (
           <>
-            <Typography variant="sidenav" color="text.primary">
+            <Typography variant="sidenav" color="text.primary" sx={{ overflowWrap: 'anywhere' }}>
               {f24Item.title}
             </Typography>
             {f24Item.applyCost && (

--- a/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentF24Item.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentF24Item.tsx
@@ -37,7 +37,7 @@ const NotificationPaymentF24Item: React.FC<Props> = ({
   disableDownload,
   handleDownload,
 }) => {
-  const isMobile = useIsMobile();
+  const isMobile = useIsMobile('sm');
   const [maxTimeError, setMaxTimeError] = useState<string | null>(null);
   const timer = useRef<NodeJS.Timeout>();
   const interval = useRef<NodeJS.Timeout>();


### PR DESCRIPTION
## Short description
lateral  scroll in notification detail

## List of changes proposed in this pull request
- add sx overflow wrap = "anywhere"  in f24 title

Documentation of overflow-wrap : https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap

## How to test
set mobile view with at least 330px on x axis
For verify every cases use this notification iun on develop enviroment and cesare as user : 

VEKV-UEZM-LUDJ-202408-W-1 for basic case
WERP-PEQV-LKDW-202408-W-1 for payment with only F24 without costi notifica label
KDER-ZDKL-GZGH-202408-Q-1 for payment with pagopa avviso and F24
Testing with netify exstension of google for failure case of download F24



