### PR TITLE
Fix/PN-13256: validate documents form

### DIFF
--- a/packages/pn-commons/src/components/FileUpload.tsx
+++ b/packages/pn-commons/src/components/FileUpload.tsx
@@ -174,7 +174,7 @@ const FileUpload = ({
   });
   const uploadInputRef = useRef();
 
-  const attachmentExists = fileUploaded?.file && fileUploaded?.file.data;
+  const attachmentExists = fileUploaded?.file?.data;
 
   const isMobile = useIsMobile();
 
@@ -335,40 +335,38 @@ const FileUpload = ({
           </OrientedBox>
         )}
         {fileData.status === UploadStatus.UPLOADED && (
-          <>
+          <Box
+            display="flex"
+            justifyContent="space-between"
+            alignItems="center"
+            sx={{ width: '100%' }}
+          >
             <Box
-              display="flex"
-              justifyContent="space-between"
+              display={isMobile ? 'block' : 'flex'}
               alignItems="center"
-              sx={{ width: '100%' }}
+              justifyContent="start"
+              width={isMobile ? 0.85 : 'auto'}
             >
-              <Box
-                display={isMobile ? 'block' : 'flex'}
-                alignItems="center"
-                justifyContent="start"
-                width={isMobile ? 0.85 : 'auto'}
-              >
-                <Box display="flex" width={isMobile ? 0.7 : 'auto'} justifyContent="start">
-                  <AttachFileIcon color="primary" />
-                  <FilenameBox filename={fileData.file.name} />
-                </Box>
-                <Typography fontWeight={600} sx={{ marginLeft: { lg: '30px' } }}>
-                  {parseFileSize(fileData.file.size)}
-                </Typography>
+              <Box display="flex" width={isMobile ? 0.7 : 'auto'} justifyContent="start">
+                <AttachFileIcon color="primary" />
+                <FilenameBox filename={fileData.file.name} />
               </Box>
-              <ButtonNaked
-                data-testid="removeDocument"
-                onClick={removeFileHandler}
-                aria-label={getLocalizedOrDefaultLabel(
-                  'common',
-                  'attachments.remove-attachment',
-                  'Elimina allegato'
-                )}
-              >
-                <CloseIcon />
-              </ButtonNaked>
+              <Typography fontWeight={600} sx={{ marginLeft: { lg: '30px' } }}>
+                {parseFileSize(fileData.file.size)}
+              </Typography>
             </Box>
-          </>
+            <ButtonNaked
+              data-testid="removeDocument"
+              onClick={removeFileHandler}
+              aria-label={getLocalizedOrDefaultLabel(
+                'common',
+                'attachments.remove-attachment',
+                'Elimina allegato'
+              )}
+            >
+              <CloseIcon />
+            </ButtonNaked>
+          </Box>
         )}
       </Box>
       {fileData.sha256 && (

--- a/packages/pn-pa-webapp/src/components/NewNotification/Attachments.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/Attachments.tsx
@@ -251,6 +251,7 @@ const Attachments: React.FC<Props> = ({
     file?: File,
     sha256?: { hashBase64: string; hashHex: string }
   ) => {
+    // await formik.setFieldTouched(`${id}.file`, true, true);
     await formik.setFieldValue(
       id,
       {
@@ -264,12 +265,8 @@ const Attachments: React.FC<Props> = ({
           versionToken: '',
         },
       },
-      false
+      true
     );
-
-    setTimeout(async () => {
-      await formik.setFieldTouched(`${id}.file`, true, true);
-    });
   };
 
   const removeFileHandler = async (id: string, index: number) => {
@@ -280,10 +277,7 @@ const Attachments: React.FC<Props> = ({
         key: '',
         versionToken: '',
       },
-      name: '',
     });
-
-    await formik.setFieldTouched(`${id}.name`, false, false);
   };
 
   const addDocumentHandler = async () => {
@@ -357,12 +351,10 @@ const Attachments: React.FC<Props> = ({
               fieldValue={d.name}
               fileUploaded={d}
               fieldTouched={
-                formik.touched.documents && formik.touched.documents[i]
-                  ? formik.touched.documents[i].name
-                  : undefined
+                formik.touched.documents?.[i] ? formik.touched.documents[i].name : undefined
               }
               fieldErrors={
-                formik.errors.documents && formik.errors.documents[i]
+                formik.errors.documents?.[i]
                   ? (formik.errors.documents[i] as FormikErrors<{ file: string; name: string }>)
                       .name
                   : undefined

--- a/packages/pn-pa-webapp/src/components/NewNotification/Attachments.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/Attachments.tsx
@@ -251,7 +251,6 @@ const Attachments: React.FC<Props> = ({
     file?: File,
     sha256?: { hashBase64: string; hashHex: string }
   ) => {
-    // await formik.setFieldTouched(`${id}.file`, true, true);
     await formik.setFieldValue(
       id,
       {

--- a/packages/pn-pa-webapp/src/components/NewNotification/Attachments.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/Attachments.tsx
@@ -266,7 +266,10 @@ const Attachments: React.FC<Props> = ({
       },
       false
     );
-    await formik.setFieldTouched(`${id}.file`, true, true);
+
+    setTimeout(async () => {
+      await formik.setFieldTouched(`${id}.file`, true, true);
+    });
   };
 
   const removeFileHandler = async (id: string, index: number) => {


### PR DESCRIPTION
## Short description
Fix field "documents" in form of manual notification creation after upload a file.

## List of changes proposed in this pull request
- remove `setFieldTouched` and set `shouldValidate` on `setFieldValue`

## How to test
Start pa-webapp. Login and create manual notification. In 3rd step upload a file and check that `send` button is enabled 