### PR TITLE
Feat/PN-14280: feature flag for optional physical address

### DIFF
--- a/packages/pn-pa-webapp/public/conf/config-dev.json
+++ b/packages/pn-pa-webapp/public/conf/config-dev.json
@@ -19,5 +19,6 @@
   "TAXONOMY_SEND_URL": "https://docs.pagopa.it/f.a.q.-per-integratori/tassonomia-send",
   "DOWNTIME_EXAMPLE_LINK": "https://www.dev.notifichedigitali.it/static/documents/LegalFactMalfunction.pdf",
   "PAYMENT_INFO_LINK": "https://developer.pagopa.it/send/guides/knowledge-base/readme/pagamenti-e-spese-di-notifica/pagamenti-pagopa",
-  "DEVELOPER_API_DOCUMENTATION_LINK": "https://developer.pagopa.it/send/api"
+  "DEVELOPER_API_DOCUMENTATION_LINK": "https://developer.pagopa.it/send/api",
+  "PHYSICAL_ADDRESS_LOOKUP": "on"
 }

--- a/packages/pn-pa-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/it/notifiche.json
@@ -472,7 +472,7 @@
         "add-recipient": "Aggiungi un destinatario",
         "remove-recipient": "Rimuovi destinatario",
         "address-subtitle": "Scegli se inserire l'indirizzo automaticamente dai registri nazionali o compilarlo manualmente. L'inserimento automatico dai registri nazionali potrebbe ritardare l'invio della notifica al destinatario.",
