### PR TITLE
fix/PN-13023: APPIO banner still showed after IO service enabled

### DIFF
--- a/packages/pn-personafisica-webapp/src/redux/sidemenu/reducers.ts
+++ b/packages/pn-personafisica-webapp/src/redux/sidemenu/reducers.ts
@@ -1,8 +1,8 @@
 import { createSlice } from '@reduxjs/toolkit';
 
-import { DigitalAddress } from '../../models/contacts';
+import { AddressType, ChannelType, DigitalAddress, IOAllowedValues } from '../../models/contacts';
 import { removeAddress, updateAddressesList } from '../../utility/contacts.utility';
-import { createOrUpdateAddress, deleteAddress } from '../contact/actions';
+import { createOrUpdateAddress, deleteAddress, disableIOAddress, enableIOAddress } from '../contact/actions';
 import { acceptMandate, rejectMandate } from '../delegation/actions';
 import { Delegator } from '../delegation/types';
 import { getDomicileInfo, getSidemenuInformation } from './actions';
@@ -50,6 +50,24 @@ const generalInfoSlice = createSlice({
         action.meta.arg.senderId,
         state.digitalAddresses
       );
+    });
+    builder.addCase(enableIOAddress.fulfilled, (state) => {
+      const addressIndex = state.digitalAddresses.findIndex(
+        (address) =>
+          address.channelType === ChannelType.IOMSG && address.addressType === AddressType.COURTESY
+      );
+      if (addressIndex > -1) {
+        state.digitalAddresses[addressIndex].value = IOAllowedValues.ENABLED;
+      }
+    });
+    builder.addCase(disableIOAddress.fulfilled, (state) => {
+      const addressIndex = state.digitalAddresses.findIndex(
+        (address) =>
+          address.channelType === ChannelType.IOMSG && address.addressType === AddressType.COURTESY
+      );
+      if (addressIndex > -1) {
+        state.digitalAddresses[addressIndex].value = IOAllowedValues.DISABLED;
+      }
     });
     builder.addCase(acceptMandate.fulfilled, (state) => {
       if (state.pendingDelegators > 0) {


### PR DESCRIPTION
## Short description
This PR adds the code needed to update APPIO status inside the generalInfoSlice. This missed update was causing the bug in question (and also not showing the banner after disabling the IO service).

## How to test
Start PF webapp on uat environment and try to replicate the bug following the steps described inside the related Jira task. Verify the IO banner becomes visible after disabling IO service and goes away after enablig it.