### PR TITLE
Fix/PN-13070 - add successful messages on appIO enable/disable (PF)

### DIFF
--- a/packages/pn-personafisica-webapp/public/locales/it/recapiti.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/recapiti.json
@@ -118,6 +118,8 @@
     "sms-added-successfully": "Numero di cellulare aggiunto correttamente",
     "email-removed-successfully": "Indirizzo email rimosso correttamente",
     "sms-removed-successfully": "Numero di cellulare rimosso correttamente",
+    "io-added-successfully": "Il servizio Notifiche Digitali è stato attivato su IO.",
+    "io-removed-successfully": "Il servizio Notifiche Digitali su IO è stato disattivato",
     "remove-email-title": "Rimuovi email",
     "remove-email-message": "Confermi di voler rimuovere l'indirizzo email {{value}}?",
     "remove-sms-title": "Rimuovi cellulare",

--- a/packages/pn-personafisica-webapp/src/components/Contacts/IOContact.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/IOContact.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import DoDisturbOnOutlinedIcon from '@mui/icons-material/DoDisturbOnOutlined';
 import VerifiedIcon from '@mui/icons-material/Verified';
 import { Alert, Box, Button, Stack, Typography } from '@mui/material';
-import { IllusAppIO, useIsMobile } from '@pagopa-pn/pn-commons';
+import { appStateActions, IllusAppIO, useIsMobile } from '@pagopa-pn/pn-commons';
 import { ButtonNaked } from '@pagopa/mui-italia';
 
 import { PFEventsType } from '../../models/PFEventsType';
@@ -49,6 +49,12 @@ const IOContact: React.FC = () => {
       .then(() => {
         // setIsConfirmModalOpen(false);
         PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_ACTIVE_IO_UX_SUCCESS, false);
+        dispatch(
+          appStateActions.addSuccess({
+            title: '',
+            message: t('courtesy-contacts.io-added-successfully', { ns: 'recapiti' }),
+          })
+        );
       })
       .catch(() => {});
   };
@@ -60,6 +66,12 @@ const IOContact: React.FC = () => {
       .then(() => {
         // etIsConfirmModalOpen(false);
         PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_DEACTIVE_IO_UX_SUCCESS);
+        dispatch(
+          appStateActions.addSuccess({
+            title: '',
+            message: t('courtesy-contacts.io-removed-successfully', { ns: 'recapiti' }),
+          })
+        );
       })
       .catch(() => {});
   };


### PR DESCRIPTION
## Short description
This code shows success message when appIO is enabled/disabled ad courtesy contact

## How to test
Log as pf user on uat and verify a success message is shown every time the appIO contact is enabled/disabled