### PR TITLE
feat/PN-13174: Add blank spaces validation to digital contact input field (PF and PG)

### DIFF
--- a/packages/pn-personafisica-webapp/public/locales/de/common.json
+++ b/packages/pn-personafisica-webapp/public/locales/de/common.json
@@ -183,5 +183,6 @@
   },
   "conjunctions": {
     "or": "oder"
-  }
+  },
+  "no-spaces-at-edges": "Lösche die Leerzeichen am Anfang oder Ende"
 }

--- a/packages/pn-personafisica-webapp/public/locales/en/common.json
+++ b/packages/pn-personafisica-webapp/public/locales/en/common.json
@@ -183,5 +183,6 @@
   },
   "conjunctions": {
     "or": "or"
-  }
+  },
+  "no-spaces-at-edges": "Delete spaces at the beginning or end"
 }

--- a/packages/pn-personafisica-webapp/public/locales/fr/common.json
+++ b/packages/pn-personafisica-webapp/public/locales/fr/common.json
@@ -183,5 +183,6 @@
   },
   "conjunctions": {
     "or": "ou"
-  }
+  },
+  "no-spaces-at-edges": "Supprimer les espaces au début ou à la fin"
 }

--- a/packages/pn-personafisica-webapp/public/locales/it/common.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/common.json
@@ -191,5 +191,6 @@
   "downtime_language_banner": {
     "message": "Il testo originario di questi documenti è in lingua italiana. In caso di contrasto tra la versione italiana e le traduzioni in altre lingue, prevarranno il significato e le condizioni della lingua italiana.",
     "link": "Consulta le traduzioni"
-  }
+  },
+  "no-spaces-at-edges": "Elimina gli spazi all'inizio o alla fine"
 }

--- a/packages/pn-personafisica-webapp/public/locales/sl/common.json
+++ b/packages/pn-personafisica-webapp/public/locales/sl/common.json
@@ -183,5 +183,6 @@
   },
   "conjunctions": {
     "or": "ali"
-  }
+  },
+  "no-spaces-at-edges": "Izbrišite presledke na začetku ali koncu"
 }

--- a/packages/pn-personafisica-webapp/src/components/Contacts/DefaultDigitalContact.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/DefaultDigitalContact.tsx
@@ -92,6 +92,11 @@ const DefaultDigitalContact = forwardRef<{ toggleEdit: () => void }, Props>(
       },
     }));
 
+    const changeContact = async (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      void handleChangeTouched(event);
+      await formik.setFieldValue(`default_${contactType}`, event.currentTarget.value.trim());
+    };
+
     // INSERT MODE
     if (!value) {
       return (
@@ -122,7 +127,7 @@ const DefaultDigitalContact = forwardRef<{ toggleEdit: () => void }, Props>(
                 ) : null,
               }}
               value={formik.values[`default_${contactType}`]}
-              onChange={(e) => void handleChangeTouched(e)}
+              onChange={changeContact}
               error={
                 formik.touched[`default_${contactType}`] &&
                 Boolean(formik.errors[`default_${contactType}`])

--- a/packages/pn-personafisica-webapp/src/components/Contacts/DefaultDigitalContact.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/DefaultDigitalContact.tsx
@@ -92,11 +92,6 @@ const DefaultDigitalContact = forwardRef<{ toggleEdit: () => void }, Props>(
       },
     }));
 
-    const changeContact = async (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-      void handleChangeTouched(event);
-      await formik.setFieldValue(`default_${contactType}`, event.currentTarget.value.trim());
-    };
-
     // INSERT MODE
     if (!value) {
       return (
@@ -127,7 +122,7 @@ const DefaultDigitalContact = forwardRef<{ toggleEdit: () => void }, Props>(
                 ) : null,
               }}
               value={formik.values[`default_${contactType}`]}
