### PR TITLE
PN-13206 - Show downtime language banner on app status and notification detail page

### DIFF
--- a/packages/pn-commons/src/components/AppStatus/AppStatusRender.tsx
+++ b/packages/pn-commons/src/components/AppStatus/AppStatusRender.tsx
@@ -7,7 +7,9 @@ import { AppStatusData, GetDowntimeHistoryParams, KnownSentiment } from '../../m
 import { PaginationData } from '../../models/Pagination';
 import { formatDateTime } from '../../utility/date.utility';
 import { getLocalizedOrDefaultLabel } from '../../utility/localization.utility';
+import { getSessionLanguage } from '../../utility/multilanguage.utility';
 import ApiErrorWrapper from '../ApiError/ApiErrorWrapper';
+import DowntimeLanguageBanner from '../DowntimeLanguageBanner';
 import EmptyState from '../EmptyState';
 import CustomPagination from '../Pagination/CustomPagination';
 import TitleBox from '../TitleBox';
@@ -24,19 +26,20 @@ type Props = {
   setPagination: (data: PaginationData) => void;
   actionIds: { GET_CURRENT_STATUS: string; GET_DOWNTIME_HISTORY: string };
   handleTrackDownloadCertificateOpposable3dparties?: () => void;
+  downtimeExampleLink: string;
 };
 
-export const AppStatusRender = (props: Props) => {
-  const {
-    appStatus,
-    actionIds,
-    fetchCurrentStatus,
-    fetchDowntimeLogPage,
-    clearPagination,
-    setPagination,
-    fetchDowntimeLegalFactDocumentDetails,
-    handleTrackDownloadCertificateOpposable3dparties,
-  } = props;
+export const AppStatusRender: React.FC<Props> = ({
+  appStatus,
+  actionIds,
+  fetchCurrentStatus,
+  fetchDowntimeLogPage,
+  clearPagination,
+  setPagination,
+  fetchDowntimeLegalFactDocumentDetails,
+  handleTrackDownloadCertificateOpposable3dparties,
+  downtimeExampleLink,
+}) => {
   const { currentStatus, downtimeLogPage, pagination: paginationData } = appStatus;
   const [isInitialized, setIsInitialized] = useState(false);
   const isMobile = useIsMobile();
@@ -123,6 +126,10 @@ export const AppStatusRender = (props: Props) => {
       <Stack direction="column">
         {/* Titolo status */}
         <TitleBox title={title} variantTitle="h4" subTitle={subtitle} variantSubTitle="body1" />
+
+        {getSessionLanguage() !== 'it' && (
+          <DowntimeLanguageBanner downtimeExampleLink={downtimeExampleLink} />
+        )}
 
         {/* Dati relativi al status */}
         <ApiErrorWrapper

--- a/packages/pn-commons/src/components/AppStatus/__test__/AppStatusRender.test.tsx
+++ b/packages/pn-commons/src/components/AppStatus/__test__/AppStatusRender.test.tsx
@@ -13,6 +13,7 @@ import {
   waitFor,
 } from '../../../test-utils';
 import { formatDateTime } from '../../../utility/date.utility';
+import { LANGUAGE_SESSION_KEY } from '../../../utility/multilanguage.utility';
 import { apiOutcomeTestHelper } from '../../../utility/test.utility';
 import { AppStatusRender } from '../AppStatusRender';
 
@@ -62,6 +63,7 @@ describe('AppStatusRender component', () => {
           fetchDowntimeLegalFactDocumentDetails={fetchDowntimeLegalFactDocumentDetails}
           fetchDowntimeLogPage={fetchDowntimeLogPage}
           setPagination={setPagination}
+          downtimeExampleLink="mock-downtime-example-link"
         />
       );
     });
@@ -117,6 +119,7 @@ describe('AppStatusRender component', () => {
           fetchDowntimeLegalFactDocumentDetails={fetchDowntimeLegalFactDocumentDetails}
           fetchDowntimeLogPage={fetchDowntimeLogPage}
           setPagination={setPagination}
+          downtimeExampleLink="mock-downtime-example-link"
         />
       );
     });
@@ -146,6 +149,7 @@ describe('AppStatusRender component', () => {
           fetchDowntimeLegalFactDocumentDetails={fetchDowntimeLegalFactDocumentDetails}
           fetchDowntimeLogPage={fetchDowntimeLogPage}
           setPagination={setPagination}
+          downtimeExampleLink="mock-downtime-example-link"
         />
       );
     });
@@ -174,6 +178,7 @@ describe('AppStatusRender component', () => {
           fetchDowntimeLegalFactDocumentDetails={fetchDowntimeLegalFactDocumentDetails}
           fetchDowntimeLogPage={fetchDowntimeLogPage}
           setPagination={setPagination}
+          downtimeExampleLink="mock-downtime-example-link"
         />
       );
     });
