### PR TITLE
PN-13999 - Create debt position step on new notification

### DIFF
--- a/packages/pn-pa-webapp/public/locales/de/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/de/notifiche.json
@@ -450,7 +450,6 @@
         "remove-recipient": "Empfänger entfernen"
       },
       "attachments": {
-        "title": "Anhänge",
         "max-attachments": "Du kannst bis zu 11 Anhänge hochladen, einschließlich des zuzustellenden Bescheids.",
         "attach-for-recipients": "Anhänge",
         "act-attachment": "Urkunde anhängen",

--- a/packages/pn-pa-webapp/public/locales/en/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/en/notifiche.json
@@ -450,7 +450,6 @@
         "remove-recipient": "Remove recipient"
       },
       "attachments": {
-        "title": "Attachments",
         "max-attachments": "You can upload up to 11 attachments, including the document to be notified.",
         "attach-for-recipients": "Attachments",
         "act-attachment": "Attach the deed",

--- a/packages/pn-pa-webapp/public/locales/fr/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/fr/notifiche.json
@@ -450,7 +450,6 @@
         "remove-recipient": "Supprimez un destinataire"
       },
       "attachments": {
-        "title": "Annexes",
         "max-attachments": "Vous pouvez télécharger jusqu’à 11 pièces jointes, y compris le document à notifier.",
         "attach-for-recipients": "Annexes",
         "act-attachment": "Joindre l’acte",

--- a/packages/pn-pa-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/it/notifiche.json
@@ -485,6 +485,19 @@
         "banner-additional-languages": "Hai scelto di inviare la notifica in più lingue. Ricorda di allegare i documenti in entrambe le lingue selezionate.",
         "file-upload-helper": "Il documento deve essere in formato {{format}} e non deve superare le dimensioni di {{size}}"
       },
+      "debt-position": {
+        "title": "Posizione debitoria",
+        "debt-position": "Posizione debitoria",
+        "debt-position-of": "Posizione debitoria di {{fullName}}",
+        "which-type-of-payments": "Quale tipo di pagamento prevedi?",
+        "back-to-recipient": "Torna a destinatario",
+        "radios": {
+          "pago-pa-notice": "Avviso pagoPA",
+          "f24": "Modello F24",
+          "pago-pa-f24": "Avviso pagoPA + Modello F24",
+          "nothing": "Nessun pagamento"
+        }
+      },
       "payment-methods": {
         "title": "Modelli di pagamento",
         "pagopa-notice": "Avviso pagoPA",

--- a/packages/pn-pa-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/it/notifiche.json
@@ -471,7 +471,7 @@
         "remove-recipient": "Rimuovi destinatario"
       },
       "attachments": {
-        "title": "Allegati",
+        "title": "Documentazione",
         "max-attachments": "Questi sono i documenti che saranno notificati tramite SEND a tutti i destinatari inseriti. Puoi allegare fino a un massimo di {{maxNumber}} documenti.",
         "attach-for-recipients": "Documenti allegati",
         "act-attachment": "Allega documento",
@@ -494,7 +494,7 @@
         "which-type-of-payments": "Quale tipo di pagamento prevedi?",
         "back-to-recipient": "Torna a destinatario",
         "radios": {
-          "pago-pa-notice": "Avviso pagoPA",
+          "pago-pa": "Avviso pagoPA",
           "f24": "Modello F24",
           "pago-pa-f24": "Avviso pagoPA + Modello F24",
           "nothing": "Nessun pagamento"

--- a/packages/pn-pa-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/it/notifiche.json
@@ -481,6 +481,8 @@
         "add-doc": "Aggiungi un documento",
         "add-another-doc": "Aggiungi un altro documento",
         "back-to-recipient": "Torna a Destinatario",
+        "back-to-debt-position": "Torna a Posizione debitoria",
+        "back-to-payment-methods": "Torna a Dettaglio posizione debitoria",
         "remove-document": "Rimuovi documento",
         "banner-additional-languages": "Hai scelto di inviare la notifica in più lingue. Ricorda di allegare i documenti in entrambe le lingue selezionate.",
         "file-upload-helper": "Il documento deve essere in formato {{format}} e non deve superare le dimensioni di {{size}}"

--- a/packages/pn-pa-webapp/public/locales/sl/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/sl/notifiche.json
@@ -450,7 +450,6 @@
         "remove-recipient": "Odstrani prejemnika"
       },
       "attachments": {
-        "title": "Priloge",
         "max-attachments": "Naložite lahko do 11 prilog, vključno z dokumentom, ki ga je treba obvestiti.",
         "attach-for-recipients": "Priloge",
         "act-attachment": "Priloži listino",

--- a/packages/pn-pa-webapp/src/__mocks__/NewNotification.mock.ts
+++ b/packages/pn-pa-webapp/src/__mocks__/NewNotification.mock.ts
@@ -16,6 +16,7 @@ import {
   NewNotificationPagoPaPayment,
   NewNotificationRecipient,
   NotificationFeePolicy,
+  PaymentModel,
 } from '../models/NewNotification';
 import { UserGroup } from '../models/user';
 import { userResponse } from './Auth.mock';
@@ -132,6 +133,7 @@ export const newNotificationRecipients: Array<NewNotificationRecipient> = [
         pagoPa: { ...newNotificationPagoPa },
       },
     ],
+    debtPosition: PaymentModel.PAGO_PA,
   },
   {
     id: 'recipient.1',
@@ -156,8 +158,9 @@ export const newNotificationRecipients: Array<NewNotificationRecipient> = [
       },
       {
         f24: { ...newNotificationF24 },
-      }
+      },
     ],
+    debtPosition: PaymentModel.PAGO_PA_F24,
   },
 ];
 
@@ -200,7 +203,7 @@ const newNotificationRecipientsForBff: Array<NotificationRecipientV23> = [
       },
       {
         f24: { ...newNotificationF24ForBff },
-      }
+      },
     ],
   },
 ];

