### PR TITLE
feat: update error graph colors

### DIFF
--- a/packages/pn-pa-webapp/src/components/Statistics/DigitalErrorsDetailStatistics.tsx
+++ b/packages/pn-pa-webapp/src/components/Statistics/DigitalErrorsDetailStatistics.tsx
@@ -64,25 +64,25 @@ const DigitalErrorsDetailStatistics: React.FC<Props> = ({ data: sData }) => {
       title: t('digital_errors_detail.virus_detected_title'),
       description: t('digital_errors_detail.virus_detected_description'),
       value: virus_detected_errors,
-      color: GraphColors.turquoise,
+      color: GraphColors.lightYellow,
     },
     {
       title: t('digital_errors_detail.server_pec_comunication_title'),
       description: t('digital_errors_detail.server_pec_comunication_description'),
       value: server_pec_comunication_errors,
-      color: GraphColors.blue,
+      color: GraphColors.gold,
     },
     {
       title: t('digital_errors_detail.sending_pec_title'),
       description: t('digital_errors_detail.sending_pec_description'),
       value: sending_pec_errors,
-      color: GraphColors.darkGreen,
+      color: GraphColors.goldenYellow,
     },
     {
       title: t('digital_errors_detail.malformed_pec_address_title'),
       description: t('digital_errors_detail.malformed_pec_address_description'),
       value: malformed_pec_address_errors,
-      color: GraphColors.navy,
+      color: GraphColors.oliveBrown,
     },
   ];
 

--- a/packages/pn-pa-webapp/src/models/Statistics.ts
+++ b/packages/pn-pa-webapp/src/models/Statistics.ts
@@ -25,8 +25,11 @@ export enum GraphColors {
   lightRed = '#FE6666',
   turquoise = '#21CDD1',
   azure = '#00C5CA',
-  pink = '#FFE0E0',
+  pink = '#FB9EAC',
   darkRed = '#761F1F',
+  lightYellow = '#FFE5A3',
+  goldenYellow = '#D9AD3C',
+  oliveBrown = '#614C15',
 }
 
 export enum CxType {


### PR DESCRIPTION
## Short description
Update error graph colors on Statistics page according to design [Figma](https://www.figma.com/design/VCVk6WrSwxuTuw0lZEzPw5/PA-Mittenti?node-id=2501-4400&p=f&t=6Uog93XLP6LdBJ8A-0)

## List of changes proposed in this pull request
- Add new colors