@@ -203,6 +208,7 @@ describe('AppStatusRender component', () => {
         fetchDowntimeLegalFactDocumentDetails={fetchDowntimeLegalFactDocumentDetails}
         fetchDowntimeLogPage={fetchDowntimeLogPage}
         setPagination={setPagination}
+        downtimeExampleLink="mock-downtime-example-link"
       />
     );
     expect(fetchCurrentStatus).toBeCalledTimes(2);
@@ -225,6 +231,7 @@ describe('AppStatusRender component', () => {
         fetchDowntimeLegalFactDocumentDetails={fetchDowntimeLegalFactDocumentDetails}
         fetchDowntimeLogPage={fetchDowntimeLogPage}
         setPagination={setPagination}
+        downtimeExampleLink="mock-downtime-example-link"
       />
     );
     rows = result.getAllByTestId('tableDowntimeLog.row');
@@ -249,6 +256,7 @@ describe('AppStatusRender component', () => {
           fetchDowntimeLegalFactDocumentDetails={fetchDowntimeLegalFactDocumentDetails}
           fetchDowntimeLogPage={fetchDowntimeLogPage}
           setPagination={setPagination}
+          downtimeExampleLink="mock-downtime-example-link"
         />
       );
     });
@@ -277,6 +285,7 @@ describe('AppStatusRender component', () => {
         fetchDowntimeLegalFactDocumentDetails={fetchDowntimeLegalFactDocumentDetails}
         fetchDowntimeLogPage={fetchDowntimeLogPage}
         setPagination={setPagination}
+        downtimeExampleLink="mock-downtime-example-link"
       />
     );
     expect(fetchCurrentStatus).toBeCalledTimes(2);
@@ -299,6 +308,7 @@ describe('AppStatusRender component', () => {
         fetchDowntimeLegalFactDocumentDetails={fetchDowntimeLegalFactDocumentDetails}
         fetchDowntimeLogPage={fetchDowntimeLogPage}
         setPagination={setPagination}
+        downtimeExampleLink="mock-downtime-example-link"
       />
     );
     rows = result.getAllByTestId('tableDowntimeLog.row');
@@ -323,6 +333,7 @@ describe('AppStatusRender component', () => {
           fetchDowntimeLegalFactDocumentDetails={fetchDowntimeLegalFactDocumentDetails}
           fetchDowntimeLogPage={fetchDowntimeLogPage}
           setPagination={setPagination}
+          downtimeExampleLink="mock-downtime-example-link"
         />,
         {
           preloadedState: {
@@ -372,6 +383,7 @@ describe('AppStatusRender component', () => {
           fetchDowntimeLegalFactDocumentDetails={fetchDowntimeLegalFactDocumentDetails}
           fetchDowntimeLogPage={fetchDowntimeLogPage}
           setPagination={setPagination}
+          downtimeExampleLink="mock-downtime-example-link"
         />,
         {
           preloadedState: {
@@ -396,5 +408,53 @@ describe('AppStatusRender component', () => {
     expect(emptyStateComponent).not.toBeInTheDocument();
     expect(errorStatusComponent).toBeInTheDocument();
     expect(errorDowntimeComponent).toBeInTheDocument();
+  });
+
+  it('should show downtime language banner if language is not italian', async () => {
+    sessionStorage.setItem(LANGUAGE_SESSION_KEY, 'en');
+    await act(async () => {
+      result = render(
+        <AppStatusRender
+          actionIds={mockActionIds}
+          appStatus={{
+            ...mockAppStatus,
+            downtimeLogPage: { result: beDowntimeHistoryWithIncidents.result },
+          }}
+          clearPagination={clearPagination}
+          fetchCurrentStatus={fetchCurrentStatus}
+          fetchDowntimeLegalFactDocumentDetails={fetchDowntimeLegalFactDocumentDetails}
+          fetchDowntimeLogPage={fetchDowntimeLogPage}
+          setPagination={setPagination}
+          downtimeExampleLink="mock-downtime-example-link"
+        />
+      );
+    });
+
+    const languageBanner = result.queryByTestId('downtimeLanguageBanner');
+    expect(languageBanner).toBeInTheDocument();
+  });
+
+  it('should not show downtime language banner if language is italian', async () => {
+    sessionStorage.setItem(LANGUAGE_SESSION_KEY, 'it');
+    await act(async () => {
+      result = render(
+        <AppStatusRender
+          actionIds={mockActionIds}
+          appStatus={{
+            ...mockAppStatus,
+            downtimeLogPage: { result: beDowntimeHistoryWithIncidents.result },
+          }}
+          clearPagination={clearPagination}
+          fetchCurrentStatus={fetchCurrentStatus}
+          fetchDowntimeLegalFactDocumentDetails={fetchDowntimeLegalFactDocumentDetails}
+          fetchDowntimeLogPage={fetchDowntimeLogPage}
+          setPagination={setPagination}
+          downtimeExampleLink="mock-downtime-example-link"
+        />
+      );
+    });
+
+    const languageBanner = result.queryByTestId('downtimeLanguageBanner');
+    expect(languageBanner).not.toBeInTheDocument();
   });
 });

--- a/packages/pn-commons/src/components/DowntimeLanguageBanner.tsx
+++ b/packages/pn-commons/src/components/DowntimeLanguageBanner.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import { Alert, Link, Typography } from '@mui/material';
+
+import { getLocalizedOrDefaultLabel } from '../utility/localization.utility';
+
+type Props = {
+  downtimeExampleLink: string;
+};
+
+const DowntimeLanguageBanner: React.FC<Props> = ({ downtimeExampleLink }) => (
+  <Alert severity="info" variant="outlined" data-testid="downtimeLanguageBanner" sx={{ mt: 2 }}>
+    <Typography variant="body2">
+      {getLocalizedOrDefaultLabel('common', 'downtime_language_banner.message')}
+      &nbsp;
+      <Link
+        target="_blank"
+        fontWeight="bold"
+        data-testid="link-downtime-example"
+        href={downtimeExampleLink}
+        sx={{ cursor: 'pointer' }}
+      >
+        {getLocalizedOrDefaultLabel('common', 'downtime_language_banner.link')}
+      </Link>
+    </Typography>
+  </Alert>
+);
+
+export default DowntimeLanguageBanner;

--- a/packages/pn-commons/src/components/NotificationDetail/NotificationRelatedDowntimes.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationRelatedDowntimes.tsx
@@ -7,7 +7,9 @@ import { ButtonNaked } from '@pagopa/mui-italia';
 import { Downtime, NotificationStatus, NotificationStatusHistory } from '../../models';
 import { formatDate, isToday } from '../../utility';
 import { getLocalizedOrDefaultLabel } from '../../utility/localization.utility';
+import { getSessionLanguage } from '../../utility/multilanguage.utility';
 import ApiErrorWrapper from '../ApiError/ApiErrorWrapper';
+import DowntimeLanguageBanner from '../DowntimeLanguageBanner';
 
 type Props = {
   // the notification history, needed to compute the time range for the downtime events query
@@ -22,6 +24,8 @@ type Props = {
   apiId: string;
   // for disabled downloads
   disableDownloads?: boolean;
+  // link to the downtime example
+  downtimeExampleLink: string;
 };
 
 /*
@@ -63,6 +67,7 @@ const NotificationRelatedDowntimes: React.FC<Props> = ({
   fetchDowntimeLegalFactDocumentDetails,
   apiId,
   disableDownloads,
+  downtimeExampleLink,
 }) => {
   const theme = useTheme();
 
@@ -172,6 +177,11 @@ const NotificationRelatedDowntimes: React.FC<Props> = ({
               </Typography>
             </Grid>
           </Grid>
+
+          {getSessionLanguage() !== 'it' && (
+            <DowntimeLanguageBanner downtimeExampleLink={downtimeExampleLink} />
+          )}
+
           <Grid key={'detail-documents-message'} item>
             <Stack direction="column">
               {/* Render each downtime event */}

--- a/packages/pn-commons/src/components/NotificationDetail/__test__/NotificationRelatedDowntimes.test.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/__test__/NotificationRelatedDowntimes.test.tsx
@@ -11,6 +11,7 @@ import {
 } from '../../../models';
 import { RenderResult, initLocalizationForTest, render, within } from '../../../test-utils';
 import { formatDate, isToday } from '../../../utility';
+import { LANGUAGE_SESSION_KEY } from '../../../utility/multilanguage.utility';
 import NotificationRelatedDowntimes from '../NotificationRelatedDowntimes';
 
 const fakePalette = {
@@ -63,6 +64,7 @@ function renderComponent(
       notificationStatusHistory={history}
       apiId="getNotificationDowntimeHistory"
       fetchDowntimeLegalFactDocumentDetails={() => {}}
+      downtimeExampleLink=""
     />,
     setApiError ? mockErrorState : undefined
   );
@@ -390,5 +392,25 @@ describe('NotificationRelatedDowntimes component', () => {
     expect(fetchDowntimeEventsMock).toHaveBeenCalledTimes(0);
     const mainComponent = queryByTestId('notification-related-downtimes-main');
     expect(mainComponent).not.toBeInTheDocument();
+  });
+
+  it('should show downtime language banner if language is not italian', () => {
+    sessionStorage.setItem(LANGUAGE_SESSION_KEY, 'en');
+    const { getByTestId } = renderComponent(
+      beDowntimeHistoryWithIncidents.result,
+      notificationDTO.notificationStatusHistory
+    );
+    const languageBanner = getByTestId('downtimeLanguageBanner');
+    expect(languageBanner).toBeInTheDocument();
+  });
+
+  it('should not show downtime language banner if language is italian', () => {
+    sessionStorage.setItem(LANGUAGE_SESSION_KEY, 'it');
+    const { queryByTestId } = renderComponent(
+      beDowntimeHistoryWithIncidents.result,
+      notificationDTO.notificationStatusHistory
+    );
+    const languageBanner = queryByTestId('downtimeLanguageBanner');
+    expect(languageBanner).not.toBeInTheDocument();
   });
 });

--- a/packages/pn-commons/src/components/__test__/DowntimeLanguageBanner.test.tsx
+++ b/packages/pn-commons/src/components/__test__/DowntimeLanguageBanner.test.tsx
@@ -1,0 +1,15 @@
+import { render } from '../../test-utils';
+import DowntimeLanguageBanner from '../DowntimeLanguageBanner';
+
+describe('DowntimeLanguageBanner Component', () => {
+  it('render components', () => {
+    const { container, getByTestId } = render(
+      <DowntimeLanguageBanner downtimeExampleLink="mock-downtime-link" />
+    );
+
+    expect(container).toHaveTextContent('downtime_language_banner.message');
+    const link = getByTestId('link-downtime-example');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveTextContent('downtime_language_banner.link');
+  });
+});

--- a/packages/pn-commons/src/utility/multilanguage.utility.ts
+++ b/packages/pn-commons/src/utility/multilanguage.utility.ts
@@ -4,6 +4,11 @@ import { LangCode } from '@pagopa/mui-italia';
 
 export const LANGUAGE_SESSION_KEY = 'lang';
 
+export const getSessionLanguage = (): string => {
+  const lang = sessionStorage.getItem(LANGUAGE_SESSION_KEY);
+  return lang ?? 'it';
+};
+
 export const setSessionLanguage = (lang: LangCode) => {
   sessionStorage.setItem(LANGUAGE_SESSION_KEY, lang);
 };

--- a/packages/pn-pa-webapp/public/conf/env/config.dev.json
+++ b/packages/pn-pa-webapp/public/conf/env/config.dev.json
@@ -16,5 +16,6 @@
   "IS_MANUAL_SEND_ENABLED": true,
   "API_B2B_LINK": "https://developer.pagopa.it/send/api#/",
   "IS_STATISTICS_ENABLED": true,
-  "TAXONOMY_SEND_URL":"https://docs.pagopa.it/f.a.q.-per-integratori/tassonomia-send"
+  "TAXONOMY_SEND_URL": "https://docs.pagopa.it/f.a.q.-per-integratori/tassonomia-send",
+  "DOWNTIME_EXAMPLE_LINK": "https://notifichedigitali.pagopa.it/static/documents/LegalFactMalfunction.pdf"
 }

--- a/packages/pn-pa-webapp/public/conf/env/config.hotfix.json
+++ b/packages/pn-pa-webapp/public/conf/env/config.hotfix.json
@@ -16,5 +16,6 @@
   "IS_MANUAL_SEND_ENABLED": true,
   "API_B2B_LINK": "https://developer.pagopa.it/send/api#/",
   "IS_STATISTICS_ENABLED": true,
-  "TAXONOMY_SEND_URL":"https://docs.pagopa.it/f.a.q.-per-integratori/tassonomia-send"
+  "TAXONOMY_SEND_URL": "https://docs.pagopa.it/f.a.q.-per-integratori/tassonomia-send",
+  "DOWNTIME_EXAMPLE_LINK": "https://notifichedigitali.pagopa.it/static/documents/LegalFactMalfunction.pdf"
 }

--- a/packages/pn-pa-webapp/public/conf/env/config.prod.json
+++ b/packages/pn-pa-webapp/public/conf/env/config.prod.json
@@ -16,5 +16,6 @@
   "IS_MANUAL_SEND_ENABLED": true,
   "API_B2B_LINK": "https://developer.pagopa.it/send/api#/",
   "IS_STATISTICS_ENABLED": true,
-  "TAXONOMY_SEND_URL":"https://docs.pagopa.it/f.a.q.-per-integratori/tassonomia-send"
+  "TAXONOMY_SEND_URL": "https://docs.pagopa.it/f.a.q.-per-integratori/tassonomia-send",
+  "DOWNTIME_EXAMPLE_LINK": "https://notifichedigitali.pagopa.it/static/documents/LegalFactMalfunction.pdf"
 }

--- a/packages/pn-pa-webapp/public/conf/env/config.test.json
+++ b/packages/pn-pa-webapp/public/conf/env/config.test.json
@@ -16,5 +16,6 @@
   "IS_MANUAL_SEND_ENABLED": true,
   "API_B2B_LINK": "https://developer.pagopa.it/send/api#/",
   "IS_STATISTICS_ENABLED": true,
-  "TAXONOMY_SEND_URL":"https://docs.pagopa.it/f.a.q.-per-integratori/tassonomia-send"
+  "TAXONOMY_SEND_URL": "https://docs.pagopa.it/f.a.q.-per-integratori/tassonomia-send",
+  "DOWNTIME_EXAMPLE_LINK": "https://notifichedigitali.pagopa.it/static/documents/LegalFactMalfunction.pdf"
 }

--- a/packages/pn-pa-webapp/public/conf/env/config.uat.json
+++ b/packages/pn-pa-webapp/public/conf/env/config.uat.json
@@ -16,5 +16,6 @@
   "IS_MANUAL_SEND_ENABLED": true,
   "API_B2B_LINK": "https://developer.pagopa.it/send/api#/",
   "IS_STATISTICS_ENABLED": true,
-  "TAXONOMY_SEND_URL":"https://docs.pagopa.it/f.a.q.-per-integratori/tassonomia-send"
+  "TAXONOMY_SEND_URL": "https://docs.pagopa.it/f.a.q.-per-integratori/tassonomia-send",
+  "DOWNTIME_EXAMPLE_LINK": "https://notifichedigitali.pagopa.it/static/documents/LegalFactMalfunction.pdf"
 }

--- a/packages/pn-pa-webapp/public/locales/it/common.json
+++ b/packages/pn-pa-webapp/public/locales/it/common.json
@@ -163,5 +163,9 @@
   },
   "attachments": {
     "remove-attachment": "Elimina allegato"
+  },
+  "downtime_language_banner": {
+    "message": "Il testo originario di questi documenti è in lingua italiana. In caso di contrasto tra la versione italiana e le traduzioni in altre lingue, prevarranno il significato e le condizioni della lingua italiana.",
+    "link": "Consulta le traduzioni"
   }
 }

--- a/packages/pn-pa-webapp/src/pages/AppStatus.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/AppStatus.page.tsx
@@ -18,11 +18,13 @@ import { APP_STATUS_ACTIONS } from '../redux/appStatus/actions';
 import { clearPagination, setPagination } from '../redux/appStatus/reducers';
 import { useAppDispatch, useAppSelector } from '../redux/hooks';
 import { RootState } from '../redux/store';
+import { getConfiguration } from '../services/configuration.service';
 
 const AppStatus = () => {
   const dispatch = useAppDispatch();
   const appStatus = useAppSelector((state: RootState) => state.appStatus);
   const { t } = useTranslation(['appStatus']);
+  const { DOWNTIME_EXAMPLE_LINK } = getConfiguration();
 
   const fetchCurrentStatus = useCallback(() => {
     void dispatch(getCurrentAppStatus());
@@ -69,6 +71,7 @@ const AppStatus = () => {
       }
       clearPagination={() => dispatch(clearPagination())}
       actionIds={APP_STATUS_ACTIONS}
+      downtimeExampleLink={DOWNTIME_EXAMPLE_LINK}
     />
   );
 };

--- a/packages/pn-pa-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/NotificationDetail.page.tsx
@@ -41,6 +41,7 @@ import {
 } from '../redux/notification/actions';
 import { resetState } from '../redux/notification/reducers';
 import { RootState } from '../redux/store';
+import { getConfiguration } from '../services/configuration.service';
 import { ServerResponseErrorCode } from '../utility/AppError/types';
 
 type Props = {
@@ -72,6 +73,7 @@ const NotificationDetail: React.FC = () => {
   const { hasApiErrors } = useErrors();
   const isMobile = useIsMobile();
   const notification = useAppSelector((state: RootState) => state.notificationState.notification);
+  const { DOWNTIME_EXAMPLE_LINK } = getConfiguration();
 
   const downtimeEvents = useAppSelector(
     (state: RootState) => state.notificationState.downtimeEvents
@@ -349,6 +351,7 @@ const NotificationDetail: React.FC = () => {
                   notificationStatusHistory={notification.notificationStatusHistory}
                   fetchDowntimeLegalFactDocumentDetails={fetchDowntimeLegalFactDocumentDetails}
                   apiId={NOTIFICATION_ACTIONS.GET_DOWNTIME_HISTORY}
+                  downtimeExampleLink={DOWNTIME_EXAMPLE_LINK}
                 />
               </Stack>
             </Grid>

--- a/packages/pn-pa-webapp/src/services/configuration.service.ts
+++ b/packages/pn-pa-webapp/src/services/configuration.service.ts
@@ -20,6 +20,7 @@ interface PaConfigurationFromFile {
   IS_MANUAL_SEND_ENABLED: boolean;
   IS_STATISTICS_ENABLED: boolean;
   TAXONOMY_SEND_URL: string;
+  DOWNTIME_EXAMPLE_LINK: string;
 }
 
 export interface PaConfiguration extends PaConfigurationFromFile {
@@ -63,6 +64,7 @@ class PaConfigurationValidator extends Validator<PaConfigurationFromFile> {
     this.ruleFor('IS_MANUAL_SEND_ENABLED').isBoolean();
     this.ruleFor('IS_STATISTICS_ENABLED').isBoolean();
     this.ruleFor('TAXONOMY_SEND_URL').isString();
+    this.ruleFor('DOWNTIME_EXAMPLE_LINK').isString();
   }
 }
 
@@ -89,6 +91,7 @@ export function getConfiguration(): PaConfiguration {
     IS_MANUAL_SEND_ENABLED: Boolean(configurationFromFile.IS_MANUAL_SEND_ENABLED),
     IS_STATISTICS_ENABLED: Boolean(configurationFromFile.IS_STATISTICS_ENABLED),
     TAXONOMY_SEND_URL: configurationFromFile.TAXONOMY_SEND_URL,
+    DOWNTIME_EXAMPLE_LINK: configurationFromFile.DOWNTIME_EXAMPLE_LINK,
   };
 }
 

--- a/packages/pn-personafisica-webapp/public/conf/env/config.dev.json
+++ b/packages/pn-personafisica-webapp/public/conf/env/config.dev.json
@@ -18,5 +18,6 @@
   "APP_IO_SITE": "https://io.italia.it/",
   "APP_IO_ANDROID": "https://play.google.com/store/apps/details?id=it.pagopa.io.app",
   "APP_IO_IOS": "https://apps.apple.com/it/app/io/id1501681835",
-  "DOD_DISABLED": false
+  "DOD_DISABLED": false,
+  "DOWNTIME_EXAMPLE_LINK": "https://notifichedigitali.pagopa.it/static/documents/LegalFactMalfunction.pdf"
 }

--- a/packages/pn-personafisica-webapp/public/conf/env/config.hotfix.json
+++ b/packages/pn-personafisica-webapp/public/conf/env/config.hotfix.json
@@ -18,5 +18,6 @@
   "APP_IO_SITE": "https://io.italia.it/",
   "APP_IO_ANDROID": "https://play.google.com/store/apps/details?id=it.pagopa.io.app",
   "APP_IO_IOS": "https://apps.apple.com/it/app/io/id1501681835",
-  "DOD_DISABLED": false
+  "DOD_DISABLED": false,
+  "DOWNTIME_EXAMPLE_LINK": "https://notifichedigitali.pagopa.it/static/documents/LegalFactMalfunction.pdf"
 }

--- a/packages/pn-personafisica-webapp/public/conf/env/config.prod.json
+++ b/packages/pn-personafisica-webapp/public/conf/env/config.prod.json
@@ -18,5 +18,6 @@
   "APP_IO_SITE": "https://io.italia.it/",
   "APP_IO_ANDROID": "https://play.google.com/store/apps/details?id=it.pagopa.io.app",
   "APP_IO_IOS": "https://apps.apple.com/it/app/io/id1501681835",
-  "DOD_DISABLED": true
+  "DOD_DISABLED": true,
+  "DOWNTIME_EXAMPLE_LINK": "https://notifichedigitali.pagopa.it/static/documents/LegalFactMalfunction.pdf"
 }

--- a/packages/pn-personafisica-webapp/public/conf/env/config.test.json
+++ b/packages/pn-personafisica-webapp/public/conf/env/config.test.json
@@ -18,5 +18,6 @@
   "APP_IO_SITE": "https://io.italia.it/",
   "APP_IO_ANDROID": "https://play.google.com/store/apps/details?id=it.pagopa.io.app",
   "APP_IO_IOS": "https://apps.apple.com/it/app/io/id1501681835",
-  "DOD_DISABLED": true
+  "DOD_DISABLED": true,
+  "DOWNTIME_EXAMPLE_LINK": "https://notifichedigitali.pagopa.it/static/documents/LegalFactMalfunction.pdf"
 }

--- a/packages/pn-personafisica-webapp/public/conf/env/config.uat.json
+++ b/packages/pn-personafisica-webapp/public/conf/env/config.uat.json
@@ -18,5 +18,6 @@
   "APP_IO_SITE": "https://io.italia.it/",
   "APP_IO_ANDROID": "https://play.google.com/store/apps/details?id=it.pagopa.io.app",
   "APP_IO_IOS": "https://apps.apple.com/it/app/io/id1501681835",
-  "DOD_DISABLED": false
+  "DOD_DISABLED": false,
+  "DOWNTIME_EXAMPLE_LINK": "https://notifichedigitali.pagopa.it/static/documents/LegalFactMalfunction.pdf"
 }

