### PR TITLE
Fix/pn-14111 - Digital Domicile bug fixes

### DIFF
--- a/packages/pn-personafisica-webapp/src/components/Contacts/DigitalContactActivation.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/DigitalContactActivation.tsx
@@ -12,6 +12,7 @@ import SercqSendContactWizard from '../../components/Contacts/SercqSendContactWi
 import { IOAllowedValues } from '../../models/contacts';
 import { contactsSelectors } from '../../redux/contact/reducers';
 import { useAppSelector } from '../../redux/hooks';
+import { getConfiguration } from '../../services/configuration.service';
 import EmailSmsContactWizard from './EmailSmsContactWizard';
 
 type Props = {
@@ -31,12 +32,13 @@ type ModalType = {
 const DigitalContactActivation: React.FC<Props> = ({ isTransferring = false }) => {
   const { t } = useTranslation(['recapiti', 'common']);
   const navigate = useNavigate();
+  const { IS_DOD_ENABLED } = getConfiguration();
   const { defaultAPPIOAddress, defaultSMSAddress, defaultEMAILAddress, defaultSERCQ_SENDAddress } =
     useAppSelector(contactsSelectors.selectAddresses);
 
   const [modal, setModal] = useState<ModalType>({ open: false });
   const [activeStep, setActiveStep] = useState(0);
-  const [showPecWizard, setShowPecWizard] = useState(!!defaultSERCQ_SENDAddress);
+  const [showPecWizard, setShowPecWizard] = useState(!!defaultSERCQ_SENDAddress || !IS_DOD_ENABLED);
 
   const showIOStep = useMemo(
     () => defaultAPPIOAddress && defaultAPPIOAddress.value === IOAllowedValues.DISABLED,

--- a/packages/pn-personafisica-webapp/src/components/Contacts/EmailContactItem.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/EmailContactItem.tsx
@@ -110,7 +110,10 @@ const EmailContactItem: React.FC = () => {
           return;
         }
 
-        PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_ADD_EMAIL_UX_SUCCESS, 'default');
+        PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_ADD_EMAIL_UX_SUCCESS, {
+          senderId: 'default',
+          fromSercqSend: true,
+        });
 
         // contact has already been verified
         // show success message

--- a/packages/pn-personafisica-webapp/src/components/Contacts/EmailSmsContactWizard.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/EmailSmsContactWizard.tsx
@@ -106,7 +106,7 @@ const EmailSmsContactWizard: React.FC = () => {
           channelType === ChannelType.EMAIL
             ? PFEventsType.SEND_ADD_EMAIL_UX_SUCCESS
             : PFEventsType.SEND_ADD_SMS_UX_SUCCESS,
-          'default'
+          { senderId: 'default', fromSercqSend: true }
         );
 
         // contact has already been verified

--- a/packages/pn-personafisica-webapp/src/components/Contacts/LegalContactAssociationDialog.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/LegalContactAssociationDialog.tsx
@@ -26,7 +26,8 @@ const LegalContactAssociationDialog: React.FC<Props> = ({
   const { t } = useTranslation(['common', 'recapiti']);
 
   const addressAlreadySet =
-    oldAddress?.channelType === newAddress?.channelType && oldAddress?.value === newAddress?.value;
+    oldAddress?.channelType === newAddress?.channelType &&
+    (oldAddress?.value === newAddress?.value || oldAddress?.channelType === ChannelType.SERCQ_SEND);
 
   const newAddressValue =
     newAddress?.channelType === ChannelType.PEC
@@ -37,8 +38,7 @@ const LegalContactAssociationDialog: React.FC<Props> = ({
       ? oldAddress.value
       : t(`special-contacts.${oldAddress?.channelType.toLowerCase()}`, { ns: 'recapiti' });
 
-  const blockConfirmation =
-    addressAlreadySet || newAddressValue === oldAddressValue ? '-block' : '';
+  const blockConfirmation = addressAlreadySet ? '-block' : '';
 
   return (
     <ConfirmationModal
@@ -65,8 +65,8 @@ const LegalContactAssociationDialog: React.FC<Props> = ({
         i18nKey={`special-contacts.legal-association-description${blockConfirmation}`}
         values={{
           senderName: sender?.senderName,
-          newAddressValue,
-          oldAddressValue,
+          newAddress: newAddressValue,
+          oldAddress: oldAddressValue,
         }}
       />
     </ConfirmationModal>

--- a/packages/pn-personafisica-webapp/src/components/Contacts/PecContactWizard.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/PecContactWizard.tsx
@@ -18,6 +18,7 @@ import {
 import { createOrUpdateAddress } from '../../redux/contact/actions';
 import { contactsSelectors } from '../../redux/contact/reducers';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
+import { RootState } from '../../redux/store';
 import PFEventStrategyFactory from '../../utility/MixpanelUtils/PFEventStrategyFactory';
 import { pecValidationSchema } from '../../utility/contacts.utility';
 import ContactCodeDialog from './ContactCodeDialog';
@@ -33,6 +34,7 @@ const PecContactWizard: React.FC<Props> = ({ isTransferring = false, setShowPecW
   const navigate = useNavigate();
   const [activeStep, setActiveStep] = useState(0);
   const { defaultSERCQ_SENDAddress } = useAppSelector(contactsSelectors.selectAddresses);
+  const externalEvent = useAppSelector((state: RootState) => state.contactsState.event);
   const [openCodeModal, setOpenCodeModal] = useState(false);
 
   const validationSchema = yup.object().shape({
@@ -47,9 +49,10 @@ const PecContactWizard: React.FC<Props> = ({ isTransferring = false, setShowPecW
     validateOnMount: true,
     enableReinitialize: true,
     onSubmit: () => {
+      const source = externalEvent?.source ?? ContactSource.RECAPITI;
       PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_ADD_PEC_START, {
         senderId: 'default',
-        source: ContactSource.RECAPITI,
+        source,
       });
       handleCodeVerification();
     },

--- a/packages/pn-personafisica-webapp/src/components/Contacts/PecContactWizard.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/PecContactWizard.tsx
@@ -19,6 +19,7 @@ import { createOrUpdateAddress } from '../../redux/contact/actions';
 import { contactsSelectors } from '../../redux/contact/reducers';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import { RootState } from '../../redux/store';
+import { getConfiguration } from '../../services/configuration.service';
 import PFEventStrategyFactory from '../../utility/MixpanelUtils/PFEventStrategyFactory';
 import { pecValidationSchema } from '../../utility/contacts.utility';
 import ContactCodeDialog from './ContactCodeDialog';
@@ -36,6 +37,7 @@ const PecContactWizard: React.FC<Props> = ({ isTransferring = false, setShowPecW
   const { defaultSERCQ_SENDAddress } = useAppSelector(contactsSelectors.selectAddresses);
   const externalEvent = useAppSelector((state: RootState) => state.contactsState.event);
   const [openCodeModal, setOpenCodeModal] = useState(false);
+  const { IS_DOD_ENABLED } = getConfiguration();
 
   const validationSchema = yup.object().shape({
     pec: pecValidationSchema(t),
@@ -105,7 +107,11 @@ const PecContactWizard: React.FC<Props> = ({ isTransferring = false, setShowPecW
         slots={{
           prevButton: () => (
             <ButtonNaked
-              onClick={isTransferring ? () => navigate(-1) : () => setShowPecWizard(false)}
+              onClick={
+                isTransferring || !IS_DOD_ENABLED
+                  ? () => navigate(-1)
+                  : () => setShowPecWizard(false)
+              }
               color="primary"
               size="medium"
               data-testid="prev-button"

--- a/packages/pn-personafisica-webapp/src/components/Contacts/SercqSendContactWizard.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/SercqSendContactWizard.tsx
@@ -77,10 +77,7 @@ const SercqSendContactWizard: React.FC<Props> = ({ goToNextStep, setShowPecWizar
       .then((consent) => {
         // eslint-disable-next-line functional/immutable-data
         tosPrivacy.current = consent;
-        const source =
-          externalEvent?.destination === ChannelType.SERCQ_SEND
-            ? externalEvent?.source ?? ContactSource.RECAPITI
-            : ContactSource.RECAPITI;
+        const source = externalEvent?.source ?? ContactSource.RECAPITI;
         PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_ADD_SERCQ_SEND_START, {
           senderId: 'default',
           source,

--- a/packages/pn-personafisica-webapp/src/components/Contacts/SmsContactItem.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/SmsContactItem.tsx
@@ -17,6 +17,7 @@ import {
 import { createOrUpdateAddress, deleteAddress } from '../../redux/contact/actions';
 import { contactsSelectors } from '../../redux/contact/reducers';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
+import { RootState } from '../../redux/store';
 import PFEventStrategyFactory from '../../utility/MixpanelUtils/PFEventStrategyFactory';
 import { contactAlreadyExists, internationalPhonePrefix } from '../../utility/contacts.utility';
 import ContactCodeDialog from './ContactCodeDialog';
@@ -52,6 +53,7 @@ const SmsContactElem: React.FC<SmsElemProps> = ({ onCancelInsert, slotsProps }) 
   const { t } = useTranslation(['common', 'recapiti']);
   const { defaultSERCQ_SENDAddress, defaultPECAddress, defaultSMSAddress, addresses } =
     useAppSelector(contactsSelectors.selectAddresses);
+  const externalEvent = useAppSelector((state: RootState) => state.contactsState.event);
   const digitalContactRef = useRef<{ toggleEdit: () => void; resetForm: () => Promise<void> }>({
     toggleEdit: () => {},
     resetForm: () => Promise.resolve(),
@@ -69,9 +71,10 @@ const SmsContactElem: React.FC<SmsElemProps> = ({ onCancelInsert, slotsProps }) 
   const currentValue = defaultSMSAddress?.value ?? '';
 
   const handleSubmit = (value: string) => {
+    const source = externalEvent?.source ?? ContactSource.RECAPITI;
     PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_ADD_SMS_START, {
       senderId: 'default',
-      source: ContactSource.RECAPITI,
+      source,
     });
     // eslint-disable-next-line functional/immutable-data
     currentAddress.current = { value };

--- a/packages/pn-personafisica-webapp/src/components/Contacts/SmsContactItem.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/SmsContactItem.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router-dom';
 
 import PowerSettingsNewIcon from '@mui/icons-material/PowerSettingsNew';
 import { Box, Button, ButtonProps, Chip, Divider, TextFieldProps, Typography } from '@mui/material';
@@ -14,6 +15,10 @@ import {
   IOAllowedValues,
   SaveDigitalAddressParams,
 } from '../../models/contacts';
+import {
+  DIGITAL_DOMICILE_ACTIVATION,
+  DIGITAL_DOMICILE_MANAGEMENT,
+} from '../../navigation/routes.const';
 import { createOrUpdateAddress, deleteAddress } from '../../redux/contact/actions';
 import { contactsSelectors } from '../../redux/contact/reducers';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
@@ -59,6 +64,7 @@ const SmsContactElem: React.FC<SmsElemProps> = ({ onCancelInsert, slotsProps }) 
     resetForm: () => Promise.resolve(),
   });
   const [modalOpen, setModalOpen] = useState<ModalType | null>(null);
+  const location = useLocation();
   // currentAddress is needed to store what address we are creating/editing/removing
   // because this variable isn't been used to render, we can use useRef
   const currentAddress = useRef<{ value: string }>({
@@ -69,6 +75,10 @@ const SmsContactElem: React.FC<SmsElemProps> = ({ onCancelInsert, slotsProps }) 
   const isDigitalDomicileActive = defaultPECAddress || defaultSERCQ_SENDAddress;
 
   const currentValue = defaultSMSAddress?.value ?? '';
+
+  const fromSercqSend = [DIGITAL_DOMICILE_ACTIVATION, DIGITAL_DOMICILE_MANAGEMENT].includes(
+    location.pathname
+  );
 
   const handleSubmit = (value: string) => {
     const source = externalEvent?.source ?? ContactSource.RECAPITI;
@@ -116,7 +126,10 @@ const SmsContactElem: React.FC<SmsElemProps> = ({ onCancelInsert, slotsProps }) 
           return;
         }
 
-        PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_ADD_SMS_UX_SUCCESS, 'default');
+        PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_ADD_SMS_UX_SUCCESS, {
+          senderId: 'default',
+          fromSercqSend,
+        });
 
         // contact has already been verified
         // show success message

--- a/packages/pn-personafisica-webapp/src/pages/Contacts.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/Contacts.page.tsx
@@ -84,8 +84,10 @@ const Contacts = () => {
   };
 
   useEffect(() => {
-    if (externalEvent && externalEvent.operation === ContactOperation.SCROLL) {
-      goToSection(externalEvent.destination);
+    if (externalEvent) {
+      if (externalEvent.operation === ContactOperation.SCROLL) {
+        goToSection(externalEvent.destination);
+      }
       dispatch(resetExternalEvent());
     }
   }, [externalEvent]);

--- a/packages/pn-personafisica-webapp/src/pages/Contacts.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/Contacts.page.tsx
@@ -27,14 +27,22 @@ const Contacts = () => {
 
   const externalEvent = useAppSelector((state: RootState) => state.contactsState.event);
 
+  const SendYourContactDetailsEvent = () => {
+    PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_YOUR_CONTACT_DETAILS, {
+      digitalAddresses: addresses,
+      contactIO: defaultAPPIOAddress,
+    });
+  };
+
+  useEffect(() => {
+    SendYourContactDetailsEvent();
+  }, []);
+
   const fetchAddresses = useCallback(() => {
     void dispatch(getDigitalAddresses())
       .unwrap()
       .then(() => {
-        PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_YOUR_CONTACT_DETAILS, {
-          digitalAddresses: addresses,
-          contactIO: defaultAPPIOAddress,
-        });
+        SendYourContactDetailsEvent();
       });
   }, []);
 

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/DigitalContactActivation.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/DigitalContactActivation.tsx
@@ -10,6 +10,7 @@ import PecContactWizard from '../../components/Contacts/PecContactWizard';
 import SercqSendContactWizard from '../../components/Contacts/SercqSendContactWizard';
 import { contactsSelectors } from '../../redux/contact/reducers';
 import { useAppSelector } from '../../redux/hooks';
+import { getConfiguration } from '../../services/configuration.service';
 import EmailSmsContactWizard from './EmailSmsContactWizard';
 
 type Props = {
@@ -23,13 +24,14 @@ type ModalType = {
 const DigitalContactActivation: React.FC<Props> = ({ isTransferring = false }) => {
   const { t } = useTranslation(['recapiti', 'common']);
   const navigate = useNavigate();
+  const { IS_DOD_ENABLED } = getConfiguration();
   const { defaultSMSAddress, defaultEMAILAddress, defaultSERCQ_SENDAddress } = useAppSelector(
     contactsSelectors.selectAddresses
   );
 
   const [modal, setModal] = useState<ModalType>({ open: false });
   const [activeStep, setActiveStep] = useState(0);
-  const [showPecWizard, setShowPecWizard] = useState(!!defaultSERCQ_SENDAddress);
+  const [showPecWizard, setShowPecWizard] = useState(!!defaultSERCQ_SENDAddress || !IS_DOD_ENABLED);
 
   const showEmailStep = useMemo(() => !(defaultSMSAddress || defaultEMAILAddress), []);
 

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/LegalContactAssociationDialog.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/LegalContactAssociationDialog.tsx
@@ -26,7 +26,8 @@ const LegalContactAssociationDialog: React.FC<Props> = ({
   const { t } = useTranslation(['common', 'recapiti']);
 
   const addressAlreadySet =
-    oldAddress?.channelType === newAddress?.channelType && oldAddress?.value === newAddress?.value;
+    oldAddress?.channelType === newAddress?.channelType &&
+    (oldAddress?.value === newAddress?.value || oldAddress?.channelType === ChannelType.SERCQ_SEND);
 
   const newAddressValue =
     newAddress?.channelType === ChannelType.PEC
@@ -37,7 +38,7 @@ const LegalContactAssociationDialog: React.FC<Props> = ({
       ? oldAddress.value
       : t(`special-contacts.${oldAddress?.channelType.toLowerCase()}`, { ns: 'recapiti' });
 
-  const blockConfirmation = addressAlreadySet || newAddress === oldAddress ? '-block' : '';
+  const blockConfirmation = addressAlreadySet ? '-block' : '';
 
   return (
     <ConfirmationModal
@@ -64,8 +65,8 @@ const LegalContactAssociationDialog: React.FC<Props> = ({
         i18nKey={`special-contacts.legal-association-description${blockConfirmation}`}
         values={{
           senderName: sender?.senderName,
-          newAddressValue,
-          oldAddressValue,
+          newAddress: newAddressValue,
+          oldAddress: oldAddressValue,
         }}
       />
     </ConfirmationModal>

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/PecContactWizard.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/PecContactWizard.tsx
@@ -12,6 +12,7 @@ import { AddressType, ChannelType, SaveDigitalAddressParams } from '../../models
 import { createOrUpdateAddress } from '../../redux/contact/actions';
 import { contactsSelectors } from '../../redux/contact/reducers';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
+import { getConfiguration } from '../../services/configuration.service';
 import { pecValidationSchema } from '../../utility/contacts.utility';
 import ContactCodeDialog from './ContactCodeDialog';
 
@@ -27,6 +28,7 @@ const PecContactWizard: React.FC<Props> = ({ isTransferring = false, setShowPecW
   const [activeStep, setActiveStep] = useState(0);
   const { defaultSERCQ_SENDAddress } = useAppSelector(contactsSelectors.selectAddresses);
   const [openCodeModal, setOpenCodeModal] = useState(false);
+  const { IS_DOD_ENABLED } = getConfiguration();
 
   const validationSchema = yup.object().shape({
     pec: pecValidationSchema(t),
@@ -84,7 +86,11 @@ const PecContactWizard: React.FC<Props> = ({ isTransferring = false, setShowPecW
         slots={{
           prevButton: () => (
             <ButtonNaked
-              onClick={isTransferring ? () => navigate(-1) : () => setShowPecWizard(false)}
+              onClick={
+                isTransferring || !IS_DOD_ENABLED
+                  ? () => navigate(-1)
+                  : () => setShowPecWizard(false)
+              }
               color="primary"
               size="medium"
               data-testid="prev-button"


### PR DESCRIPTION
## Short description
This PR fixes the following bugs reported on Digital Domicile feature: PN-14103, PN-14104, PN-14111, PN-14115, PN-14116.

## List of changes proposed in this pull request
- add from_sercq_send property to SEND_ADD_EMAIL_UX_SUCCESS and SEND_ADD_SMS_UX_SUCCESS registering a new email/sms contact during sercq activation/transfer wizard
- trigger SEND_YOUR_CONTACT_DETAILS when the user navigates to contacts page
- set the correct source for the events SEND_ADD_PEC_START and SEND_ADD_EMAIL_START
- with FF to false (SERCQ_SEND disabled) now the wizard directly shows the PecContactWizard with the input to specify the PEC address and without the stepper above the component
- the LegalContactAssociationDialog now properly shows the new and old address values instead of their placeholders