### PR TITLE
Fix/PN-13598: tooltip deleghe

### DIFF
--- a/packages/pn-commons/src/components/CustomTagGroup/CustomTagGroup.tsx
+++ b/packages/pn-commons/src/components/CustomTagGroup/CustomTagGroup.tsx
@@ -21,9 +21,15 @@ const TagIndicator: React.FC<{
   arrayChildren: Array<JSX.Element>;
   visibleItems: number;
   dataTestId: string;
-}> = ({ boxProps, arrayChildren, visibleItems, dataTestId }) => (
-  <Box {...boxProps} sx={{ cursor: 'pointer', display: 'inline-block' }} data-testid={dataTestId}>
-    <Tag value={`+${arrayChildren.length - visibleItems}`} />
+  ariaLabel?: string;
+}> = ({ boxProps, arrayChildren, visibleItems, dataTestId, ariaLabel }) => (
+  <Box
+    {...boxProps}
+    sx={{ cursor: 'pointer', display: 'inline-block' }}
+    data-testid={dataTestId}
+    aria-label={ariaLabel || undefined}
+  >
+    <Tag value={`+${arrayChildren.length - visibleItems}`} aria-hidden={!!ariaLabel} />
   </Box>
 );
 
@@ -55,6 +61,11 @@ const CustomTagGroup: React.FC<CustomTagGroupProps> = ({
                   arrayChildren={arrayChildren}
                   visibleItems={visibleItems as number}
                   dataTestId="custom-tooltip-indicator"
+                  ariaLabel={arrayChildren
+                    .slice(visibleItems)
+                    .map((c) => c.props?.children?.props?.value) // <Box><Tag value={v}></Tag></Box>
+                    .filter(Boolean)
+                    .join(',')}
                 />
               </Box>
             </CustomTooltip>

--- a/packages/pn-commons/src/components/CustomTagGroup/CustomTagGroup.tsx
+++ b/packages/pn-commons/src/components/CustomTagGroup/CustomTagGroup.tsx
@@ -50,14 +50,13 @@ const CustomTagGroup: React.FC<CustomTagGroupProps> = ({
               onOpen={onOpen}
               tooltipContent={<>{arrayChildren.slice(visibleItems).map((c) => c)}</>}
             >
-              <div>
+              <Box sx={{ width: 'fit-content' }}>
                 <TagIndicator
-                  boxProps={{ role: 'button' }}
                   arrayChildren={arrayChildren}
                   visibleItems={visibleItems as number}
                   dataTestId="custom-tooltip-indicator"
                 />
-              </div>
+              </Box>
             </CustomTooltip>
           )}
           {disableTooltip && (

--- a/packages/pn-commons/src/components/CustomTagGroup/__test__/CustomTagGroup.test.tsx
+++ b/packages/pn-commons/src/components/CustomTagGroup/__test__/CustomTagGroup.test.tsx
@@ -1,13 +1,18 @@
 import { vi } from 'vitest';
 
 import { Box } from '@mui/material';
+import { Tag } from '@pagopa/mui-italia';
 
 import { fireEvent, render, screen, waitFor } from '../../../test-utils';
 import CustomTagGroup from '../CustomTagGroup';
 
 describe('CustomTagGroup component', () => {
   const tagsArray = ['mock-tag-1', 'mock-tag-2', 'mock-tag-3', 'mock-tag-4'];
-  const tags = tagsArray.map((v, i) => <Box key={i}>{v}</Box>);
+  const tags = tagsArray.map((v, i) => (
+    <Box key={i}>
+      <Tag value={v}></Tag>
+    </Box>
+  ));
   const mockCallbackFn = vi.fn();
 
   beforeEach(() => {
@@ -56,5 +61,16 @@ describe('CustomTagGroup component', () => {
     const tooltip = await waitFor(() => screen.queryByRole('tooltip'));
     expect(tooltip).not.toBeInTheDocument();
     expect(mockCallbackFn).toBeCalledTimes(0);
+  });
+
+  it('renders component with limited 1 tags with aria-label', () => {
+    const { getByTestId } = render(
+      <CustomTagGroup visibleItems={2} disableTooltip={false}>
+        {tags}
+      </CustomTagGroup>
+    );
+    const tooltipIndicator = getByTestId('custom-tooltip-indicator');
+    expect(tooltipIndicator).toBeInTheDocument();
+    expect(tooltipIndicator).toHaveAttribute('aria-label', 'mock-tag-3,mock-tag-4');
   });
 });

--- a/packages/pn-commons/src/components/Data/PnTable/PnTableHeaderCell.tsx
+++ b/packages/pn-commons/src/components/Data/PnTable/PnTableHeaderCell.tsx
@@ -49,6 +49,13 @@ const PnTableHeaderCell = <T,>({
           direction={sort.orderBy === columnId ? sort.order : 'asc'}
           onClick={sortHandler(columnId)}
           data-testid={testId ? `${testId}.sort.${columnId.toString()}` : null}
+          sx={{
+            '&:focus-visible': {
+              borderRadius: '2px',
+              outlineOffset: '4px',
+              outline: '2px solid currentColor'
+            }
+          }}
         >
           {children}
           {sort.orderBy === columnId && (

--- a/packages/pn-personafisica-webapp/src/components/Deleghe/Delegates.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Deleghe/Delegates.tsx
@@ -81,17 +81,17 @@ const Delegates = () => {
     {
       id: 'visibilityIds',
       label: t('deleghe.table.permissions'),
-      cellProps: { width: 'auto' },
+      cellProps: { width: '20%' },
     },
     {
       id: 'status',
       label: t('deleghe.table.status'),
-      cellProps: { width: '18%' },
+      cellProps: { width: '15%' },
     },
     {
       id: 'menu',
       label: '',
-      cellProps: { width: '5%' },
+      cellProps: { width: '5%', align: 'right' },
     },
   ];
 
@@ -140,7 +140,10 @@ const Delegates = () => {
           reloadAction={() => dispatch(getMandatesByDelegator())}
         >
           {rows.length > 0 ? (
-            <PnTable testId="delegatesTable">
+            <PnTable
+              testId="delegatesTable"
+              slotProps={{ table: { sx: { tableLayout: 'fixed' } } }}
+            >
               <PnTableHeader>
                 {delegatesColumns.map((column) => (
                   <PnTableHeaderCell
@@ -150,6 +153,7 @@ const Delegates = () => {
                     sortable={column.sortable}
                     handleClick={handleChangeSorting}
                     testId="delegatesTable.header.cell"
+                    cellProps={column.cellProps}
                   >
                     {column.label}
                   </PnTableHeaderCell>

--- a/packages/pn-personafisica-webapp/src/components/Deleghe/Delegates.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Deleghe/Delegates.tsx
@@ -81,7 +81,7 @@ const Delegates = () => {
     {
       id: 'visibilityIds',
       label: t('deleghe.table.permissions'),
-      cellProps: { width: '14%' },
+      cellProps: { width: 'auto' },
     },
     {
       id: 'status',

--- a/packages/pn-personafisica-webapp/src/components/Deleghe/Delegates.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Deleghe/Delegates.tsx
@@ -91,7 +91,7 @@ const Delegates = () => {
     {
       id: 'menu',
       label: '',
-      cellProps: { width: '5%', align: 'right' },
+      cellProps: { width: '5%' },
     },
   ];
 

--- a/packages/pn-personafisica-webapp/src/components/Deleghe/DelegationsElements.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Deleghe/DelegationsElements.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import { Box, Button, IconButton, Menu as MUIMenu, MenuItem, Typography } from '@mui/material';
 import { Variant } from '@mui/material/styles/createTypography';
-import { CustomTagGroup, useIsMobile } from '@pagopa-pn/pn-commons';
+import { CustomTagGroup } from '@pagopa-pn/pn-commons';
 import { Tag } from '@pagopa/mui-italia';
 
 import { PFEventsType } from '../../models/PFEventsType';
@@ -99,7 +99,6 @@ export const OrganizationsList = (props: {
   visibleItems?: number;
 }) => {
   const { t } = useTranslation(['deleghe']);
-  const isMobile = useIsMobile();
   return (
     <>
       {props.organizations.length === 0 ? (
@@ -107,7 +106,7 @@ export const OrganizationsList = (props: {
           {t('deleghe.table.allNotifications')}
         </Typography>
       ) : (
-        <Box sx={{ minWidth: isMobile ? '' : '35rem', maxWidth: '60rem' }}>
+        <Box>
           <Typography variant={props.textVariant || 'inherit'} mb={2}>
             {t('deleghe.table.notificationsFrom')}
           </Typography>

--- a/packages/pn-personagiuridica-webapp/src/components/Deleghe/DelegatesByCompany.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Deleghe/DelegatesByCompany.tsx
@@ -98,7 +98,7 @@ const DelegatesByCompany = () => {
       id: 'visibilityIds',
       label: t('deleghe.table.permissions'),
       tableConfiguration: {
-        cellProps: { width: 'auto' },
+        cellProps: { width: '20%' },
       },
       cardConfiguration: {
         wrapValueInTypography: false,
@@ -108,7 +108,7 @@ const DelegatesByCompany = () => {
       id: 'status',
       label: t('deleghe.table.status'),
       tableConfiguration: {
-        cellProps: { width: '18%' },
+        cellProps: { width: '15%' },
       },
       cardConfiguration: {
         position: 'left',
@@ -178,6 +178,7 @@ const DelegatesByCompany = () => {
             currentSort={sort}
             onChangeSorting={setSort}
             testId="delegatesTable"
+            slotProps={{ table: { sx: { tableLayout: 'fixed' } } }}
           >
             <SmartHeader>
               {delegatesColumn.map((column) => (
@@ -185,6 +186,7 @@ const DelegatesByCompany = () => {
                   key={column.id.toString()}
                   columnId={column.id}
                   sortable={column.tableConfiguration.sortable}
+                  cellProps={column.tableConfiguration.cellProps}
                 >
                   {column.label}
                 </SmartHeaderCell>

--- a/packages/pn-personagiuridica-webapp/src/components/Deleghe/DelegatesByCompany.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Deleghe/DelegatesByCompany.tsx
@@ -98,7 +98,7 @@ const DelegatesByCompany = () => {
       id: 'visibilityIds',
       label: t('deleghe.table.permissions'),
       tableConfiguration: {
-        cellProps: { width: '11%' },
+        cellProps: { width: 'auto' },
       },
       cardConfiguration: {
         wrapValueInTypography: false,

--- a/packages/pn-personagiuridica-webapp/src/components/Deleghe/DelegationsElements.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Deleghe/DelegationsElements.tsx
@@ -11,7 +11,6 @@ import {
   CustomTagGroup,
   Row,
   appStateActions,
-  useIsMobile,
 } from '@pagopa-pn/pn-commons';
 import { Tag } from '@pagopa/mui-italia';
 import { AnyAction } from '@reduxjs/toolkit';
@@ -294,7 +293,6 @@ export const OrganizationsList: React.FC<OrganizationsListProps> = ({
   visibleItems,
 }) => {
   const { t } = useTranslation(['deleghe']);
-  const isMobile = useIsMobile();
 
   return (
     <>
@@ -303,7 +301,7 @@ export const OrganizationsList: React.FC<OrganizationsListProps> = ({
           {t('deleghe.table.allNotifications')}
         </Typography>
       ) : (
-        <Box sx={{ minWidth: isMobile ? '' : '35rem', maxWidth: '60rem' }}>
+        <Box>
           <Typography variant={textVariant || 'inherit'} mb={2}>
             {t('deleghe.table.notificationsFrom')}
           </Typography>


### PR DESCRIPTION
## Short description
This PR adds an ariaLabel to `CustomTagGroup` that reads content of tooltip for a11y
 
## How to test
Start and login PF app. Go to "Deleghe" page and create a delegation with more than 3 `enti selezionati`. Go back and start voiceover. Navigate with keyboard on chips in column "Permessi"