### PR TITLE
feat/PN-13894: [MIXPANEL]: add property "psp" in event SEND_START_PAYMENT 

### DIFF
--- a/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentRecipient.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentRecipient.tsx
@@ -40,7 +40,7 @@ type Props = {
     unwrap: () => Promise<PaymentAttachment>;
   };
   onPayClick: (noticeCode?: string, creditorTaxId?: string, amount?: number) => void;
-  onPayTppClick?: (noticeCode?: string, creditorTaxId?: string, retrievalId?: string) => void;
+  onPayTppClick?: (noticeCode?: string, creditorTaxId?: string, retrievalId?: string, tppName?: string) => void;
   handleTrackEvent?: (event: EventPaymentRecipientType, param?: object) => void;
   handleFetchPaymentsInfo: (payment: Array<PaymentDetails | NotificationDetailPayment>) => void;
 };
@@ -149,7 +149,8 @@ const NotificationPaymentRecipient: React.FC<Props> = ({
         onPayTppClick?.(
           selectedPayment?.pagoPa?.noticeCode,
           selectedPayment?.pagoPa?.creditorTaxId,
-          paymentTpp?.retrievalId
+          paymentTpp?.retrievalId,
+          paymentTpp?.paymentButton,
         );
         return;
       }

--- a/packages/pn-commons/src/components/NotificationDetail/__test__/NotificationPaymentRecipient.test.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/__test__/NotificationPaymentRecipient.test.tsx
@@ -477,7 +477,8 @@ describe('NotificationPaymentRecipient Component', () => {
     expect(onPayTppClick).toHaveBeenCalledWith(
       paymentsData.pagoPaF24[paymentIndex].pagoPa?.noticeCode,
       paymentsData.pagoPaF24[paymentIndex].pagoPa?.creditorTaxId,
-      paymentTpp.retrievalId
+      paymentTpp.retrievalId,
+      paymentTpp.paymentButton,
     );
   });
 });

