### PR TITLE
show AppIO banner when dod feature is disabled - pn-12538

### DIFF
--- a/packages/pn-personafisica-webapp/src/components/DomicileBanner/DomicileBanner.tsx
+++ b/packages/pn-personafisica-webapp/src/components/DomicileBanner/DomicileBanner.tsx
@@ -85,9 +85,8 @@ const getDomicileData = (
       callToAction: source === ContactSource.RECAPITI ? undefined : 'complete-addresses',
     };
   } else if (
-    !dodDisabled &&
     source !== ContactSource.RECAPITI &&
-    hasSercqSend &&
+    (hasSercqSend || dodDisabled) &&
     hasAppIODisabled &&
     hasCourtesyAddresses
   ) {


### PR DESCRIPTION
## Short description
Show AppIO banner when dod feature is disabled and user has AppIO installed but SEND service disabled.

## List of changes proposed in this pull request
- Updated DomicileBanner.tsx

## How to test
- Add in configuration file "DOD_DISABLED": true -> login with pf -> with netify simulate an user with a pec, a courtesy contact and AppIO installed but disabled -> check that the AppIO banner is shown
- Add in configuration file "DOD_DISABLED": true -> login with pf -> with netify simulate an user with a pec, a courtesy contact and AppIO installed and enabled -> check that the AppIO banner is not shown
- Remove the DOD_DISABLED -> login with pf -> with netify simulate an user with DoD, a courtesy contact and AppIO installed but disabled -> check that the AppIO banner is shown
- Remove the DOD_DISABLED -> login with pf -> with netify simulate an user with DoD, a courtesy contact and AppIO installed and enabled -> check that the AppIO banner is not shown
