### PR TITLE
Fixed wrong copy

### DIFF
--- a/packages/pn-commons/src/models/NotificationDetail.ts
+++ b/packages/pn-commons/src/models/NotificationDetail.ts
@@ -109,7 +109,7 @@ interface BaseDetails {
 
 export interface AnalogWorkflowDetails extends BaseDetails {
   physicalAddress?: PhysicalAddress;
-  getGeneratedAarUrl?: string;
+  generatedAarUrl?: string;
 }
 
 export interface SendCourtesyMessageDetails extends BaseDetails {

--- a/packages/pn-commons/src/utility/__test__/notification.utility.test.ts
+++ b/packages/pn-commons/src/utility/__test__/notification.utility.test.ts
@@ -410,7 +410,7 @@ describe('timeline legal fact link text', () => {
       timestamp: '2023-08-25T09:35:37.467148235Z',
       category: TimelineCategory.ANALOG_FAILURE_WORKFLOW,
       details: {
-        getGeneratedAarUrl: 'https://aar-fake-url.com',
+        generatedAarUrl: 'https://aar-fake-url.com',
       },
     };
     const label = getLegalFactLabel(timelineElem);

--- a/packages/pn-commons/src/utility/notification.utility.ts
+++ b/packages/pn-commons/src/utility/notification.utility.ts
@@ -6,7 +6,6 @@
 import _ from 'lodash';
 
 import {
-  AnalogWorkflowDetails,
   ExtRegistriesPaymentDetails,
   F24PaymentDetails,
   INotificationDetailTimeline,
@@ -309,6 +308,12 @@ export function getLegalFactLabel(
   legalFactType?: LegalFactType | 'AAR',
   legalFactKey?: string
 ): string {
+  console.log(
+    'timelineStep,legalFactType,legalFactKey :>> ',
+    timelineStep,
+    legalFactType,
+    legalFactKey
+  );
   const legalFactLabel = getLocalizedOrDefaultLabel(
     'notifications',
     `detail.legalfact`,
@@ -386,10 +391,7 @@ export function getLegalFactLabel(
       'detail.timeline.legalfact.analog-failure-delivery',
       'Deposito di avvenuta ricezione'
     );
-  } else if (
-    timelineStep.category === TimelineCategory.ANALOG_FAILURE_WORKFLOW &&
-    (timelineStep.details as AnalogWorkflowDetails).getGeneratedAarUrl
-  ) {
+  } else if (timelineStep.category === TimelineCategory.ANALOG_FAILURE_WORKFLOW) {
     return getLocalizedOrDefaultLabel(
       'notifications',
       'detail.timeline.aar-document',
@@ -489,14 +491,14 @@ export function getNotificationTimelineStatusInfos(
   const recipient = _.isNil(step.details.recIndex)
     ? undefined
     : // For the accesses from recipient apps (cittadino / impresa)
-    // the API response will probably (in some future) include only the info about the requester recipient,
-    // i.e. recipients will be an array with exactly one element, disregarding how many recipients are included
-    // in the notification being requested.
-    // In that case, we don't consider the recIndex indicated in each timeline step,
-    // but otherwise take all steps as related with the only recipient included in the API response.
-    recipients.length === 1
-    ? recipients[0]
-    : recipients[step.details.recIndex];
+      // the API response will probably (in some future) include only the info about the requester recipient,
+      // i.e. recipients will be an array with exactly one element, disregarding how many recipients are included
+      // in the notification being requested.
+      // In that case, we don't consider the recIndex indicated in each timeline step,
+      // but otherwise take all steps as related with the only recipient included in the API response.
+      recipients.length === 1
+      ? recipients[0]
+      : recipients[step.details.recIndex];
 
   // we show the multirecipient versions of the step descriptions
   // only if the array of recipients include more than one "full" element

--- a/packages/pn-commons/src/utility/notification.utility.ts
+++ b/packages/pn-commons/src/utility/notification.utility.ts
@@ -6,6 +6,7 @@
 import _ from 'lodash';
 
 import {
+  AnalogWorkflowDetails,
   ExtRegistriesPaymentDetails,
   F24PaymentDetails,
   INotificationDetailTimeline,
@@ -308,12 +309,6 @@ export function getLegalFactLabel(
   legalFactType?: LegalFactType | 'AAR',
   legalFactKey?: string
 ): string {
-  console.log(
-    'timelineStep,legalFactType,legalFactKey :>> ',
-    timelineStep,
-    legalFactType,
-    legalFactKey
-  );
   const legalFactLabel = getLocalizedOrDefaultLabel(
     'notifications',
     `detail.legalfact`,
@@ -391,7 +386,10 @@ export function getLegalFactLabel(
       'detail.timeline.legalfact.analog-failure-delivery',
       'Deposito di avvenuta ricezione'
     );
-  } else if (timelineStep.category === TimelineCategory.ANALOG_FAILURE_WORKFLOW) {
+  } else if (
+    timelineStep.category === TimelineCategory.ANALOG_FAILURE_WORKFLOW &&
+    (timelineStep.details as AnalogWorkflowDetails).generatedAarUrl
+  ) {
     return getLocalizedOrDefaultLabel(
       'notifications',
       'detail.timeline.aar-document',


### PR DESCRIPTION
## Short description
Insert correct copy when timeline status is analog failure workflow
## List of changes proposed in this pull request

in notification utilities file delete control on generetadAarUrl

## How to test
login with PF, username: leonardo in dev enviroment and go on notification with iun : 
YDWX-JQGA-XVTL-202410-H-1

and visualize in timeline correct copy