### PR TITLE
(fix-pn/12727) Fix of render a long title of notification

### DIFF
--- a/packages/pn-commons/src/components/TitleBox.tsx
+++ b/packages/pn-commons/src/components/TitleBox.tsx
@@ -2,8 +2,6 @@ import { ReactNode } from 'react';
 
 import { Grid, GridProps, GridSize, SxProps, Theme, Typography } from '@mui/material';
 import { Variant } from '@mui/material/styles/createTypography';
-import React from 'react';
-import { useIsMobile } from '../hooks';
 
 type Props = {
   /** Title of the page to render */
@@ -44,11 +42,7 @@ const TitleBox: React.FC<Props> = ({
   variantSubTitle = 'h5',
   sx,
   children,
-}) => {
-
-  const isMobile = useIsMobile();
-
-  return (
+}) => (
   <Grid id="page-header-container" aria-orientation="horizontal" container mt={mtGrid} sx={sx}>
     {title && (
       <Grid id="item" item xs={12} mb={mbTitle} {...propsTitle}>
@@ -58,7 +52,7 @@ const TitleBox: React.FC<Props> = ({
           role="heading"
           variant={variantTitle}
           display="inline-block"
-          sx={{ verticalAlign: 'middle', maxWidth: `${isMobile ? '70vw': '40vw' }`,
+          sx={{ verticalAlign: 'middle', maxWidth:{ xs:'70vw', lg:'40vw' },
           wordWrap: 'break-word',overflow: 'visible' }}
           
         >
@@ -84,6 +78,5 @@ const TitleBox: React.FC<Props> = ({
     </Grid>
   </Grid>
 );
-};
 
 export default TitleBox;

--- a/packages/pn-commons/src/components/TitleBox.tsx
+++ b/packages/pn-commons/src/components/TitleBox.tsx
@@ -52,8 +52,8 @@ const TitleBox: React.FC<Props> = ({
           role="heading"
           variant={variantTitle}
           display="inline-block"
-          sx={{ verticalAlign: 'middle', maxWidth:{ xs:'70vw', lg:'40vw' },
-          wordWrap: 'break-word',overflow: 'visible' }}
+          sx={{ verticalAlign: 'middle',
+          wordWrap: 'break-word',overflowWrap: 'anywhere' }}
           
         >
           {title}

--- a/packages/pn-commons/src/components/TitleBox.tsx
+++ b/packages/pn-commons/src/components/TitleBox.tsx
@@ -2,6 +2,8 @@ import { ReactNode } from 'react';
 
 import { Grid, GridProps, GridSize, SxProps, Theme, Typography } from '@mui/material';
 import { Variant } from '@mui/material/styles/createTypography';
+import React from 'react';
+import { useIsMobile } from '../hooks';
 
 type Props = {
   /** Title of the page to render */
@@ -42,7 +44,11 @@ const TitleBox: React.FC<Props> = ({
   variantSubTitle = 'h5',
   sx,
   children,
-}) => (
+}) => {
+
+  const isMobile = useIsMobile();
+
+  return (
   <Grid id="page-header-container" aria-orientation="horizontal" container mt={mtGrid} sx={sx}>
     {title && (
       <Grid id="item" item xs={12} mb={mbTitle} {...propsTitle}>
@@ -52,7 +58,9 @@ const TitleBox: React.FC<Props> = ({
           role="heading"
           variant={variantTitle}
           display="inline-block"
-          sx={{ verticalAlign: 'middle' }}
+          sx={{ verticalAlign: 'middle', maxWidth: `${isMobile ? '70vw': '40vw' }`,
+          wordWrap: 'break-word',overflow: 'visible' }}
+          
         >
           {title}
         </Typography>
@@ -76,5 +84,6 @@ const TitleBox: React.FC<Props> = ({
     </Grid>
   </Grid>
 );
+};
 
 export default TitleBox;

--- a/packages/pn-commons/src/components/TitleBox.tsx
+++ b/packages/pn-commons/src/components/TitleBox.tsx
@@ -52,8 +52,8 @@ const TitleBox: React.FC<Props> = ({
           role="heading"
           variant={variantTitle}
           display="inline-block"
-          sx={{ verticalAlign: 'middle',
-          wordWrap: 'break-word',overflowWrap: 'anywhere' }}
+          sx={{ verticalAlign: 'middle'
+         ,overflowWrap: 'anywhere' }}
           
         >
           {title}


### PR DESCRIPTION
## Short description

fix how render title of notification

## List of changes proposed in this pull request
- insert css of viewport and wrap in title box component

## How to test
go in PA, UAT with ggiorgi user and go in notification with iun YVTG-WVRL-XWMW-202409-J-1