### PR TITLE
PN-12537 - PecContactItem if SERCQ is enabled

### DIFF
--- a/packages/pn-personafisica-webapp/public/locales/it/recapiti.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/recapiti.json
@@ -54,7 +54,9 @@
     "all-organisations": "Tutti gli enti",
     "all-organisations-description": "La PEC sostituisce il Domicilio Digitale SEND come tuo recapito a valore legale principale. Se scegli questa opzione, il Domicilio Digitale verrà disattivato.",
     "specific-organisations": "Enti selezionati",
-    "specific-organisations-description": "La PEC sostituisce il Domicilio Digitale SEND come tuo recapito a valore legale solo per le notifiche inviate dagli enti selezionati."
+    "specific-organisations-description": "La PEC sostituisce il Domicilio Digitale SEND come tuo recapito a valore legale solo per le notifiche inviate dagli enti selezionati.",
+    "delete-sercq-send-dialog-title": "Confermi di voler disattivare il Domicilio Digitale su SEND?",
+    "delete-sercq-send-dialog-description": "L’indirizzo PEC indicato sostituirà il Domicilio Digitale SEND come tuo recapito a valore legale principale."
   },
   "io-contact": {
     "title": "App IO",

--- a/packages/pn-personafisica-webapp/public/locales/it/recapiti.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/recapiti.json
@@ -48,7 +48,13 @@
     "remove-sercq-send-title": "Confermi di voler disattivare il Domicilio Digitale?",
     "remove-sercq-send-message": "Non avrai più un recapito a valore legale per le comunicazioni inviate su SEND. Potresti tornare a ricevere le notifiche in forma cartacea.",
     "remove-sercq-send-button": "Disattiva Domicilio Digitale",
-    "sercq-send-removed-successfully": "Domicilio Digitale disattivato correttamente"
+    "sercq-send-removed-successfully": "Domicilio Digitale disattivato correttamente",
+    "sercq-send-disambiguation-title": "Configura il recapito",
+    "sercq-send-disambiguation-description": "Aggiungi la PEC come recapito a valore legale per le notifiche inviate da:",
+    "all-organisations": "Tutti gli enti",
+    "all-organisations-description": "La PEC sostituisce il Domicilio Digitale SEND come tuo recapito a valore legale principale. Se scegli questa opzione, il Domicilio Digitale verrà disattivato.",
+    "specific-organisations": "Enti selezionati",
+    "specific-organisations-description": "La PEC sostituisce il Domicilio Digitale SEND come tuo recapito a valore legale solo per le notifiche inviate dagli enti selezionati."
   },
   "io-contact": {
     "title": "App IO",

--- a/packages/pn-personafisica-webapp/public/locales/it/recapiti.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/recapiti.json
@@ -56,7 +56,9 @@
     "specific-organisations": "Enti selezionati",
     "specific-organisations-description": "La PEC sostituisce il Domicilio Digitale SEND come tuo recapito a valore legale solo per le notifiche inviate dagli enti selezionati.",
     "delete-sercq-send-dialog-title": "Confermi di voler disattivare il Domicilio Digitale su SEND?",
-    "delete-sercq-send-dialog-description": "L’indirizzo PEC indicato sostituirà il Domicilio Digitale SEND come tuo recapito a valore legale principale."
+    "delete-sercq-send-dialog-description": "L’indirizzo PEC indicato sostituirà il Domicilio Digitale SEND come tuo recapito a valore legale principale.",
+    "sercq-add-pec": "Preferisci usare una PEC come recapito a valore legale?",
+    "insert-pec": "Inserisci PEC"
   },
   "io-contact": {
     "title": "App IO",

--- a/packages/pn-personafisica-webapp/src/components/Contacts/LegalContacts.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/LegalContacts.tsx
@@ -1,12 +1,17 @@
 import { Trans, useTranslation } from 'react-i18next';
 
-import { Box, Divider, List, ListItem, Stack, Typography } from '@mui/material';
+import { Box, Divider, List, ListItem, Typography } from '@mui/material';
 
+import { contactsSelectors } from '../../redux/contact/reducers';
+import { useAppSelector } from '../../redux/hooks';
 import PecContactItem from './PecContactItem';
 import SercqSendContactItem from './SercqSendContactItem';
 
 const LegalContacts = () => {
   const { t } = useTranslation(['common', 'recapiti']);
+  const { defaultSERCQAddress, defaultPECAddress } = useAppSelector(
+    contactsSelectors.selectAddresses
+  );
 
   const legalContactList: Array<string> = t('legal-contacts.list', {
     returnObjects: true,
@@ -26,13 +31,20 @@ const LegalContacts = () => {
           </ListItem>
         ))}
       </List>
-      <Stack spacing={0} mt={3} data-testid="legalContacts">
+      <Box
+        data-testid="legalContacts"
+        mt={3}
+        display="flex"
+        flexDirection={!defaultSERCQAddress && defaultPECAddress ? 'column-reverse' : 'column'}
+      >
         <SercqSendContactItem />
-        <Divider sx={{ backgroundColor: 'white', color: 'text.secondary' }}>
-          {t('conjunctions.or')}
-        </Divider>
-        <PecContactItem />
-      </Stack>
+        {!defaultSERCQAddress && (
+          <>
+            <Divider sx={{ color: 'text.secondary', my: 2 }}>{t('conjunctions.or')}</Divider>
+            <PecContactItem />
+          </>
+        )}
+      </Box>
     </Box>
   );
 };

