### PR TITLE
PN-14166 - Clear payment fields when set debt position to NOTHING

### DIFF
--- a/packages/pn-pa-webapp/src/redux/newNotification/reducers.ts
+++ b/packages/pn-pa-webapp/src/redux/newNotification/reducers.ts
@@ -7,6 +7,7 @@ import {
   NewNotificationRecipient,
   NotificationFeePolicy,
   PagoPaIntegrationMode,
+  PaymentModel,
   PreliminaryInformationsPayload,
 } from '../../models/NewNotification';
 import { UserGroup } from '../../models/user';
@@ -113,6 +114,16 @@ const newNotificationSlice = createSlice({
           payments: updatedPayments,
         };
       });
+
+      if (recipients.every((r) => r.debtPosition === PaymentModel.NOTHING)) {
+        state.notification = {
+          ...state.notification,
+          notificationFeePolicy: '' as NotificationFeePolicy,
+          paFee: undefined,
+          vat: undefined,
+          pagoPaIntMode: undefined,
+        };
+      }
     },
     setDebtPositionDetail: (
       state,

--- a/packages/pn-pa-webapp/src/utility/notification.utility.ts
+++ b/packages/pn-pa-webapp/src/utility/notification.utility.ts
@@ -18,6 +18,7 @@ import {
   NewNotificationPagoPaPayment,
   NewNotificationPayment,
   NewNotificationRecipient,
+  NotificationFeePolicy,
   PaymentModel,
 } from '../models/NewNotification';
 
@@ -175,6 +176,10 @@ export function newNotificationMapper(newNotification: NewNotification): BffNewN
 
   if (additionalLanguages) {
     newNotificationParsed.additionalLanguages = additionalLanguages;
+  }
+
+  if (!newNotification.notificationFeePolicy) {
+    newNotificationParsed.notificationFeePolicy = NotificationFeePolicy.FLAT_RATE;
   }
 
   // format recipients


### PR DESCRIPTION
## Short description
Clear payment fields (`paFee`, `vat`, and `pagoPaIntMode`) when setting the debt position to NOTHING. Also, set `notificationFeePolicy` to FLAT_RATE when no `notificationFeePolicy` is set

## List of changes proposed in this pull request
- Clear the fields (`paFee`, `vat`, and `pagoPaIntMode`) when the debt position is set to NONE in the reducer
- Provide a default value for `notificationFeePolicy`

## How to test
1. Start PA
2. Create a new notification with some payments and proceed to the last step
3. From the last step, go back to the Debt Position step and select "Nessuna posizione debitoria"  
4. Then, move forward, send the notification, and verify that `paFee`, `vat`, and `pagoPaIntMode` are not present in the request payload