### PR TITLE
fix/PN-12735 -  Very long PEC/Email address not fully shown on code confirmation modal window

### DIFF
--- a/packages/pn-commons/src/components/CodeModal/CodeModal.tsx
+++ b/packages/pn-commons/src/components/CodeModal/CodeModal.tsx
@@ -127,7 +127,9 @@ const CodeModal = forwardRef<ModalHandle, Props>(
         data-testid="codeDialog"
         disableEscapeKeyDown
       >
-        <DialogTitle id="dialog-title">{title}</DialogTitle>
+        <DialogTitle id="dialog-title" sx={{ overflowWrap: 'anywhere' }}>
+          {title}
+        </DialogTitle>
         <PnDialogContent>
           <DialogContentText id="dialog-description">{subtitle}</DialogContentText>
           <Divider sx={{ my: 2 }} />


### PR DESCRIPTION
## Short description
This code sets the overflow-wrap property on CodeModal title to grant very long pec/mail addresses are shown.

## How to test
Follow the steps described on the relative Jira task, check it works on both PF and PG webapps