### PR TITLE
fixed layout when pec is in validation state - pn-12537

### DIFF
--- a/packages/pn-personafisica-webapp/src/components/Contacts/PecContactItem.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/PecContactItem.tsx
@@ -207,7 +207,7 @@ const PecContactItem: React.FC = () => {
       {verifyingAddress && (
         <PecValidationItem senderId="default" onCancelValidation={handleCancelValidation} />
       )}
-      {defaultSERCQ_SENDAddress && (
+      {!verifyingAddress && defaultSERCQ_SENDAddress && (
         <>
           <Divider sx={{ color: 'text.secondary' }} />
           <Typography mt={2} variant="body2" color="text.secondary">

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/PecContactItem.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/PecContactItem.tsx
@@ -179,7 +179,7 @@ const PecContactItem: React.FC = () => {
       {verifyingAddress && (
         <PecValidationItem senderId="default" onCancelValidation={handleCancelValidation} />
       )}
-      {defaultSERCQ_SENDAddress && (
+      {!verifyingAddress && defaultSERCQ_SENDAddress && (
         <>
           <Divider sx={{ color: 'text.secondary' }} />
           <Typography mt={2} variant="body2" color="text.secondary">


### PR DESCRIPTION
## Short description
Sercq enabled. When user adds a PEC and it goes under validation, sercq and pec are shown under the same card.

## List of changes proposed in this pull request
- Updated PecContactItem

## How to test
Login with pf/pg -> enable DoD -> add a PEC -> check that until the PEC is validated, two cards are shown