### PR TITLE
Fix/PN-12969: Admin with groups is not able to view/rotate his/her own virtual keys

### DIFF
--- a/packages/pn-personagiuridica-webapp/src/components/IntegrazioneApi/VirtualKeysTable.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/IntegrazioneApi/VirtualKeysTable.tsx
@@ -32,7 +32,7 @@ const VirtualKeysTable: React.FC<Props> = ({ virtualKeys, handleModalClick }) =>
   const { t } = useTranslation(['integrazioneApi']);
   const currentUser = useAppSelector((state: RootState) => state.userState.user);
   const role = currentUser.organization?.roles ? currentUser.organization?.roles[0] : null;
-  const isUserAdmin = useHasPermissions(role ? [role.role] : [], [PNRole.ADMIN]);
+  const isUserAdmin = useHasPermissions(role ? [role.role] : [], [PNRole.ADMIN]) && !currentUser.hasGroup;
 
   const data: Array<Row<ApiKeyColumnData>> = virtualKeys.items.map((n: VirtualKey) => {
     const isPersonalKey = n.user?.fiscalCode === currentUser.fiscal_number;


### PR DESCRIPTION
…keys

## Short description
This PR fixes a bug causing the inability, for a admin with groups, to view and rotate his/her own personal keys

## How to test
Run pn-personagiuridica-webapp and log as admin with groups. Create a personal key and verify the context menu shows the rotate/view actions.