--- a/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
@@ -252,7 +252,7 @@ const NotificationDetail: React.FC = () => {
 
   const onPayClick = (noticeCode?: string, creditorTaxId?: string, amount?: number) => {
     if (noticeCode && creditorTaxId && amount && notification.senderDenomination) {
-      PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_START_PAYMENT);
+      PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_START_PAYMENT, { psp: 'pagopa' });
       dispatch(
         getReceivedNotificationPaymentUrl({
           paymentNotice: {
@@ -273,9 +273,14 @@ const NotificationDetail: React.FC = () => {
     }
   };
 
-  const onPayTppClick = (noticeCode?: string, creditorTaxId?: string, retrievalId?: string) => {
+  const onPayTppClick = (
+    noticeCode?: string,
+    creditorTaxId?: string,
+    retrievalId?: string,
+    tppName?: string
+  ) => {
     if (noticeCode && creditorTaxId && retrievalId) {
-      PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_START_PAYMENT);
+      PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_START_PAYMENT, { psp: tppName });
       dispatch(
         getReceivedNotificationPaymentTppUrl({
           noticeCode,

--- a/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/PFEventStrategyFactory.ts
+++ b/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/PFEventStrategyFactory.ts
@@ -42,12 +42,12 @@ import { TechScreenViewStrategy } from './Strategies/TechScreenViewStrategy';
 import { TechStrategy } from './Strategies/TechStrategy';
 import { UXActionStrategy } from './Strategies/UXActionStrategy';
 import { UXErrorStrategy } from './Strategies/UXErrorStrategy';
+import { UXPspActionStrategy } from './Strategies/UXPspActionStrategy';
 import { UXScreenViewStrategy } from './Strategies/UXScreenViewStrategy';
 
 const uxActionStrategy = [
   PFEventsType.SEND_DOWNLOAD_ATTACHMENT,
   PFEventsType.SEND_DOWNLOAD_RECEIPT_NOTICE,
-  PFEventsType.SEND_START_PAYMENT,
   PFEventsType.SEND_PAYMENT_DETAIL_REFRESH,
   PFEventsType.SEND_ADD_MANDATE_START,
   PFEventsType.SEND_ADD_MANDATE_BACK,
@@ -66,6 +66,8 @@ const uxActionStrategy = [
   PFEventsType.SEND_DOWNLOAD_PAYMENT_NOTICE,
   PFEventsType.SEND_ADD_CUSTOMIZED_CONTACT,
 ] as const;
+
+const uxPspActionStrategy = [PFEventsType.SEND_START_PAYMENT] as const;
 
 const sendAddContactWithSourceActionStrategy = [
   PFEventsType.SEND_ADD_SERCQ_SEND_START,
@@ -180,6 +182,10 @@ class PFEventStrategyFactory extends EventStrategyFactory<PFEventsType> {
   getStrategy(eventType: PFEventsType): EventStrategy | null {
     if (uxActionStrategy.findIndex((el) => el === eventType) > -1) {
       return new UXActionStrategy();
+    }
+
+    if (uxPspActionStrategy.findIndex((el) => el === eventType) > -1) {
+      return new UXPspActionStrategy();
     }
 
     if (sendAddLegalContactUXSuccessStrategy.findIndex((el) => el === eventType) > -1) {

--- a/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/UXPspActionStrategy.ts
+++ b/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/UXPspActionStrategy.ts
@@ -1,0 +1,13 @@
+import { EventAction, EventCategory, EventPropertyType, EventStrategy, TrackedEvent } from '@pagopa-pn/pn-commons';
+
+export class UXPspActionStrategy implements EventStrategy {
+  performComputations({ psp }: { psp: 'pagopa' | string }): TrackedEvent<{ psp: 'pagopa' | string }> {
+    return {
+      [EventPropertyType.TRACK]: {
+        event_category: EventCategory.UX,
+        event_type: EventAction.ACTION,
+        psp,
+      },
+    };
+  }
+}

--- a/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/__test__/UXPspActionStrategy.test.ts
+++ b/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/__test__/UXPspActionStrategy.test.ts
@@ -1,0 +1,18 @@
+import { EventAction, EventCategory, EventPropertyType } from '@pagopa-pn/pn-commons';
+
+import { UXPspActionStrategy } from '../UXPspActionStrategy';
+
+describe('Mixpanel - UX PSP Action Strategy', () => {
+  it('should return UX PSP action event', () => {
+    const strategy = new UXPspActionStrategy();
+
+    const uxPspActionEvent = strategy.performComputations({ psp: 'pagopa' });
+    expect(uxPspActionEvent).toEqual({
+      [EventPropertyType.TRACK]: {
+        event_category: EventCategory.UX,
+        event_type: EventAction.ACTION,
+        psp: 'pagopa',
+      },
+    });
+  });
+});

--- a/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/__test__/PFEventStrategyFactory.test.ts
+++ b/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/__test__/PFEventStrategyFactory.test.ts
@@ -40,6 +40,7 @@ import { TechScreenViewStrategy } from '../Strategies/TechScreenViewStrategy';
 import { TechStrategy } from '../Strategies/TechStrategy';
 import { UXActionStrategy } from '../Strategies/UXActionStrategy';
 import { UXErrorStrategy } from '../Strategies/UXErrorStrategy';
+import { UXPspActionStrategy } from '../Strategies/UXPspActionStrategy';
 import { UXScreenViewStrategy } from '../Strategies/UXScreenViewStrategy';
 
 describe('Event Strategy Factory', () => {
@@ -220,7 +221,6 @@ describe('Event Strategy Factory', () => {
     const eventTypes = [
       PFEventsType.SEND_DOWNLOAD_ATTACHMENT,
       PFEventsType.SEND_DOWNLOAD_RECEIPT_NOTICE,
-      PFEventsType.SEND_START_PAYMENT,
       PFEventsType.SEND_PAYMENT_DETAIL_REFRESH,
       PFEventsType.SEND_ADD_MANDATE_START,
       PFEventsType.SEND_ADD_MANDATE_BACK,
@@ -240,6 +240,13 @@ describe('Event Strategy Factory', () => {
     ];
     eventTypes.forEach((eventType) => {
       expect(factory.getStrategy(eventType)).toBeInstanceOf(UXActionStrategy);
+    });
+  });
+
+  it('should return UXPspActionStrategy for UX Psp Action events', () => {
+    const eventTypes = [PFEventsType.SEND_START_PAYMENT];
+    eventTypes.forEach((eventType) => {
+      expect(factory.getStrategy(eventType)).toBeInstanceOf(UXPspActionStrategy);
     });
   });
 


### PR DESCRIPTION
## Short description
Added property `psp` in SEND_START_PAYMENT event. 
Possible values: `pagopa` or specific tpp name. 

## List of changes proposed in this pull request
- Create new strategy for UX Action with psp property

## How to test
Login in PF with rapid access with retrievalId. Click on payment button with bank.