### PR TITLE
fixed tos and privacy pages - pn-12661

### DIFF
--- a/packages/pn-pa-webapp/src/services/configuration.service.ts
+++ b/packages/pn-pa-webapp/src/services/configuration.service.ts
@@ -44,16 +44,14 @@ class PaConfigurationValidator extends Validator<PaConfigurationFromFile> {
   constructor() {
     super();
     this.ruleFor('OT_DOMAIN_ID').isString().matches(dataRegex.token);
-    this.makeRequired(
-      this.ruleFor('SELFCARE_URL_FE_LOGIN').isString().matches(dataRegex.htmlPageUrl)
-    );
-    this.makeRequired(this.ruleFor('SELFCARE_BASE_URL').isString().matches(dataRegex.htmlPageUrl));
-    this.makeRequired(this.ruleFor('API_BASE_URL').isString().matches(dataRegex.htmlPageUrl));
-    this.makeRequired(this.ruleFor('LANDING_SITE_URL').isString());
+    this.ruleFor('SELFCARE_URL_FE_LOGIN').isString().isRequired().matches(dataRegex.htmlPageUrl);
+    this.ruleFor('SELFCARE_BASE_URL').isString().isRequired().matches(dataRegex.htmlPageUrl);
+    this.ruleFor('API_BASE_URL').isString().isRequired().matches(dataRegex.htmlPageUrl);
+    this.ruleFor('LANDING_SITE_URL').isString().isRequired();
     this.ruleFor('ONE_TRUST_DRAFT_MODE').isBoolean();
     this.ruleFor('ONE_TRUST_PP').isString().matches(dataRegex.token);
     this.ruleFor('ONE_TRUST_TOS').isString().matches(dataRegex.token);
-    this.makeRequired(this.ruleFor('PAGOPA_HELP_EMAIL').isString().matches(dataRegex.email));
+    this.ruleFor('PAGOPA_HELP_EMAIL').isString().isRequired().matches(dataRegex.email);
     this.ruleFor('DISABLE_INACTIVITY_HANDLER').isBoolean();
     this.ruleFor('IS_PAYMENT_ENABLED').isBoolean();
     this.ruleFor('MIXPANEL_TOKEN').isString();
@@ -62,10 +60,6 @@ class PaConfigurationValidator extends Validator<PaConfigurationFromFile> {
     this.ruleFor('API_B2B_LINK').isString();
     this.ruleFor('IS_MANUAL_SEND_ENABLED').isBoolean();
     this.ruleFor('IS_STATISTICS_ENABLED').isBoolean();
-  }
-
-  makeRequired(rule: any): void {
-    rule.not().isEmpty().not().isUndefined().not().isNull();
   }
 }
 
@@ -90,7 +84,7 @@ export function getConfiguration(): PaConfiguration {
     SELFCARE_SEND_PROD_ID: configurationFromFile.SELFCARE_SEND_PROD_ID,
     API_B2B_LINK: configurationFromFile.API_B2B_LINK || '',
     IS_MANUAL_SEND_ENABLED: Boolean(configurationFromFile.IS_MANUAL_SEND_ENABLED),
-    IS_STATISTICS_ENABLED: Boolean(configurationFromFile.IS_STATISTICS_ENABLED)
+    IS_STATISTICS_ENABLED: Boolean(configurationFromFile.IS_STATISTICS_ENABLED),
   };
 }
 

--- a/packages/pn-personafisica-webapp/src/pages/PrivacyPolicy.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/PrivacyPolicy.page.tsx
@@ -48,11 +48,7 @@ const PrivacyPolicyPage: React.FC<{ type?: ConsentType }> = ({ type }) => {
 
   return (
     <>
-      <div
-        role="article"
-        id="otnotice-365c84c5-9329-4ec5-89f5-e53572eda132"
-        className="otnotice"
-      ></div>
+      <div role="article" id={`otnotice-${pp}`} className="otnotice"></div>
     </>
   );
 };

