### PR TITLE
fix disabling SERCQ SEND when special address is added - pn-12424

### DIFF
--- a/packages/pn-personafisica-webapp/src/components/Contacts/SercqSendContactItem.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/SercqSendContactItem.tsx
@@ -72,8 +72,13 @@ const SercqSendContactItem: React.FC = () => {
   const isMobile = useIsMobile();
   const [modalOpen, setModalOpen] = useState<{ type: ModalType; data?: any } | null>(null);
   const dispatch = useAppDispatch();
-  const { defaultSERCQ_SENDAddress, defaultAPPIOAddress, courtesyAddresses, specialPECAddresses } =
-    useAppSelector(contactsSelectors.selectAddresses);
+  const {
+    defaultSERCQ_SENDAddress,
+    defaultAPPIOAddress,
+    courtesyAddresses,
+    specialPECAddresses,
+    specialSERCQ_SENDAddresses,
+  } = useAppSelector(contactsSelectors.selectAddresses);
   const externalEvent = useAppSelector((state: RootState) => state.contactsState.event);
 
   const tosPrivacy = useRef<Array<TosPrivacyConsent>>();
@@ -81,7 +86,7 @@ const SercqSendContactItem: React.FC = () => {
   const hasAppIO = defaultAPPIOAddress?.value === IOAllowedValues.DISABLED;
   const hasCourtesy =
     hasAppIO && courtesyAddresses.length === 1 ? false : courtesyAddresses.length > 0;
-  const blockDelete = specialPECAddresses.length > 0;
+  const blockDelete = specialPECAddresses.length > 0 || specialSERCQ_SENDAddresses.length > 0;
 
   const handleActivation = () => {
     dispatch(getSercqSendTosPrivacyApproval())

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/SercqSendContactItem.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/SercqSendContactItem.tsx
@@ -64,14 +64,17 @@ const SercqSendContactItem: React.FC = () => {
   const isMobile = useIsMobile();
   const [modalOpen, setModalOpen] = useState<{ type: ModalType; data?: any } | null>(null);
   const dispatch = useAppDispatch();
-  const { defaultSERCQ_SENDAddress, courtesyAddresses, specialPECAddresses } = useAppSelector(
-    contactsSelectors.selectAddresses
-  );
+  const {
+    defaultSERCQ_SENDAddress,
+    courtesyAddresses,
+    specialPECAddresses,
+    specialSERCQ_SENDAddresses,
+  } = useAppSelector(contactsSelectors.selectAddresses);
   const tosPrivacy = useRef<Array<TosPrivacyConsent>>();
 
   const value = defaultSERCQ_SENDAddress?.value ?? '';
   const hasCourtesy = courtesyAddresses.length > 0;
-  const blockDelete = specialPECAddresses.length > 0;
+  const blockDelete = specialPECAddresses.length > 0 || specialSERCQ_SENDAddresses.length > 0;
 
   const handleActivation = () => {
     dispatch(getSercqSendTosPrivacyApproval())


### PR DESCRIPTION
## Short description
When Sercq SEND is enabled ad default address, the disabling action must be blocked if a PEC or a Sercq SEND address is added as special contact

## List of changes proposed in this pull request
- Updated SercqSendContactItem

## How to test
Login with pf/pg -> go to recapiti -> add PEC as default address -> add SERCQ SEND as special address -> activate SERCQ SEND as default address -> try to disable the default SERCQ SEND -> the action must be blocked