### PR TITLE
fix/PN-12934 - Hide "add courtesy contact" modal after enabling SERCQ as special contact for PG

### DIFF
--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/SercqSendContactItem.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/SercqSendContactItem.tsx
@@ -219,12 +219,12 @@ const SercqSendContactItem: React.FC = () => {
   };
 
   useEffect(() => {
-    if (externalEvent && externalEvent.destination === ChannelType.SERCQ_SEND) {
-      if (externalEvent.operation === ContactOperation.ADD) {
-        handleActivation();
-      } else if (externalEvent.operation === ContactOperation.ADD_COURTESY && !hasCourtesy) {
-        setModalOpen({ type: ModalType.COURTESY });
-      }
+    if (
+      externalEvent &&
+      externalEvent.destination === ChannelType.SERCQ_SEND &&
+      externalEvent.operation === ContactOperation.ADD
+    ) {
+      handleActivation();
       dispatch(resetExternalEvent());
     }
   }, [externalEvent]);


### PR DESCRIPTION
## Short description
This PR fixes a bug on PG (PF was already working fine) which was showing the modal window allowing the user to set a courtesy contact after enabling SERCQ for a specific party (special contact)

## How to test
Follow the steps detailed on the corresponding Jira task to verify the issue is solved