### PR TITLE
(PN-13215) Lettura timeline

### DIFF
--- a/packages/pn-commons/src/components/NotificationDetail/NotificationDetailTimelineStep.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationDetailTimelineStep.tsx
@@ -290,7 +290,14 @@ const NotificationDetailTimelineStep = ({
                       display="inline"
                       variant="button"
                       color={disableDownloads ? 'text.disabled' : 'primary'}
-                      sx={{ cursor: disableDownloads ? 'default' : 'pointer' }}
+                      sx={{ cursor: disableDownloads ? 'default' : 'pointer', outline: 'none',
+                        '&:focus': {
+                          outline: (theme) => `2px solid ${theme.palette.primary.main}`, 
+                          outlineOffset: '2px',
+                          borderRadius: 2,
+                          px:0.5 
+                        }, }}
+                      tabIndex={disableDownloads ? -1 : 0}
                       onClick={() => clickHandler(lf)}
                       key={lf.key}
                       data-testid="download-legalfact-micro"

--- a/packages/pn-commons/src/components/NotificationDetail/NotificationDetailTimelineStep.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationDetailTimelineStep.tsx
@@ -281,7 +281,7 @@ const NotificationDetailTimelineStep = ({
             </Typography>
             <Box sx={{ overflowWrap: 'anywhere' }}>
               <Typography color="text.primary" fontSize={14}>
-                {timelineStatusInfos.description}&nbsp;
+                {timelineStatusInfos.description}
               </Typography>
               {s.legalFactsIds &&
                 s.legalFactsIds.length > 0 &&

--- a/packages/pn-commons/src/components/NotificationDetail/NotificationDetailTimelineStep.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationDetailTimelineStep.tsx
@@ -285,25 +285,17 @@ const NotificationDetailTimelineStep = ({
                 {s.legalFactsIds &&
                   s.legalFactsIds.length > 0 &&
                   s.legalFactsIds.map((lf) => (
-                    <Typography
+                    <ButtonNaked
                       fontSize={14}
                       display="inline"
-                      variant="button"
-                      color={disableDownloads ? 'text.disabled' : 'primary'}
-                      sx={{ cursor: disableDownloads ? 'default' : 'pointer', outline: 'none',
-                        '&:focus': {
-                          outline: (theme) => `2px solid ${theme.palette.primary.main}`, 
-                          outlineOffset: '2px',
-                          borderRadius: 2,
-                          px:0.5 
-                        }, }}
-                      tabIndex={disableDownloads ? -1 : 0}
+                      color='primary'
                       onClick={() => clickHandler(lf)}
+                      disabled={disableDownloads}
                       key={lf.key}
                       data-testid="download-legalfact-micro"
                     >
                       {getLegalFactLabel(s, lf.category, lf.key || '')}
-                    </Typography>
+                    </ButtonNaked>
                   ))}
               </Typography>
             </Box>

--- a/packages/pn-commons/src/components/NotificationDetail/NotificationDetailTimelineStep.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationDetailTimelineStep.tsx
@@ -282,22 +282,21 @@ const NotificationDetailTimelineStep = ({
             <Box sx={{ overflowWrap: 'anywhere' }}>
               <Typography color="text.primary" fontSize={14}>
                 {timelineStatusInfos.description}&nbsp;
-                {s.legalFactsIds &&
-                  s.legalFactsIds.length > 0 &&
-                  s.legalFactsIds.map((lf) => (
-                    <ButtonNaked
-                      fontSize={14}
-                      display="inline"
-                      color='primary'
-                      onClick={() => clickHandler(lf)}
-                      disabled={disableDownloads}
-                      key={lf.key}
-                      data-testid="download-legalfact-micro"
-                    >
-                      {getLegalFactLabel(s, lf.category, lf.key || '')}
-                    </ButtonNaked>
-                  ))}
               </Typography>
+              {s.legalFactsIds &&
+                s.legalFactsIds.length > 0 &&
+                s.legalFactsIds.map((lf) => (
+                  <ButtonNaked
+                    fontSize={14}
+                    color='primary'
+                    onClick={() => clickHandler(lf)}
+                    disabled={disableDownloads}
+                    key={lf.key}
+                    data-testid="download-legalfact-micro"
+                  >
+                    {getLegalFactLabel(s, lf.category, lf.key || '')}
+                  </ButtonNaked>
+                ))}
             </Box>
           </Fragment>
         }

--- a/packages/pn-commons/src/components/NotificationDetail/__test__/NotificationDetailTimelineStep.test.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/__test__/NotificationDetailTimelineStep.test.tsx
@@ -137,7 +137,7 @@ describe('NotificationDetailTimelineStep', () => {
     moreLessButton = getByTestId('more-less-timeline-step');
     expect(moreLessButton).toHaveTextContent('Show Less');
     fireEvent.click(moreLessButton);
-    expect(eventTrackingCallbackShowMore).toBeCalledTimes(2);
+    expect(eventTrackingCallbackShowMore).toHaveBeenCalledTimes(2);
     // After clicking "Show Less", additional steps should be hidden
     dateItemsMicro = queryAllByTestId('dateItemMicro');
     expect(dateItemsMicro).toHaveLength(0);
@@ -162,7 +162,7 @@ describe('NotificationDetailTimelineStep', () => {
       fireEvent.click(btn);
       // Verify that the clickHandler function is called with the expected arguments
       expect(mockClickHandler).toHaveBeenCalledTimes(index + 1);
-      expect(mockClickHandler).toBeCalledWith(legalFacts[index].file);
+      expect(mockClickHandler).toHaveBeenCalledWith(legalFacts[index].file);
     });
     // expand step
     const moreLessButton = getByTestId('more-less-timeline-step');
@@ -176,7 +176,7 @@ describe('NotificationDetailTimelineStep', () => {
           fireEvent.click(microLegalFacts[counter]);
           // Verify that the clickHandler function is called with the expected arguments
           expect(mockClickHandler).toHaveBeenCalledTimes(legalFacts.length + counter + 1);
-          expect(mockClickHandler).toBeCalledWith(lf);
+          expect(mockClickHandler).toHaveBeenCalledWith(lf);
         }
         counter++;
       }

--- a/packages/pn-commons/src/components/NotificationDetail/__test__/NotificationDetailTimelineStep.test.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/__test__/NotificationDetailTimelineStep.test.tsx
@@ -129,6 +129,7 @@ describe('NotificationDetailTimelineStep', () => {
             getLegalFactLabel(step, lf.category, lf.key || '')
           );
         }
+        expect(microLegalFacts[counter]).toBeEnabled()
         counter++;
       }
     });

--- a/packages/pn-commons/src/components/NotificationDetail/__test__/NotificationDetailTimelineStep.test.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/__test__/NotificationDetailTimelineStep.test.tsx
@@ -2,7 +2,7 @@ import { vi } from 'vitest';
 
 import { notificationDTO } from '../../../__mocks__/NotificationDetail.mock';
 import { INotificationDetailTimeline, LegalFactId, NotificationStatus } from '../../../models';
-import { fireEvent, render, theme } from '../../../test-utils';
+import { fireEvent, render } from '../../../test-utils';
 import {
   formatDay,
   formatMonthString,
@@ -128,10 +128,6 @@ describe('NotificationDetailTimelineStep', () => {
           expect(microLegalFacts[counter]).toHaveTextContent(
             getLegalFactLabel(step, lf.category, lf.key || '')
           );
-          expect(microLegalFacts[counter]).toHaveStyle({
-            color: theme.palette.primary.main,
-            cursor: 'pointer',
-          });
         }
         counter++;
       }
@@ -186,7 +182,7 @@ describe('NotificationDetailTimelineStep', () => {
     });
   });
 
-  it('renders component with disabled donwloads', () => {
+  it('renders component with disabled downloads', () => {
     const { getAllByTestId, getByTestId } = render(
       <NotificationDetailTimelineStep
         timelineStep={mockTimelineStep!}
@@ -204,10 +200,7 @@ describe('NotificationDetailTimelineStep', () => {
     fireEvent.click(moreLessButton);
     const microLegalFacts = getAllByTestId('download-legalfact-micro');
     microLegalFacts.forEach((btn) => {
-      expect(btn).toHaveStyle({
-        color: theme.palette.text.disabled,
-        cursor: 'default',
-      });
+      expect(btn).toBeDisabled();
     });
   });
 


### PR DESCRIPTION
## Short description
fix SEND-477 focus on dowload-legal-micro Same logic as the main timeline documents inserted

## List of changes proposed in this pull request
- change TextField with tabindex and insert style for focus

## How to test
-check that the See more details button in the timeline is clickable and interactable with the tab
-check that exploding the previous button opens the details and that the documents are reachable with the card
- check that they have the correct focus, when you get there with the tab a blue border appears as in the other links
- check that the Canceled status chip cannot be clicked or interacted with the mouse or keyboard