### PR TITLE
feat/PN-13044: info banner in attachments tab

### DIFF
--- a/packages/pn-pa-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/it/notifiche.json
@@ -474,7 +474,8 @@
         "add-doc": "Aggiungi un documento (per esempio, la lettera d’accompagnamento)",
         "add-another-doc": "Aggiungi un altro documento (per esempio, la lettera d’accompagnamento)",
         "back-to-recipient": "Torna a Destinatario",
-        "remove-document": "Rimuovi documento"
+        "remove-document": "Rimuovi documento",
+        "banner-additional-languages": "Hai scelto di inviare la notifica in più lingue. Ricorda di allegare i documenti in entrambe le lingue selezionate."
       },
       "payment-methods": {
         "title": "Modelli di pagamento",

--- a/packages/pn-pa-webapp/src/components/NewNotification/Attachments.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/Attachments.tsx
@@ -5,7 +5,7 @@ import * as yup from 'yup';
 
 import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
-import { Box, SxProps, TextField, Typography } from '@mui/material';
+import { Alert, Box, SxProps, TextField, Typography } from '@mui/material';
 import { FileUpload, useIsMobile } from '@pagopa-pn/pn-commons';
 import { ButtonNaked } from '@pagopa/mui-italia';
 
@@ -105,6 +105,7 @@ type Props = {
   attachmentsData?: Array<NewNotificationDocument>;
   forwardedRef: ForwardedRef<unknown>;
   isCompleted: boolean;
+  hasAdditionalLang?: boolean;
 };
 
 const emptyFileData = {
@@ -130,6 +131,7 @@ const Attachments: React.FC<Props> = ({
   attachmentsData,
   forwardedRef,
   isCompleted,
+  hasAdditionalLang,
 }) => {
   const dispatch = useAppDispatch();
   const { t } = useTranslation(['notifiche'], {
@@ -300,6 +302,11 @@ const Attachments: React.FC<Props> = ({
         previousStepLabel={t('back-to-recipient')}
         previousStepOnClick={() => handlePreviousStep()}
       >
+        {hasAdditionalLang && (
+          <Alert severity="info" sx={{ mt: 2, mb: 2 }} data-testid="bannerAdditionalLanguages">
+            {t('banner-additional-languages')}
+          </Alert>
+        )}
         {formik.values.documents.map((d, i) => (
           <AttachmentBox
             key={d.id}

--- a/packages/pn-pa-webapp/src/components/NewNotification/__test__/Attachments.test.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/__test__/Attachments.test.tsx
@@ -394,6 +394,16 @@ describe('Attachments Component with payment enabled', async () => {
     }
     expect(buttonAddAnotherDoc).not.toBeInTheDocument();
   });
+  
+  it('should appear info banner with additional languages', async () => {
+    // render component
+    await act(async () => {
+      result = render(<Attachments isCompleted={false} onConfirm={confirmHandlerMk} hasAdditionalLang={true}/>);
+    });
+    const form = result.container.querySelector('form');
+    const banner = within(form!).getByTestId('bannerAdditionalLanguages');
+    expect(banner).toBeInTheDocument();
+  });
 });
 
 describe('Attachments Component without payment enabled', () => {

--- a/packages/pn-pa-webapp/src/pages/NewNotification.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/NewNotification.page.tsx
@@ -9,6 +9,7 @@ import Attachments from '../components/NewNotification/Attachments';
 import PreliminaryInformations from '../components/NewNotification/PreliminaryInformations';
 import Recipient from '../components/NewNotification/Recipient';
 import SyncFeedback from '../components/NewNotification/SyncFeedback';
+import { NewNotificationLangOther } from '../models/NewNotification';
 import * as routes from '../navigation/routes.const';
 import { useAppDispatch, useAppSelector } from '../redux/hooks';
 import { createNewNotification } from '../redux/newNotification/actions';
@@ -169,6 +170,9 @@ const NewNotification = () => {
                 onPreviousStep={goToPreviousStep}
                 isCompleted={isCompleted}
                 attachmentsData={notification.documents}
+                hasAdditionalLang={
+                  notification.lang === NewNotificationLangOther && !!notification.additionalLang
+                }
                 ref={childRef}
               />
             )}


### PR DESCRIPTION
## Short description
An info banner is shown in attachments tab when PA user creates a manual notification with an additional language 

## How to test
Start pa-webapp and login with a PA user. 
Create manual notification with an additional language. In attachment tab, check the banner 