--- a/packages/pn-personafisica-webapp/public/locales/it/common.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/common.json
@@ -187,5 +187,9 @@
   },
   "conjunctions": {
     "or": "oppure"
+  },
+  "downtime_language_banner": {
+    "message": "Il testo originario di questi documenti è in lingua italiana. In caso di contrasto tra la versione italiana e le traduzioni in altre lingue, prevarranno il significato e le condizioni della lingua italiana.",
+    "link": "Consulta le traduzioni"
   }
 }

--- a/packages/pn-personafisica-webapp/src/pages/AppStatus.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/AppStatus.page.tsx
@@ -19,12 +19,14 @@ import {
 import { clearPagination, setPagination } from '../redux/appStatus/reducers';
 import { useAppDispatch, useAppSelector } from '../redux/hooks';
 import { RootState } from '../redux/store';
+import { getConfiguration } from '../services/configuration.service';
 import PFEventStrategyFactory from '../utility/MixpanelUtils/PFEventStrategyFactory';
 
 const AppStatus = () => {
   const dispatch = useAppDispatch();
   const appStatus = useAppSelector((state: RootState) => state.appStatus);
   const { t } = useTranslation(['appStatus']);
+  const { DOWNTIME_EXAMPLE_LINK } = getConfiguration();
 
   const fetchCurrentStatus = useCallback(() => {
     void dispatch(getCurrentAppStatus());
@@ -90,6 +92,7 @@ const AppStatus = () => {
       handleTrackDownloadCertificateOpposable3dparties={
         handleTrackDownloadCertificateOpposable3dparties
       }
+      downtimeExampleLink={DOWNTIME_EXAMPLE_LINK}
     />
   );
 };

--- a/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
@@ -78,7 +78,7 @@ const NotificationDetail: React.FC = () => {
   const { hasApiErrors } = useErrors();
   const [pageReady, setPageReady] = useState(false);
   const [downtimesReady, setDowntimesReady] = useState(false);
-  const { F24_DOWNLOAD_WAIT_TIME, LANDING_SITE_URL } = getConfiguration();
+  const { F24_DOWNLOAD_WAIT_TIME, LANDING_SITE_URL, DOWNTIME_EXAMPLE_LINK } = getConfiguration();
   const navigate = useNavigate();
 
   const currentUser = useAppSelector((state: RootState) => state.userState.user);
@@ -547,6 +547,7 @@ const NotificationDetail: React.FC = () => {
                   fetchDowntimeLegalFactDocumentDetails={fetchDowntimeLegalFactDocumentDetails}
                   apiId={NOTIFICATION_ACTIONS.GET_DOWNTIME_HISTORY}
                   disableDownloads={isCancelled.cancellationInTimeline}
+                  downtimeExampleLink={DOWNTIME_EXAMPLE_LINK}
                 />
               </Stack>
             </Grid>

--- a/packages/pn-personafisica-webapp/src/services/configuration.service.ts
+++ b/packages/pn-personafisica-webapp/src/services/configuration.service.ts
@@ -25,6 +25,7 @@ interface PfConfigurationFromFile {
   APP_IO_ANDROID: string;
   APP_IO_IOS: string;
   DOD_DISABLED: boolean;
+  DOWNTIME_EXAMPLE_LINK: string;
 }
 
 interface PfConfiguration extends PfConfigurationFromFile {
@@ -68,6 +69,7 @@ class PfConfigurationValidator extends Validator<PfConfigurationFromFile> {
     this.ruleFor('APP_IO_ANDROID').isString();
     this.ruleFor('APP_IO_IOS').isString();
     this.ruleFor('DOD_DISABLED').isBoolean();
+    this.ruleFor('DOWNTIME_EXAMPLE_LINK').isString();
   }
 }
 
@@ -95,7 +97,8 @@ export function getConfiguration(): PfConfiguration {
     DELEGATIONS_TO_PG_ENABLED: Boolean(configurationFromFile.DELEGATIONS_TO_PG_ENABLED),
     WORK_IN_PROGRESS: Boolean(configurationFromFile.WORK_IN_PROGRESS),
     F24_DOWNLOAD_WAIT_TIME: configurationFromFile.F24_DOWNLOAD_WAIT_TIME || 0,
-    DOD_DISABLED: Boolean(configurationFromFile.DOD_DISABLED)
+    DOD_DISABLED: Boolean(configurationFromFile.DOD_DISABLED),
+    DOWNTIME_EXAMPLE_LINK: configurationFromFile.DOWNTIME_EXAMPLE_LINK || '',
   };
 }
 

--- a/packages/pn-personagiuridica-webapp/public/conf/env/config.dev.json
+++ b/packages/pn-personagiuridica-webapp/public/conf/env/config.dev.json
@@ -17,5 +17,6 @@
   "WORK_IN_PROGRESS": false,
   "F24_DOWNLOAD_WAIT_TIME": 15000,
   "IS_B2B_ENABLED": true,
-  "DOD_DISABLED": false
+  "DOD_DISABLED": false,
+  "DOWNTIME_EXAMPLE_LINK": "https://notifichedigitali.pagopa.it/static/documents/LegalFactMalfunction.pdf"
 }

--- a/packages/pn-personagiuridica-webapp/public/conf/env/config.hotfix.json
+++ b/packages/pn-personagiuridica-webapp/public/conf/env/config.hotfix.json
@@ -17,5 +17,6 @@
   "WORK_IN_PROGRESS": false,
   "F24_DOWNLOAD_WAIT_TIME": 15000,
   "IS_B2B_ENABLED": true,
-  "DOD_DISABLED": false
+  "DOD_DISABLED": false,
+  "DOWNTIME_EXAMPLE_LINK": "https://notifichedigitali.pagopa.it/static/documents/LegalFactMalfunction.pdf"
 }

--- a/packages/pn-personagiuridica-webapp/public/conf/env/config.prod.json
+++ b/packages/pn-personagiuridica-webapp/public/conf/env/config.prod.json
@@ -17,5 +17,6 @@
   "WORK_IN_PROGRESS": false,
   "F24_DOWNLOAD_WAIT_TIME": 15000,
   "IS_B2B_ENABLED": false,
-  "DOD_DISABLED": true
+  "DOD_DISABLED": true,
+  "DOWNTIME_EXAMPLE_LINK": "https://notifichedigitali.pagopa.it/static/documents/LegalFactMalfunction.pdf"
 }

--- a/packages/pn-personagiuridica-webapp/public/conf/env/config.test.json
+++ b/packages/pn-personagiuridica-webapp/public/conf/env/config.test.json
@@ -17,5 +17,6 @@
   "WORK_IN_PROGRESS": false,
   "F24_DOWNLOAD_WAIT_TIME": 15000,
   "IS_B2B_ENABLED": true,
-  "DOD_DISABLED": true
+  "DOD_DISABLED": true,
+  "DOWNTIME_EXAMPLE_LINK": "https://notifichedigitali.pagopa.it/static/documents/LegalFactMalfunction.pdf"
 }

