### PR TITLE
Feat/PN-13043: pre-select additionalLanguage from settings

### DIFF
--- a/packages/pn-pa-webapp/src/App.tsx
+++ b/packages/pn-pa-webapp/src/App.tsx
@@ -28,7 +28,7 @@ import { LinkType, ProductEntity } from '@pagopa/mui-italia';
 import Router from './navigation/routes';
 import * as routes from './navigation/routes.const';
 import { getCurrentAppStatus } from './redux/appStatus/actions';
-import { getInstitutions, getProductsOfInstitution, logout } from './redux/auth/actions';
+import { getAdditionalLanguages, getInstitutions, getProductsOfInstitution, logout } from './redux/auth/actions';
 import { useAppDispatch, useAppSelector } from './redux/hooks';
 import { RootState } from './redux/store';
 import { getConfiguration } from './services/configuration.service';
@@ -182,6 +182,7 @@ const ActualApp = () => {
     if (sessionToken) {
       void dispatch(getCurrentAppStatus());
       void dispatch(getInstitutions());
+      void dispatch(getAdditionalLanguages());
     }
     if (idOrganization) {
       void dispatch(getProductsOfInstitution());

--- a/packages/pn-pa-webapp/src/__mocks__/NewNotification.mock.ts
+++ b/packages/pn-pa-webapp/src/__mocks__/NewNotification.mock.ts
@@ -177,7 +177,6 @@ export const newNotification: NewNotification = {
   notificationFeePolicy: NotificationFeePolicy.FLAT_RATE,
   senderDenomination: userResponse.organization.name,
   senderTaxId: userResponse.organization.fiscal_code,
-  lang: 'it',
 };
 
 export const newNotificationEmpty: NewNotification = {
@@ -192,7 +191,6 @@ export const newNotificationEmpty: NewNotification = {
   taxonomyCode: '',
   notificationFeePolicy: '' as NotificationFeePolicy,
   senderDenomination: userResponse.organization.name,
-  lang: 'it',
 };
 
 export const newNotificationDTO: NewNotificationDTO = newNotificationMapper(newNotification);

--- a/packages/pn-pa-webapp/src/__test__/App.test.tsx
+++ b/packages/pn-pa-webapp/src/__test__/App.test.tsx
@@ -97,6 +97,7 @@ describe('App', async () => {
     mock.onGet(/\/bff\/v2\/tos-privacy.*/).reply(200, tosPrivacyConsentMock(true, true));
     mock.onGet('/bff/v1/institutions').reply(200, institutionsDTO);
     mock.onGet('/bff/v1/institutions/products').reply(200, productsDTO);
+    mock.onGet('/bff/v1/pa/additional-languages').reply(200, { additionalLanguages: [] });
     mock.onGet('downtime/v1/status').reply(200, currentStatusDTO);
     await act(async () => {
       result = render(<Component />, { preloadedState: reduxInitialState });
@@ -108,7 +109,7 @@ describe('App', async () => {
     const sideMenu = result.queryByTestId('side-menu');
     expect(sideMenu).toBeInTheDocument();
     expect(result.container).toHaveTextContent('Generic Page');
-    expect(mock.history.get).toHaveLength(4);
+    expect(mock.history.get).toHaveLength(5);
   });
 
   it('Sidemenu not included if error in API call to fetch TOS and Privacy', async () => {
@@ -116,13 +117,14 @@ describe('App', async () => {
     mock.onGet('downtime/v1/status').reply(200, currentStatusDTO);
     mock.onGet('/bff/v1/institutions').reply(200, institutionsDTO);
     mock.onGet('/bff/v1/institutions/products').reply(200, productsDTO);
+    mock.onGet('/bff/v1/pa/additional-languages').reply(200, { additionalLanguages: [] });
     await act(async () => {
       result = render(<Component />, { preloadedState: reduxInitialState });
     });
     const sideMenu = result.queryByTestId('side-menu');
     expect(sideMenu).not.toBeInTheDocument();
     expect(result.container).not.toHaveTextContent('Generic Page');
-    expect(mock.history.get).toHaveLength(4);
+    expect(mock.history.get).toHaveLength(5);
   });
 
   it('Sidemenu not included if user has not accepted the TOS and PRIVACY', async () => {
@@ -130,6 +132,7 @@ describe('App', async () => {
     mock.onGet('downtime/v1/status').reply(200, currentStatusDTO);
     mock.onGet('/bff/v1/institutions').reply(200, institutionsDTO);
     mock.onGet('/bff/v1/institutions/products').reply(200, productsDTO);
+    mock.onGet('/bff/v1/pa/additional-languages').reply(200, { additionalLanguages: [] });
     await act(async () => {
       result = render(<Component />, { preloadedState: reduxInitialState });
     });
@@ -138,6 +141,6 @@ describe('App', async () => {
     const tosPage = result.queryByTestId('tos-acceptance-page');
     expect(tosPage).toBeInTheDocument();
     expect(result.container).not.toHaveTextContent('Generic Page');
-    expect(mock.history.get).toHaveLength(4);
+    expect(mock.history.get).toHaveLength(5);
   });
 });

--- a/packages/pn-pa-webapp/src/components/NewNotification/PreliminaryInformations.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/PreliminaryInformations.tsx
@@ -52,6 +52,9 @@ const PreliminaryInformations = ({ notification, onConfirm }: Props) => {
   const hasGroups = useAppSelector(
     (state: RootState) => state.userState.user.organization.hasGroups
   );
+  const additionalLanguages = useAppSelector(
+    (state: RootState) => state.userState.additionalLanguages
+  );
 
   // this is the initial value of the sender denomination. it used to show the error
   const senderDenomination = useAppSelector((state: RootState) =>
@@ -73,24 +76,24 @@ const PreliminaryInformations = ({ notification, onConfirm }: Props) => {
     return LANGUAGES[currentLang] ?? LANGUAGES.it;
   }, [i18n.language]);
 
-  const initialValues = useCallback(
-    () =>
-      ({
-        paProtocolNumber: notification.paProtocolNumber || '',
-        subject: notification.subject || '',
-        senderDenomination: notification.senderDenomination ?? '',
-        abstract: notification.abstract ?? '',
-        group: notification.group ?? '',
-        taxonomyCode: notification.taxonomyCode || '',
-        physicalCommunicationType: notification.physicalCommunicationType || '',
-        paymentMode: notification.paymentMode || (IS_PAYMENT_ENABLED ? '' : PaymentModel.NOTHING),
-        lang: notification.lang || 'it',
-        additionalLang: notification.additionalLang || '',
-        additionalSubject: notification.additionalSubject || '',
-        additionalAbstract: notification.additionalAbstract || '',
-      } as PreliminaryInformationsPayload),
-    [notification, IS_PAYMENT_ENABLED]
-  );
+  const initialValues = useCallback(() => {
+    const additionalLang = additionalLanguages?.length > 0 ? additionalLanguages[0] : undefined;
+
+    return {
+      paProtocolNumber: notification.paProtocolNumber || '',
+      subject: notification.subject || '',
+      senderDenomination: notification.senderDenomination ?? '',
+      abstract: notification.abstract ?? '',
+      group: notification.group ?? '',
+      taxonomyCode: notification.taxonomyCode || '',
+      physicalCommunicationType: notification.physicalCommunicationType || '',
+      paymentMode: notification.paymentMode || (IS_PAYMENT_ENABLED ? '' : PaymentModel.NOTHING),
+      lang: notification.lang || (additionalLang ? NewNotificationLangOther : 'it'),
+      additionalLang: notification.additionalLang || additionalLang || '',
+      additionalSubject: notification.additionalSubject || '',
+      additionalAbstract: notification.additionalAbstract || '',
+    } as PreliminaryInformationsPayload;
+  }, [notification, IS_PAYMENT_ENABLED, additionalLanguages]);
 
   const validationSchema = yup.object({
     paProtocolNumber: requiredStringFieldValidation(tc, 256),

--- a/packages/pn-pa-webapp/src/components/NewNotification/__test__/PreliminaryInformations.test.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/__test__/PreliminaryInformations.test.tsx
@@ -572,6 +572,39 @@ describe('PreliminaryInformations Component with payment disabled', async () => 
       );
     });
 
-    expect(screen.getByRole('link')).toHaveAttribute('href', 'https://mock-taxonomy-url')
+    expect(screen.getByRole('link')).toHaveAttribute('href', 'https://mock-taxonomy-url');
+  });
+
+  it('should set default additionalLang of user', async () => {
+    await act(async () => {
+      result = render(
+        <PreliminaryInformations
+          notification={{
+            ...newNotificationEmpty,
+          }}
+          onConfirm={confirmHandlerMk}
+        />,
+        {
+          preloadedState: {
+            userState: {
+              additionalLanguages: ['de'],
+              user: {
+                organization: { name: 'Comune di Palermo', hasGroup: true },
+              },
+            },
+          },
+        }
+      );
+    });
+
+    const form = result.getByTestId('preliminaryInformationsForm') as HTMLFormElement;
+
+    await testRadio(
+      form,
+      'notificationLanguageRadio',
+      ['Italiano', 'italian-and-other-language'],
+      1
+    );
+    testFormElements(form, 'additionalLang', 'select-other-language*', 'de');
   });
 });

--- a/packages/pn-pa-webapp/src/pages/Dashboard.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/Dashboard.page.tsx
@@ -17,7 +17,6 @@ import DesktopNotifications from '../components/Notifications/DesktopNotificatio
 import MobileNotifications from '../components/Notifications/MobileNotifications';
 import NotificationSettingsDrawer from '../components/Notifications/NotificationSettingsDrawer';
 import * as routes from '../navigation/routes.const';
-import { getAdditionalLanguages } from '../redux/auth/actions';
 import { DASHBOARD_ACTIONS, getSentNotifications } from '../redux/dashboard/actions';
 import { setPagination } from '../redux/dashboard/reducers';
 import { useAppDispatch, useAppSelector } from '../redux/hooks';
@@ -79,10 +78,6 @@ const Dashboard = () => {
   useEffect(() => {
     fetchNotifications();
   }, [fetchNotifications]);
-
-  useEffect(() => {
-    void dispatch(getAdditionalLanguages());
-  }, []);
 
   return (
     <Box p={3}>

--- a/packages/pn-pa-webapp/src/pages/__test__/Dashboard.page.test.tsx
+++ b/packages/pn-pa-webapp/src/pages/__test__/Dashboard.page.test.tsx
@@ -18,7 +18,6 @@ import { DASHBOARD_ACTIONS } from '../../redux/dashboard/actions';
 import Dashboard from '../Dashboard.page';
 
 const mockNavigateFn = vi.fn();
-const ADDITIONAL_LANG_PATH = '/bff/v1/pa/additional-languages';
 
 // mock imports
 vi.mock('react-router-dom', async () => ({
@@ -51,10 +50,6 @@ describe('Dashboard Page', async () => {
     mock = new MockAdapter(apiClient);
   });
 
-  beforeEach(() => {
-    mock.onGet(ADDITIONAL_LANG_PATH).reply(200, { additionalLanguages: [] });
-  });
-
   afterEach(() => {
     mock.reset();
     vi.clearAllMocks();
@@ -71,7 +66,7 @@ describe('Dashboard Page', async () => {
       result = render(<Dashboard />);
     });
     expect(result.container).toHaveTextContent(/empty-state/);
-    expect(mock.history.get).toHaveLength(2);
+    expect(mock.history.get).toHaveLength(1);
     expect(mock.history.get[0].url).toContain('/bff/v1/notifications/sent');
     const newNotificationBtn = result.queryByTestId('link-create-notification');
     fireEvent.click(newNotificationBtn!);
@@ -86,7 +81,7 @@ describe('Dashboard Page', async () => {
       result = render(<Dashboard />);
     });
     expect(result.container).toHaveTextContent(/empty-state/);
-    expect(mock.history.get).toHaveLength(2);
+    expect(mock.history.get).toHaveLength(1);
     expect(mock.history.get[0].url).toContain('/bff/v1/notifications/sent');
     const newNotificationBtn = result.queryByTestId('newNotificationBtn');
     expect(newNotificationBtn).toHaveTextContent('new-notification-button');
@@ -102,7 +97,7 @@ describe('Dashboard Page', async () => {
       result = render(<Dashboard />);
     });
     expect(result.container).toHaveTextContent(/empty-state/);
-    expect(mock.history.get).toHaveLength(2);
+    expect(mock.history.get).toHaveLength(1);
     expect(mock.history.get[0].url).toContain('/bff/v1/notifications/sent');
     const apiKeysBtn = result.queryByTestId('link-api-keys');
     fireEvent.click(apiKeysBtn!);
@@ -118,7 +113,7 @@ describe('Dashboard Page', async () => {
       result = render(<Dashboard />);
     });
     expect(screen.getByRole('heading')).toHaveTextContent(/title/i);
-    expect(mock.history.get).toHaveLength(2);
+    expect(mock.history.get).toHaveLength(1);
     expect(mock.history.get[0].url).toContain('/bff/v1/notifications/sent');
     const filterForm = result.getByTestId('filter-form');
     expect(filterForm).toBeInTheDocument();
@@ -141,7 +136,7 @@ describe('Dashboard Page', async () => {
     await act(async () => {
       result = render(<Dashboard />);
     });
-    expect(mock.history.get).toHaveLength(2);
+    expect(mock.history.get).toHaveLength(1);
     expect(mock.history.get[0].url).toContain('/bff/v1/notifications/sent');
     let rows = result.getAllByTestId('notificationsTable.body.row');
     expect(rows).toHaveLength(1);
@@ -152,8 +147,8 @@ describe('Dashboard Page', async () => {
     const itemsPerPageList = screen.getAllByRole('menuitem');
     fireEvent.click(itemsPerPageList[1]!);
     await waitFor(() => {
-      expect(mock.history.get).toHaveLength(3);
-      expect(mock.history.get[2].url).toContain('/bff/v1/notifications/sent');
+      expect(mock.history.get).toHaveLength(2);
+      expect(mock.history.get[1].url).toContain('/bff/v1/notifications/sent');
     });
     rows = result.getAllByTestId('notificationsTable.body.row');
     expect(rows).toHaveLength(4);
@@ -174,7 +169,7 @@ describe('Dashboard Page', async () => {
     await act(async () => {
       result = render(<Dashboard />);
     });
-    expect(mock.history.get).toHaveLength(2);
+    expect(mock.history.get).toHaveLength(1);
     expect(mock.history.get[0].url).toContain('/bff/v1/notifications/sent');
     let rows = result.getAllByTestId('notificationsTable.body.row');
     expect(rows).toHaveLength(1);
@@ -185,8 +180,8 @@ describe('Dashboard Page', async () => {
     // the buttons are < 1 2 >
     fireEvent.click(pageButtons[2]);
     await waitFor(() => {
-      expect(mock.history.get).toHaveLength(3);
-      expect(mock.history.get[2].url).toContain('/bff/v1/notifications/sent');
+      expect(mock.history.get).toHaveLength(2);
+      expect(mock.history.get[1].url).toContain('/bff/v1/notifications/sent');
     });
     rows = result.getAllByTestId('notificationsTable.body.row');
     expect(rows).toHaveLength(1);
@@ -206,7 +201,7 @@ describe('Dashboard Page', async () => {
     await act(async () => {
       result = render(<Dashboard />);
     });
-    expect(mock.history.get).toHaveLength(2);
+    expect(mock.history.get).toHaveLength(1);
     expect(mock.history.get[0].url).toContain('/bff/v1/notifications/sent');
     let rows = result.getAllByTestId('notificationsTable.body.row');
     expect(rows).toHaveLength(4);
@@ -220,8 +215,8 @@ describe('Dashboard Page', async () => {
     expect(submitButton).toBeEnabled();
     fireEvent.click(submitButton!);
     await waitFor(() => {
-      expect(mock.history.get).toHaveLength(3);
-      expect(mock.history.get[2].url).toContain('/bff/v1/notifications/sent');
+      expect(mock.history.get).toHaveLength(2);
+      expect(mock.history.get[1].url).toContain('/bff/v1/notifications/sent');
     });
     rows = result.getAllByTestId('notificationsTable.body.row');
     expect(rows).toHaveLength(1);
@@ -255,7 +250,7 @@ describe('Dashboard Page', async () => {
       result = render(<Dashboard />);
     });
     expect(screen.getByRole('heading')).toHaveTextContent(/title/i);
-    expect(mock.history.get).toHaveLength(2);
+    expect(mock.history.get).toHaveLength(1);
     expect(mock.history.get[0].url).toContain('/bff/v1/notifications/sent');
     const filterForm = result.getByTestId('dialogToggle');
     expect(filterForm).toBeInTheDocument();
@@ -265,17 +260,5 @@ describe('Dashboard Page', async () => {
     expect(itemsPerPageSelector).toBeInTheDocument();
     const pageSelector = result.queryByTestId('pageSelector');
     expect(pageSelector).toBeInTheDocument();
-  });
-
-  it('should call API and appear button for settings language', async () => {
-    await act(async () => {
-      result = render(<Dashboard />);
-    });
-    
-    expect(mock.history.get).toHaveLength(2);
-    expect(mock.history.get[1].url).toContain(ADDITIONAL_LANG_PATH);
-
-    const settingsLangBtn = result.queryByTestId('settingsLangBtn');
-    expect(settingsLangBtn).toBeInTheDocument();
   });
 });

--- a/packages/pn-pa-webapp/src/pages/__test__/Dashboard.page.test.tsx
+++ b/packages/pn-pa-webapp/src/pages/__test__/Dashboard.page.test.tsx
@@ -230,7 +230,6 @@ describe('Dashboard Page', async () => {
 
   it('errors on api', async () => {
     mock.onGet(notificationsPath).reply(500);
-    console.log((mock as any).handlers.get)
 
     await act(async () => {
       result = render(

--- a/packages/pn-pa-webapp/src/redux/newNotification/__test__/reducers.test.ts
+++ b/packages/pn-pa-webapp/src/redux/newNotification/__test__/reducers.test.ts
@@ -41,7 +41,6 @@ const initialState = {
     taxonomyCode: '',
     notificationFeePolicy: '',
     senderDenomination: '',
-    lang: 'it',
   },
   groups: [],
   isCompleted: false,
@@ -107,7 +106,6 @@ describe('New notification redux state tests', () => {
       group: '',
       taxonomyCode: '010801N',
       paymentMode: PaymentModel.PAGO_PA_NOTICE_F24,
-      lang: 'it',
     };
     const action = store.dispatch(setPreliminaryInformations(preliminaryInformations));
     expect(action.type).toBe('newNotificationSlice/setPreliminaryInformations');

--- a/packages/pn-pa-webapp/src/redux/newNotification/reducers.ts
+++ b/packages/pn-pa-webapp/src/redux/newNotification/reducers.ts
@@ -33,7 +33,6 @@ const initialState = {
     paymentMode: '' as PaymentModel,
     notificationFeePolicy: '' as NotificationFeePolicy,
     senderDenomination: '',
-    lang: 'it',
   } as NewNotification,
   groups: [] as Array<UserGroup>,
   isCompleted: false,

--- a/packages/pn-pa-webapp/src/redux/newNotification/reducers.ts
+++ b/packages/pn-pa-webapp/src/redux/newNotification/reducers.ts
@@ -2,10 +2,8 @@ import { PhysicalCommunicationType } from '@pagopa-pn/pn-commons';
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
 import {
-  BILINGUALISM_LANGUAGES,
   NewNotification,
   NewNotificationDocument,
-  NewNotificationLangOther,
   NewNotificationRecipient,
   NotificationFeePolicy,
   PaymentModel,
@@ -99,21 +97,6 @@ const newNotificationSlice = createSlice({
     setIsCompleted: (state) => {
       state.isCompleted = true;
     },
-    setNewNotificationLang: (state, action: PayloadAction<{ lang: string }>) => {
-      if (BILINGUALISM_LANGUAGES.includes(action.payload.lang)) {
-        state.notification = {
-          ...state.notification,
-          lang: NewNotificationLangOther,
-          additionalLang: action.payload.lang,
-        };
-        return;
-      }
-      state.notification = {
-        ...state.notification,
-        lang: 'it',
-        additionalLang: undefined,
-      };
-    },
     resetState: () => initialState,
   },
   extraReducers: (builder) => {
@@ -143,7 +126,6 @@ export const {
   setPaymentDocuments,
   resetState,
   setIsCompleted,
-  setNewNotificationLang,
 } = newNotificationSlice.actions;
 
 export default newNotificationSlice;


### PR DESCRIPTION
## Short description


## List of changes proposed in this pull request
- Move call api in App.ts

## How to test
Start pa-webapp. Go to "notifications" page and set an additional language from settings drawer.
Now go to the manual notification creation page and check selection of additional language.