--- a/packages/pn-personafisica-webapp/src/pages/TermsOfService.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/TermsOfService.page.tsx
@@ -48,11 +48,7 @@ const TermsOfServicePage: React.FC<{ type?: ConsentType }> = ({ type }) => {
 
   return (
     <>
-      <div
-        role="article"
-        id="otnotice-b0da531e-8370-4373-8bd2-61ddc89e7fa6"
-        className="otnotice"
-      ></div>
+      <div role="article" id={`otnotice-${tos}`} className="otnotice"></div>
     </>
   );
 };

--- a/packages/pn-personafisica-webapp/src/services/configuration.service.ts
+++ b/packages/pn-personafisica-webapp/src/services/configuration.service.ts
@@ -1,6 +1,5 @@
 import { Configuration, dataRegex } from '@pagopa-pn/pn-commons';
 import { Validator } from '@pagopa-pn/pn-validator';
-import { StringRuleValidator } from '@pagopa-pn/pn-validator/src/ruleValidators/StringRuleValidator';
 
 interface PfConfigurationFromFile {
   API_BASE_URL: string;
@@ -50,8 +49,8 @@ interface PfConfiguration extends PfConfigurationFromFile {
 class PfConfigurationValidator extends Validator<PfConfigurationFromFile> {
   constructor() {
     super();
-    this.makeRequired(this.ruleFor('API_BASE_URL').isString().matches(dataRegex.htmlPageUrl));
-    this.makeRequired(this.ruleFor('PAGOPA_HELP_EMAIL').isString().matches(dataRegex.email));
+    this.ruleFor('API_BASE_URL').isString().isRequired().matches(dataRegex.htmlPageUrl);
+    this.ruleFor('PAGOPA_HELP_EMAIL').isString().isRequired().matches(dataRegex.email);
     this.ruleFor('MIXPANEL_TOKEN').isString();
     this.ruleFor('ONE_TRUST_DRAFT_MODE').isBoolean();
     this.ruleFor('ONE_TRUST_PP').isString().matches(dataRegex.lettersNumbersAndDashs);
@@ -63,7 +62,7 @@ class PfConfigurationValidator extends Validator<PfConfigurationFromFile> {
     this.ruleFor('ONE_TRUST_PP_SERCQ_SEND').isString().matches(dataRegex.lettersNumbersAndDashs);
     this.ruleFor('ONE_TRUST_SERCQ_SEND_DRAFT_MODE').isBoolean();
     this.ruleFor('OT_DOMAIN_ID').isString().matches(dataRegex.lettersNumbersAndDashs);
-    this.makeRequired(this.ruleFor('LANDING_SITE_URL').isString());
+    this.ruleFor('LANDING_SITE_URL').isString().isRequired();
     this.ruleFor('DELEGATIONS_TO_PG_ENABLED').isBoolean();
     this.ruleFor('WORK_IN_PROGRESS').isBoolean();
     this.ruleFor('F24_DOWNLOAD_WAIT_TIME').isNumber();
@@ -72,10 +71,6 @@ class PfConfigurationValidator extends Validator<PfConfigurationFromFile> {
     this.ruleFor('APP_IO_ANDROID').isString();
     this.ruleFor('APP_IO_IOS').isString();
     this.ruleFor('DOD_DISABLED').isBoolean();
-  }
-
-  makeRequired(rule: StringRuleValidator<PfConfigurationFromFile, string>): void {
-    rule.not().isEmpty().not().isUndefined().not().isNull();
   }
 }
 

--- a/packages/pn-personagiuridica-webapp/src/pages/PrivacyPolicy.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/PrivacyPolicy.page.tsx
@@ -48,11 +48,7 @@ const PrivacyPolicyPage: React.FC<{ type?: ConsentType }> = ({ type }) => {
 
   return (
     <>
-      <div
-        role="article"
-        id="otnotice-9d7b7236-956b-4669-8943-5284fba6a815"
-        className="otnotice"
-      ></div>
+      <div role="article" id={`otnotice-${pp}`} className="otnotice"></div>
     </>
   );
 };

--- a/packages/pn-personagiuridica-webapp/src/pages/TermsOfService.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/TermsOfService.page.tsx
@@ -48,11 +48,7 @@ const TermsOfServicePage: React.FC<{ type?: ConsentType }> = ({ type }) => {
 
   return (
     <>
-      <div
-        role="article"
-        id="otnotice-112fd95d-6e88-461b-b8fc-534ee4277e96"
-        className="otnotice"
-      ></div>
+      <div role="article" id={`otnotice-${tos}`} className="otnotice"></div>
     </>
   );
 };

--- a/packages/pn-personagiuridica-webapp/src/services/configuration.service.ts
+++ b/packages/pn-personagiuridica-webapp/src/services/configuration.service.ts
@@ -1,6 +1,5 @@
 import { Configuration, dataRegex } from '@pagopa-pn/pn-commons';
 import { Validator } from '@pagopa-pn/pn-validator';
-import { StringRuleValidator } from '@pagopa-pn/pn-validator/src/ruleValidators/StringRuleValidator';
 
 interface PgConfigurationFromFile {
   API_BASE_URL: string;
@@ -50,9 +49,9 @@ interface PgConfiguration extends PgConfigurationFromFile {
 class PgConfigurationValidator extends Validator<PgConfigurationFromFile> {
   constructor() {
     super();
-    this.makeRequired(this.ruleFor('API_BASE_URL').isString().matches(dataRegex.htmlPageUrl));
-    this.makeRequired(this.ruleFor('PAGOPA_HELP_EMAIL').isString().matches(dataRegex.email));
-    this.makeRequired(this.ruleFor('SELFCARE_BASE_URL').isString().matches(dataRegex.htmlPageUrl));
+    this.ruleFor('API_BASE_URL').isString().isRequired().matches(dataRegex.htmlPageUrl);
+    this.ruleFor('PAGOPA_HELP_EMAIL').isString().isRequired().matches(dataRegex.email);
+    this.ruleFor('SELFCARE_BASE_URL').isString().isRequired().matches(dataRegex.htmlPageUrl);
     this.ruleFor('MIXPANEL_TOKEN').isString();
     this.ruleFor('ONE_TRUST_DRAFT_MODE').isBoolean();
     this.ruleFor('ONE_TRUST_PP').isString().matches(dataRegex.lettersNumbersAndDashs);
@@ -61,15 +60,11 @@ class PgConfigurationValidator extends Validator<PgConfigurationFromFile> {
     this.ruleFor('ONE_TRUST_PP_SERCQ_SEND').isString().matches(dataRegex.lettersNumbersAndDashs);
     this.ruleFor('ONE_TRUST_SERCQ_SEND_DRAFT_MODE').isBoolean();
     this.ruleFor('OT_DOMAIN_ID').isString().matches(dataRegex.lettersNumbersAndDashs);
-    this.makeRequired(this.ruleFor('LANDING_SITE_URL').isString());
+    this.ruleFor('LANDING_SITE_URL').isString().isRequired();
     this.ruleFor('DELEGATIONS_TO_PG_ENABLED').isBoolean();
     this.ruleFor('WORK_IN_PROGRESS').isBoolean();
     this.ruleFor('F24_DOWNLOAD_WAIT_TIME').isNumber();
     this.ruleFor('DOD_DISABLED').isBoolean();
-  }
-
-  makeRequired(rule: StringRuleValidator<PgConfigurationFromFile, string>): void {
-    rule.not().isEmpty().not().isUndefined().not().isNull();
   }
 }
 


### PR DESCRIPTION
## Short description
When the user navigates to sercq send tos and privacy pages, it sees an empty pages. This is due to a wrong id in the html.

## List of changes proposed in this pull request
- Parametrized main div id in tos and privacy pages (pf/pg)

## How to test
Login with pf/pg -> go to tos and privacy pages and check that correct pages are shown
Login with pfpg -> go to sercq send tos and privacy pages and check that correct pages are shown