--- a/packages/pn-personagiuridica-webapp/public/conf/env/config.uat.json
+++ b/packages/pn-personagiuridica-webapp/public/conf/env/config.uat.json
@@ -17,5 +17,6 @@
   "WORK_IN_PROGRESS": false,
   "F24_DOWNLOAD_WAIT_TIME": 15000,
   "IS_B2B_ENABLED": true,
-  "DOD_DISABLED": false
+  "DOD_DISABLED": false,
+  "DOWNTIME_EXAMPLE_LINK": "https://notifichedigitali.pagopa.it/static/documents/LegalFactMalfunction.pdf"
 }

--- a/packages/pn-personagiuridica-webapp/public/locales/it/common.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/it/common.json
@@ -200,5 +200,9 @@
   },
   "conjunctions": {
     "or": "oppure"
+  },
+  "downtime_language_banner": {
+    "message": "Il testo originario di questi documenti è in lingua italiana. In caso di contrasto tra la versione italiana e le traduzioni in altre lingue, prevarranno il significato e le condizioni della lingua italiana.",
+    "link": "Consulta le traduzioni"
   }
 }

--- a/packages/pn-personagiuridica-webapp/src/pages/AppStatus.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/AppStatus.page.tsx
@@ -18,11 +18,13 @@ import { APP_STATUS_ACTIONS } from '../redux/appStatus/actions';
 import { clearPagination, setPagination } from '../redux/appStatus/reducers';
 import { useAppDispatch, useAppSelector } from '../redux/hooks';
 import { RootState } from '../redux/store';