--- a/packages/pn-pa-webapp/src/components/NewNotification/Attachments.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/Attachments.tsx
@@ -136,7 +136,7 @@ type Props = {
   forwardedRef: ForwardedRef<unknown>;
   isCompleted: boolean;
   hasAdditionalLang?: boolean;
-  hasDebtPosition: boolean;
+  hasDebtPosition?: boolean;
 };
 
 const emptyFileData = {
@@ -310,7 +310,7 @@ const Attachments: React.FC<Props> = ({
   const handlePreviousStep = () => {
     if (onPreviousStep) {
       storeAttachments(formik.values.documents);
-      return !hasDebtPosition ? onPreviousStep(2) : onPreviousStep();
+      return hasDebtPosition ? onPreviousStep() : onPreviousStep(2);
     }
   };
 
@@ -319,7 +319,7 @@ const Attachments: React.FC<Props> = ({
       return t('back-to-recipient');
     }
 
-    return !hasDebtPosition ? t('back-to-debt-position') : t('back-to-payment-methods');
+    return hasDebtPosition ? t('back-to-payment-methods') : t('back-to-debt-position');
   };
 
   useImperativeHandle(forwardedRef, () => ({

--- a/packages/pn-pa-webapp/src/components/NewNotification/Attachments.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/Attachments.tsx
@@ -131,11 +131,12 @@ const AttachmentBox: React.FC<AttachmentBoxProps> = ({
 
 type Props = {
   onConfirm: () => void;
-  onPreviousStep?: () => void;
+  onPreviousStep?: (step?: number) => void;
   attachmentsData?: Array<NewNotificationDocument>;
   forwardedRef: ForwardedRef<unknown>;
   isCompleted: boolean;
   hasAdditionalLang?: boolean;
+  hasDebtPosition: boolean;
 };
 
 const emptyFileData = {
@@ -162,6 +163,7 @@ const Attachments: React.FC<Props> = ({
   forwardedRef,
   isCompleted,
   hasAdditionalLang,
+  hasDebtPosition,
 }) => {
   const dispatch = useAppDispatch();
   const { t } = useTranslation(['notifiche'], {
@@ -308,8 +310,16 @@ const Attachments: React.FC<Props> = ({
   const handlePreviousStep = () => {
     if (onPreviousStep) {
       storeAttachments(formik.values.documents);
-      onPreviousStep();
+      return !hasDebtPosition ? onPreviousStep(2) : onPreviousStep();
     }
+  };
+
+  const getPreviousStepLabel = () => {
+    if (!IS_PAYMENT_ENABLED) {
+      return t('back-to-recipient');
+    }
+
+    return !hasDebtPosition ? t('back-to-debt-position') : t('back-to-payment-methods');
   };
 
   useImperativeHandle(forwardedRef, () => ({
@@ -323,8 +333,8 @@ const Attachments: React.FC<Props> = ({
       <NewNotificationCard
         isContinueDisabled={!formik.isValid}
         title={t('attach-for-recipients')}
-        submitLabel={IS_PAYMENT_ENABLED ? tc('button.continue') : tc('button.send')}
-        previousStepLabel={t('back-to-recipient')}
+        submitLabel={tc('button.send')}
+        previousStepLabel={getPreviousStepLabel()}
         previousStepOnClick={() => handlePreviousStep()}
       >
         <Typography variant="body2">

--- a/packages/pn-pa-webapp/src/components/NewNotification/DebtPosition.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/DebtPosition.tsx
@@ -1,0 +1,162 @@
+import { useFormik } from 'formik';
+import React, { ChangeEvent, ForwardedRef, forwardRef, useImperativeHandle } from 'react';
+import { useTranslation } from 'react-i18next';
+import * as yup from 'yup';
+
+import { Box, FormControlLabel, Paper, Radio, RadioGroup, Stack, Typography } from '@mui/material';
+
+import { NewNotificationRecipient, PaymentModel } from '../../models/NewNotification';
+import { useAppDispatch } from '../../redux/hooks';
+import { setDebtPosition } from '../../redux/newNotification/reducers';
+import NewNotificationCard from './NewNotificationCard';
+
+type Props = {
+  recipients: Array<NewNotificationRecipient>;
+  onConfirm: () => void;
+  onPreviousStep: () => void;
+  forwardedRef: ForwardedRef<unknown>;
+};
+
+interface DebtPositionFormValues {
+  recipientDebtPositions: {
+    [taxId: string]: PaymentModel | undefined;
+  };
+}
+
+// const recipients = [
+//   {
+//     taxId: 'xx',
+//     firstName: 'Ale',
+//     lastName: 'Gelmi',
+//   },
+//   {
+//     taxId: 'xxx',
+//     firstName: 'Giorgio',
+//     lastName: 'Troisi',
+//   },
+// ];
+
+const DebtPosition: React.FC<Props> = ({ recipients, onConfirm, onPreviousStep, forwardedRef }) => {
+  const dispatch = useAppDispatch();
+  const { t } = useTranslation(['notifiche'], {
+    keyPrefix: 'new-notification.steps.debt-position',
+  });
+  const { t: tc } = useTranslation(['common']);
+
+  const initialValues = (): DebtPositionFormValues => ({
+    recipientDebtPositions: recipients.reduce(
+      (acc, recipient) => ({
+        ...acc,
+        [recipient.taxId]: undefined,
+      }),
+      {}
+    ),
+  });
+
+  const validationSchema = yup.object().shape({
+    recipientDebtPositions: yup.object().shape(
+      recipients.reduce((acc, recipient) => {
+        // eslint-disable-next-line functional/immutable-data
+        acc[recipient.taxId] = yup.string().required(tc('required-field'));
+        return acc;
+      }, {} as { [key: string]: yup.StringSchema })
+    ),
+  });
+
+  const formik = useFormik({
+    initialValues: initialValues(),
+    validateOnMount: true,
+    validationSchema,
+    enableReinitialize: true,
+    onSubmit: (values) => {
+      console.log(values);
+      if (formik.isValid) {
+        dispatch(setDebtPosition(values));
+        onConfirm();
+      }
+    },
+  });
+
+  const handleChange = async (event: ChangeEvent<HTMLInputElement>, taxId: string) => {
+    const { value } = event.target;
+
+    if (Object.values(PaymentModel).includes(value as PaymentModel)) {
+      await formik.setFieldValue(`recipientDebtPositions.${taxId}`, value);
+    }
+
+    await formik.setFieldTouched(`recipientDebtPositions.${taxId}`, true, false);
+  };
+
+  useImperativeHandle(forwardedRef, () => ({
+    confirm() {
+      setDebtPosition(formik.values);
+    },
+  }));
+
+  return (
+    <form onSubmit={formik.handleSubmit}>
+      <NewNotificationCard
+        isContinueDisabled={!formik.isValid}
+        noPaper={true}
+        previousStepLabel={t('back-to-recipient')}
+        previousStepOnClick={onPreviousStep}
+      >
+        {recipients.map((recipient) => (
+          <Paper key={recipient.taxId} sx={{ padding: '24px', marginTop: '40px' }} elevation={0}>
+            <Typography variant="h6" fontWeight={700}>
+              {recipients.length === 1
+                ? t('debt-position')
+                : t('debt-position-of', {
+                    fullName: `${recipient.firstName} ${recipient.lastName}`,
+                  })}
+            </Typography>
+            <Box mt={3} p={3} border={1} borderColor="divider" borderRadius={1}>
+              <Stack direction="column">
+                <Typography fontSize="16px" fontWeight={600}>
+                  {t('which-type-of-payments')}
+                </Typography>
+                <RadioGroup
+                  aria-labelledby="comunication-type-label"
+                  name="debtPosition"
+                  value={formik.values.recipientDebtPositions[recipient.taxId] || ''}
+                  onChange={(e) => handleChange(e, recipient.taxId)}
+                  sx={{ mt: 2 }}
+                >
+                  <FormControlLabel
+                    value={PaymentModel.PAGO_PA_NOTICE}
+                    control={<Radio />}
+                    label={t('radios.pago-pa-notice')}
+                    componentsProps={{ typography: { fontSize: '16px' } }}
+                  />
+                  <FormControlLabel
+                    value={PaymentModel.F24}
+                    control={<Radio />}
+                    label={t('radios.f24')}
+                    componentsProps={{ typography: { fontSize: '16px' } }}
+                  />
+                  <FormControlLabel
+                    value={PaymentModel.PAGO_PA_F24}
+                    control={<Radio />}
+                    label={t('radios.pago-pa-f24')}
+                    componentsProps={{ typography: { fontSize: '16px' } }}
+                  />
+                  <FormControlLabel
+                    value={PaymentModel.NOTHING}
+                    control={<Radio />}
+                    label={t('radios.nothing')}
+                    componentsProps={{ typography: { fontSize: '16px' } }}
+                  />
+                </RadioGroup>
+              </Stack>
+            </Box>
+          </Paper>
+        ))}
+      </NewNotificationCard>
+    </form>
+  );
+};
+
+// This is a workaorund to prevent cognitive complexity warning
+export default forwardRef((props: Omit<Props, 'forwardedRef'>, ref) => (
+  <DebtPosition {...props} forwardedRef={ref} />
+));

--- a/packages/pn-pa-webapp/src/components/NewNotification/DebtPosition.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/DebtPosition.tsx
@@ -3,12 +3,22 @@ import React, { ChangeEvent, ForwardedRef, forwardRef, useImperativeHandle } fro
 import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
 
-import { Box, FormControlLabel, Paper, Radio, RadioGroup, Stack, Typography } from '@mui/material';
+import {
+  Box,
+  FormControl,
+  FormControlLabel,
+  FormLabel,
+  Paper,
+  Radio,
+  RadioGroup,
+  Typography,
+} from '@mui/material';
 
 import { NewNotificationRecipient, PaymentModel } from '../../models/NewNotification';
 import { useAppDispatch } from '../../redux/hooks';
 import { setDebtPosition } from '../../redux/newNotification/reducers';
 import NewNotificationCard from './NewNotificationCard';
+import { FormBoxTitle } from './NewNotificationFormElelements';
 
 type Props = {
   recipients: Array<NewNotificationRecipient>;
@@ -52,16 +62,12 @@ const DebtPosition: React.FC<Props> = ({
     validationSchema,
     enableReinitialize: true,
     onSubmit: (values) => {
-      if (formik.isValid) {
-        dispatch(setDebtPosition(values));
-        if (
-          values.recipients.every((recipient) => recipient.debtPosition === PaymentModel.NOTHING)
-        ) {
-          goToLastStep();
-          return;
-        }
-        onConfirm();
+      dispatch(setDebtPosition(values));
+      if (values.recipients.every((recipient) => recipient.debtPosition === PaymentModel.NOTHING)) {
+        goToLastStep();
+        return;
       }
+      onConfirm();
     },
   });
 
@@ -85,7 +91,12 @@ const DebtPosition: React.FC<Props> = ({
         previousStepOnClick={onPreviousStep}
       >
         {recipients.map((recipient, index) => (
-          <Paper key={recipient.taxId} sx={{ padding: '24px', marginTop: '40px' }} elevation={0}>
+          <Paper
+            key={recipient.taxId}
+            sx={{ padding: '24px', marginTop: '40px' }}
+            elevation={0}
+            data-testid="payments-type-choice"
+          >
             <Typography variant="h6" fontWeight={700}>
               {recipients.length === 1
                 ? t('debt-position')
@@ -94,43 +105,47 @@ const DebtPosition: React.FC<Props> = ({
                   })}
             </Typography>
             <Box mt={3} p={3} border={1} borderColor="divider" borderRadius={1}>
-              <Stack direction="column">
-                <Typography fontSize="16px" fontWeight={600}>
-                  {t('which-type-of-payments')}
-                </Typography>
+              <FormControl margin="none" fullWidth>
+                <FormLabel id="payments-type">
+                  <FormBoxTitle text={t('which-type-of-payments')} />
+                </FormLabel>
                 <RadioGroup
-                  aria-labelledby="comunication-type-label"
+                  aria-labelledby="payments-type"
                   name={`recipients.${index}.debtPosition`}
-                  value={formik.values.recipients[index].debtPosition}
+                  value={formik.values.recipients[index].debtPosition ?? ''}
                   onChange={(e) => handleChange(e, index)}
                   sx={{ mt: 2 }}
                 >
                   <FormControlLabel
-                    value={PaymentModel.PAGO_PA_NOTICE}
+                    value={PaymentModel.PAGO_PA}
                     control={<Radio />}
-                    label={t('radios.pago-pa-notice')}
+                    label={t('radios.pago-pa')}
                     componentsProps={{ typography: { fontSize: '16px' } }}
+                    data-testid="paymentModel"
                   />
                   <FormControlLabel
                     value={PaymentModel.F24}
                     control={<Radio />}
                     label={t('radios.f24')}
                     componentsProps={{ typography: { fontSize: '16px' } }}
+                    data-testid="paymentModel"
                   />
                   <FormControlLabel
                     value={PaymentModel.PAGO_PA_F24}
                     control={<Radio />}
                     label={t('radios.pago-pa-f24')}
                     componentsProps={{ typography: { fontSize: '16px' } }}
+                    data-testid="paymentModel"
                   />
                   <FormControlLabel
                     value={PaymentModel.NOTHING}
                     control={<Radio />}
                     label={t('radios.nothing')}
                     componentsProps={{ typography: { fontSize: '16px' } }}
+                    data-testid="paymentModel"
                   />
                 </RadioGroup>
-              </Stack>
+              </FormControl>
             </Box>
           </Paper>
         ))}

--- a/packages/pn-pa-webapp/src/components/NewNotification/DebtPosition.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/DebtPosition.tsx
@@ -34,7 +34,7 @@ const DebtPosition: React.FC<Props> = ({ recipients, onConfirm, onPreviousStep, 
   const validationSchema = yup.object().shape({
     recipients: yup.array().of(
       yup.object().shape({
-        debtPosition: yup.string().required(tc('required-fields')),
+        debtPosition: yup.string().required(tc('required-field')),
       })
     ),
   });

--- a/packages/pn-pa-webapp/src/components/NewNotification/DebtPosition.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/DebtPosition.tsx
@@ -76,9 +76,16 @@ const DebtPosition: React.FC<Props> = ({
     await formik.setFieldValue(`recipients.${index}.debtPosition`, value);
   };
 
+  const handlePreviousStep = () => {
+    if (onPreviousStep) {
+      dispatch(setDebtPosition(formik.values));
+      onPreviousStep();
+    }
+  };
+
   useImperativeHandle(forwardedRef, () => ({
     confirm() {
-      setDebtPosition(formik.values);
+      dispatch(setDebtPosition(formik.values));
     },
   }));
 
@@ -88,7 +95,7 @@ const DebtPosition: React.FC<Props> = ({
         isContinueDisabled={!formik.isValid}
         noPaper={true}
         previousStepLabel={t('back-to-recipient')}
-        previousStepOnClick={onPreviousStep}
+        previousStepOnClick={handlePreviousStep}
       >
         {recipients.map((recipient, index) => (
           <Paper

--- a/packages/pn-pa-webapp/src/components/NewNotification/DebtPosition.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/DebtPosition.tsx
@@ -14,10 +14,17 @@ type Props = {
   recipients: Array<NewNotificationRecipient>;
   onConfirm: () => void;
   onPreviousStep: () => void;
+  goToLastStep: () => void;
   forwardedRef: ForwardedRef<unknown>;
 };
 
-const DebtPosition: React.FC<Props> = ({ recipients, onConfirm, onPreviousStep, forwardedRef }) => {
+const DebtPosition: React.FC<Props> = ({
+  recipients,
+  onConfirm,
+  onPreviousStep,
+  goToLastStep,
+  forwardedRef,
+}) => {
   const dispatch = useAppDispatch();
   const { t } = useTranslation(['notifiche'], {
     keyPrefix: 'new-notification.steps.debt-position',
@@ -45,9 +52,14 @@ const DebtPosition: React.FC<Props> = ({ recipients, onConfirm, onPreviousStep, 
     validationSchema,
     enableReinitialize: true,
     onSubmit: (values) => {
-      console.log(values);
       if (formik.isValid) {
         dispatch(setDebtPosition(values));
+        if (
+          values.recipients.every((recipient) => recipient.debtPosition === PaymentModel.NOTHING)
+        ) {
+          goToLastStep();
+          return;
+        }
         onConfirm();
       }
     },

--- a/packages/pn-pa-webapp/src/components/NewNotification/__test__/Attachments.test.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/__test__/Attachments.test.tsx
@@ -96,7 +96,7 @@ describe('Attachments Component with payment enabled', async () => {
     const buttonSubmit = result.getByTestId('step-submit');
     const buttonPrevious = result.getByTestId('previous-step');
     expect(buttonSubmit).toBeDisabled();
-    expect(buttonSubmit).toHaveTextContent('button.continue');
+    expect(buttonSubmit).toHaveTextContent('button.send');
     expect(buttonPrevious).toBeInTheDocument();
   });
 
@@ -394,11 +394,13 @@ describe('Attachments Component with payment enabled', async () => {
     }
     expect(buttonAddAnotherDoc).not.toBeInTheDocument();
   });
-  
+
   it('should appear info banner with additional languages', async () => {
     // render component
     await act(async () => {
-      result = render(<Attachments isCompleted={false} onConfirm={confirmHandlerMk} hasAdditionalLang={true}/>);
+      result = render(
+        <Attachments isCompleted={false} onConfirm={confirmHandlerMk} hasAdditionalLang={true} />
+      );
     });
     const form = result.container.querySelector('form');
     const banner = within(form!).getByTestId('bannerAdditionalLanguages');

--- a/packages/pn-pa-webapp/src/components/NewNotification/__test__/Attachments.test.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/__test__/Attachments.test.tsx
@@ -165,7 +165,7 @@ describe('Attachments Component with payment enabled', async () => {
         },
       ]);
     });
-    expect(confirmHandlerMk).toBeCalledTimes(1);
+    expect(confirmHandlerMk).toHaveBeenCalledTimes(1);
   });
 
   it('fills form with invalid values - one document', async () => {
@@ -230,7 +230,7 @@ describe('Attachments Component with payment enabled', async () => {
         },
       ]);
     });
-    expect(previousHandlerMk).toBeCalledTimes(1);
+    expect(previousHandlerMk).toHaveBeenCalledTimes(1);
   });
 
   it('changes form values and clicks on confirm - two documents', async () => {
@@ -325,7 +325,7 @@ describe('Attachments Component with payment enabled', async () => {
         },
       ]);
     });
-    expect(confirmHandlerMk).toBeCalledTimes(1);
+    expect(confirmHandlerMk).toHaveBeenCalledTimes(1);
   });
 
   it('fills form with invalid values - two documents', async () => {
@@ -441,7 +441,7 @@ describe('Attachments Component without payment enabled', () => {
     expect(buttonSubmit).toBeEnabled();
     fireEvent.click(buttonSubmit);
     await waitFor(() => {
-      expect(confirmHandlerMk).toBeCalledTimes(1);
+      expect(confirmHandlerMk).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/pn-pa-webapp/src/components/NewNotification/__test__/DebtPosition.test.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/__test__/DebtPosition.test.tsx
@@ -1,0 +1,249 @@
+import { vi } from 'vitest';
+
+import { testRadio } from '@pagopa-pn/pn-commons/src/test-utils';
+
+import { newNotification } from '../../../__mocks__/NewNotification.mock';
+import { fireEvent, render, testStore, waitFor } from '../../../__test__/test-utils';
+import { PaymentModel } from '../../../models/NewNotification';
+import DebtPosition from '../DebtPosition';
+
+const recipientsWithoutPayment = newNotification.recipients.map(
+  ({ payments, debtPosition, ...recipient }) => recipient
+);
+const confirmHandlerMk = vi.fn();
+const goToLasStepMk = vi.fn();
+const previousStepMk = vi.fn();
+
+// mock imports
+vi.mock('react-i18next', () => ({
+  // this mock makes sure any components using the translate hook can use it without a warning being shown
+  useTranslation: () => ({
+    t: (str: string) => str,
+    i18n: { language: 'it' },
+  }),
+}));
+
+describe('DebtPosition Component', async () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders component - empty state (one recipient)', async () => {
+    // render component
+    const { getByTestId } = render(
+      <DebtPosition
+        recipients={[recipientsWithoutPayment[0]]}
+        onConfirm={confirmHandlerMk}
+        goToLastStep={goToLasStepMk}
+        onPreviousStep={previousStepMk}
+      />
+    );
+    // we wait that the component is correctly rendered
+    const paymentChoiceBox = await waitFor(() => getByTestId('payments-type-choice'));
+    expect(paymentChoiceBox).toHaveTextContent('debt-position');
+    expect(paymentChoiceBox).toHaveTextContent('which-type-of-payments');
+    await testRadio(paymentChoiceBox, 'paymentModel', [
+      'radios.pago-pa',
+      'radios.f24',
+      'radios.pago-pa-f24',
+      'radios.nothing',
+    ]);
+    const buttonSubmit = getByTestId('step-submit');
+    const buttonPrevious = getByTestId('previous-step');
+    expect(buttonSubmit).toBeDisabled();
+    expect(buttonSubmit).toHaveTextContent('button.continue');
+    expect(buttonPrevious).toBeInTheDocument();
+    expect(buttonPrevious).toHaveTextContent('back-to-recipient');
+    // check the click on prev button
+    fireEvent.click(buttonPrevious);
+    expect(previousStepMk).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders component - empty state (multi recipienta)', async () => {
+    // render component
+    const { getAllByTestId, getByTestId } = render(
+      <DebtPosition
+        recipients={recipientsWithoutPayment}
+        onConfirm={confirmHandlerMk}
+        goToLastStep={goToLasStepMk}
+        onPreviousStep={previousStepMk}
+      />
+    );
+    // we wait that the component is correctly rendered
+    const paymentChoiceBoxes = await waitFor(() => getAllByTestId('payments-type-choice'));
+    expect(paymentChoiceBoxes).toHaveLength(recipientsWithoutPayment.length);
+    for (const paymentChoiceBox of paymentChoiceBoxes) {
+      expect(paymentChoiceBox).toHaveTextContent('debt-position-of');
+      expect(paymentChoiceBox).toHaveTextContent('which-type-of-payments');
+      await testRadio(paymentChoiceBox, 'paymentModel', [
+        'radios.pago-pa',
+        'radios.f24',
+        'radios.pago-pa-f24',
+        'radios.nothing',
+      ]);
+    }
+    const buttonSubmit = getByTestId('step-submit');
+    const buttonPrevious = getByTestId('previous-step');
+    expect(buttonSubmit).toBeDisabled();
+    expect(buttonSubmit).toHaveTextContent('button.continue');
+    expect(buttonPrevious).toBeInTheDocument();
+    expect(buttonPrevious).toHaveTextContent('back-to-recipient');
+  });
+
+  it('choose an option (two recipients)', async () => {
+    // render component
+    const { getAllByTestId, getByTestId } = render(
+      <DebtPosition
+        recipients={[recipientsWithoutPayment[0], recipientsWithoutPayment[1]]}
+        onConfirm={confirmHandlerMk}
+        goToLastStep={goToLasStepMk}
+        onPreviousStep={previousStepMk}
+      />,
+      {
+        preloadedState: {
+          newNotificationState: {
+            notification: {
+              ...newNotification,
+              recipients: [recipientsWithoutPayment[0], recipientsWithoutPayment[1]],
+            },
+          },
+        },
+      }
+    );
+    // we wait that the component is correctly rendered
+    const paymentChoiceBoxes = await waitFor(() => getAllByTestId('payments-type-choice'));
+    expect(paymentChoiceBoxes).toHaveLength(recipientsWithoutPayment.length);
+    const buttonSubmit = getByTestId('step-submit');
+    expect(buttonSubmit).toBeDisabled();
+    // choose an option for the first recipient
+    await testRadio(
+      paymentChoiceBoxes[0],
+      'paymentModel',
+      ['radios.pago-pa', 'radios.f24', 'radios.pago-pa-f24', 'radios.nothing'],
+      1,
+      true
+    );
+    // to enable the continue button we need that all the recipients have an option selected
+    expect(buttonSubmit).toBeDisabled();
+    // choose an option for the second recipient
+    await testRadio(
+      paymentChoiceBoxes[1],
+      'paymentModel',
+      ['radios.pago-pa', 'radios.f24', 'radios.pago-pa-f24', 'radios.nothing'],
+      3,
+      true
+    );
+    expect(buttonSubmit).toBeEnabled();
+    fireEvent.click(buttonSubmit);
+    // check if redux is updated correctly
+    await waitFor(() =>
+      expect(testStore.getState().newNotificationState.notification.recipients).toStrictEqual(
+        [recipientsWithoutPayment[0], recipientsWithoutPayment[1]].map((recipient, index) => ({
+          ...recipient,
+          debtPosition: index === 0 ? PaymentModel.F24 : PaymentModel.NOTHING,
+          payments: [],
+        }))
+      )
+    );
+    expect(confirmHandlerMk).toHaveBeenCalledTimes(1);
+  });
+
+  it('choose nothing option (multi recipients)', async () => {
+    // render component
+    const { getAllByTestId, getByTestId } = render(
+      <DebtPosition
+        recipients={recipientsWithoutPayment}
+        onConfirm={confirmHandlerMk}
+        goToLastStep={goToLasStepMk}
+        onPreviousStep={previousStepMk}
+      />,
+      {
+        preloadedState: {
+          newNotificationState: {
+            notification: {
+              ...newNotification,
+              recipients: recipientsWithoutPayment,
+            },
+          },
+        },
+      }
+    );
+    // we wait that the component is correctly rendered
+    const paymentChoiceBoxes = await waitFor(() => getAllByTestId('payments-type-choice'));
+    expect(paymentChoiceBoxes).toHaveLength(recipientsWithoutPayment.length);
+    const buttonSubmit = getByTestId('step-submit');
+    expect(buttonSubmit).toBeDisabled();
+    // choose nothing option for all the recipients
+    for (const paymentChoiceBox of paymentChoiceBoxes) {
+      expect(paymentChoiceBox).toHaveTextContent('debt-position-of');
+      expect(paymentChoiceBox).toHaveTextContent('which-type-of-payments');
+      await testRadio(
+        paymentChoiceBox,
+        'paymentModel',
+        ['radios.pago-pa', 'radios.f24', 'radios.pago-pa-f24', 'radios.nothing'],
+        3,
+        true
+      );
+    }
+    expect(buttonSubmit).toBeEnabled();
+    fireEvent.click(buttonSubmit);
+    // check if redux is updated correctly
+    await waitFor(() =>
+      expect(testStore.getState().newNotificationState.notification.recipients).toStrictEqual(
+        recipientsWithoutPayment.map((recipient) => ({
+          ...recipient,
+          debtPosition: PaymentModel.NOTHING,
+          payments: [],
+        }))
+      )
+    );
+    expect(goToLasStepMk).toHaveBeenCalledTimes(1);
+  });
+
+  it('initally filled (multi recipients)', async () => {
+    // render component
+    const { getAllByTestId, getByTestId } = render(
+      <DebtPosition
+        recipients={newNotification.recipients}
+        onConfirm={confirmHandlerMk}
+        goToLastStep={goToLasStepMk}
+        onPreviousStep={previousStepMk}
+      />,
+      {
+        preloadedState: {
+          newNotificationState: {
+            notification: newNotification,
+          },
+        },
+      }
+    );
+    // we wait that the component is correctly rendered
+    const paymentChoiceBoxes = await waitFor(() => getAllByTestId('payments-type-choice'));
+    expect(paymentChoiceBoxes).toHaveLength(newNotification.recipients.length);
+    const buttonSubmit = getByTestId('step-submit');
+    expect(buttonSubmit).toBeEnabled();
+    // check that radio buttons are correctly filled
+    const radioOptions = ['radios.pago-pa', 'radios.f24', 'radios.pago-pa-f24', 'radios.nothing'];
+    let recipientIdx = 0;
+    for (const paymentChoiceBox of paymentChoiceBoxes) {
+      // get radio value from debtPosition set for the recipient
+      const radioSelectedValue = newNotification.recipients[recipientIdx].debtPosition
+        ?.toLocaleLowerCase()
+        .replace(/_/g, '-');
+      const radioSelectedIndex = radioOptions.indexOf(`radios.${radioSelectedValue!}`);
+      expect(paymentChoiceBox).toHaveTextContent('debt-position-of');
+      expect(paymentChoiceBox).toHaveTextContent('which-type-of-payments');
+      await testRadio(paymentChoiceBox, 'paymentModel', radioOptions, radioSelectedIndex);
+      recipientIdx++;
+    }
+    expect(buttonSubmit).toBeEnabled();
+    fireEvent.click(buttonSubmit);
+    // check if redux is not updated
+    await waitFor(() =>
+      expect(testStore.getState().newNotificationState.notification.recipients).toStrictEqual(
+        newNotification.recipients
+      )
+    );
+    expect(confirmHandlerMk).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/pn-pa-webapp/src/components/NewNotification/__test__/Recipient.test.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/__test__/Recipient.test.tsx
@@ -158,7 +158,7 @@ const testStringFieldValidation = async (
 };
 
 const recipientsWithoutPayments = newNotification.recipients.map(
-  ({ payments, ...recipient }) => recipient
+  ({ payments, debtPosition, ...recipient }) => recipient
 );
 
 describe('Recipient Component with payment enabled', async () => {

--- a/packages/pn-pa-webapp/src/models/NewNotification.ts
+++ b/packages/pn-pa-webapp/src/models/NewNotification.ts
@@ -5,6 +5,7 @@ import { NotificationAttachmentBodyRef } from '../generated-client/notifications
 export enum PaymentModel {
   PAGO_PA_NOTICE = 'PAGO_PA_NOTICE',
   F24 = 'F24',
+  PAGO_PA_F24 = 'PAGO_PA_F24',
   NOTHING = 'NOTHING',
 }
 
@@ -85,6 +86,7 @@ export interface NewNotificationRecipient {
   province: string;
   foreignState: string;
   payments?: Array<NewNotificationPayment>;
+  debtPosition?: PaymentModel;
 }
 
 export interface NewNotification extends NewNotificationBilingualism {

--- a/packages/pn-pa-webapp/src/models/NewNotification.ts
+++ b/packages/pn-pa-webapp/src/models/NewNotification.ts
@@ -3,7 +3,7 @@ import { PhysicalCommunicationType, RecipientType } from '@pagopa-pn/pn-commons'
 import { NotificationAttachmentBodyRef } from '../generated-client/notifications';
 
 export enum PaymentModel {
-  PAGO_PA_NOTICE = 'PAGO_PA_NOTICE',
+  PAGO_PA = 'PAGO_PA',
   F24 = 'F24',
   PAGO_PA_F24 = 'PAGO_PA_F24',
   NOTHING = 'NOTHING',

--- a/packages/pn-pa-webapp/src/pages/NewNotification.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/NewNotification.page.tsx
@@ -58,7 +58,7 @@ const NewNotification = () => {
     // eslint-disable-next-line functional/immutable-data
     baseSteps.push(t('new-notification.steps.attachments.title', { ns: 'notifiche' }));
     return baseSteps;
-  }, [t, IS_PAYMENT_ENABLED]);
+  }, []);
 
   const hasDebtPosition =
     IS_PAYMENT_ENABLED &&
@@ -197,7 +197,7 @@ const NewNotification = () => {
                 ref={childRef}
               />
             )}
-            {activeStep === 3 && IS_PAYMENT_ENABLED && hasDebtPosition && (
+            {activeStep === 3 && IS_PAYMENT_ENABLED && (
               <PaymentMethods
                 onConfirm={goToNextStep}
                 notification={notification}

--- a/packages/pn-pa-webapp/src/pages/NewNotification.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/NewNotification.page.tsx
@@ -6,6 +6,7 @@ import { Alert, Box, Grid, Step, StepLabel, Stepper, Typography } from '@mui/mat
 import { PnBreadcrumb, Prompt, TitleBox, useIsMobile } from '@pagopa-pn/pn-commons';
 
 import Attachments from '../components/NewNotification/Attachments';
+import DebtPosition from '../components/NewNotification/DebtPosition';
 import PaymentMethods from '../components/NewNotification/PaymentMethods';
 import PreliminaryInformations from '../components/NewNotification/PreliminaryInformations';
 import Recipient from '../components/NewNotification/Recipient';
@@ -48,8 +49,10 @@ const NewNotification = () => {
   const childRef = useRef<{ confirm: () => void }>();
 
   if (IS_PAYMENT_ENABLED) {
-    // eslint-disable-next-line functional/immutable-data
-    steps.push(t('new-notification.steps.payment-methods.title', { ns: 'notifiche' }));
+    /* eslint-disable functional/immutable-data */
+    steps.splice(2, 0, t('new-notification.steps.debt-position.title', { ns: 'notifiche' }));
+    steps.splice(3, 0, t('new-notification.steps.payment-methods.title', { ns: 'notifiche' }));
+    /* eslint-enable functional/immutable-data */
   }
 
   const goToNextStep = () => {
@@ -158,22 +161,18 @@ const NewNotification = () => {
             )}
             {activeStep === 1 && (
               <Recipient
-                onConfirm={goToNextStep}
+                onConfirm={IS_PAYMENT_ENABLED ? goToNextStep : () => setActiveStep(4)}
                 onPreviousStep={goToPreviousStep}
                 recipientsData={notification.recipients}
                 paymentMode={notification.paymentMode}
                 ref={childRef}
               />
             )}
-            {activeStep === 2 && (
-              <Attachments
-                onConfirm={IS_PAYMENT_ENABLED ? goToNextStep : createNotification}
+            {activeStep === 2 && IS_PAYMENT_ENABLED && (
+              <DebtPosition
+                recipients={notification.recipients}
+                onConfirm={goToNextStep}
                 onPreviousStep={goToPreviousStep}
-                isCompleted={isCompleted}
-                attachmentsData={notification.documents}
-                hasAdditionalLang={
-                  notification.lang === NewNotificationLangOther && !!notification.additionalLang
-                }
                 ref={childRef}
               />
             )}
@@ -183,6 +182,18 @@ const NewNotification = () => {
                 notification={notification}
                 isCompleted={isCompleted}
                 onPreviousStep={goToPreviousStep}
+                ref={childRef}
+              />
+            )}
+            {activeStep === 4 && (
+              <Attachments
+                onConfirm={createNotification}
+                onPreviousStep={goToPreviousStep}
+                isCompleted={isCompleted}
+                attachmentsData={notification.documents}
+                hasAdditionalLang={
+                  notification.lang === NewNotificationLangOther && !!notification.additionalLang
+                }
                 ref={childRef}
               />
             )}

--- a/packages/pn-pa-webapp/src/redux/newNotification/__test__/reducers.test.ts
+++ b/packages/pn-pa-webapp/src/redux/newNotification/__test__/reducers.test.ts
@@ -109,7 +109,7 @@ describe('New notification redux state tests', () => {
       physicalCommunicationType: PhysicalCommunicationType.REGISTERED_LETTER_890,
       group: '',
       taxonomyCode: '010801N',
-      paymentMode: PaymentModel.PAGO_PA_NOTICE,
+      paymentMode: PaymentModel.PAGO_PA,
     };
     const action = store.dispatch(setPreliminaryInformations(preliminaryInformations));
     expect(action.type).toBe('newNotificationSlice/setPreliminaryInformations');

--- a/packages/pn-pa-webapp/src/redux/newNotification/__test__/reducers.test.ts
+++ b/packages/pn-pa-webapp/src/redux/newNotification/__test__/reducers.test.ts
@@ -25,6 +25,7 @@ import {
   saveRecipients,
   setAttachments,
   setCancelledIun,
+  setDebtPosition,
   setIsCompleted,
   setPayments,
   setPreliminaryInformations,
@@ -173,6 +174,44 @@ describe('New notification redux state tests', () => {
       }))
     );
     extMock.restore();
+  });
+
+  it('should be able to set new debt position', () => {
+    const recipients = newNotification.recipients.map((recipient) => ({
+      ...recipient,
+      debtPosition: PaymentModel.PAGO_PA_F24,
+    }));
+
+    const action = store.dispatch(setDebtPosition({ recipients }));
+    expect(action.type).toBe('newNotificationSlice/setDebtPosition');
+    expect(action.payload).toEqual({ recipients });
+    expect(store.getState().newNotificationState.notification.recipients).toEqual(recipients);
+  });
+
+  it('should clear payments when set debt position to NOTHING', () => {
+    store.dispatch(
+      setDebtPosition({
+        recipients: newNotificationRecipients.map((recipient) => ({
+          ...recipient,
+          debtPosition: PaymentModel.PAGO_PA_F24,
+        })),
+      })
+    );
+
+    const updatedRecipients = newNotification.recipients.map((recipient) => ({
+      ...recipient,
+      debtPosition: PaymentModel.NOTHING,
+    }));
+
+    const action = store.dispatch(setDebtPosition({ recipients: updatedRecipients }));
+    expect(action.type).toBe('newNotificationSlice/setDebtPosition');
+    expect(action.payload).toEqual({ recipients: updatedRecipients });
+    expect(store.getState().newNotificationState.notification.recipients).toEqual(
+      updatedRecipients.map((recipient) => ({
+        ...recipient,
+        payments: [],
+      }))
+    );
   });
 
   it('Should be able to save payment documents', () => {

--- a/packages/pn-pa-webapp/src/redux/newNotification/reducers.ts
+++ b/packages/pn-pa-webapp/src/redux/newNotification/reducers.ts
@@ -6,6 +6,7 @@ import {
   NewNotificationDocument,
   NewNotificationRecipient,
   NotificationFeePolicy,
+  PaymentModel,
   PreliminaryInformationsPayload,
 } from '../../models/NewNotification';
 import { UserGroup } from '../../models/user';
@@ -78,6 +79,19 @@ const newNotificationSlice = createSlice({
     ) => {
       state.notification.documents = action.payload.documents;
     },
+    setDebtPosition: (
+      state,
+      action: PayloadAction<{
+        recipientDebtPositions: {
+          [taxId: string]: PaymentModel | undefined;
+        };
+      }>
+    ) => {
+      state.notification.recipients = state.notification.recipients.map((recipient) => ({
+        ...recipient,
+        debtPosition: action.payload.recipientDebtPositions[recipient.taxId],
+      }));
+    },
     setPayments: (
       state,
       action: PayloadAction<{ recipients: Array<NewNotificationRecipient> }>
@@ -119,6 +133,7 @@ export const {
   setPayments,
   resetState,
   setIsCompleted,
+  setDebtPosition,
 } = newNotificationSlice.actions;
 
 export default newNotificationSlice;

--- a/packages/pn-pa-webapp/src/redux/newNotification/reducers.ts
+++ b/packages/pn-pa-webapp/src/redux/newNotification/reducers.ts
@@ -6,7 +6,6 @@ import {
   NewNotificationDocument,
   NewNotificationRecipient,
   NotificationFeePolicy,
-  PaymentModel,
   PreliminaryInformationsPayload,
 } from '../../models/NewNotification';
 import { UserGroup } from '../../models/user';
@@ -82,15 +81,10 @@ const newNotificationSlice = createSlice({
     setDebtPosition: (
       state,
       action: PayloadAction<{
-        recipientDebtPositions: {
-          [taxId: string]: PaymentModel | undefined;
-        };
+        recipients: Array<NewNotificationRecipient>;
       }>
     ) => {
-      state.notification.recipients = state.notification.recipients.map((recipient) => ({
-        ...recipient,
-        debtPosition: action.payload.recipientDebtPositions[recipient.taxId],
-      }));
+      state.notification.recipients = action.payload.recipients;
     },
     setPayments: (
       state,

--- a/packages/pn-pa-webapp/src/utility/__test__/notification.utility.test.ts
+++ b/packages/pn-pa-webapp/src/utility/__test__/notification.utility.test.ts
@@ -56,8 +56,8 @@ describe('Test notification utility', () => {
     it('should return the same payments if the debt position does not change', () => {
       const result = filterPaymentsByDebtPositionChange(
         recipientPayments,
-        PaymentModel.PAGO_PA_NOTICE,
-        PaymentModel.PAGO_PA_NOTICE
+        PaymentModel.PAGO_PA,
+        PaymentModel.PAGO_PA
       );
       expect(result).toEqual(recipientPayments);
     });
@@ -65,7 +65,7 @@ describe('Test notification utility', () => {
     it('should return all payments when previous debt position is undefined', () => {
       const result = filterPaymentsByDebtPositionChange(
         recipientPayments,
-        PaymentModel.PAGO_PA_NOTICE,
+        PaymentModel.PAGO_PA,
         undefined
       );
       expect(result).toEqual(recipientPayments);
@@ -75,7 +75,7 @@ describe('Test notification utility', () => {
       const result = filterPaymentsByDebtPositionChange(
         recipientPayments,
         PaymentModel.NOTHING,
-        PaymentModel.PAGO_PA_NOTICE
+        PaymentModel.PAGO_PA
       );
       expect(result).toEqual([]);
     });
@@ -88,7 +88,7 @@ describe('Test notification utility', () => {
 
       const result = filterPaymentsByDebtPositionChange(
         recipientPayments,
-        PaymentModel.PAGO_PA_NOTICE,
+        PaymentModel.PAGO_PA,
         PaymentModel.PAGO_PA_F24
       );
       expect(result).toEqual(pagopaPayments);
@@ -112,7 +112,7 @@ describe('Test notification utility', () => {
       const result = filterPaymentsByDebtPositionChange(
         recipientPayments,
         PaymentModel.F24,
-        PaymentModel.PAGO_PA_NOTICE
+        PaymentModel.PAGO_PA
       );
       expect(result).toEqual([]);
     });
@@ -120,7 +120,7 @@ describe('Test notification utility', () => {
     it('should clear all payments when debt position change from F24 to PAGOPA', () => {
       const result = filterPaymentsByDebtPositionChange(
         recipientPayments,
-        PaymentModel.PAGO_PA_NOTICE,
+        PaymentModel.PAGO_PA,
         PaymentModel.F24
       );
       expect(result).toEqual([]);
@@ -129,18 +129,14 @@ describe('Test notification utility', () => {
     it('should return all payments when debt position change from NONE', () => {
       const result = filterPaymentsByDebtPositionChange(
         recipientPayments,
-        PaymentModel.PAGO_PA_NOTICE,
+        PaymentModel.PAGO_PA,
         PaymentModel.NOTHING
       );
       expect(result).toEqual(recipientPayments);
     });
 
     it('should handle empty payments array', () => {
-      const result = filterPaymentsByDebtPositionChange(
-        [],
-        PaymentModel.PAGO_PA_NOTICE,
-        PaymentModel.F24
-      );
+      const result = filterPaymentsByDebtPositionChange([], PaymentModel.PAGO_PA, PaymentModel.F24);
       expect(result).toEqual([]);
     });
   });

--- a/packages/pn-pa-webapp/src/utility/__test__/notification.utility.test.ts
+++ b/packages/pn-pa-webapp/src/utility/__test__/notification.utility.test.ts
@@ -1,6 +1,15 @@
-import { newNotification, newNotificationForBff } from '../../__mocks__/NewNotification.mock';
+import {
+  newNotification,
+  newNotificationForBff,
+  newNotificationRecipients,
+} from '../../__mocks__/NewNotification.mock';
 import { BffNewNotificationRequest } from '../../generated-client/notifications';
-import { getDuplicateValuesByKeys, newNotificationMapper } from '../notification.utility';
+import { NewNotificationPayment, PaymentModel } from '../../models/NewNotification';
+import {
+  filterPaymentsByDebtPositionChange,
+  getDuplicateValuesByKeys,
+  newNotificationMapper,
+} from '../notification.utility';
 
 const mockArray = [
   { key1: 'value1', key2: 'value2', key3: 'value3' },
@@ -31,7 +40,7 @@ describe('Test notification utility', () => {
       additionalAbstract: 'abstract for de',
       additionalSubject: 'subject for de',
     });
-    // 
+
     const response: BffNewNotificationRequest = {
       ...newNotificationForBff,
       subject: 'Multone esagerato|subject for de',
@@ -39,5 +48,100 @@ describe('Test notification utility', () => {
       additionalLanguages: ['DE'],
     };
     expect(result).toEqual(response);
+  });
+
+  describe('Test filter payments by debt position change', () => {
+    const recipientPayments = newNotificationRecipients[1].payments ?? [];
+
+    it('should return the same payments if the debt position does not change', () => {
+      const result = filterPaymentsByDebtPositionChange(
+        recipientPayments,
+        PaymentModel.PAGO_PA_NOTICE,
+        PaymentModel.PAGO_PA_NOTICE
+      );
+      expect(result).toEqual(recipientPayments);
+    });
+
+    it('should return all payments when previous debt position is undefined', () => {
+      const result = filterPaymentsByDebtPositionChange(
+        recipientPayments,
+        PaymentModel.PAGO_PA_NOTICE,
+        undefined
+      );
+      expect(result).toEqual(recipientPayments);
+    });
+
+    it('should return empty array when set debt position to NOTHING', () => {
+      const result = filterPaymentsByDebtPositionChange(
+        recipientPayments,
+        PaymentModel.NOTHING,
+        PaymentModel.PAGO_PA_NOTICE
+      );
+      expect(result).toEqual([]);
+    });
+
+    it('should keep only PAGOPA payments when debt position change from PAGO_PA_F24 to PAGOPA', () => {
+      const pagopaPayments = recipientPayments.reduce((acc, item) => {
+        acc.push({ pagoPa: item.pagoPa });
+        return acc;
+      }, [] as Array<NewNotificationPayment>);
+
+      const result = filterPaymentsByDebtPositionChange(
+        recipientPayments,
+        PaymentModel.PAGO_PA_NOTICE,
+        PaymentModel.PAGO_PA_F24
+      );
+      expect(result).toEqual(pagopaPayments);
+    });
+
+    it('should keep only F24 payments when debt position change from PAGO_PA_F24 to F24', () => {
+      const f24Payments = recipientPayments.reduce((acc, item) => {
+        acc.push({ f24: item.f24 });
+        return acc;
+      }, [] as Array<NewNotificationPayment>);
+
+      const result = filterPaymentsByDebtPositionChange(
+        recipientPayments,
+        PaymentModel.F24,
+        PaymentModel.PAGO_PA_F24
+      );
+      expect(result).toEqual(f24Payments);
+    });
+
+    it('should clear all payments when debt position change from from PAGOPA to F24', () => {
+      const result = filterPaymentsByDebtPositionChange(
+        recipientPayments,
+        PaymentModel.F24,
+        PaymentModel.PAGO_PA_NOTICE
+      );
+      expect(result).toEqual([]);
+    });
+
+    it('should clear all payments when debt position change from F24 to PAGOPA', () => {
+      const result = filterPaymentsByDebtPositionChange(
+        recipientPayments,
+        PaymentModel.PAGO_PA_NOTICE,
+        PaymentModel.F24
+      );
+      expect(result).toEqual([]);
+    });
+
+    it('should return all payments when debt position change from NONE', () => {
+      const result = filterPaymentsByDebtPositionChange(
+        recipientPayments,
+        PaymentModel.PAGO_PA_NOTICE,
+        PaymentModel.NOTHING
+      );
+      expect(result).toEqual(recipientPayments);
+    });
+
+    it('should handle empty payments array', () => {
+      const result = filterPaymentsByDebtPositionChange(
+        [],
+        PaymentModel.PAGO_PA_NOTICE,
+        PaymentModel.F24
+      );
+      expect(result).toEqual([]);
+    });
   });
 });

--- a/packages/pn-pa-webapp/src/utility/__test__/validation.utility.test.ts
+++ b/packages/pn-pa-webapp/src/utility/__test__/validation.utility.test.ts
@@ -90,7 +90,7 @@ describe('test custom validation for recipients', () => {
         { creditorTaxId: 'creditorTaxId1', noticeCode: 'noticeCode1' },
         { creditorTaxId: 'creditorTaxId2', noticeCode: 'noticeCode2' },
       ] as Array<NewNotificationRecipient>,
-      PaymentModel.PAGO_PA_NOTICE
+      PaymentModel.PAGO_PA
     );
     expect(result).toHaveLength(0);
   });
@@ -102,7 +102,7 @@ describe('test custom validation for recipients', () => {
         { creditorTaxId: 'creditorTaxId2', noticeCode: 'noticeCode2' },
         { creditorTaxId: 'creditorTaxId1', noticeCode: 'noticeCode1' },
       ] as Array<NewNotificationRecipient>,
-      PaymentModel.PAGO_PA_NOTICE
+      PaymentModel.PAGO_PA
     );
     expect(result).toHaveLength(4);
     expect(result).toStrictEqual([

--- a/packages/pn-pa-webapp/src/utility/notification.utility.ts
+++ b/packages/pn-pa-webapp/src/utility/notification.utility.ts
@@ -225,26 +225,26 @@ const shouldClearPayments = (newMethod: PaymentModel, previousMethod?: PaymentMo
   }
 
   const transitionMap: Record<PaymentModel, Record<PaymentModel, boolean>> = {
-    PAGO_PA_NOTICE: {
-      PAGO_PA_NOTICE: false,
+    PAGO_PA: {
+      PAGO_PA: false,
       F24: true,
       PAGO_PA_F24: false,
       NOTHING: true,
     },
     F24: {
-      PAGO_PA_NOTICE: true,
+      PAGO_PA: true,
       F24: false,
       PAGO_PA_F24: false,
       NOTHING: true,
     },
     PAGO_PA_F24: {
-      PAGO_PA_NOTICE: true, // Remove f24 payments
+      PAGO_PA: true, // Remove f24 payments
       F24: true, // Remove pagopa payments
       PAGO_PA_F24: false,
       NOTHING: true,
     },
     NOTHING: {
-      PAGO_PA_NOTICE: false,
+      PAGO_PA: false,
       F24: false,
       PAGO_PA_F24: false,
       NOTHING: false,
@@ -268,7 +268,7 @@ export const filterPaymentsByDebtPositionChange = (
   }
 
   if (previousDebtPosition === PaymentModel.PAGO_PA_F24) {
-    if (newDebtPosition === PaymentModel.PAGO_PA_NOTICE) {
+    if (newDebtPosition === PaymentModel.PAGO_PA) {
       return payments.reduce((acc, item) => {
         // eslint-disable-next-line functional/immutable-data
         acc.push({ pagoPa: item.pagoPa });

--- a/packages/pn-pa-webapp/src/utility/notification.utility.ts
+++ b/packages/pn-pa-webapp/src/utility/notification.utility.ts
@@ -18,6 +18,7 @@ import {
   NewNotificationPagoPaPayment,
   NewNotificationPayment,
   NewNotificationRecipient,
+  PaymentModel,
 } from '../models/NewNotification';
 
 const checkPhysicalAddress = (recipient: NewNotificationRecipient) => {
@@ -212,4 +213,76 @@ const concatAdditionalContent = (content?: string, additionalContent?: string): 
     return `${content}|${additionalContent}`;
   }
   return content || additionalContent || '';
+};
+
+const shouldClearPayments = (newMethod: PaymentModel, previousMethod?: PaymentModel): boolean => {
+  if (!previousMethod || previousMethod === PaymentModel.NOTHING) {
+    return false;
+  }
+
+  if (newMethod === PaymentModel.NOTHING) {
+    return true;
+  }
+
+  const transitionMap: Record<PaymentModel, Record<PaymentModel, boolean>> = {
+    PAGO_PA_NOTICE: {
+      PAGO_PA_NOTICE: false,
+      F24: true,
+      PAGO_PA_F24: false,
+      NOTHING: true,
+    },
+    F24: {
+      PAGO_PA_NOTICE: true,
+      F24: false,
+      PAGO_PA_F24: false,
+      NOTHING: true,
+    },
+    PAGO_PA_F24: {
+      PAGO_PA_NOTICE: true, // Remove f24 payments
+      F24: true, // Remove pagopa payments
+      PAGO_PA_F24: false,
+      NOTHING: true,
+    },
+    NOTHING: {
+      PAGO_PA_NOTICE: false,
+      F24: false,
+      PAGO_PA_F24: false,
+      NOTHING: false,
+    },
+  };
+
+  return transitionMap[previousMethod]?.[newMethod] ?? false;
+};
+
+export const filterPaymentsByDebtPositionChange = (
+  payments: Array<NewNotificationPayment>,
+  newDebtPosition: PaymentModel,
+  previousDebtPosition?: PaymentModel
+): Array<NewNotificationPayment> => {
+  if (!shouldClearPayments(newDebtPosition, previousDebtPosition)) {
+    return payments;
+  }
+
+  if (newDebtPosition === PaymentModel.NOTHING) {
+    return [];
+  }
+
+  if (previousDebtPosition === PaymentModel.PAGO_PA_F24) {
+    if (newDebtPosition === PaymentModel.PAGO_PA_NOTICE) {
+      return payments.reduce((acc, item) => {
+        // eslint-disable-next-line functional/immutable-data
+        acc.push({ pagoPa: item.pagoPa });
+        return acc;
+      }, [] as Array<NewNotificationPayment>);
+    }
+    if (newDebtPosition === PaymentModel.F24) {
+      return payments.reduce((acc, item) => {
+        // eslint-disable-next-line functional/immutable-data
+        acc.push({ f24: item.f24 });
+        return acc;
+      }, [] as Array<NewNotificationPayment>);
+    }
+  }
+
+  return [];
 };


### PR DESCRIPTION
## Short description
Create new step on New Notification process to handle the debt position of every recipient.

## List of changes proposed in this pull request
- Add new step
- Moved attachments step to the end 
- Create utility to handle payments when debtPosition change

## How to test
- Run tests and checks that passes
- Start PA and try to create a new notification, you should see a new step called "Posizione debitoria"
- Check that payment methods step is skipped if debt position is set to `Nessun pagamento`