-              onChange={changeContact}
+              onChange={handleChangeTouched}
               error={
                 formik.touched[`default_${contactType}`] &&
                 Boolean(formik.errors[`default_${contactType}`])

--- a/packages/pn-personafisica-webapp/src/utility/contacts.utility.ts
+++ b/packages/pn-personafisica-webapp/src/utility/contacts.utility.ts
@@ -65,6 +65,7 @@ export const pecValidationSchema = (t: TFunction) =>
     .string()
     .required(t('legal-contacts.valid-pec', { ns: 'recapiti' }))
     .max(254, t('common.too-long-field-error', { ns: 'recapiti', maxLength: 254 }))
+    .matches(dataRegex.noSpaceAtEdges, t('no-spaces-at-edges'))
     .matches(dataRegex.email, t('legal-contacts.valid-pec', { ns: 'recapiti' }));
 
 export const emailValidationSchema = (t: TFunction) =>
@@ -72,12 +73,14 @@ export const emailValidationSchema = (t: TFunction) =>
     .string()
     .required(t('courtesy-contacts.valid-email', { ns: 'recapiti' }))
     .max(254, t('common.too-long-field-error', { ns: 'recapiti', maxLength: 254 }))
+    .matches(dataRegex.noSpaceAtEdges, t('no-spaces-at-edges'))
     .matches(dataRegex.email, t('courtesy-contacts.valid-email', { ns: 'recapiti' }));
 
 export const phoneValidationSchema = (t: TFunction, withPrefix = false) =>
   yup
     .string()
     .required(t('courtesy-contacts.valid-sms', { ns: 'recapiti' }))
+    .matches(dataRegex.noSpaceAtEdges, t('no-spaces-at-edges'))
     .matches(
       withPrefix ? dataRegex.phoneNumberWithItalyPrefix : dataRegex.phoneNumber,
       t('courtesy-contacts.valid-sms', { ns: 'recapiti' })

--- a/packages/pn-personagiuridica-webapp/public/locales/de/common.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/de/common.json
@@ -181,5 +181,6 @@
     "pg-operator": "Sachbearbeiter",
     "pg-admin": "Administrator"
   },
-  "required-field": "Pflichtfeld"
+  "required-field": "Pflichtfeld",
+  "no-spaces-at-edges": "Lösche die Leerzeichen am Anfang oder Ende"
 }

--- a/packages/pn-personagiuridica-webapp/public/locales/en/common.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/en/common.json
@@ -181,5 +181,6 @@
     "pg-operator": "Operational contact person",
     "pg-admin": "Administrator"
   },
-  "required-field": "Required field"
+  "required-field": "Required field",
+  "no-spaces-at-edges": "Delete spaces at the beginning or end"
 }

--- a/packages/pn-personagiuridica-webapp/public/locales/fr/common.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/fr/common.json
@@ -181,5 +181,6 @@
     "pg-operator": "Personne de contact opérationnelle",
     "pg-admin": "Administrateur"
   },
-  "required-field": "Champ obligatoire"
+  "required-field": "Champ obligatoire",
+  "no-spaces-at-edges": "Supprimer les espaces au début ou à la fin"
 }

--- a/packages/pn-personagiuridica-webapp/public/locales/it/common.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/it/common.json
@@ -204,5 +204,6 @@
   "downtime_language_banner": {
     "message": "Il testo originario di questi documenti è in lingua italiana. In caso di contrasto tra la versione italiana e le traduzioni in altre lingue, prevarranno il significato e le condizioni della lingua italiana.",
     "link": "Consulta le traduzioni"
-  }
+  },
+  "no-spaces-at-edges": "Elimina gli spazi all'inizio o alla fine"
 }

--- a/packages/pn-personagiuridica-webapp/public/locales/sl/common.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/sl/common.json
@@ -181,5 +181,6 @@
     "pg-operator": "Operativna kontaktna oseba",
     "pg-admin": "Upravitelj"
   },
