### PR TITLE
Migrated to pg api for tos retrieve and acceptance - pn-12392

### DIFF
--- a/packages/pn-pa-webapp/openapitools.json
+++ b/packages/pn-pa-webapp/openapitools.json
@@ -6,7 +6,7 @@
     "generators": {
       "bff-notifications": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/cbef3f46b70fdeb53b7106ab6d71e5a1bc10b8aa/docs/openapi/api-external-pn-bff-pa-notifications.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/99f5094b0490281f9307be54458c98b74768521e/docs/openapi/api-external-pn-bff-pa-notifications.yaml",
         "output": "./src/generated-client/notifications",
         "additionalProperties": {
           "supportsES6": true,
@@ -17,7 +17,7 @@
       },
       "bff-api-keys": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/cbef3f46b70fdeb53b7106ab6d71e5a1bc10b8aa/docs/openapi/api-external-pn-bff-pa-apikeys.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/99f5094b0490281f9307be54458c98b74768521e/docs/openapi/api-external-pn-bff-pa-apikeys.yaml",
         "output": "./src/generated-client/api-keys",
         "additionalProperties": {
           "supportsES6": true,
@@ -28,7 +28,7 @@
       },
       "bff-tos-privacy": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/cbef3f46b70fdeb53b7106ab6d71e5a1bc10b8aa/docs/openapi/api-external-pn-bff-tos-privacy.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/99f5094b0490281f9307be54458c98b74768521e/docs/openapi/api-external-pn-bff-tos-privacy.yaml",
         "output": "./src/generated-client/tos-privacy",
         "additionalProperties": {
           "supportsES6": true,
@@ -39,7 +39,7 @@
       },
       "bff-pa-info": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/cbef3f46b70fdeb53b7106ab6d71e5a1bc10b8aa/docs/openapi/api-external-pn-bff-pa-info.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/99f5094b0490281f9307be54458c98b74768521e/docs/openapi/api-external-pn-bff-pa-info.yaml",
         "output": "./src/generated-client/info-pa",
         "additionalProperties": {
           "supportsES6": true,
@@ -50,7 +50,7 @@
       },
       "bff-downtime-logs": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/cbef3f46b70fdeb53b7106ab6d71e5a1bc10b8aa/docs/openapi/api-external-pn-bff-downtime-logs.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/99f5094b0490281f9307be54458c98b74768521e/docs/openapi/api-external-pn-bff-downtime-logs.yaml",
         "output": "./src/generated-client/downtime-logs",
         "additionalProperties": {
           "supportsES6": true,

--- a/packages/pn-personafisica-webapp/openapitools.json
+++ b/packages/pn-personafisica-webapp/openapitools.json
@@ -6,7 +6,7 @@
     "generators": {
       "bff-notifications": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/cbef3f46b70fdeb53b7106ab6d71e5a1bc10b8aa/docs/openapi/api-external-pn-bff-recipient-notifications.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/99f5094b0490281f9307be54458c98b74768521e/docs/openapi/api-external-pn-bff-recipient-notifications.yaml",
         "output": "./src/generated-client/notifications",
         "additionalProperties": {
           "supportsES6": true,
@@ -17,7 +17,7 @@
       },
       "bff-tos-privacy": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/cbef3f46b70fdeb53b7106ab6d71e5a1bc10b8aa/docs/openapi/api-external-pn-bff-tos-privacy.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/99f5094b0490281f9307be54458c98b74768521e/docs/openapi/api-external-pn-bff-tos-privacy.yaml",
         "output": "./src/generated-client/tos-privacy",
         "additionalProperties": {
           "supportsES6": true,
@@ -28,7 +28,7 @@
       },
       "bff-downtime-logs": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/cbef3f46b70fdeb53b7106ab6d71e5a1bc10b8aa/docs/openapi/api-external-pn-bff-downtime-logs.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/99f5094b0490281f9307be54458c98b74768521e/docs/openapi/api-external-pn-bff-downtime-logs.yaml",
         "output": "./src/generated-client/downtime-logs",
         "additionalProperties": {
           "supportsES6": true,
@@ -39,7 +39,7 @@
       },
       "bff-payments": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/cbef3f46b70fdeb53b7106ab6d71e5a1bc10b8aa/docs/openapi/api-external-pn-bff-payments.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/99f5094b0490281f9307be54458c98b74768521e/docs/openapi/api-external-pn-bff-payments.yaml",
         "output": "./src/generated-client/payments",
         "additionalProperties": {
           "supportsES6": true,
@@ -50,7 +50,7 @@
       },
       "bff-digital-addresses": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/cbef3f46b70fdeb53b7106ab6d71e5a1bc10b8aa/docs/openapi/api-external-pn-bff-recipient-digital-addresses.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/99f5094b0490281f9307be54458c98b74768521e/docs/openapi/api-external-pn-bff-recipient-digital-addresses.yaml",
         "output": "./src/generated-client/digital-addresses",
         "additionalProperties": {
           "supportsES6": true,
@@ -61,7 +61,7 @@
       },
       "bff-mandate": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/cbef3f46b70fdeb53b7106ab6d71e5a1bc10b8aa/docs/openapi/api-external-pn-bff-recipient-mandate.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/99f5094b0490281f9307be54458c98b74768521e/docs/openapi/api-external-pn-bff-recipient-mandate.yaml",
         "output": "./src/generated-client/mandate",
         "additionalProperties": {
           "supportsES6": true,
@@ -72,7 +72,7 @@
       },
       "bff-recipient-info": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/cbef3f46b70fdeb53b7106ab6d71e5a1bc10b8aa/docs/openapi/api-external-pn-bff-recipient-info.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/99f5094b0490281f9307be54458c98b74768521e/docs/openapi/api-external-pn-bff-recipient-info.yaml",
         "output": "./src/generated-client/recipient-info",
         "additionalProperties": {
           "supportsES6": true,

--- a/packages/pn-personagiuridica-webapp/openapitools.json
+++ b/packages/pn-personagiuridica-webapp/openapitools.json
@@ -6,7 +6,7 @@
     "generators": {
       "bff-notifications": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/cbef3f46b70fdeb53b7106ab6d71e5a1bc10b8aa/docs/openapi/api-external-pn-bff-recipient-notifications.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/99f5094b0490281f9307be54458c98b74768521e/docs/openapi/api-external-pn-bff-recipient-notifications.yaml",
         "output": "./src/generated-client/notifications",
         "additionalProperties": {
           "supportsES6": true,
@@ -17,7 +17,7 @@
       },
       "bff-tos-privacy": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/cbef3f46b70fdeb53b7106ab6d71e5a1bc10b8aa/docs/openapi/api-external-pn-bff-tos-privacy.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/99f5094b0490281f9307be54458c98b74768521e/docs/openapi/api-external-pn-bff-tos-privacy.yaml",
         "output": "./src/generated-client/tos-privacy",
         "additionalProperties": {
           "supportsES6": true,
@@ -28,7 +28,7 @@
       },
       "bff-downtime-logs": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/cbef3f46b70fdeb53b7106ab6d71e5a1bc10b8aa/docs/openapi/api-external-pn-bff-downtime-logs.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/99f5094b0490281f9307be54458c98b74768521e/docs/openapi/api-external-pn-bff-downtime-logs.yaml",
         "output": "./src/generated-client/downtime-logs",
         "additionalProperties": {
           "supportsES6": true,
@@ -39,7 +39,7 @@
       },
       "bff-payments": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/cbef3f46b70fdeb53b7106ab6d71e5a1bc10b8aa/docs/openapi/api-external-pn-bff-payments.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/99f5094b0490281f9307be54458c98b74768521e/docs/openapi/api-external-pn-bff-payments.yaml",
         "output": "./src/generated-client/payments",
         "additionalProperties": {
           "supportsES6": true,
@@ -50,7 +50,7 @@
       },
       "bff-digital-addresses": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/cbef3f46b70fdeb53b7106ab6d71e5a1bc10b8aa/docs/openapi/api-external-pn-bff-recipient-digital-addresses.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/99f5094b0490281f9307be54458c98b74768521e/docs/openapi/api-external-pn-bff-recipient-digital-addresses.yaml",
         "output": "./src/generated-client/digital-addresses",
         "additionalProperties": {
           "supportsES6": true,
@@ -61,7 +61,7 @@
       },
       "bff-mandate": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/cbef3f46b70fdeb53b7106ab6d71e5a1bc10b8aa/docs/openapi/api-external-pn-bff-recipient-mandate.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/99f5094b0490281f9307be54458c98b74768521e/docs/openapi/api-external-pn-bff-recipient-mandate.yaml",
         "output": "./src/generated-client/mandate",
         "additionalProperties": {
           "supportsES6": true,
@@ -72,7 +72,7 @@
       },
       "bff-recipient-info": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/cbef3f46b70fdeb53b7106ab6d71e5a1bc10b8aa/docs/openapi/api-external-pn-bff-recipient-info.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/99f5094b0490281f9307be54458c98b74768521e/docs/openapi/api-external-pn-bff-recipient-info.yaml",
         "output": "./src/generated-client/recipient-info",
         "additionalProperties": {
           "supportsES6": true,

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/__test__/SercqSendContactItem.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/__test__/SercqSendContactItem.test.tsx
@@ -72,10 +72,12 @@ describe('test SercqSendContactItem', () => {
         value: SERCQ_SEND_VALUE,
       })
       .reply(204);
-    mock.onGet(/\/bff\/v2\/tos-privacy.*/).reply(200, sercqSendTosPrivacyConsentMock(false, false));
+    mock
+      .onGet(/\/bff\/v1\/pg\/tos-privacy.*/)
+      .reply(200, sercqSendTosPrivacyConsentMock(false, false));
     mock
       .onPut(
-        '/bff/v2/tos-privacy',
+        '/bff/v1/pg/tos-privacy',
         acceptTosPrivacyConsentBodyMock(ConsentType.TOS_SERCQ, ConsentType.DATAPRIVACY_SERCQ)
       )
       .reply(200);
@@ -132,7 +134,9 @@ describe('test SercqSendContactItem', () => {
         value: SERCQ_SEND_VALUE,
       })
       .reply(204);
-    mock.onGet(/\/bff\/v2\/tos-privacy.*/).reply(200, sercqSendTosPrivacyConsentMock(true, true));
+    mock
+      .onGet(/\/bff\/v1\/pg\/tos-privacy.*/)
+      .reply(200, sercqSendTosPrivacyConsentMock(true, true));
     // render component
     const { container, getByTestId, getByText } = render(<SercqSendContactItem />);
     const activateButton = getByTestId('activateButton');
@@ -182,7 +186,9 @@ describe('test SercqSendContactItem', () => {
         verificationCode: '01234',
       })
       .reply(204);
-    mock.onGet(/\/bff\/v2\/tos-privacy.*/).reply(200, sercqSendTosPrivacyConsentMock(true, true));
+    mock
+      .onGet(/\/bff\/v1\/pg\/tos-privacy.*/)
+      .reply(200, sercqSendTosPrivacyConsentMock(true, true));
     // render component
     const result = render(<SercqSendContactItem />);
     const activateButton = result.getByTestId('activateButton');

--- a/packages/pn-personagiuridica-webapp/src/redux/contact/actions.ts
+++ b/packages/pn-personagiuridica-webapp/src/redux/contact/actions.ts
@@ -139,7 +139,7 @@ export const getSercqSendTosPrivacyApproval = createAsyncThunk(
   async (_, { rejectWithValue }) => {
     try {
       const tosPrivacyFactory = UserConsentsApiFactory(undefined, undefined, apiClient);
-      const response = await tosPrivacyFactory.getTosPrivacyV2([
+      const response = await tosPrivacyFactory.getPgConsentByType([
         ConsentType.TOS_SERCQ,
         ConsentType.DATAPRIVACY_SERCQ,
       ]);
@@ -159,7 +159,7 @@ export const acceptSercqSendTosPrivacy = createAsyncThunk<void, Array<BffTosPriv
   async (body: Array<BffTosPrivacyActionBody>, { rejectWithValue }) => {
     try {
       const tosPrivacyFactory = UserConsentsApiFactory(undefined, undefined, apiClient);
-      const response = await tosPrivacyFactory.acceptTosPrivacyV2(body);
+      const response = await tosPrivacyFactory.acceptPgTosPrivacyV1(body);
 
       return response.data;
     } catch (e: any) {


### PR DESCRIPTION
## Short description
When a PG enables the SERCQ SEND, it has to accept the linked tos and privacy. For the PG there are specific api to call

## List of changes proposed in this pull request
- Updated bff dependencies
- Updated api called during retrieve and acceptance of tos and dataprivacy

## How to test
Login with PG (no DivinaCommedia) -> enable SERCQ SEND -> check everything is ok 