### PR TITLE
fix/PN-13045 - New API key confirmation component wrongly shows key id instead of its value (PA)

### DIFF
--- a/packages/pn-pa-webapp/src/__mocks__/Statistics.mock.ts
+++ b/packages/pn-pa-webapp/src/__mocks__/Statistics.mock.ts
@@ -12,15 +12,18 @@ import {
   StatisticsResponse,
 } from '../models/Statistics';
 
+const baseDate = threeMonthsAgo.toISOString();
+const dateYearMonth = baseDate.substring(0, 7);
+
 export const rawResponseMock: StatisticsResponse = {
   senderId: 'sender-id',
-  genTimestamp: '2024-04-24T11:09:36.432251Z',
-  lastDate: '2024-04-21',
-  startDate: '2023-12-06',
-  endDate: '2024-04-24',
+  genTimestamp: `${dateYearMonth}-24T11:09:36.432251Z`,
+  lastDate: `${dateYearMonth}-21`,
+  startDate: baseDate,
+  endDate: `${dateYearMonth}-24`,
   notificationsOverview: [
     {
-      notification_send_date: '2024-03-15',
+      notification_send_date: `${dateYearMonth}-15`,
       notification_request_status: NotificationStatus.ACCEPTED,
       notification_status: NotificationStatus.DELIVERED,
       notification_type: DeliveryMode.ANALOG,
@@ -36,7 +39,7 @@ export const rawResponseMock: StatisticsResponse = {
       validation_time: 2.77,
     },
     {
-      notification_send_date: '2024-03-15',
+      notification_send_date: `${dateYearMonth}-15`,
       notification_request_status: NotificationStatus.ACCEPTED,
       notification_status: NotificationStatus.DELIVERED,
       notification_type: DeliveryMode.ANALOG,
@@ -52,7 +55,7 @@ export const rawResponseMock: StatisticsResponse = {
       validation_time: 0.11,
     },
     {
-      notification_send_date: '2024-03-15',
+      notification_send_date: `${dateYearMonth}-15`,
       notification_request_status: NotificationStatus.ACCEPTED,
       notification_status: NotificationStatus.DELIVERING,
       notification_type: DeliveryMode.ANALOG,
@@ -68,7 +71,7 @@ export const rawResponseMock: StatisticsResponse = {
       validation_time: 67.24,
     },
     {
-      notification_send_date: '2024-03-15',
+      notification_send_date: `${dateYearMonth}-15`,
       notification_request_status: NotificationStatus.ACCEPTED,
       notification_status: NotificationStatus.EFFECTIVE_DATE,
       notification_type: DeliveryMode.ANALOG,
@@ -84,7 +87,7 @@ export const rawResponseMock: StatisticsResponse = {
       validation_time: 31.62,
     },
     {
-      notification_send_date: '2024-03-15',
+      notification_send_date: `${dateYearMonth}-15`,
       notification_request_status: NotificationStatus.ACCEPTED,
       notification_status: NotificationStatus.EFFECTIVE_DATE,
       notification_type: DeliveryMode.ANALOG,
@@ -100,7 +103,7 @@ export const rawResponseMock: StatisticsResponse = {
       validation_time: 7.63,
     },
     {
-      notification_send_date: '2024-03-15',
+      notification_send_date: `${dateYearMonth}-15`,
       notification_request_status: NotificationStatus.ACCEPTED,
       notification_status: NotificationStatus.VIEWED,
       notification_type: DeliveryMode.DIGITAL,
@@ -116,7 +119,7 @@ export const rawResponseMock: StatisticsResponse = {
       validation_time: 7.23,
     },
     {
-      notification_send_date: '2024-03-18',
+      notification_send_date: `${dateYearMonth}-18`,
       notification_request_status: NotificationStatus.ACCEPTED,
       notification_status: NotificationStatus.DELIVERED,
       notification_type: DeliveryMode.ANALOG,
@@ -132,7 +135,7 @@ export const rawResponseMock: StatisticsResponse = {
       validation_time: 8.47,
     },
     {
-      notification_send_date: '2024-03-18',
+      notification_send_date: `${dateYearMonth}-18`,
       notification_request_status: NotificationStatus.ACCEPTED,
       notification_status: NotificationStatus.DELIVERING,
       notification_type: DeliveryMode.ANALOG,
@@ -148,7 +151,7 @@ export const rawResponseMock: StatisticsResponse = {
       validation_time: 1.95,
     },
     {
-      notification_send_date: '2024-03-18',
+      notification_send_date: `${dateYearMonth}-18`,
       notification_request_status: NotificationStatus.ACCEPTED,
       notification_status: NotificationStatus.EFFECTIVE_DATE,
       notification_type: DeliveryMode.ANALOG,
@@ -164,7 +167,7 @@ export const rawResponseMock: StatisticsResponse = {
       validation_time: 40.56,
     },
     {
-      notification_send_date: '2024-03-18',
+      notification_send_date: `${dateYearMonth}-18`,
       notification_request_status: NotificationStatus.ACCEPTED,
       notification_status: NotificationStatus.EFFECTIVE_DATE,
       notification_type: DeliveryMode.ANALOG,
@@ -180,7 +183,7 @@ export const rawResponseMock: StatisticsResponse = {
       validation_time: 7.1,
     },
     {
-      notification_send_date: '2024-03-18',
+      notification_send_date: `${dateYearMonth}-18`,
       notification_request_status: NotificationStatus.ACCEPTED,
       notification_status: NotificationStatus.EFFECTIVE_DATE,
       notification_type: DeliveryMode.DIGITAL,
@@ -198,25 +201,25 @@ export const rawResponseMock: StatisticsResponse = {
   ],
   digitalNotificationFocus: [
     {
-      notification_send_date: '2024-03-15',
+      notification_send_date: `${dateYearMonth}-15`,
       error_type: DigitaErrorTypes.DELIVERY_ERROR,
       failed_attempts_count: 11,
       notifications_count: 4,
     },
     {
-      notification_send_date: '2024-03-15',
+      notification_send_date: `${dateYearMonth}-15`,
       error_type: DigitaErrorTypes.UNKNOWN,
       failed_attempts_count: 0,
       notifications_count: 234,
     },
     {
-      notification_send_date: '2024-03-18',
+      notification_send_date: `${dateYearMonth}-18`,
       error_type: DigitaErrorTypes.INVALID_PEC,
       failed_attempts_count: 7,
       notifications_count: 4,
     },
     {
-      notification_send_date: '2024-03-18',
+      notification_send_date: `${dateYearMonth}-18`,
       error_type: DigitaErrorTypes.UNKNOWN,
       failed_attempts_count: 0,
       notifications_count: 227,
@@ -240,8 +243,8 @@ export const parsedResponseMock: StatisticsParsedResponse = {
       [NotificationStatus.ACCEPTED]: {
         count: 1802,
         details: [
-          { send_date: '2024-03-15', count: 920 },
-          { send_date: '2024-03-18', count: 882 },
+          { send_date: `${dateYearMonth}-15`, count: 920 },
+          { send_date: `${dateYearMonth}-18`, count: 882 },
         ],
       },
       [NotificationStatus.REFUSED]: { count: 0, details: [] },
@@ -260,15 +263,15 @@ export const parsedResponseMock: StatisticsParsedResponse = {
       [DeliveryMode.ANALOG]: {
         count: 1591,
         details: [
-          { send_date: '2024-03-15', count: 788 },
-          { send_date: '2024-03-18', count: 803 },
+          { send_date: `${dateYearMonth}-15`, count: 788 },
+          { send_date: `${dateYearMonth}-18`, count: 803 },
         ],
       },
       [DeliveryMode.DIGITAL]: {
         count: 211,
         details: [
-          { send_date: '2024-03-15', count: 132 },
-          { send_date: '2024-03-18', count: 79 },
+          { send_date: `${dateYearMonth}-15`, count: 132 },
+          { send_date: `${dateYearMonth}-18`, count: 79 },
         ],
       },
       [DeliveryMode.UNKNOWN]: {
@@ -363,8 +366,8 @@ export const filters: Array<StatisticsFilter> = [
   },
   {
     selected: SelectedStatisticsFilter.custom,
-    startDate: new Date('2023-08-26'),
-    endDate: new Date('2024-06-22'),
+    startDate: new Date(`${dateYearMonth}-15`),
+    endDate: new Date(`${dateYearMonth}-18`),
   },
 ];
 

--- a/packages/pn-pa-webapp/src/components/NewApiKey/SyncFeedbackApiKey.tsx
+++ b/packages/pn-pa-webapp/src/components/NewApiKey/SyncFeedbackApiKey.tsx
@@ -7,7 +7,7 @@ import { IllusCompleted } from '@pagopa/mui-italia';
 
 import * as routes from '../../navigation/routes.const';
 
-const SyncFeedbackApiKey = ({ newApiKeyId = '' }) => {
+const SyncFeedbackApiKey = ({ newApiKey = '' }) => {
   const navigate = useNavigate();
   const { t } = useTranslation(['apikeys']);
   const isMobile = useIsMobile('xl');
@@ -44,7 +44,8 @@ const SyncFeedbackApiKey = ({ newApiKeyId = '' }) => {
         <Box sx={{ mt: 3, mb: 5 }}>
           <TextField
             id="apiKeyId"
-            value={newApiKeyId}
+            data-testid="apiKeyValue"
+            value={newApiKey}
             name="apiKeyId"
             sx={{
               width: isMobile ? '100%' : '450px',
@@ -61,7 +62,7 @@ const SyncFeedbackApiKey = ({ newApiKeyId = '' }) => {
                   <CopyToClipboard
                     tooltipMode={true}
                     tooltip={t('api-key-copied')}
-                    getValue={() => newApiKeyId || ''}
+                    getValue={() => newApiKey ?? ''}
                   />
                 </InputAdornment>
               ),

--- a/packages/pn-pa-webapp/src/pages/NewApiKey.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/NewApiKey.page.tsx
@@ -179,7 +179,7 @@ const NewApiKey = () => {
         </Prompt>
       )}
 
-      {apiKeySent && apiKey.id !== '' && <SyncFeedbackApiKey newApiKeyId={apiKey.id} />}
+      {apiKeySent && apiKey.apiKey !== '' && <SyncFeedbackApiKey newApiKey={apiKey.apiKey} />}
     </>
   );
 };

--- a/packages/pn-pa-webapp/src/pages/__test__/NewApiKey.page.test.tsx
+++ b/packages/pn-pa-webapp/src/pages/__test__/NewApiKey.page.test.tsx
@@ -110,6 +110,10 @@ describe('NewApiKey component', async () => {
     expect(mock.history.post).toHaveLength(1);
     expect(mock.history.post[0].url).toContain('/bff/v1/api-keys');
     expect(JSON.parse(mock.history.post[0].data)).toStrictEqual(newApiKeyDTO);
+
+    // verify the key value is shown on the response page
+    const apiKeyInput = result.getByTestId("apiKeyValue").querySelector("input");
+    expect(apiKeyInput).toHaveValue(newApiKeyResponse.apiKey);
   });
 
   it('clicks on the breadcrumb button', async () => {


### PR DESCRIPTION
## Short description
This PR fixes a bug which was causing to show api key id instead of its value after key creation for PA, adds the code to test this behaviour and fixes an switches from static to dynamic dates for statistics mock to avoid too old dates to cause tests about quick filters to fail.

## List of changes proposed in this pull request
- SyncFeedbackApiKey.tsx: change prop name to clarify its content and other minor changes
- NewApiKey.page.tsx: pass the right value to the SyncFeedbackApiKey component
- NewApiKey.page.test.tsx: add the code to check the right value is showed after api key creation
- Statistics.mock.ts: make dates dynamic to fix 'quick filters' test failure

## How to test
Log in as PA administrator, create a new API key and verify the value showed inside the response page is the key value.