+import { getConfiguration } from '../services/configuration.service';
 
 const AppStatus = () => {
   const dispatch = useAppDispatch();
   const appStatus = useAppSelector((state: RootState) => state.appStatus);
   const { t } = useTranslation(['appStatus']);
+  const { DOWNTIME_EXAMPLE_LINK } = getConfiguration();
 
   const fetchCurrentStatus = useCallback(() => {
     void dispatch(getCurrentAppStatus());
@@ -69,6 +71,7 @@ const AppStatus = () => {
       }
       clearPagination={() => dispatch(clearPagination())}
       actionIds={APP_STATUS_ACTIONS}
+      downtimeExampleLink={DOWNTIME_EXAMPLE_LINK}
     />
   );
 };

--- a/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
@@ -76,7 +76,7 @@ const NotificationDetail = () => {
   const isMobile = useIsMobile();
   const { hasApiErrors } = useErrors();
   const [pageReady, setPageReady] = useState(false);
-  const { F24_DOWNLOAD_WAIT_TIME, LANDING_SITE_URL } = getConfiguration();
+  const { F24_DOWNLOAD_WAIT_TIME, LANDING_SITE_URL, DOWNTIME_EXAMPLE_LINK } = getConfiguration();
   const navigate = useNavigate();
 
   const currentUser = useAppSelector((state: RootState) => state.userState.user);
@@ -490,6 +490,7 @@ const NotificationDetail = () => {
                   fetchDowntimeLegalFactDocumentDetails={fetchDowntimeLegalFactDocumentDetails}
                   apiId={NOTIFICATION_ACTIONS.GET_DOWNTIME_HISTORY}
                   disableDownloads={isCancelled.cancellationInTimeline}
+                  downtimeExampleLink={DOWNTIME_EXAMPLE_LINK}
                 />
               </Stack>
             </Grid>

--- a/packages/pn-personagiuridica-webapp/src/services/configuration.service.ts
+++ b/packages/pn-personagiuridica-webapp/src/services/configuration.service.ts
@@ -24,6 +24,7 @@ interface PgConfigurationFromFile {
   F24_DOWNLOAD_WAIT_TIME: number;
   DOD_DISABLED: boolean;
   IS_B2B_ENABLED: boolean;
+  DOWNTIME_EXAMPLE_LINK: string;
 }
 
 interface PgConfiguration extends PgConfigurationFromFile {
@@ -48,6 +49,7 @@ interface PgConfiguration extends PgConfigurationFromFile {
   WORK_IN_PROGRESS: boolean;
   F24_DOWNLOAD_WAIT_TIME: number;
   IS_B2B_ENABLED: boolean;
+  DOWNTIME_EXAMPLE_LINK: string;
 }
 
 class PgConfigurationValidator extends Validator<PgConfigurationFromFile> {
@@ -71,6 +73,7 @@ class PgConfigurationValidator extends Validator<PgConfigurationFromFile> {
     this.ruleFor('F24_DOWNLOAD_WAIT_TIME').isNumber();
     this.ruleFor('DOD_DISABLED').isBoolean();
     this.ruleFor('IS_B2B_ENABLED').isBoolean();
+    this.ruleFor('DOWNTIME_EXAMPLE_LINK').isString();
   }
 }
 
@@ -102,6 +105,7 @@ export function getConfiguration(): PgConfiguration {
     F24_DOWNLOAD_WAIT_TIME: configurationFromFile.F24_DOWNLOAD_WAIT_TIME || 0,
     IS_B2B_ENABLED: Boolean(configurationFromFile.IS_B2B_ENABLED),
     DOD_DISABLED: Boolean(configurationFromFile.DOD_DISABLED),
+    DOWNTIME_EXAMPLE_LINK: configurationFromFile.DOWNTIME_EXAMPLE_LINK,
   };
 }
 


### PR DESCRIPTION
## Short description
Show downtime language banner on app status and notification detail page of PF, PG and PA

## List of changes proposed in this pull request
- Add banner

## How to test
- Start PF,PG,PA
- Change language to en (or de, fr, sl) 
- Go to app status page and check that banner is shown 
- Go to notification detail anche check that banner is shown inside downtime box
- Set language to IT and check that banners are not shown