### PR TITLE
PN-14148 - Update formik recipient key to handle numeric CF

### DIFF
--- a/packages/pn-pa-webapp/src/components/NewNotification/DebtPositionDetail.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/DebtPositionDetail.tsx
@@ -109,8 +109,8 @@ const DebtPositionDetail: React.FC<Props> = ({
   const formatPayments = (): Array<NewNotificationRecipient> => {
     const recipients = _.cloneDeep(notification.recipients);
     return recipients.map((recipient) => {
-      const recipientIndex = `${recipient.recipientType}-${recipient.taxId}`;
-      const recipientData = formik.values.recipients[recipientIndex];
+      const recipientKey = `${recipient.recipientType}-${recipient.taxId}`;
+      const recipientData = formik.values.recipients[recipientKey];
       const payments = [
         ...recipientData.pagoPa
           // .filter((payment) => payment?.file?.data)
@@ -200,13 +200,13 @@ const DebtPositionDetail: React.FC<Props> = ({
 
   const recipientSchema = () => {
     const recipientSchema: { [key: string]: yup.ObjectSchema<any> } = {};
-    Object.keys(initialValues.recipients).forEach((recipientIndex) => {
-      const taxId = recipientIndex.split('-')[1];
+    Object.keys(initialValues.recipients).forEach((recipientKey) => {
+      const taxId = recipientKey.split('-')[1];
       const recipient = notification.recipients.find((r) => r.taxId === taxId);
       const debtPosition = recipient?.debtPosition;
 
       // eslint-disable-next-line functional/immutable-data
-      recipientSchema[recipientIndex] = yup.object({
+      recipientSchema[recipientKey] = yup.object({
         pagoPa: yup.array().of(
           yup.object().when([], {
             is: () =>

--- a/packages/pn-pa-webapp/src/components/NewNotification/PaymentMethods.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/PaymentMethods.tsx
@@ -126,10 +126,10 @@ const PaymentMethods: React.FC<Props> = ({
         if (recipient.debtPosition === PaymentModel.NOTHING) {
           return <></>;
         }
-        const recipientIndex = `${recipient.recipientType}-${recipient.taxId}`;
+        const recipientKey = `${recipient.recipientType}-${recipient.taxId}`;
         return (
           <Paper
-            key={recipientIndex}
+            key={recipientKey}
             sx={{ padding: '24px', marginTop: '40px' }}
             elevation={0}
             data-testid="paymentForRecipient"
@@ -138,7 +138,7 @@ const PaymentMethods: React.FC<Props> = ({
               {t('payment-models')} {recipient.firstName} {recipient.lastName}
             </Typography>
 
-            {formik.values.recipients[recipientIndex].pagoPa.length > 0 && (
+            {formik.values.recipients[recipientKey].pagoPa.length > 0 && (
               <Stack
                 spacing={3}
                 mt={3}
@@ -151,19 +151,19 @@ const PaymentMethods: React.FC<Props> = ({
                 <Typography fontSize="16px" fontWeight={600} data-testid="pagoPaPaymentBox">
                   {`${t('pagopa.attach-pagopa-notice')}`}
                 </Typography>
-                {formik.values.recipients[recipientIndex].pagoPa.map((pagoPaPayment, index) => (
+                {formik.values.recipients[recipientKey].pagoPa.map((pagoPaPayment, index) => (
                   <PagoPaPaymentBox
-                    id={`recipients.${recipientIndex}.pagoPa.${index}`}
-                    key={`${recipientIndex}-pagoPa-${pagoPaPayment.idx}`}
+                    id={`recipients.${recipientKey}.pagoPa.${index}`}
+                    key={`${recipientKey}-pagoPa-${pagoPaPayment.idx}`}
                     onFileUploaded={(_, file, sha256) =>
-                      fileUploadedHandler(recipientIndex, 'pagoPa', index, file, sha256)
+                      fileUploadedHandler(recipientKey, 'pagoPa', index, file, sha256)
                     }
-                    onRemoveFile={() => removeFileHandler(recipientIndex, 'pagoPa', index)}
+                    onRemoveFile={() => removeFileHandler(recipientKey, 'pagoPa', index)}
                     pagoPaPayment={pagoPaPayment}
                     notificationFeePolicy={formik.values.notificationFeePolicy}
-                    handleChange={(event) => handleChange(event, recipientIndex, 'pagoPa', index)}
+                    handleChange={(event) => handleChange(event, recipientKey, 'pagoPa', index)}
                     showDeleteButton={index > 0}
-                    onDeletePayment={() => handleRemovePagoPa(recipientIndex, index)}
+                    onDeletePayment={() => handleRemovePagoPa(recipientKey, index)}
                     fieldMeta={(fieldName) => formik.getFieldMeta(fieldName)}
                   />
                 ))}
@@ -171,7 +171,7 @@ const PaymentMethods: React.FC<Props> = ({
                 <ButtonNaked
                   color="primary"
                   startIcon={<AddIcon />}
-                  onClick={() => handleAddNewPagoPa(recipientIndex)}
+                  onClick={() => handleAddNewPagoPa(recipientKey)}
                   sx={{ justifyContent: 'start' }}
                 >
                   {t('pagopa.add-new-pagopa-notice')}
@@ -179,7 +179,7 @@ const PaymentMethods: React.FC<Props> = ({
               </Stack>
             )}
 
-            {formik.values.recipients[recipientIndex].f24.length > 0 && (
+            {formik.values.recipients[recipientKey].f24.length > 0 && (
               <Stack
                 spacing={3}
                 mt={3}
@@ -192,19 +192,19 @@ const PaymentMethods: React.FC<Props> = ({
                 <Typography fontSize="16px" fontWeight={600} data-testid="f24PaymentBox">
                   {t('f24.attach-f24')}
                 </Typography>
-                {formik.values.recipients[recipientIndex].f24.map((f24Payment, index) => (
+                {formik.values.recipients[recipientKey].f24.map((f24Payment, index) => (
                   <F24PaymentBox
-                    id={`recipients.${recipientIndex}.f24.${index}`}
-                    key={`${recipientIndex}-f24-${f24Payment?.idx}`}
+                    id={`recipients.${recipientKey}.f24.${index}`}
+                    key={`${recipientKey}-f24-${f24Payment?.idx}`}
                     onFileUploaded={(_, file, sha256) =>
-                      fileUploadedHandler(recipientIndex, 'f24', index, file, sha256)
+                      fileUploadedHandler(recipientKey, 'f24', index, file, sha256)
                     }
-                    onRemoveFile={() => removeFileHandler(recipientIndex, 'f24', index)}
+                    onRemoveFile={() => removeFileHandler(recipientKey, 'f24', index)}
                     f24Payment={f24Payment}
                     notificationFeePolicy={formik.values.notificationFeePolicy}
-                    handleChange={(event) => handleChange(event, recipientIndex, 'f24', index)}
+                    handleChange={(event) => handleChange(event, recipientKey, 'f24', index)}
                     showDeleteButton={index > 0}
-                    onDeletePayment={() => handleRemoveF24(recipientIndex, index)}
+                    onDeletePayment={() => handleRemoveF24(recipientKey, index)}
                     fieldMeta={(fieldName) => formik.getFieldMeta(fieldName)}
                   />
                 ))}
@@ -212,7 +212,7 @@ const PaymentMethods: React.FC<Props> = ({
                 <ButtonNaked
                   color="primary"
                   startIcon={<AddIcon />}
-                  onClick={() => handleAddNewF24(recipientIndex)}
+                  onClick={() => handleAddNewF24(recipientKey)}
                   sx={{ justifyContent: 'start' }}
                 >
                   {t('f24.add-new-f24')}

--- a/packages/pn-pa-webapp/src/components/NewNotification/PaymentMethods.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/PaymentMethods.tsx
@@ -126,9 +126,10 @@ const PaymentMethods: React.FC<Props> = ({
         if (recipient.debtPosition === PaymentModel.NOTHING) {
           return <></>;
         }
+        const recipientIndex = `${recipient.recipientType}-${recipient.taxId}`;
         return (
           <Paper
-            key={recipient.taxId}
+            key={recipientIndex}
             sx={{ padding: '24px', marginTop: '40px' }}
             elevation={0}
             data-testid="paymentForRecipient"
@@ -137,7 +138,7 @@ const PaymentMethods: React.FC<Props> = ({
               {t('payment-models')} {recipient.firstName} {recipient.lastName}
             </Typography>
 
-            {formik.values.recipients[recipient.taxId].pagoPa.length > 0 && (
+            {formik.values.recipients[recipientIndex].pagoPa.length > 0 && (
               <Stack
                 spacing={3}
                 mt={3}
@@ -150,19 +151,19 @@ const PaymentMethods: React.FC<Props> = ({
                 <Typography fontSize="16px" fontWeight={600} data-testid="pagoPaPaymentBox">
                   {`${t('pagopa.attach-pagopa-notice')}`}
                 </Typography>
-                {formik.values.recipients[recipient.taxId].pagoPa.map((pagoPaPayment, index) => (
+                {formik.values.recipients[recipientIndex].pagoPa.map((pagoPaPayment, index) => (
                   <PagoPaPaymentBox
-                    id={`recipients.${recipient.taxId}.pagoPa.${index}`}
-                    key={`${recipient.taxId}-pagoPa-${pagoPaPayment.idx}`}
+                    id={`recipients.${recipientIndex}.pagoPa.${index}`}
+                    key={`${recipientIndex}-pagoPa-${pagoPaPayment.idx}`}
                     onFileUploaded={(_, file, sha256) =>
-                      fileUploadedHandler(recipient.taxId, 'pagoPa', index, file, sha256)
+                      fileUploadedHandler(recipientIndex, 'pagoPa', index, file, sha256)
                     }
-                    onRemoveFile={() => removeFileHandler(recipient.taxId, 'pagoPa', index)}
+                    onRemoveFile={() => removeFileHandler(recipientIndex, 'pagoPa', index)}
                     pagoPaPayment={pagoPaPayment}
                     notificationFeePolicy={formik.values.notificationFeePolicy}
-                    handleChange={(event) => handleChange(event, recipient.taxId, 'pagoPa', index)}
+                    handleChange={(event) => handleChange(event, recipientIndex, 'pagoPa', index)}
                     showDeleteButton={index > 0}
-                    onDeletePayment={() => handleRemovePagoPa(recipient.taxId, index)}
+                    onDeletePayment={() => handleRemovePagoPa(recipientIndex, index)}
                     fieldMeta={(fieldName) => formik.getFieldMeta(fieldName)}
                   />
                 ))}
@@ -170,7 +171,7 @@ const PaymentMethods: React.FC<Props> = ({
                 <ButtonNaked
                   color="primary"
                   startIcon={<AddIcon />}
-                  onClick={() => handleAddNewPagoPa(recipient.taxId)}
+                  onClick={() => handleAddNewPagoPa(recipientIndex)}
                   sx={{ justifyContent: 'start' }}
                 >
                   {t('pagopa.add-new-pagopa-notice')}
@@ -178,7 +179,7 @@ const PaymentMethods: React.FC<Props> = ({
               </Stack>
             )}
 
-            {formik.values.recipients[recipient.taxId].f24.length > 0 && (
+            {formik.values.recipients[recipientIndex].f24.length > 0 && (
               <Stack
                 spacing={3}
                 mt={3}
@@ -191,19 +192,19 @@ const PaymentMethods: React.FC<Props> = ({
                 <Typography fontSize="16px" fontWeight={600} data-testid="f24PaymentBox">
                   {t('f24.attach-f24')}
                 </Typography>
-                {formik.values.recipients[recipient.taxId].f24.map((f24Payment, index) => (
+                {formik.values.recipients[recipientIndex].f24.map((f24Payment, index) => (
                   <F24PaymentBox
-                    id={`recipients.${recipient.taxId}.f24.${index}`}
-                    key={`${recipient.taxId}-f24-${f24Payment?.idx}`}
+                    id={`recipients.${recipientIndex}.f24.${index}`}
+                    key={`${recipientIndex}-f24-${f24Payment?.idx}`}
                     onFileUploaded={(_, file, sha256) =>
-                      fileUploadedHandler(recipient.taxId, 'f24', index, file, sha256)
+                      fileUploadedHandler(recipientIndex, 'f24', index, file, sha256)
                     }
-                    onRemoveFile={() => removeFileHandler(recipient.taxId, 'f24', index)}
+                    onRemoveFile={() => removeFileHandler(recipientIndex, 'f24', index)}
                     f24Payment={f24Payment}
                     notificationFeePolicy={formik.values.notificationFeePolicy}
-                    handleChange={(event) => handleChange(event, recipient.taxId, 'f24', index)}
+                    handleChange={(event) => handleChange(event, recipientIndex, 'f24', index)}
                     showDeleteButton={index > 0}
-                    onDeletePayment={() => handleRemoveF24(recipient.taxId, index)}
+                    onDeletePayment={() => handleRemoveF24(recipientIndex, index)}
                     fieldMeta={(fieldName) => formik.getFieldMeta(fieldName)}
                   />
                 ))}
@@ -211,7 +212,7 @@ const PaymentMethods: React.FC<Props> = ({
                 <ButtonNaked
                   color="primary"
                   startIcon={<AddIcon />}
-                  onClick={() => handleAddNewF24(recipient.taxId)}
+                  onClick={() => handleAddNewF24(recipientIndex)}
                   sx={{ justifyContent: 'start' }}
                 >
                   {t('f24.add-new-f24')}

--- a/packages/pn-pa-webapp/src/utility/validation.utility.ts
+++ b/packages/pn-pa-webapp/src/utility/validation.utility.ts
@@ -161,12 +161,12 @@ export function identicalIUV(
           {
             messageKey: 'identical-notice-codes-error',
             value: payment,
-            id: `recipients[${payment.taxIdKey}].pagoPa[${payment.idx}].noticeCode`,
+            id: `recipients.${payment.taxIdKey}.pagoPa[${payment.idx}].noticeCode`,
           },
           {
             messageKey: '',
             value: payment,
-            id: `recipients[${payment.taxIdKey}].pagoPa[${payment.idx}].creditorTaxId`,
+            id: `recipients.${payment.taxIdKey}.pagoPa[${payment.idx}].creditorTaxId`,
           }
         );
       }


### PR DESCRIPTION
## Short description
Update formik recipient key to handle numeric CF by adding `recipientType` before `taxId`

## List of changes proposed in this pull request
- Edit formik `initialValues` and `validationSchema`

## How to test
- Start PA
- Create a new notification with only a PG as recipient (or a PF and a PG)
- Select PagoPA as debt position for both recipients
- Try to insert the same `noticeCode` and check that error is show. Same for the applyCost switch