### PR TITLE
fix/PN-14201 - Fix copy in timeline

### DIFF
--- a/packages/pn-commons/src/utility/notification.utility.ts
+++ b/packages/pn-commons/src/utility/notification.utility.ts
@@ -238,7 +238,7 @@ export function getNotificationStatusInfos(
           'Annullamento in corso. Lo stato sarà aggiornato a breve.'
         ),
       };
-      case NotificationStatus.RETURNED_TO_SENDER:
+    case NotificationStatus.RETURNED_TO_SENDER:
       return {
         color: 'warning',
         ...localizeStatus(
@@ -246,7 +246,8 @@ export function getNotificationStatusInfos(
           'Resa al mittente',
           `Il destinatario risulta deceduto.`,
           `Il destinatario risulta deceduto.`,
-          { isMultiRecipient }),
+          { isMultiRecipient }
+        ),
       };
     default:
       return {
@@ -404,7 +405,7 @@ export function getLegalFactLabel(
     return getLocalizedOrDefaultLabel(
       'notifications',
       'detail.timeline.legalfact.analog-failure-delivery',
-      'Deposito di avvenuta ricezione'
+      'Deposito avviso di avvenuta ricezione'
     );
   } else if (
     timelineStep.category === TimelineCategory.ANALOG_FAILURE_WORKFLOW &&
@@ -663,6 +664,6 @@ export const populatePaymentsPagoPaF24 = (
   return paymentDetails;
 };
 
-export const isNotificationDetailOtherDocument = 
-(value: NotificationDetailDocument | NotificationDetailOtherDocument): value is NotificationDetailOtherDocument => 
-  value.documentType === 'AAR';
+export const isNotificationDetailOtherDocument = (
+  value: NotificationDetailDocument | NotificationDetailOtherDocument
+): value is NotificationDetailOtherDocument => value.documentType === 'AAR';

--- a/packages/pn-pa-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/it/notifiche.json
@@ -288,7 +288,7 @@
         "pec-receipt-not-delivered": "di mancata consegna PEC",
         "paper-receipt-delivered": "di consegna raccomandata",
         "paper-receipt-not-delivered": "di mancata consegna raccomandata",
-        "analog-failure-delivery": "Deposito di avvenuta ricezione"
+        "analog-failure-delivery": "Deposito avviso di avvenuta ricezione"
       },
       "registered-letter-kind": {
         "AR": "A/R",

--- a/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
@@ -307,7 +307,7 @@
         "pec-receipt-not-delivered": "di mancata consegna PEC",
         "paper-receipt-delivered": "di consegna raccomandata",
         "paper-receipt-not-delivered": "di mancata consegna raccomandata",
-        "analog-failure-delivery": "Deposito di avvenuta ricezione"
+        "analog-failure-delivery": "Deposito avviso di avvenuta ricezione"
       },
       "registered-letter-kind": {
         "AR": "A/R",

--- a/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
@@ -308,7 +308,7 @@
         "pec-receipt-not-delivered": "di mancata consegna PEC",
         "paper-receipt-delivered": "di consegna raccomandata",
         "paper-receipt-not-delivered": "di mancata consegna raccomandata",
-        "analog-failure-delivery": "Deposito di avvenuta ricezione"
+        "analog-failure-delivery": "Deposito avviso di avvenuta ricezione"
       },
       "registered-letter-kind": {
         "AR": "A/R",


### PR DESCRIPTION
## Short description
This changes italian translation for analog failure delivery in timeline when recipient is unreachable

## How to test
- PA: login as 'Comune di Palermo' and search for a notification having IUN 'DQTM-XPVY-KAEV-202408-H-1'
- PF: Login as 'Alessandro Manzoni' and search for the notification having IUN 'DQTM-XPVY-KAEV-202408-H-1'
- PG: Login as any user, access a notification and mock the response to return the same response obtained above for PF
Look at the timeline and verify the text for analog failure delivery is correct.