### PR TITLE
PN-14326 - Hide Installment alert on F24 payment box when fee policy is FLAT_RATE

### DIFF
--- a/packages/pn-pa-webapp/src/components/NewNotification/F24PaymentBox.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/F24PaymentBox.tsx
@@ -139,7 +139,7 @@ const F24PaymentBox: React.FC<PaymentBoxProps> = ({
         </Stack>
       )}
 
-      {showDeleteButton && (
+      {showDeleteButton && notificationFeePolicy === NotificationFeePolicy.DELIVERY_MODE && (
         <Alert severity="warning" sx={{ mt: 4 }} data-testid="f24-installment-alert">
           {t('new-notification.steps.debt-position-detail.payment-methods.apply-cost-installment')}
         </Alert>

--- a/packages/pn-pa-webapp/src/components/NewNotification/__test__/F24PaymentBox.test.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/__test__/F24PaymentBox.test.tsx
@@ -79,7 +79,7 @@ describe('F24PaymentBox', () => {
   });
 
   it('should shows warning alert when both showDeleteButton and DELIVERY_MODE are true', () => {
-    const { getByTestId } = render(
+    const { rerender, getByTestId, queryByTestId } = render(
       <Formik initialValues={{}} onSubmit={() => {}}>
         {() => (
           <F24PaymentBox
@@ -92,6 +92,20 @@ describe('F24PaymentBox', () => {
     );
 
     expect(getByTestId('f24-installment-alert')).toBeInTheDocument();
+
+    rerender(
+      <Formik initialValues={{}} onSubmit={() => {}}>
+        {() => (
+          <F24PaymentBox
+            {...defaultProps}
+            showDeleteButton={true}
+            notificationFeePolicy={NotificationFeePolicy.FLAT_RATE}
+          />
+        )}
+      </Formik>
+    );
+
+    expect(queryByTestId('f24-installment-alert')).not.toBeInTheDocument();
   });
 
   it('should calls onFileUploaded when a file is uploaded', async () => {

--- a/packages/pn-pa-webapp/src/components/NewNotification/__test__/PagoPaPaymentBox.test.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/__test__/PagoPaPaymentBox.test.tsx
@@ -80,7 +80,7 @@ describe('PagoPaPaymentBox', () => {
   });
 
   it('should shows warning alert when both showDeleteButton and DELIVERY_MODE are true', () => {
-    const { getByTestId } = render(
+    const { rerender, getByTestId, queryByTestId } = render(
       <Formik initialValues={{}} onSubmit={() => {}}>
         {() => (
           <PagoPaPaymentBox
@@ -93,6 +93,20 @@ describe('PagoPaPaymentBox', () => {
     );
 
     expect(getByTestId('pagopa-installment-alert')).toBeInTheDocument();
+
+    rerender(
+      <Formik initialValues={{}} onSubmit={() => {}}>
+        {() => (
+          <PagoPaPaymentBox
+            {...defaultProps}
+            showDeleteButton={true}
+            notificationFeePolicy={NotificationFeePolicy.FLAT_RATE}
+          />
+        )}
+      </Formik>
+    );
+
+    expect(queryByTestId('pagopa-installment-alert')).not.toBeInTheDocument();
   });
 
   it('should calls onFileUploaded when a file is uploaded', async () => {


### PR DESCRIPTION
## Short description
 Hide Installment alert on F24 payment box when fee policy is `FLAT_RATE`

## List of changes proposed in this pull request
- Edit logic on F24PaymentBox
- Add some unit tests 

## How to test
- Start PA
- Create a new notification
- On debt position step select F24
- Select `Incluso nell’atto (forfettario)` as notification fee policy
- Try adding multiple F24 and verify that no alert is displayed