### PR TITLE
fix/PN-13269: Manage Notification of receipt translation

### DIFF
--- a/packages/pn-commons/src/components/NotificationDetail/NotificationDetailDocuments.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationDetailDocuments.tsx
@@ -3,11 +3,18 @@ import { Box, Grid, Stack, Typography, TypographyProps } from '@mui/material';
 // import DownloadIcon from '@mui/icons-material/Download';
 import { ButtonNaked } from '@pagopa/mui-italia';
 
-import { NotificationDetailDocument, NotificationDetailOtherDocument } from '../../models';
+import {
+  NotificationDetailDocument,
+  NotificationDetailOtherDocument,
+  NotificationDetailRecipient,
+} from '../../models';
+import { getLocalizedOrDefaultLabel } from '../../utility/localization.utility';
+import { isNotificationDetailOtherDocument } from '../../utility/notification.utility';
 
 type Props = {
   title: string;
   documents: Array<NotificationDetailDocument> | undefined;
+  recipients?: Array<NotificationDetailRecipient>;
   clickHandler: (document: string | NotificationDetailOtherDocument | undefined) => void;
   documentsAvailable?: boolean;
   downloadFilesMessage?: string;
@@ -20,6 +27,7 @@ type Props = {
  *  Notification detail documents
  *  @param title title to show
  *  @param documents data to show
+ *  @param recipient the notification recipients
  *  @param clickHandler function called when user clicks on the download button
  *  @param documentsAvailable flag that allows download file or not (after 120 days)
  *  @param downloadFilesMessage disclaimer to show about downloadable acts
@@ -31,6 +39,7 @@ const NotificationDetailDocuments: React.FC<Props> = (
   {
     title,
     documents = [],
+    recipients = [],
     clickHandler,
     documentsAvailable = true,
     downloadFilesMessage,
@@ -38,20 +47,30 @@ const NotificationDetailDocuments: React.FC<Props> = (
     titleVariant = 'overline',
   } // TODO: remove comment when link ready downloadFilesLink
 ) => {
-  const mapOtherDocuments = (documents: Array<NotificationDetailDocument>) =>
+  const mapOtherDocuments = (
+    documents: Array<NotificationDetailDocument | NotificationDetailOtherDocument>
+  ) =>
     documents.map((d) => {
+      const isOtherDocument = isNotificationDetailOtherDocument(d);
       const recipient =
-        documents.length > 1 && d.documentType === 'AAR' && d.recipient
-          ? ` - ${d.recipient.denomination} (${d.recipient.taxId})`
+        recipients.filter((recipient) => recipient.taxId).length > 1 && isOtherDocument
+          ? ` - ${d.recipient?.denomination} (${d.recipient?.taxId})`
           : '';
+      const docName = isOtherDocument
+        ? getLocalizedOrDefaultLabel('notifications', 'detail.aar-acts')
+        : d.title || d.ref.key;
+
       const document = {
         key: d.ref.key || d.documentId,
-        name: d.title ? `${d.title}${recipient}` : d.ref.key,
+        name: `${docName}${recipient}`,
         downloadHandler: d.documentId
-          ? ({
+          ? {
               documentId: d.documentId,
               documentType: d.documentType,
-            } as NotificationDetailOtherDocument)
+              digests: d.digests,
+              contentType: d.contentType,
+              ref: d.ref,
+            }
           : d.docIdx,
       };
 

--- a/packages/pn-commons/src/components/NotificationDetail/NotificationDetailDocuments.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationDetailDocuments.tsx
@@ -45,7 +45,9 @@ const NotificationDetailDocuments: React.FC<Props> = (
   const mapOtherDocuments = (documents: Array<NotificationDetailDocument>) =>
     documents.map((d) => {
       const recipient =
-        documents.length > 1 ? ` - ${d.recipient.denomination} (${d.recipient.taxId})` : '';
+        documents.length > 1 && d.recipient
+          ? ` - ${d.recipient.denomination} (${d.recipient.taxId})`
+          : '';
       const document = {
         key: d.ref.key || d.documentId,
         name:

--- a/packages/pn-commons/src/components/NotificationDetail/NotificationDetailDocuments.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationDetailDocuments.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next';
+
 import AttachFileIcon from '@mui/icons-material/AttachFile';
 import { Box, Grid, Stack, Typography, TypographyProps } from '@mui/material';
 // import DownloadIcon from '@mui/icons-material/Download';
@@ -38,11 +40,18 @@ const NotificationDetailDocuments: React.FC<Props> = (
     titleVariant = 'overline',
   } // TODO: remove comment when link ready downloadFilesLink
 ) => {
+  const { t } = useTranslation(['notifiche']);
+
   const mapOtherDocuments = (documents: Array<NotificationDetailDocument>) =>
     documents.map((d) => {
+      const recipient =
+        documents.length > 1 ? ` - ${d.recipient.denomination} (${d.recipient.taxId})` : '';
       const document = {
         key: d.ref.key || d.documentId,
-        name: d.title || d.ref.key,
+        name:
+          d.documentType === 'AAR'
+            ? `${t('detail.aar-acts', { ns: 'notifiche' })}${recipient}`
+            : d.title || d.ref.key,
         downloadHandler: d.documentId
           ? ({
               documentId: d.documentId,

--- a/packages/pn-commons/src/components/NotificationDetail/NotificationDetailDocuments.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationDetailDocuments.tsx
@@ -46,7 +46,7 @@ const NotificationDetailDocuments: React.FC<Props> = (
           : '';
       const document = {
         key: d.ref.key || d.documentId,
-        name: d.title + recipient || d.ref.key,
+        name: d.title ? `${d.title}${recipient}` : d.ref.key,
         downloadHandler: d.documentId
           ? ({
               documentId: d.documentId,

--- a/packages/pn-commons/src/components/NotificationDetail/NotificationDetailDocuments.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationDetailDocuments.tsx
@@ -57,12 +57,12 @@ const NotificationDetailDocuments: React.FC<Props> = (
           ? ` - ${d.recipient?.denomination} (${d.recipient?.taxId})`
           : '';
       const docName = isOtherDocument
-        ? getLocalizedOrDefaultLabel('notifications', 'detail.aar-acts')
+        ? `${getLocalizedOrDefaultLabel('notifications', 'detail.aar-acts')}${recipient}`
         : d.title || d.ref.key;
 
       const document = {
         key: d.ref.key || d.documentId,
-        name: `${docName}${recipient}`,
+        name: docName,
         downloadHandler: d.documentId
           ? {
               documentId: d.documentId,

--- a/packages/pn-commons/src/components/NotificationDetail/NotificationDetailDocuments.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationDetailDocuments.tsx
@@ -1,5 +1,3 @@
-import { useTranslation } from 'react-i18next';
-
 import AttachFileIcon from '@mui/icons-material/AttachFile';
 import { Box, Grid, Stack, Typography, TypographyProps } from '@mui/material';
 // import DownloadIcon from '@mui/icons-material/Download';
@@ -40,20 +38,15 @@ const NotificationDetailDocuments: React.FC<Props> = (
     titleVariant = 'overline',
   } // TODO: remove comment when link ready downloadFilesLink
 ) => {
-  const { t } = useTranslation(['notifiche']);
-
   const mapOtherDocuments = (documents: Array<NotificationDetailDocument>) =>
     documents.map((d) => {
       const recipient =
-        documents.length > 1 && d.recipient
+        documents.length > 1 && d.documentType === 'AAR' && d.recipient
           ? ` - ${d.recipient.denomination} (${d.recipient.taxId})`
           : '';
       const document = {
         key: d.ref.key || d.documentId,
-        name:
-          d.documentType === 'AAR'
-            ? `${t('detail.aar-acts', { ns: 'notifiche' })}${recipient}`
-            : d.title || d.ref.key,
+        name: d.title + recipient || d.ref.key,
         downloadHandler: d.documentId
           ? ({
               documentId: d.documentId,

--- a/packages/pn-commons/src/models/NotificationDetail.ts
+++ b/packages/pn-commons/src/models/NotificationDetail.ts
@@ -165,7 +165,7 @@ export interface NotificationDetailDocument extends Attachment {
   documentId?: string;
   documentType?: string;
   recIndex?: number;
-  recipient: {
+  recipient?: {
     denomination: string;
     taxId: string;
   };

--- a/packages/pn-commons/src/models/NotificationDetail.ts
+++ b/packages/pn-commons/src/models/NotificationDetail.ts
@@ -165,6 +165,10 @@ export interface NotificationDetailDocument extends Attachment {
   documentId?: string;
   documentType?: string;
   recIndex?: number;
+  recipient: {
+    denomination: string;
+    taxId: string;
+  };
 }
 
 export interface PaymentAttachment {

--- a/packages/pn-commons/src/models/NotificationDetail.ts
+++ b/packages/pn-commons/src/models/NotificationDetail.ts
@@ -165,10 +165,6 @@ export interface NotificationDetailDocument extends Attachment {
   documentId?: string;
   documentType?: string;
   recIndex?: number;
-  recipient?: {
-    denomination: string;
-    taxId: string;
-  };
 }
 
 export interface PaymentAttachment {
@@ -313,9 +309,11 @@ export interface LegalFactId {
   category: LegalFactType | 'AAR';
 }
 
-export interface NotificationDetailOtherDocument {
-  documentId: string;
-  documentType: string;
+export interface NotificationDetailOtherDocument extends NotificationDetailDocument {
+  recipient?: {
+    denomination: string;
+    taxId: string;
+  };
 }
 
 export enum PhysicalCommunicationType {

--- a/packages/pn-commons/src/models/PaymentCache.ts
+++ b/packages/pn-commons/src/models/PaymentCache.ts
@@ -59,6 +59,10 @@ const notificationDetailDocumentSchema: yup.SchemaOf<NotificationDetailDocument>
       documentId: yup.string().optional(),
       documentType: yup.string().optional(),
       recIndex: yup.number().optional(),
+      recipient: yup.object().shape({
+        denomination: yup.string().required(),
+        taxId: yup.string().required()
+      }).default(undefined)
     })
   )
   .noUnknown(true);

--- a/packages/pn-commons/src/models/PaymentCache.ts
+++ b/packages/pn-commons/src/models/PaymentCache.ts
@@ -58,7 +58,7 @@ const notificationDetailDocumentSchema: yup.SchemaOf<NotificationDetailDocument>
       docIdx: yup.string().optional(),
       documentId: yup.string().optional(),
       documentType: yup.string().optional(),
-      recIndex: yup.number().optional()
+      recIndex: yup.number().optional(),
     })
   )
   .noUnknown(true);

--- a/packages/pn-commons/src/models/PaymentCache.ts
+++ b/packages/pn-commons/src/models/PaymentCache.ts
@@ -58,11 +58,7 @@ const notificationDetailDocumentSchema: yup.SchemaOf<NotificationDetailDocument>
       docIdx: yup.string().optional(),
       documentId: yup.string().optional(),
       documentType: yup.string().optional(),
-      recIndex: yup.number().optional(),
-      recipient: yup.object().shape({
-        denomination: yup.string().required(),
-        taxId: yup.string().required()
-      }).default(undefined)
+      recIndex: yup.number().optional()
     })
   )
   .noUnknown(true);

--- a/packages/pn-commons/src/utility/notification.utility.ts
+++ b/packages/pn-commons/src/utility/notification.utility.ts
@@ -12,6 +12,8 @@ import {
   INotificationDetailTimeline,
   LegalFactType,
   NotificationDeliveryMode,
+  NotificationDetailDocument,
+  NotificationDetailOtherDocument,
   NotificationDetailPayment,
   NotificationDetailRecipient,
   NotificationDetailTimelineDetails,
@@ -642,3 +644,7 @@ export const populatePaymentsPagoPaF24 = (
 
   return paymentDetails;
 };
+
+export const isNotificationDetailOtherDocument = 
+(value: NotificationDetailDocument | NotificationDetailOtherDocument): value is NotificationDetailOtherDocument => 
+  value.documentType === 'AAR';

--- a/packages/pn-pa-webapp/openapitools.json
+++ b/packages/pn-pa-webapp/openapitools.json
@@ -6,7 +6,7 @@
     "generators": {
       "bff-notifications": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0d61ea3e5e63161b14d92c22eedb4a37278fd6e5/docs/openapi/api-external-pn-bff-pa-notifications.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0bfc0309773bd0aad72415a78989e85417303769/docs/openapi/api-external-pn-bff-pa-notifications.yaml",
         "output": "./src/generated-client/notifications",
         "additionalProperties": {
           "supportsES6": true,
@@ -17,7 +17,7 @@
       },
       "bff-api-keys": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0d61ea3e5e63161b14d92c22eedb4a37278fd6e5/docs/openapi/api-external-pn-bff-pa-apikeys.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0bfc0309773bd0aad72415a78989e85417303769/docs/openapi/api-external-pn-bff-pa-apikeys.yaml",
         "output": "./src/generated-client/api-keys",
         "additionalProperties": {
           "supportsES6": true,
@@ -28,7 +28,7 @@
       },
       "bff-tos-privacy": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0d61ea3e5e63161b14d92c22eedb4a37278fd6e5/docs/openapi/api-external-pn-bff-tos-privacy.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0bfc0309773bd0aad72415a78989e85417303769/docs/openapi/api-external-pn-bff-tos-privacy.yaml",
         "output": "./src/generated-client/tos-privacy",
         "additionalProperties": {
           "supportsES6": true,
@@ -39,7 +39,7 @@
       },
       "bff-pa-info": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0d61ea3e5e63161b14d92c22eedb4a37278fd6e5/docs/openapi/api-external-pn-bff-pa-info.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0bfc0309773bd0aad72415a78989e85417303769/docs/openapi/api-external-pn-bff-pa-info.yaml",
         "output": "./src/generated-client/info-pa",
         "additionalProperties": {
           "supportsES6": true,
@@ -50,7 +50,7 @@
       },
       "bff-downtime-logs": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0d61ea3e5e63161b14d92c22eedb4a37278fd6e5/docs/openapi/api-external-pn-bff-downtime-logs.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0bfc0309773bd0aad72415a78989e85417303769/docs/openapi/api-external-pn-bff-downtime-logs.yaml",
         "output": "./src/generated-client/downtime-logs",
         "additionalProperties": {
           "supportsES6": true,
@@ -61,7 +61,7 @@
       },
       "bff-sender-dashboard": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/af412f72d4e0b20b5fd485ff8b981ebf00aa00b1/docs/openapi/api-external-pn-bff-sender-dashboard.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0bfc0309773bd0aad72415a78989e85417303769/docs/openapi/api-external-pn-bff-sender-dashboard.yaml",
         "output": "./src/generated-client/sender-dashboard",
         "additionalProperties": {
           "supportsES6": true,

--- a/packages/pn-pa-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/NotificationDetail.page.tsx
@@ -338,12 +338,8 @@ const NotificationDetail: React.FC = () => {
                 <Paper sx={{ p: 3, mb: 3 }} elevation={0} data-testid="aarDownload">
                   <NotificationDetailDocuments
                     title={t('detail.aar-acts', { ns: 'notifiche' })}
-                    documents={
-                      notification.otherDocuments?.map((document) => ({
-                        ...document,
-                        title: t('detail.aar-acts', { ns: 'notifiche' }),
-                      })) ?? []
-                    }
+                    documents={notification.otherDocuments ?? []}
+                    recipients={notification.recipients}
                     clickHandler={documentDowloadHandler}
                     disableDownloads={!dateIsLessThan10Years(notification.sentAt)}
                     downloadFilesMessage={getDownloadFilesMessage('aar')}

--- a/packages/pn-pa-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/NotificationDetail.page.tsx
@@ -338,7 +338,12 @@ const NotificationDetail: React.FC = () => {
                 <Paper sx={{ p: 3, mb: 3 }} elevation={0} data-testid="aarDownload">
                   <NotificationDetailDocuments
                     title={t('detail.aar-acts', { ns: 'notifiche' })}
-                    documents={notification.otherDocuments ?? []}
+                    documents={
+                      notification.otherDocuments?.map((document) => ({
+                        ...document,
+                        title: t('detail.aar-acts', { ns: 'notifiche' }),
+                      })) ?? []
+                    }
                     clickHandler={documentDowloadHandler}
                     disableDownloads={!dateIsLessThan10Years(notification.sentAt)}
                     downloadFilesMessage={getDownloadFilesMessage('aar')}

--- a/packages/pn-pa-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
+++ b/packages/pn-pa-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
@@ -164,6 +164,12 @@ describe('NotificationDetail Page', async () => {
     const otherDocument: NotificationDetailOtherDocument = {
       documentId: notificationAfter150Days.otherDocuments?.[0].documentId ?? '',
       documentType: notificationAfter150Days.otherDocuments?.[0].documentType ?? '',
+      digests: { sha256: '' },
+      contentType: '',
+      ref: {
+        key: '',
+        versionToken: '',
+      },
     };
 
     mock

--- a/packages/pn-personafisica-webapp/openapitools.json
+++ b/packages/pn-personafisica-webapp/openapitools.json
@@ -6,7 +6,7 @@
     "generators": {
       "bff-notifications": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0d61ea3e5e63161b14d92c22eedb4a37278fd6e5/docs/openapi/api-external-pn-bff-recipient-notifications.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0bfc0309773bd0aad72415a78989e85417303769/docs/openapi/api-external-pn-bff-recipient-notifications.yaml",
         "output": "./src/generated-client/notifications",
         "additionalProperties": {
           "supportsES6": true,
@@ -17,7 +17,7 @@
       },
       "bff-tos-privacy": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0d61ea3e5e63161b14d92c22eedb4a37278fd6e5/docs/openapi/api-external-pn-bff-tos-privacy.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0bfc0309773bd0aad72415a78989e85417303769/docs/openapi/api-external-pn-bff-tos-privacy.yaml",
         "output": "./src/generated-client/tos-privacy",
         "additionalProperties": {
           "supportsES6": true,
@@ -28,7 +28,7 @@
       },
       "bff-downtime-logs": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0d61ea3e5e63161b14d92c22eedb4a37278fd6e5/docs/openapi/api-external-pn-bff-downtime-logs.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0bfc0309773bd0aad72415a78989e85417303769/docs/openapi/api-external-pn-bff-downtime-logs.yaml",
         "output": "./src/generated-client/downtime-logs",
         "additionalProperties": {
           "supportsES6": true,
@@ -39,7 +39,7 @@
       },
       "bff-payments": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0d61ea3e5e63161b14d92c22eedb4a37278fd6e5/docs/openapi/api-external-pn-bff-payments.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0bfc0309773bd0aad72415a78989e85417303769/docs/openapi/api-external-pn-bff-payments.yaml",
         "output": "./src/generated-client/payments",
         "additionalProperties": {
           "supportsES6": true,
@@ -50,7 +50,7 @@
       },
       "bff-digital-addresses": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0d61ea3e5e63161b14d92c22eedb4a37278fd6e5/docs/openapi/api-external-pn-bff-recipient-digital-addresses.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0bfc0309773bd0aad72415a78989e85417303769/docs/openapi/api-external-pn-bff-recipient-digital-addresses.yaml",
         "output": "./src/generated-client/digital-addresses",
         "additionalProperties": {
           "supportsES6": true,
@@ -61,7 +61,7 @@
       },
       "bff-mandate": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0d61ea3e5e63161b14d92c22eedb4a37278fd6e5/docs/openapi/api-external-pn-bff-recipient-mandate.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0bfc0309773bd0aad72415a78989e85417303769/docs/openapi/api-external-pn-bff-recipient-mandate.yaml",
         "output": "./src/generated-client/mandate",
         "additionalProperties": {
           "supportsES6": true,
@@ -72,7 +72,7 @@
       },
       "bff-recipient-info": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0d61ea3e5e63161b14d92c22eedb4a37278fd6e5/docs/openapi/api-external-pn-bff-recipient-info.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0bfc0309773bd0aad72415a78989e85417303769/docs/openapi/api-external-pn-bff-recipient-info.yaml",
         "output": "./src/generated-client/recipient-info",
         "additionalProperties": {
           "supportsES6": true,

--- a/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
@@ -530,12 +530,8 @@ const NotificationDetail: React.FC = () => {
                 <Paper sx={{ p: 3, mb: 3 }} elevation={0} data-testid="aarBox">
                   <NotificationDetailDocuments
                     title={t('detail.aar-acts', { ns: 'notifiche' })}
-                    documents={
-                      notification.otherDocuments?.map((document) => ({
-                        ...document,
-                        title: t('detail.aar-acts', { ns: 'notifiche' }),
-                      })) ?? []
-                    }
+                    documents={notification.otherDocuments ?? []}
+                    recipients={notification.recipients}
                     clickHandler={documentDowloadHandler}
                     downloadFilesMessage={getDownloadFilesMessage('aar')}
                     downloadFilesLink={t('detail.acts_files.effected_faq', { ns: 'notifiche' })}

--- a/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
@@ -530,7 +530,12 @@ const NotificationDetail: React.FC = () => {
                 <Paper sx={{ p: 3, mb: 3 }} elevation={0} data-testid="aarBox">
                   <NotificationDetailDocuments
                     title={t('detail.aar-acts', { ns: 'notifiche' })}
-                    documents={notification.otherDocuments ?? []}
+                    documents={
+                      notification.otherDocuments?.map((document) => ({
+                        ...document,
+                        title: t('detail.aar-acts', { ns: 'notifiche' }),
+                      })) ?? []
+                    }
                     clickHandler={documentDowloadHandler}
                     downloadFilesMessage={getDownloadFilesMessage('aar')}
                     downloadFilesLink={t('detail.acts_files.effected_faq', { ns: 'notifiche' })}

--- a/packages/pn-personafisica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
@@ -351,6 +351,12 @@ describe('NotificationDetail Page', async () => {
     const otherDocument: NotificationDetailOtherDocument = {
       documentId: notificationToFe.otherDocuments?.[0].documentId ?? '',
       documentType: notificationToFe.otherDocuments?.[0].documentType ?? '',
+      digests: { sha256: '' },
+      contentType: '',
+      ref: {
+        key: '',
+        versionToken: '',
+      },
     };
     mock.onGet(`/bff/v1/notifications/received/${notificationDTO.iun}`).reply(200, notificationDTO);
     mock.onPost(`/bff/v1/payments/info`, paymentInfoRequest).reply(200, paymentInfo);

--- a/packages/pn-personagiuridica-webapp/openapitools.json
+++ b/packages/pn-personagiuridica-webapp/openapitools.json
@@ -6,7 +6,7 @@
     "generators": {
       "bff-notifications": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0d61ea3e5e63161b14d92c22eedb4a37278fd6e5/docs/openapi/api-external-pn-bff-recipient-notifications.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0bfc0309773bd0aad72415a78989e85417303769/docs/openapi/api-external-pn-bff-recipient-notifications.yaml",
         "output": "./src/generated-client/notifications",
         "additionalProperties": {
           "supportsES6": true,
@@ -17,7 +17,7 @@
       },
       "bff-tos-privacy": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0d61ea3e5e63161b14d92c22eedb4a37278fd6e5/docs/openapi/api-external-pn-bff-tos-privacy.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0bfc0309773bd0aad72415a78989e85417303769/docs/openapi/api-external-pn-bff-tos-privacy.yaml",
         "output": "./src/generated-client/tos-privacy",
         "additionalProperties": {
           "supportsES6": true,
@@ -28,7 +28,7 @@
       },
       "bff-downtime-logs": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0d61ea3e5e63161b14d92c22eedb4a37278fd6e5/docs/openapi/api-external-pn-bff-downtime-logs.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0bfc0309773bd0aad72415a78989e85417303769/docs/openapi/api-external-pn-bff-downtime-logs.yaml",
         "output": "./src/generated-client/downtime-logs",
         "additionalProperties": {
           "supportsES6": true,
@@ -39,7 +39,7 @@
       },
       "bff-payments": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0d61ea3e5e63161b14d92c22eedb4a37278fd6e5/docs/openapi/api-external-pn-bff-payments.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0bfc0309773bd0aad72415a78989e85417303769/docs/openapi/api-external-pn-bff-payments.yaml",
         "output": "./src/generated-client/payments",
         "additionalProperties": {
           "supportsES6": true,
@@ -50,7 +50,7 @@
       },
       "bff-digital-addresses": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0d61ea3e5e63161b14d92c22eedb4a37278fd6e5/docs/openapi/api-external-pn-bff-recipient-digital-addresses.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0bfc0309773bd0aad72415a78989e85417303769/docs/openapi/api-external-pn-bff-recipient-digital-addresses.yaml",
         "output": "./src/generated-client/digital-addresses",
         "additionalProperties": {
           "supportsES6": true,
@@ -61,7 +61,7 @@
       },
       "bff-mandate": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0d61ea3e5e63161b14d92c22eedb4a37278fd6e5/docs/openapi/api-external-pn-bff-recipient-mandate.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0bfc0309773bd0aad72415a78989e85417303769/docs/openapi/api-external-pn-bff-recipient-mandate.yaml",
         "output": "./src/generated-client/mandate",
         "additionalProperties": {
           "supportsES6": true,
@@ -72,7 +72,7 @@
       },
       "bff-recipient-info": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0d61ea3e5e63161b14d92c22eedb4a37278fd6e5/docs/openapi/api-external-pn-bff-recipient-info.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0bfc0309773bd0aad72415a78989e85417303769/docs/openapi/api-external-pn-bff-recipient-info.yaml",
         "output": "./src/generated-client/recipient-info",
         "additionalProperties": {
           "supportsES6": true,
@@ -83,7 +83,7 @@
       },
       "bff-pg-apikeys": {
         "generatorName": "typescript-axios",
-        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0d61ea3e5e63161b14d92c22eedb4a37278fd6e5/docs/openapi/api-external-pn-bff-pg-apikeys.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/pagopa/pn-bff/0bfc0309773bd0aad72415a78989e85417303769/docs/openapi/api-external-pn-bff-pg-apikeys.yaml",
         "output": "./src/generated-client/pg-apikeys",
         "additionalProperties": {
           "supportsES6": true,

--- a/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
@@ -473,7 +473,12 @@ const NotificationDetail = () => {
                 <Paper sx={{ p: 3, mb: 3 }} elevation={0} data-testid="aarBox">
                   <NotificationDetailDocuments
                     title={t('detail.aar-acts', { ns: 'notifiche' })}
-                    documents={notification.otherDocuments ?? []}
+                    documents={
+                      notification.otherDocuments?.map((document) => ({
+                        ...document,
+                        title: t('detail.aar-acts', { ns: 'notifiche' }),
+                      })) ?? []
+                    }
                     clickHandler={documentDowloadHandler}
                     downloadFilesMessage={getDownloadFilesMessage('aar')}
                     downloadFilesLink={t('detail.acts_files.effected_faq', { ns: 'notifiche' })}

--- a/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
@@ -473,12 +473,8 @@ const NotificationDetail = () => {
                 <Paper sx={{ p: 3, mb: 3 }} elevation={0} data-testid="aarBox">
                   <NotificationDetailDocuments
                     title={t('detail.aar-acts', { ns: 'notifiche' })}
-                    documents={
-                      notification.otherDocuments?.map((document) => ({
-                        ...document,
-                        title: t('detail.aar-acts', { ns: 'notifiche' }),
-                      })) ?? []
-                    }
+                    documents={notification.otherDocuments ?? []}
+                    recipients={notification.recipients}
                     clickHandler={documentDowloadHandler}
                     downloadFilesMessage={getDownloadFilesMessage('aar')}
                     downloadFilesLink={t('detail.acts_files.effected_faq', { ns: 'notifiche' })}

--- a/packages/pn-personagiuridica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
@@ -361,6 +361,12 @@ describe('NotificationDetail Page', async () => {
     const otherDocument: NotificationDetailOtherDocument = {
       documentId: notificationToFe.otherDocuments?.[0].documentId ?? '',
       documentType: notificationToFe.otherDocuments?.[0].documentType ?? '',
+      digests: { sha256: '' },
+      contentType: '',
+      ref: {
+        key: '',
+        versionToken: '',
+      },
     };
     mock.onGet(`/bff/v1/notifications/received/${notificationDTO.iun}`).reply(200, notificationDTO);
     mock.onPost(`/bff/v1/payments/info`, paymentInfoRequest).reply(200, paymentInfo);
@@ -756,14 +762,13 @@ describe('NotificationDetail Page', async () => {
       })
       .reply(500);
 
-      await act(async () => {
-        result = render(<NotificationDetail />, {
-          preloadedState: {
-            userState: { user: { fiscal_number: notificationDTO.recipients[2].taxId } }
-            ,
-          },
-        });
+    await act(async () => {
+      result = render(<NotificationDetail />, {
+        preloadedState: {
+          userState: { user: { fiscal_number: notificationDTO.recipients[2].taxId } },
+        },
       });
+    });
 
     expect(testStore.getState().notificationState.paymentsData.pagoPaF24.length).toBe(6);
 


### PR DESCRIPTION
## Short description
This PR makes use of the lates changes in bff response to properly manage the translation of the `Notifications of receipt` shown inside the notification detail page. It fixes both PN-13269 and PN-13132 bugs.

## List of changes proposed in this pull request
- NotificationDetail.ts model
- NotificationDetailDocuments.tsx

## How to test
This PR should be tested on PF, PG and PA (single and multi-recipient notifications) using netify to mock the notification detail response. The `otherDocuments` array inside the original response should be modified removing, from everyone of contained elements, the `title` property and adding a recipient object as in the following example:

```
"recipient": {
        "denomination": "Cristoforo Colombo",
        "taxId": "CLMCST42R12D969Z"
}
```