### PR TITLE
fix/PN-12966: Set maximum lenght for public key value

### DIFF
--- a/packages/pn-personagiuridica-webapp/src/components/IntegrazioneApi/NewPublicKey/PublicKeyDataInsert.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/IntegrazioneApi/NewPublicKey/PublicKeyDataInsert.tsx
@@ -16,6 +16,7 @@ import * as routes from '../../../navigation/routes.const';
 import NewPublicKeyCard from './NewPublicKeyCard';
 
 const nameMaxLen = 254;
+const publicKeyMaxLen = 500;
 const nameAllowedChars = 'a-zA-Z0-9-\\';
 
 type Props = {
@@ -44,11 +45,12 @@ const PublicKeyDataInsert: React.FC<Props> = ({ onConfirm, duplicateKey, tosAcce
     name: yup
       .string()
       .required(t('required-field', { ns: 'common' }))
-      .max(nameMaxLen, t('too-long-field-error', { ns: 'common', maxLength: 254 }))
+      .max(nameMaxLen, t('too-long-field-error', { ns: 'common', maxLength: nameMaxLen }))
       .matches(dataRegex.publicKeyName, t('messages.error.name-allowed-charset', { allowedCharset: nameAllowedChars })),
     publicKey: yup
       .string()
       .required(t('required-field', { ns: 'common' }))
+      .max(publicKeyMaxLen, t('too-long-field-error', { ns: 'common', maxLength: publicKeyMaxLen }))
       .test('publicKey', t('messages.error.key-already-registered'), duplicateKey),
   });
 


### PR DESCRIPTION
## Short description
This PR fixes a bug due to missed validition on public key maximum lenght.

## How to test
Run PG as Admin and try to insert a new public key (or rotate an existing one). Verify the user is not allowed to specify public key value longer than 500 chars