### PR TITLE
fix(PN-13212)  chip stato notifica/pagamenti

### DIFF
--- a/packages/pn-commons/src/components/CustomTooltip.tsx
+++ b/packages/pn-commons/src/components/CustomTooltip.tsx
@@ -53,7 +53,7 @@ const CustomTooltip: React.FC<Props> = ({
           {...tooltipProps}
         >
           {cloneElement(children, {
-            onClick: handleTooltipOpen,
+            onClick: openOnClick && handleTooltipOpen,
           })}
         </Tooltip>
       </Box>

--- a/packages/pn-commons/src/components/CustomTooltip.tsx
+++ b/packages/pn-commons/src/components/CustomTooltip.tsx
@@ -52,9 +52,9 @@ const CustomTooltip: React.FC<Props> = ({
           onOpen={onOpen}
           {...tooltipProps}
         >
-          {cloneElement(children, {
-            onClick: openOnClick && handleTooltipOpen,
-          })}
+          {openOnClick ? cloneElement(children, {
+            onClick: handleTooltipOpen,
+          }) : children}
         </Tooltip>
       </Box>
     </ClickAwayListener>

--- a/packages/pn-commons/src/components/Notifications/StatusTooltip.tsx
+++ b/packages/pn-commons/src/components/Notifications/StatusTooltip.tsx
@@ -26,6 +26,7 @@ const StatusTooltip = ({
         id={`status-chip-${label}`}
         label={label}
         color={color}
+        role={undefined}
         sx={{ ...chipProps, cursor: 'default' }}
         data-testid={`statusChip-${label}`}
       />

--- a/packages/pn-commons/src/components/Notifications/StatusTooltip.tsx
+++ b/packages/pn-commons/src/components/Notifications/StatusTooltip.tsx
@@ -26,7 +26,6 @@ const StatusTooltip = ({
         id={`status-chip-${label}`}
         label={label}
         color={color}
-        role='cell'
         sx={{ ...chipProps, cursor: 'default' }}
         data-testid={`statusChip-${label}`}
       />

--- a/packages/pn-commons/src/components/Notifications/StatusTooltip.tsx
+++ b/packages/pn-commons/src/components/Notifications/StatusTooltip.tsx
@@ -26,7 +26,7 @@ const StatusTooltip = ({
         id={`status-chip-${label}`}
         label={label}
         color={color}
-        role={undefined}
+        role='cell'
         sx={{ ...chipProps, cursor: 'default' }}
         data-testid={`statusChip-${label}`}
       />

--- a/packages/pn-commons/src/components/Notifications/__test__/StatusTooltip.test.tsx
+++ b/packages/pn-commons/src/components/Notifications/__test__/StatusTooltip.test.tsx
@@ -11,6 +11,7 @@ describe('Status Tooltip Component', () => {
     const { getByTestId } = render(<StatusTooltip tooltip={tooltip} label={label} color={color} />);
     const button = getByTestId(`statusChip-${label}`);
     expect(button).toHaveTextContent(/mocked label/i);
+    expect(button).not.toHaveAttribute('role','button'); //For A11Y
     const buttonClass = `${classRoot}${color.charAt(0).toUpperCase() + color.slice(1)}`;
     expect(button.classList.contains(buttonClass)).toBe(true);
     fireEvent.mouseOver(button);

--- a/packages/pn-commons/src/components/Notifications/__test__/StatusTooltip.test.tsx
+++ b/packages/pn-commons/src/components/Notifications/__test__/StatusTooltip.test.tsx
@@ -11,7 +11,6 @@ describe('Status Tooltip Component', () => {
     const { getByTestId } = render(<StatusTooltip tooltip={tooltip} label={label} color={color} />);
     const button = getByTestId(`statusChip-${label}`);
     expect(button).toHaveTextContent(/mocked label/i);
-    expect(button).not.toHaveAttribute('role','button'); //For A11Y
     const buttonClass = `${classRoot}${color.charAt(0).toUpperCase() + color.slice(1)}`;
     expect(button.classList.contains(buttonClass)).toBe(true);
     fireEvent.mouseOver(button);

--- a/packages/pn-commons/src/components/Notifications/__test__/StatusTooltip.test.tsx
+++ b/packages/pn-commons/src/components/Notifications/__test__/StatusTooltip.test.tsx
@@ -8,8 +8,8 @@ const colors = ['warning', 'error', 'success', 'info', 'default', 'primary', 'se
 
 describe('Status Tooltip Component', () => {
   it.each(colors)('renders status tooltip (%s)', async (color) => {
-    const { getByRole } = render(<StatusTooltip tooltip={tooltip} label={label} color={color} />);
-    const button = getByRole('button');
+    const { getByTestId } = render(<StatusTooltip tooltip={tooltip} label={label} color={color} />);
+    const button = getByTestId(`statusChip-${label}`);
     expect(button).toHaveTextContent(/mocked label/i);
     const buttonClass = `${classRoot}${color.charAt(0).toUpperCase() + color.slice(1)}`;
     expect(button.classList.contains(buttonClass)).toBe(true);

--- a/packages/pn-commons/src/components/__test__/CustomTooltip.test.tsx
+++ b/packages/pn-commons/src/components/__test__/CustomTooltip.test.tsx
@@ -11,7 +11,7 @@ describe('CustomTooltip Component', () => {
     await act(async () => {
       result = render(
         <CustomTooltip tooltipContent="Mocked content" openOnClick={false}>
-          <button onClick={false ? ()=>{}: undefined}>Mocked Text</button>
+          <p >Mocked Text</p>
         </CustomTooltip>
       );
     });
@@ -28,7 +28,7 @@ describe('CustomTooltip Component', () => {
           openOnClick={false}
           onOpen={mockOnOpenCallback}
         >
-          <button data-testid="testTooltipText" onClick={false ? ()=>{}: undefined}>Mocked Text</button>       
+          <p data-testid="testTooltipText">Mocked Text</p>       
         </CustomTooltip>
       );
     });
@@ -54,10 +54,10 @@ describe('CustomTooltip Component', () => {
     // render component
     const { container, getByRole } = render(
       <CustomTooltip tooltipContent="Mocked content" openOnClick={true}>
-        <button onClick={true ? ()=>{}: undefined}>Mocked Text</button>     
+        <p>Mocked Text</p>     
        </CustomTooltip>
     );
-    const paragraph = container.querySelector('button');
+    const paragraph = container.querySelector('p');
     // open tooltip
     fireEvent.click(paragraph!);
     const tooltip = await waitFor(() => getByRole('tooltip'));

--- a/packages/pn-commons/src/components/__test__/CustomTooltip.test.tsx
+++ b/packages/pn-commons/src/components/__test__/CustomTooltip.test.tsx
@@ -11,7 +11,7 @@ describe('CustomTooltip Component', () => {
     await act(async () => {
       result = render(
         <CustomTooltip tooltipContent="Mocked content" openOnClick={false}>
-          <p>Mocked Text</p>
+          <button onClick={false ? ()=>{}: undefined}>Mocked Text</button>
         </CustomTooltip>
       );
     });
@@ -28,7 +28,7 @@ describe('CustomTooltip Component', () => {
           openOnClick={false}
           onOpen={mockOnOpenCallback}
         >
-          <p data-testid="testTooltipText">Mocked Text</p>
+          <button data-testid="testTooltipText" onClick={false ? ()=>{}: undefined}>Mocked Text</button>       
         </CustomTooltip>
       );
     });
@@ -54,10 +54,10 @@ describe('CustomTooltip Component', () => {
     // render component
     const { container, getByRole } = render(
       <CustomTooltip tooltipContent="Mocked content" openOnClick={true}>
-        <p>Mocked Text</p>
-      </CustomTooltip>
+        <button onClick={true ? ()=>{}: undefined}>Mocked Text</button>     
+       </CustomTooltip>
     );
-    const paragraph = container.querySelector('p');
+    const paragraph = container.querySelector('button');
     // open tooltip
     fireEvent.click(paragraph!);
     const tooltip = await waitFor(() => getByRole('tooltip'));

--- a/packages/pn-commons/src/components/__test__/CustomTooltip.test.tsx
+++ b/packages/pn-commons/src/components/__test__/CustomTooltip.test.tsx
@@ -11,7 +11,7 @@ describe('CustomTooltip Component', () => {
     await act(async () => {
       result = render(
         <CustomTooltip tooltipContent="Mocked content" openOnClick={false}>
-          <p >Mocked Text</p>
+          <p>Mocked Text</p>
         </CustomTooltip>
       );
     });
@@ -28,7 +28,7 @@ describe('CustomTooltip Component', () => {
           openOnClick={false}
           onOpen={mockOnOpenCallback}
         >
-          <p data-testid="testTooltipText">Mocked Text</p>       
+          <p data-testid="testTooltipText">Mocked Text</p>
         </CustomTooltip>
       );
     });
@@ -42,7 +42,7 @@ describe('CustomTooltip Component', () => {
     tooltip = await waitFor(() => result.getByRole('tooltip'));
     expect(tooltip).toBeInTheDocument();
     expect(tooltip).toHaveTextContent(/Mocked content/i);
-    expect(mockOnOpenCallback).toBeCalledTimes(1);
+    expect(mockOnOpenCallback).toHaveBeenCalledTimes(1);
     // again check that click doesn't work
     fireEvent.click(paragraph!);
     await waitFor(() => {
@@ -54,8 +54,8 @@ describe('CustomTooltip Component', () => {
     // render component
     const { container, getByRole } = render(
       <CustomTooltip tooltipContent="Mocked content" openOnClick={true}>
-        <p>Mocked Text</p>     
-       </CustomTooltip>
+        <p>Mocked Text</p>
+      </CustomTooltip>
     );
     const paragraph = container.querySelector('p');
     // open tooltip


### PR DESCRIPTION
## Short description
delete default role in chip for status of notification

## List of changes proposed in this pull request
- insert role cell for StatusTooltip component

## How to test
in table of notification, with voice over activeted , voice over read status of notification and description explained in the tooltip, only description is clickable 
