### PR TITLE
reset modal state when cancel is clicked - pn-12394

### DIFF
--- a/packages/pn-personafisica-webapp/src/components/Contacts/SpecialContacts.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/SpecialContacts.tsx
@@ -339,10 +339,6 @@ const SpecialContacts: React.FC = () => {
     setModalOpen(ModalType.SPECIAL);
   };
 
-  const handleCancelCode = async () => {
-    setModalOpen(null);
-  };
-
   const handleClickAddSpecialContact = () => {
     PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_ADD_SECONDARY_CONTACT);
     setModalOpen(ModalType.SPECIAL);
@@ -427,7 +423,7 @@ const SpecialContacts: React.FC = () => {
         channelType={currentAddress.current.channelType}
         open={modalOpen === ModalType.CODE}
         onConfirm={(code) => handleCodeVerification(code)}
-        onDiscard={handleCancelCode}
+        onDiscard={handleCloseModal}
         onError={() => sendCodeErrorEvent(currentAddress.current.channelType)}
       />
       <DeleteDialog
@@ -480,7 +476,7 @@ const SpecialContacts: React.FC = () => {
       />
       <SercqSendInfoDialog
         open={modalOpen === ModalType.INFO}
-        onDiscard={() => setModalOpen(null)}
+        onDiscard={handleCloseModal}
         onConfirm={handleInfoConfirm}
       />
     </>

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/SpecialContacts.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/SpecialContacts.tsx
@@ -295,10 +295,6 @@ const SpecialContacts: React.FC = () => {
     setModalOpen(ModalType.SPECIAL);
   };
 
-  const handleCancelCode = async () => {
-    setModalOpen(null);
-  };
-
   const groupedAddresses: Addresses = specialAddresses.reduce((obj, a) => {
     if (!obj[a.senderId]) {
       // eslint-disable-next-line functional/immutable-data
@@ -378,7 +374,7 @@ const SpecialContacts: React.FC = () => {
         channelType={currentAddress.current.channelType}
         open={modalOpen === ModalType.CODE}
         onConfirm={(code) => handleCodeVerification(code)}
-        onDiscard={handleCancelCode}
+        onDiscard={handleCloseModal}
       />
       <DeleteDialog
         showModal={modalOpen === ModalType.DELETE}
@@ -430,7 +426,7 @@ const SpecialContacts: React.FC = () => {
       />
       <SercqSendInfoDialog
         open={modalOpen === ModalType.INFO}
-        onDiscard={() => setModalOpen(null)}
+        onDiscard={handleCloseModal}
         onConfirm={handleInfoConfirm}
       />
     </>


### PR DESCRIPTION
## Short description
Section "Recapiti personalizzati". When user click on button "personalizza recapiti" and go forward to code modal, clicking on cancel button doesn't reset the AddSpecialContactDialog's state.

## List of changes proposed in this pull request
- Updated SpecialContacts (pf/pg)

## How to test
Login with pf/pg -> go to "Recapiti" page -> add a default legal address and click on "personalizza recapiti" -> go forward to the code modal dialog -> click on cancel button -> click on "personalizza recapiti" -> check that the opened modal hasn't the fields filled with the previous values