--- a/packages/pn-personafisica-webapp/src/components/Contacts/PecContactItem.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/PecContactItem.tsx
@@ -20,6 +20,7 @@ import DeleteDialog from './DeleteDialog';
 import DigitalContactsCard from './DigitalContactsCard';
 import ExistingContactDialog from './ExistingContactDialog';
 import PecVerificationDialog from './PecVerificationDialog';
+import SercqSendDisambiguationDialog from './SercqSendDisambiguationDialog';
 import SpecialDigitalContacts from './SpecialDigitalContacts';
 
 enum ModalType {
@@ -28,11 +29,12 @@ enum ModalType {
   CANCEL_VALIDATION = 'cancel_validation',
   DELETE = 'delete',
   CODE = 'code',
+  DISAMBIGUATION = 'disambiguation',
 }
 
 const PecContactItem: React.FC = () => {
   const { t } = useTranslation(['common', 'recapiti']);
-  const { defaultPECAddress, specialPECAddresses, addresses } = useAppSelector(
+  const { defaultPECAddress, specialPECAddresses, defaultSERCQAddress, addresses } = useAppSelector(
     contactsSelectors.selectAddresses
   );
   const digitalContactRef = useRef<{ toggleEdit: () => void; resetForm: () => Promise<void> }>({
@@ -60,6 +62,10 @@ const PecContactItem: React.FC = () => {
     // first check if contact already exists
     if (contactAlreadyExists(addresses, value, sender.senderId, ChannelType.PEC)) {
       setModalOpen(ModalType.EXISTING);
+      return;
+    }
+    if (defaultSERCQAddress) {
+      setModalOpen(ModalType.DISAMBIGUATION);
       return;
     }
     handleCodeVerification();
@@ -243,6 +249,12 @@ const PecContactItem: React.FC = () => {
         open={modalOpen === ModalType.CANCEL_VALIDATION}
         senderId={currentAddress.current.sender.senderId}
         handleClose={() => setModalOpen(null)}
+      />
+      <SercqSendDisambiguationDialog
+        open={modalOpen === ModalType.DISAMBIGUATION}
+        currentAddress={currentAddress}
+        onCancel={() => setModalOpen(null)}
+        onConfirm={() => handleCodeVerification()}
       />
       <DeleteDialog
         showModal={modalOpen === ModalType.DELETE}

--- a/packages/pn-personafisica-webapp/src/components/Contacts/PecDisableSercqDialog.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/PecDisableSercqDialog.tsx
@@ -1,0 +1,171 @@
+import { useFormik } from 'formik';
+import React, { ChangeEvent, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import * as yup from 'yup';
+
+import {
+  Button,
+  DialogContentText,
+  DialogTitle,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { PnDialog, PnDialogActions, PnDialogContent, appStateActions } from '@pagopa-pn/pn-commons';
+
+import { PFEventsType } from '../../models/PFEventsType';
+import { AddressType, ChannelType, SaveDigitalAddressParams } from '../../models/contacts';
+import { createOrUpdateAddress } from '../../redux/contact/actions';
+import { useAppDispatch } from '../../redux/hooks';
+import PFEventStrategyFactory from '../../utility/MixpanelUtils/PFEventStrategyFactory';
+import { pecValidationSchema } from '../../utility/contacts.utility';
+import ContactCodeDialog from './ContactCodeDialog';
+import PecVerificationDialog from './PecVerificationDialog';
+
+type Props = {
+  open: boolean;
+  handleClose: () => void;
+};
+
+enum ModalType {
+  CODE = 'code',
+  VALIDATION = 'validation',
+}
+
+const PecDisableSercqDialog: React.FC<Props> = ({ open = false, handleClose }) => {
+  const { t } = useTranslation(['common', 'recapiti']);
+  const dispatch = useAppDispatch();
+
+  const [modalOpen, setModalOpen] = useState<ModalType | null>(null);
+
+  const formik = useFormik({
+    initialValues: {
+      pec: '',
+    },
+    validationSchema: yup.object().shape({
+      pec: pecValidationSchema(t),
+    }),
+    validateOnMount: true,
+    enableReinitialize: true,
+    onSubmit: () => handleCodeVerification(),
+  });
+
+  const handleChangeTouched = async (e: ChangeEvent) => {
+    formik.handleChange(e);
+    await formik.setFieldTouched(e.target.id, true, false);
+  };
+
+  const handleCodeVerification = (verificationCode?: string) => {
+    if (verificationCode) {
+      PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_ADD_PEC_UX_CONVERSION, 'default');
+    }
+
+    const digitalAddressParams: SaveDigitalAddressParams = {
+      addressType: AddressType.LEGAL,
+      senderId: 'default',
+      channelType: ChannelType.PEC,
+      value: formik.values.pec,
+      code: verificationCode,
+    };
+
+    dispatch(createOrUpdateAddress(digitalAddressParams))
+      .unwrap()
+      .then((res) => {
+        // contact to verify
+        // open code modal
+        if (!res) {
+          setModalOpen(ModalType.CODE);
+          return;
+        }
+
+        PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_ADD_PEC_UX_SUCCESS, 'default');
+
+        // contact has already been verified
+        if (res.pecValid) {
+          // show success message
+          dispatch(
+            appStateActions.addSuccess({
+              title: '',
+              message: t(`legal-contacts.pec-added-successfully`, { ns: 'recapiti' }),
+            })
+          );
+          setModalOpen(null);
+          return;
+        }
+        // contact must be validated
+        // open validation modal
+        setModalOpen(ModalType.VALIDATION);
+      })
+      .catch(() => {});
+  };
+
+  const handleCancelCode = () => {
+    setModalOpen(null);
+    handleClose();
+  };
+
+  return (
+    <>
+      <PnDialog
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="dialog-title"
+        aria-describedby="dialog-description"
+        data-testid="duplicateDialog"
+      >
+        <DialogTitle id="dialog-title">Inserisci PEC</DialogTitle>
+        <PnDialogContent>
+          <Stack spacing={2}>
+            <DialogContentText id="dialog-description">
+              La PEC sostituirà il Domicilio Digitale come tuo recapito a valore legale di SEND. Il
+              Domicilio Digitale verrà disattivato automaticamente.
+            </DialogContentText>
+
+            <Typography variant="caption-semibold" color="black">
+              {t('legal-contacts.pec-to-add', { ns: 'recapiti' })}
+            </Typography>
+            <TextField
+              id="pec"
+              name="pec"
+              placeholder={t('legal-contacts.link-pec-placeholder', { ns: 'recapiti' })}
+              size="small"
+              fullWidth
+              value={formik.values.pec}
+              onChange={(e) => void handleChangeTouched(e)}
+              error={formik.touched.pec && Boolean(formik.errors.pec)}
+              helperText={formik.touched.pec && formik.errors.pec}
+            />
+          </Stack>
+        </PnDialogContent>
+        <PnDialogActions>
+          <Button onClick={handleClose} variant="outlined">
+            {t('button.annulla')}
+          </Button>
+          <Button
+            onClick={() => formik.handleSubmit()}
+            disabled={!formik.isValid}
+            variant="contained"
+          >
+            {t('button.conferma')}
+          </Button>
+        </PnDialogActions>
+      </PnDialog>
+
+      <ContactCodeDialog
+        value={formik.values.pec}
+        addressType={AddressType.LEGAL}
+        channelType={ChannelType.PEC}
+        open={modalOpen === ModalType.CODE}
+        onConfirm={(code) => handleCodeVerification(code)}
+        onDiscard={handleCancelCode}
+        onError={() => PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_ADD_PEC_CODE_ERROR)}
+      />
+      <PecVerificationDialog
+        open={modalOpen === ModalType.VALIDATION}
+        handleConfirm={() => setModalOpen(null)}
+      />
+    </>
+  );
+};
+
+export default PecDisableSercqDialog;

--- a/packages/pn-personafisica-webapp/src/components/Contacts/SercqSendContactItem.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/SercqSendContactItem.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import VerifiedIcon from '@mui/icons-material/Verified';
-import { Box, Button, Chip, Stack, Typography } from '@mui/material';
+import { Box, Button, Chip, Divider, Stack, Typography } from '@mui/material';
 import { appStateActions, useIsMobile } from '@pagopa-pn/pn-commons';
 import { ButtonNaked } from '@pagopa/mui-italia';
 
@@ -20,6 +20,7 @@ import { internationalPhonePrefix } from '../../utility/contacts.utility';
 import ContactCodeDialog from './ContactCodeDialog';
 import DeleteDialog from './DeleteDialog';
 import DigitalContactsCard from './DigitalContactsCard';
+import PecDisableSercqDialog from './PecDisableSercqDialog';
 import SercqSendCourtesyDialog from './SercqSendCourtesyDialog';
 import SercqSendInfoDialog from './SercqSendInfoDialog';
 
@@ -33,6 +34,7 @@ enum ModalType {
   COURTESY = 'courtesy',
   CODE = 'code',
   DELETE = 'delete',
+  ADD_PEC = 'add_pec',
 }
 
 const SercqSendCardTitle: React.FC = () => {
@@ -62,7 +64,6 @@ const SercqSendCardTitle: React.FC = () => {
 
 const SercqSendContactItem: React.FC<Props> = ({ senderId = 'default', senderName }) => {
   const { t } = useTranslation(['common', 'recapiti']);
-  const isMobile = useIsMobile();
   const [modalOpen, setModalOpen] = useState<{ type: ModalType; data?: any } | null>(null);
   const dispatch = useAppDispatch();
   const { defaultSERCQAddress, defaultAPPIOAddress, courtesyAddresses } = useAppSelector(
@@ -181,10 +182,7 @@ const SercqSendContactItem: React.FC<Props> = ({ senderId = 'default', senderNam
       }
       subtitle={t('legal-contacts.sercq-send-description', { ns: 'recapiti' })}
     >
-      <Box
-        data-testid={`${senderId}_sercqSendContact`}
-        style={{ width: isMobile ? '100%' : '50%' }}
-      >
+      <Box data-testid={`${senderId}_sercqSendContact`}>
         {!value && (
           <Button
             variant="contained"
@@ -195,21 +193,43 @@ const SercqSendContactItem: React.FC<Props> = ({ senderId = 'default', senderNam
           </Button>
         )}
         {value && (
-          <Stack direction="row" spacing={2}>
-            <VerifiedIcon
-              fontSize="small"
-              color="success"
-              sx={{ position: 'relative', top: '2px' }}
-            />
-            <Box>
-              <Typography data-testid="IO status" fontWeight={600}>
-                {t('legal-contacts.sercq-send-enabled', { ns: 'recapiti' })}
+          <Box>
+            <Stack direction="row" spacing={2}>
+              <VerifiedIcon
+                fontSize="small"
+                color="success"
+                sx={{ position: 'relative', top: '2px' }}
+              />
+              <Box>
+                <Typography data-testid="IO status" fontWeight={600}>
+                  {t('legal-contacts.sercq-send-enabled', { ns: 'recapiti' })}
+                </Typography>
+                <ButtonNaked onClick={() => setModalOpen({ type: ModalType.DELETE })} color="error">
+                  {t('button.disable')}
+                </ButtonNaked>
+              </Box>
+            </Stack>
+
+            <Divider sx={{ color: 'text.secondary', mt: 4, mb: 2 }} />
+
+            <Stack alignItems="baseline" direction="row" spacing={0.5}>
+              <Typography variant="body2" color="textSecondary">
+                {t(`legal-contacts.sercq-add-pec`, { ns: 'recapiti' })}
               </Typography>
-              <ButtonNaked onClick={() => setModalOpen({ type: ModalType.DELETE })} color="error">
-                {t('button.disable')}
+              <ButtonNaked
+                onClick={() =>
+                  setModalOpen({ type: ModalType.ADD_PEC, data: { value: '', senders: [] } })
+                }
+                color="primary"
+                size="small"
+                p={{ xs: '0.5rem 0', sm: 1 }}
+                data-testid="addMoreButton"
+                sx={{ fontSize: '1rem' }}
+              >
+                {t(`legal-contacts.insert-pec`, { ns: 'recapiti' })}
               </ButtonNaked>
-            </Box>
-          </Stack>
+            </Stack>
+          </Box>
         )}
       </Box>
       <SercqSendInfoDialog
@@ -240,6 +260,10 @@ const SercqSendContactItem: React.FC<Props> = ({ senderId = 'default', senderNam
         removeButtonLabel={t(`legal-contacts.remove-sercq-send-button`, { ns: 'recapiti' })}
         handleModalClose={() => setModalOpen(null)}
         confirmHandler={deleteConfirmHandler}
+      />
+      <PecDisableSercqDialog
+        open={modalOpen?.type === ModalType.ADD_PEC}
+        handleClose={() => setModalOpen(null)}
       />
     </DigitalContactsCard>
   );

--- a/packages/pn-personafisica-webapp/src/components/Contacts/SercqSendDisambiguationDialog.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/SercqSendDisambiguationDialog.tsx
@@ -1,0 +1,172 @@
+import { useFormik } from 'formik';
+import React, { MutableRefObject, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import {
+  Button,
+  DialogContentText,
+  DialogTitle,
+  FormControlLabel,
+  Radio,
+  RadioGroup,
+  Typography,
+} from '@mui/material';
+import { PnDialog, PnDialogActions, PnDialogContent } from '@pagopa-pn/pn-commons';
+
+import { ChannelType, Sender } from '../../models/contacts';
+import { Party } from '../../models/party';
+import { getAllActivatedParties } from '../../redux/contact/actions';
+import { useAppDispatch } from '../../redux/hooks';
+import SpecialContactsInput from './SpecialContactsInput';
+
+type Props = {
+  open: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+  currentAddress: MutableRefObject<{ value: string; sender: Sender }>;
+};
+
+const SercqSendDisambiguationRadio: React.FC<{ title: string; description: string }> = ({
+  title,
+  description,
+}) => (
+  <>
+    <Typography fontWeight={400} fontSize="18px">
+      {title}
+    </Typography>
+    <Typography fontWeight={400} fontSize="14px" color="text.secondary">
+      {description}
+    </Typography>
+  </>
+);
+
+const SercqSendDisambiguationDialog: React.FC<Props> = ({
+  open,
+  onCancel,
+  onConfirm,
+  currentAddress,
+}) => {
+  const dispatch = useAppDispatch();
+  const { t } = useTranslation(['common', 'recapiti']);
+  const [type, setType] = useState<string>('');
+  const [senderInputValue, setSenderInputValue] = useState<string>('');
+
+  const formik = useFormik({
+    initialValues: {
+      senders: [] as Array<Party>,
+      s_value: currentAddress.current.value,
+    },
+    validateOnMount: true,
+    enableReinitialize: true,
+    onSubmit: (values) => {
+      if (values.senders.length > 0) {
+        onConfirm();
+      }
+    },
+  });
+
+  const handleChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    setType(e.target.value);
+  };
+
+  const handleConfirm = () => {
+    if (type === 'SOME') {
+      // TODO qui prende solo un sender, ma in realtà dovrebbe prendere tutti i sender selezionati
+      // eslint-disable-next-line functional/immutable-data
+      currentAddress.current = {
+        ...currentAddress.current,
+        sender: {
+          senderId: formik.values.senders[0].id,
+          senderName: formik.values.senders[0].name,
+        },
+      };
+    }
+
+    onConfirm();
+  };
+
+  const getParties = () => {
+    if (senderInputValue.length >= 4) {
+      void dispatch(getAllActivatedParties({ paNameFilter: senderInputValue, blockLoading: true }));
+    } else if (senderInputValue.length === 0) {
+      void dispatch(getAllActivatedParties({ blockLoading: true }));
+    }
+  };
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    getParties();
+  }, [senderInputValue, open]);
+
+  return (
+    <PnDialog
+      open={open}
+      data-testid="sercqSendDisambiguationDialog"
+      aria-labelledby="dialog-title"
+      aria-describedby="dialog-description"
+    >
+      <DialogTitle id="dialog-title" sx={{ fontWeight: 700 }}>
+        {t('legal-contacts.sercq-send-disambiguation-title', { ns: 'recapiti' })}
+      </DialogTitle>
+      <PnDialogContent>
+        <DialogContentText id="dialog-description" sx={{ color: 'text.primary' }}>
+          {t('legal-contacts.sercq-send-disambiguation-description', { ns: 'recapiti' })}
+        </DialogContentText>
+
+        <RadioGroup value={type} onChange={handleChange} sx={{ px: 1, mt: 2 }}>
+          <FormControlLabel
+            value={'ALL'}
+            control={<Radio />}
+            sx={{ mb: 1 }}
+            label={
+              <SercqSendDisambiguationRadio
+                title={t('legal-contacts.all-organisations', { ns: 'recapiti' })}
+                description={t('legal-contacts.all-organisations-description', { ns: 'recapiti' })}
+              />
+            }
+            data-testid="courtesyAddressRadio"
+          />
+
+          <FormControlLabel
+            value={'SOME'}
+            control={<Radio />}
+            sx={{ mb: 1 }}
+            label={
+              <SercqSendDisambiguationRadio
+                title={t('legal-contacts.specific-organisations', { ns: 'recapiti' })}
+                description={t('legal-contacts.specific-organisations-description', {
+                  ns: 'recapiti',
+                })}
+              />
+            }
+            data-testid="courtesyAddressRadio"
+          />
+        </RadioGroup>
+
+        {type === 'SOME' && (
+          <SpecialContactsInput
+            formik={formik}
+            value={currentAddress.current.value}
+            digitalAddresses={[]}
+            contactType={ChannelType.PEC}
+            senders={formik.values.senders}
+            senderInputValue={senderInputValue}
+            setSenderInputValue={setSenderInputValue}
+          />
+        )}
+      </PnDialogContent>
+      <PnDialogActions>
+        <Button variant="outlined" onClick={onCancel}>
+          {t('button.annulla')}
+        </Button>
+        <Button variant="contained" onClick={handleConfirm}>
+          {t('button.conferma')}
+        </Button>
+      </PnDialogActions>
+    </PnDialog>
+  );
+};
+
+export default SercqSendDisambiguationDialog;

--- a/packages/pn-personafisica-webapp/src/components/Contacts/SpecialContactsInput.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/SpecialContactsInput.tsx
@@ -1,0 +1,166 @@
+import { useFormik } from 'formik';
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Alert, Box, Chip, MenuItem, TextField } from '@mui/material';
+import {
+  ApiErrorWrapper,
+  PnAutocomplete,
+  searchStringLimitReachedText,
+} from '@pagopa-pn/pn-commons';
+
+import { ChannelType } from '../../models/contacts';
+import { Party } from '../../models/party';
+import { CONTACT_ACTIONS, getAllActivatedParties } from '../../redux/contact/actions';
+import { useAppDispatch, useAppSelector } from '../../redux/hooks';
+import { RootState } from '../../redux/store';
+import DropDownPartyMenuItem from '../Party/DropDownParty';
+import { SpecialAddress } from './SpecialDigitalContacts';
+
+type Props = {
+  formik: ReturnType<typeof useFormik<{
+    senders: Array<Party>;
+    s_value: string;
+  }>>;
+  value: string;
+  digitalAddresses: Array<SpecialAddress>;
+  contactType: ChannelType;
+  senders: Array<Party>;
+  senderInputValue: string;
+  setSenderInputValue: (value: string) => void;
+};
+
+const SpecialContactsInput: React.FC<Props> = ({
+  formik,
+  value,
+  digitalAddresses,
+  contactType,
+  senders,
+  senderInputValue,
+  setSenderInputValue,
+}) => {
+  const dispatch = useAppDispatch();
+  const { t } = useTranslation(['common', 'recapiti']);
+  const parties = useAppSelector((state: RootState) => state.contactsState.parties);
+
+  const [alreadyExistsMessage, setAlreadyExistsMessage] = useState('');
+
+  const entitySearchLabel: string = `${t('special-contacts.add-sender', {
+    ns: 'recapiti',
+  })}${searchStringLimitReachedText(senderInputValue)}`;
+
+  const getOptionLabel = (option: Party) => option.name || '';
+
+  const getParties = () => {
+    if (senderInputValue.length >= 4) {
+      void dispatch(getAllActivatedParties({ paNameFilter: senderInputValue, blockLoading: true }));
+    } else if (senderInputValue.length === 0) {
+      void dispatch(getAllActivatedParties({ blockLoading: true }));
+    }
+  };
+
+  const senderChangeHandler = async (_: any, newValue: Party | null) => {
+    setSenderInputValue('');
+    if (newValue) {
+      const senders = [...formik.values.senders, newValue];
+      await formik.setFieldValue('senders', senders);
+      checkIfSenderIsAlreadyAdded(senders);
+      return;
+    }
+    checkIfSenderIsAlreadyAdded(formik.values.senders);
+  };
+
+  const handleSenderDelete = async (sender: Party) => {
+    const senders = formik.values.senders.filter((s) => s.id !== sender.id);
+    await formik.setFieldValue('senders', senders);
+    checkIfSenderIsAlreadyAdded(senders);
+  };
+
+  const checkIfSenderIsAlreadyAdded = (senders: Array<Party>) => {
+    const alreadyExists = digitalAddresses.some(
+      (addr) =>
+        addr.value !== value &&
+        addr.senders.some((sender) => senders.some((s) => s.id === sender.senderId))
+    );
+    if (alreadyExists) {
+      setAlreadyExistsMessage(
+        t(`special-contacts.${contactType}-already-exists`, {
+          ns: 'recapiti',
+        })
+      );
+      return;
+    }
+    setAlreadyExistsMessage('');
+  };
+
+  const renderOption = (props: any, option: Party) => (
+    <MenuItem
+      {...props}
+      value={option.id}
+      key={option.id}
+      disabled={senders.findIndex((sender) => sender.id === option.id) > -1}
+    >
+      <DropDownPartyMenuItem name={option.name} />
+    </MenuItem>
+  );
+
+  return (
+    <>
+      <ApiErrorWrapper
+        apiId={CONTACT_ACTIONS.GET_ALL_ACTIVATED_PARTIES}
+        mainText={t('special-contacts.fetch-party-error', { ns: 'recapiti' })}
+        reloadAction={getParties}
+      >
+        <PnAutocomplete
+          id="sender"
+          data-testid="sender"
+          size="small"
+          options={parties ?? []}
+          autoComplete
+          getOptionLabel={getOptionLabel}
+          noOptionsText={t('common.enti-not-found', { ns: 'recapiti' })}
+          isOptionEqualToValue={(option, value) => option.id === value.id}
+          onChange={senderChangeHandler}
+          inputValue={senderInputValue}
+          onInputChange={(_event, newInputValue, reason) => {
+            if (reason === 'input') {
+              setSenderInputValue(newInputValue);
+            }
+          }}
+          filterOptions={(e) => e}
+          renderOption={renderOption}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              name="sender"
+              label={entitySearchLabel}
+              error={senderInputValue.length > 80}
+              helperText={
+                senderInputValue.length > 80 && t('too-long-field-error', { maxLength: 80 })
+              }
+            />
+          )}
+          sx={{ flexGrow: 1, flexBasis: 0 }}
+        />
+      </ApiErrorWrapper>
+      <Box sx={{ mt: 2 }}>
+        {senders.map((sender) => (
+          <Chip
+            data-testid="sender_chip"
+            key={`${sender.id}_chip`}
+            label={sender.name}
+            onDelete={() => handleSenderDelete(sender)}
+            sx={{ mr: 1, mb: 1 }}
+          />
+        ))}
+      </Box>
+      {alreadyExistsMessage && (
+        <Alert severity="warning" sx={{ marginBottom: '20px' }} data-testid="alreadyExistsAlert">
+          {alreadyExistsMessage}
+        </Alert>
+      )}
+    </>
+  );
+};
+
+export default SpecialContactsInput;


### PR DESCRIPTION
## Short description
Fix the behaviour of PecContactItem if SERCQ is enabled

## List of changes proposed in this pull request
- Create `SpecialAddressInput` component
- Create `SercqSendDisambiguationDialog`

## How to test
Use Netify to simulate the activation of the SERCQ service: the URL `https://webapi.dev.notifichedigitali.it/bff/v1/addresses/LEGAL/default/SERCQ` with the `POST` method should respond with status 204.
Also use Netify to simulate the delete of SERCQ service:
`https://webapi.dev.notifichedigitali.it/bff/v1/addresses/LEGAL/default/SERCQ` with the `DELETE` method should respond with status `204`.

Now, try to add a PEC, and you should see a dialog asking if you want to associate the PEC with all entities or only some of them (a special address input should be shown).
If you select all entities you should see a modal that asks you if you want to override the SERCQ address with PEC address. If you confirm the SERCQ address will be deleted and you should see the code modal for PEC address.