-  "required-field": "Obvezno polje"
+  "required-field": "Obvezno polje",
+  "no-spaces-at-edges": "Izbrišite presledke na začetku ali koncu"
 }

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/DefaultDigitalContact.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/DefaultDigitalContact.tsx
@@ -92,6 +92,11 @@ const DefaultDigitalContact = forwardRef<{ toggleEdit: () => void }, Props>(
       },
     }));
 
+    const changeContact = async (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      void handleChangeTouched(event);
+      await formik.setFieldValue(`default_${contactType}`, event.currentTarget.value.trim());
+    };
+
     // INSERT MODE
     if (!value) {
       return (
@@ -122,7 +127,7 @@ const DefaultDigitalContact = forwardRef<{ toggleEdit: () => void }, Props>(
                 ) : null,
               }}
               value={formik.values[`default_${contactType}`]}
-              onChange={(e) => void handleChangeTouched(e)}
+              onChange={changeContact}
               error={
                 formik.touched[`default_${contactType}`] &&
                 Boolean(formik.errors[`default_${contactType}`])

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/DefaultDigitalContact.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/DefaultDigitalContact.tsx
@@ -92,11 +92,6 @@ const DefaultDigitalContact = forwardRef<{ toggleEdit: () => void }, Props>(
       },
     }));
 
-    const changeContact = async (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-      void handleChangeTouched(event);
-      await formik.setFieldValue(`default_${contactType}`, event.currentTarget.value.trim());
-    };
-
     // INSERT MODE
     if (!value) {
       return (
@@ -127,7 +122,7 @@ const DefaultDigitalContact = forwardRef<{ toggleEdit: () => void }, Props>(
                 ) : null,
               }}
               value={formik.values[`default_${contactType}`]}
-              onChange={changeContact}
+              onChange={handleChangeTouched}
               error={
                 formik.touched[`default_${contactType}`] &&
                 Boolean(formik.errors[`default_${contactType}`])

--- a/packages/pn-personagiuridica-webapp/src/utility/contacts.utility.ts
+++ b/packages/pn-personagiuridica-webapp/src/utility/contacts.utility.ts
@@ -61,6 +61,7 @@ export const pecValidationSchema = (t: TFunction) =>
     .string()
     .required(t('legal-contacts.valid-pec', { ns: 'recapiti' }))
     .max(254, t('common.too-long-field-error', { ns: 'recapiti', maxLength: 254 }))
+    .matches(dataRegex.noSpaceAtEdges, t('no-spaces-at-edges'))
     .matches(dataRegex.email, t('legal-contacts.valid-pec', { ns: 'recapiti' }));
 
 export const emailValidationSchema = (t: TFunction) =>
@@ -68,12 +69,14 @@ export const emailValidationSchema = (t: TFunction) =>
     .string()
     .required(t('courtesy-contacts.valid-email', { ns: 'recapiti' }))
     .max(254, t('common.too-long-field-error', { ns: 'recapiti', maxLength: 254 }))
+    .matches(dataRegex.noSpaceAtEdges, t('no-spaces-at-edges'))
     .matches(dataRegex.email, t('courtesy-contacts.valid-email', { ns: 'recapiti' }));
 
 export const phoneValidationSchema = (t: TFunction, withPrefix = false) =>
   yup
     .string()
     .required(t('courtesy-contacts.valid-sms', { ns: 'recapiti' }))
+    .matches(dataRegex.noSpaceAtEdges, t('no-spaces-at-edges'))
     .matches(
       withPrefix ? dataRegex.phoneNumberWithItalyPrefix : dataRegex.phoneNumber,
       t('courtesy-contacts.valid-sms', { ns: 'recapiti' })


### PR DESCRIPTION
## Short description
The proposed code adds a control to the yup validation schema of the digital contacts to show a specific error message when blank spaces are added before/after the value (PF and PG)

## How to test
Verify on both PF and PG webapps the user is not allowed to add spaces before/after any digital contact