-        "address-physical-lookup-error": "<0>Servizio VAS attualmente non disponibile</0>Non è al momento possibile richiamare automaticamente l'indirizzo da registro nazionale, l'indirizzo deve essere inserito manualmente",
+        "address-physical-lookup-down": "Al momento non è possibile richiamare l'indirizzo dai registri nazionali. Inserisci l'indirizzo manualmente.",
         "address-physical-lookup-radios": {
           "national-registry": "Inserimento automatico da registro nazionale",
           "manual": "Inserimento manuale"

--- a/packages/pn-pa-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/it/notifiche.json
@@ -471,7 +471,7 @@
         "address-details": "Note aggiuntive (presso, scala, piano)",
         "add-recipient": "Aggiungi un destinatario",
         "remove-recipient": "Rimuovi destinatario",
-        "address-subtitle": "Scegli se inserire l'indirizzo automaticamente dai registri nazionali o compilarlo manualmente. L'inserimento automatico dai registri nazionali potrebbe ritardare l'invio della notifica al destinatario.",
+        "address-subtitle": "Scegli se consentire a SEND di inserire automaticamente l'indirizzo dai registri nazionali. L'inserimento automatico potrebbe ritardare l'invio della notifica al destinatario. In alternativa puoi compilare l'indirizzo manualmente.",
         "address-physical-lookup-down": "Al momento non è possibile richiamare l'indirizzo dai registri nazionali. Inserisci l'indirizzo manualmente.",
         "address-physical-lookup-radios": {
           "national-registry": "Inserimento automatico da registro nazionale",

--- a/packages/pn-pa-webapp/src/components/NewNotification/Recipient.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/Recipient.tsx
@@ -463,15 +463,19 @@ const Recipient: React.FC<Props> = ({
                       sx={{ mt: 4 }}
                     >
                       <FormBoxTitle text={t('address')} />
-                      {
-                        PHYSICAL_ADDRESS_LOOKUP !== PhysicalAddressLookupConfig.OFF && (
-                          <FormBoxSubtitle text={t('address-subtitle')} />
-                        )
-                      }
+                      {PHYSICAL_ADDRESS_LOOKUP !== PhysicalAddressLookupConfig.OFF && (
+                        <FormBoxSubtitle text={t('address-subtitle')} />
+                      )}
                     </FormLabel>
-                    <Alert severity="error" sx={{ mb: 2 }}>
-                      {t('address-physical-lookup-down')}
-                    </Alert>
+                    {PHYSICAL_ADDRESS_LOOKUP === PhysicalAddressLookupConfig.DOWN && (
+                      <Alert
+                        severity="error"
+                        sx={{ mb: 2 }}
+                        data-testid="alert-physicalAddressLookupDown"
+                      >
+                        {t('address-physical-lookup-down')}
+                      </Alert>
+                    )}
                     {PHYSICAL_ADDRESS_LOOKUP !== PhysicalAddressLookupConfig.OFF && (
                       <RadioGroup
                         aria-labelledby={`recipients[${index}].physicalAddressLabel`}
@@ -487,7 +491,7 @@ const Recipient: React.FC<Props> = ({
                         }
                       >
                         <FormControlLabel
-                          disabled={PHYSICAL_ADDRESS_LOOKUP !== PhysicalAddressLookupConfig.ON}
+                          disabled={PHYSICAL_ADDRESS_LOOKUP === PhysicalAddressLookupConfig.DOWN}
                           value={PhysicalAddressLookup.NATIONAL_REGISTRY}
                           control={<Radio />}
                           label={t('address-physical-lookup-radios.national-registry')}

--- a/packages/pn-pa-webapp/src/components/NewNotification/Recipient.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/Recipient.tsx
@@ -469,7 +469,7 @@ const Recipient: React.FC<Props> = ({
                         )
                       }
                     </FormLabel>
-                    <Alert severity="error">
+                    <Alert severity="error" sx={{ mb: 2 }}>
                       {t('address-physical-lookup-down')}
                     </Alert>
                     {PHYSICAL_ADDRESS_LOOKUP !== PhysicalAddressLookupConfig.OFF && (

--- a/packages/pn-pa-webapp/src/components/NewNotification/__test__/Recipient.test.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/__test__/Recipient.test.tsx
@@ -1,6 +1,7 @@
 import { vi } from 'vitest';
 
 import { PhysicalAddressLookup, RecipientType } from '@pagopa-pn/pn-commons';
+import { Configuration } from '@pagopa-pn/pn-commons';
 import { testFormElements, testInput, testRadio } from '@pagopa-pn/pn-commons/src/test-utils';
 
 import { newNotification } from '../../../__mocks__/NewNotification.mock';
@@ -14,7 +15,11 @@ import {
   waitFor,
   within,
 } from '../../../__test__/test-utils';
-import { NewNotificationRecipient } from '../../../models/NewNotification';
+import {
+  NewNotificationRecipient,
+  PhysicalAddressLookupConfig,
+} from '../../../models/NewNotification';
+import { PaConfiguration } from '../../../services/configuration.service';
 import Recipient from '../Recipient';
 
 const testRecipientFormRendering = async (
@@ -118,6 +123,8 @@ const populateForm = async (
   recipientIndex: number,
   recipient: NewNotificationRecipient
 ) => {
+  const configPhysicalAddressLookup = Configuration.get<PaConfiguration>().PHYSICAL_ADDRESS_LOOKUP;
+
   // if pg select the right radio button
   if (recipient.recipientType === RecipientType.PG) {
     await testRadio(
@@ -134,16 +141,21 @@ const populateForm = async (
   }
   await testInput(form, `recipients[${recipientIndex}].taxId`, recipient.taxId);
 
-  await testRadio(
-    form,
-    `physicalAddressLookupRadio.${recipientIndex}`,
-    ['address-physical-lookup-radios.national-registry', 'address-physical-lookup-radios.manual'],
-    recipient.physicalAddressLookup === PhysicalAddressLookup.MANUAL ? 1 : 0,
-    true
-  );
+  if (configPhysicalAddressLookup !== PhysicalAddressLookupConfig.OFF) {
+    await testRadio(
+      form,
+      `physicalAddressLookupRadio.${recipientIndex}`,
+      ['address-physical-lookup-radios.national-registry', 'address-physical-lookup-radios.manual'],
+      recipient.physicalAddressLookup === PhysicalAddressLookup.MANUAL ? 1 : 0,
+      true
+    );
+  }
 
   // show physical address form
-  if (recipient.physicalAddressLookup === PhysicalAddressLookup.MANUAL) {
+  if (
+    configPhysicalAddressLookup !== PhysicalAddressLookupConfig.OFF &&
+    recipient.physicalAddressLookup === PhysicalAddressLookup.MANUAL
+  ) {
     await testInput(form, `recipients[${recipientIndex}].address`, recipient.address);
     await testInput(form, `recipients[${recipientIndex}].houseNumber`, recipient.houseNumber);
     await testInput(form, `recipients[${recipientIndex}].municipality`, recipient.municipality);
@@ -478,5 +490,52 @@ describe('Recipient Component without payment enabled', async () => {
       ]);
     });
     expect(confirmHandlerMk).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('Feature flag for physical address lookup', async () => {
+  let result: RenderResult;
+
+  it('FF is off', async () => {
+    Configuration.setForTest<PaConfiguration>({
+      ...Configuration.get(),
+      PHYSICAL_ADDRESS_LOOKUP: PhysicalAddressLookupConfig.OFF,
+    });
+
+    await act(async () => {
+      result = render(<Recipient onConfirm={() => {}} />);
+    });
+
+    const form = result.getByTestId('recipientForm') as HTMLFormElement;
+    await populateForm(form, 0, newNotification.recipients[0]);
+
+    const physicalForm = within(form).queryByTestId(`physicalAddressForm0`);
+    expect(physicalForm).toBeInTheDocument();
+
+    const alert = within(form).queryByTestId(`alert-physicalAddressLookupDown`);
+    expect(alert).not.toBeInTheDocument();
+  });
+
+  it('FF is down', async () => {
+    Configuration.setForTest<PaConfiguration>({
+      ...Configuration.get(),
+      PHYSICAL_ADDRESS_LOOKUP: PhysicalAddressLookupConfig.DOWN,
+    });
+
+    await act(async () => {
+      result = render(<Recipient onConfirm={() => {}} />);
+    });
+
+    const form = result.getByTestId('recipientForm') as HTMLFormElement;
+    await populateForm(form, 0, newNotification.recipients[0]);
+
+    const physicalForm = within(form).queryByTestId(`physicalAddressForm0`);
+    expect(physicalForm).toBeInTheDocument();
+
+    const radioNR = within(form).getByLabelText('address-physical-lookup-radios.national-registry');
+    expect(radioNR).toBeDisabled();
+
+    const alert = within(form).getByTestId('alert-physicalAddressLookupDown');
+    expect(alert).toBeInTheDocument();
   });
 });

--- a/packages/pn-pa-webapp/src/models/NewNotification.ts
+++ b/packages/pn-pa-webapp/src/models/NewNotification.ts
@@ -170,3 +170,9 @@ export const BILINGUALISM_LANGUAGES = ['de', 'sl', 'fr'];
 export const NewNotificationLangOther = 'other';
 
 export const VAT = [4, 5, 10, 22];
+
+export enum PhysicalAddressLookupConfig {
+  ON = 'on',
+  OFF = 'off',
+  DOWN = 'down',
+}

--- a/packages/pn-pa-webapp/src/services/configuration.service.ts
+++ b/packages/pn-pa-webapp/src/services/configuration.service.ts
@@ -57,6 +57,7 @@ class PaConfigurationValidator extends Validator<PaConfiguration> {
       .matches(dataRegex.htmlPageUrl);
     this.ruleFor('PHYSICAL_ADDRESS_LOOKUP')
       .isString()
+      .isRequired()
       .isOneOf(Object.values(PhysicalAddressLookupConfig));
   }
 }

--- a/packages/pn-pa-webapp/src/services/configuration.service.ts
+++ b/packages/pn-pa-webapp/src/services/configuration.service.ts
@@ -1,6 +1,8 @@
 import { Configuration, IS_DEVELOP, dataRegex } from '@pagopa-pn/pn-commons';
 import { Validator } from '@pagopa-pn/pn-validator';
 
+import { PhysicalAddressLookupConfig } from '../models/NewNotification';
+
 export interface PaConfiguration {
   OT_DOMAIN_ID: string;
   SELFCARE_URL_FE_LOGIN: string;
@@ -23,6 +25,7 @@ export interface PaConfiguration {
   DOWNTIME_EXAMPLE_LINK: string;
   PAYMENT_INFO_LINK: string;
   DEVELOPER_API_DOCUMENTATION_LINK: string;
+  PHYSICAL_ADDRESS_LOOKUP: PhysicalAddressLookupConfig;
 }
 
 class PaConfigurationValidator extends Validator<PaConfiguration> {
@@ -52,6 +55,9 @@ class PaConfigurationValidator extends Validator<PaConfiguration> {
       .isString()
       .isRequired()
       .matches(dataRegex.htmlPageUrl);
+    this.ruleFor('PHYSICAL_ADDRESS_LOOKUP')
+      .isString()
+      .isOneOf(Object.values(PhysicalAddressLookupConfig));
   }
 }
 

--- a/packages/pn-pa-webapp/src/setupTests.tsx
+++ b/packages/pn-pa-webapp/src/setupTests.tsx
@@ -12,6 +12,7 @@ import '@testing-library/jest-dom';
 import { initAxiosClients } from './api/apiClients';
 import { initStore } from './redux/store';
 import { PaConfiguration } from './services/configuration.service';
+import { PhysicalAddressLookupConfig } from './models/NewNotification';
 
 beforeAll(() => {
   Configuration.setForTest<PaConfiguration>({
@@ -36,6 +37,7 @@ beforeAll(() => {
     LANDING_SITE_URL: 'https://test.landing.pagopa.it',
     PAYMENT_INFO_LINK: 'https://test.payment.pagopa.it',
     DEVELOPER_API_DOCUMENTATION_LINK: 'https://test.api.pagopa.it',
+    PHYSICAL_ADDRESS_LOOKUP: PhysicalAddressLookupConfig.ON,
   });
   initStore(false);
   initAxiosClients();


### PR DESCRIPTION
## Short description
Add feature flag for manage this PR https://github.com/pagopa/pn-frontend/pull/1523


## List of changes proposed in this pull request
- `PHYSICAL_ADDRESS_LOOKUP` takes 3 possibile values `on`, `off`, `down`

## How to test
Add `PHYSICAL_ADDRESS_LOOKUP` in your configurations.
Start PA and check form in second step of manual notification creation with these scenarios:
`on`: radio group is shown
`off`: radio group is not present and physical form is "as is"
`down`: radio group is shown but physical address is required (national registry radio button is disabled)