### PR TITLE
fix/PN-13660 - Hide 'name' column on VirtualKeyTable for non-admin users (PG)

### DIFF
--- a/packages/pn-personagiuridica-webapp/src/components/IntegrazioneApi/VirtualKeysTable.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/IntegrazioneApi/VirtualKeysTable.tsx
@@ -108,6 +108,8 @@ const VirtualKeysTable: React.FC<Props> = ({
     },
   ];
 
+  const VirtualKeysVisibleColumns = isUserAdmin ? virtualKeysColumns : virtualKeysColumns.slice(1);
+
   if (!virtualKeys || virtualKeys.items.length === 0) {
     return (
       <EmptyState sentimentIcon={KnownSentiment.NONE}>{t('virtualKeys.empty-state')}</EmptyState>
@@ -117,7 +119,7 @@ const VirtualKeysTable: React.FC<Props> = ({
   return (
     <SmartTable
       data={data}
-      conf={virtualKeysColumns}
+      conf={VirtualKeysVisibleColumns}
       sortLabels={{
         title: t('sort.title', { ns: 'notifiche' }),
         optionsTitle: t('sort.options', { ns: 'notifiche' }),
@@ -129,7 +131,7 @@ const VirtualKeysTable: React.FC<Props> = ({
       slotProps={{ table: { sx: { tableLayout: 'fixed' } } }}
     >
       <SmartHeader>
-        {virtualKeysColumns.map((column) => (
+        {VirtualKeysVisibleColumns.map((column) => (
           <SmartHeaderCell
             key={column.id.toString()}
             columnId={column.id}
@@ -143,7 +145,7 @@ const VirtualKeysTable: React.FC<Props> = ({
       <SmartBody>
         {data.map((row, index) => (
           <SmartBodyRow key={row.id} index={index} testId="publicKeysBodyRow">
-            {virtualKeysColumns.map((column) => (
+            {VirtualKeysVisibleColumns.map((column) => (
               <SmartBodyCell
                 key={column.id.toString()}
                 columnId={column.id}

--- a/packages/pn-personagiuridica-webapp/src/components/IntegrazioneApi/VirtualKeysTable.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/IntegrazioneApi/VirtualKeysTable.tsx
@@ -108,7 +108,7 @@ const VirtualKeysTable: React.FC<Props> = ({
     },
   ];
 
-  const VirtualKeysVisibleColumns = isUserAdmin ? virtualKeysColumns : virtualKeysColumns.slice(1);
+  const virtualKeysVisibleColumns = isUserAdmin ? virtualKeysColumns : virtualKeysColumns.slice(1);
 
   if (!virtualKeys || virtualKeys.items.length === 0) {
     return (
@@ -119,7 +119,7 @@ const VirtualKeysTable: React.FC<Props> = ({
   return (
     <SmartTable
       data={data}
-      conf={VirtualKeysVisibleColumns}
+      conf={virtualKeysVisibleColumns}
       sortLabels={{
         title: t('sort.title', { ns: 'notifiche' }),
         optionsTitle: t('sort.options', { ns: 'notifiche' }),
@@ -131,7 +131,7 @@ const VirtualKeysTable: React.FC<Props> = ({
       slotProps={{ table: { sx: { tableLayout: 'fixed' } } }}
     >
       <SmartHeader>
-        {VirtualKeysVisibleColumns.map((column) => (
+        {virtualKeysVisibleColumns.map((column) => (
           <SmartHeaderCell
             key={column.id.toString()}
             columnId={column.id}
@@ -145,7 +145,7 @@ const VirtualKeysTable: React.FC<Props> = ({
       <SmartBody>
         {data.map((row, index) => (
           <SmartBodyRow key={row.id} index={index} testId="publicKeysBodyRow">
-            {VirtualKeysVisibleColumns.map((column) => (
+            {virtualKeysVisibleColumns.map((column) => (
               <SmartBodyCell
                 key={column.id.toString()}
                 columnId={column.id}

--- a/packages/pn-personagiuridica-webapp/src/components/IntegrazioneApi/VirtualKeysTable.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/IntegrazioneApi/VirtualKeysTable.tsx
@@ -144,7 +144,7 @@ const VirtualKeysTable: React.FC<Props> = ({
       </SmartHeader>
       <SmartBody>
         {data.map((row, index) => (
-          <SmartBodyRow key={row.id} index={index} testId="publicKeysBodyRow">
+          <SmartBodyRow key={row.id} index={index} testId="virtualKeysBodyRow">
             {virtualKeysVisibleColumns.map((column) => (
               <SmartBodyCell
                 key={column.id.toString()}


### PR DESCRIPTION
## Short description
Hide 'name' field for personal keys when the user is entitled to only view his/her own keys (non-admin)

## How to test
On PG webapp verify that only admin can see the 'name' column inside the API Integration section but admin with groups and operator cannot