### PR TITLE
fix/PN-14129 - DDOM activation feedback redirects to contacts page

### DIFF
--- a/packages/pn-personafisica-webapp/public/locales/it/recapiti.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/recapiti.json
@@ -108,7 +108,7 @@
       "feedback": {
         "title-activation": "Hai attivato il tuo domicilio digitale",
         "title-transfer": "Hai aggiornato il tuo domicilio digitale",
-        "back-to-contacts": "Torna ai tuoi recapiti"
+        "go-to-contacts": "Vai ai tuoi recapiti"
       }
     },
     "pec-contact-wizard": {

--- a/packages/pn-personafisica-webapp/src/components/Contacts/DigitalContactActivation.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/DigitalContactActivation.tsx
@@ -10,6 +10,7 @@ import IOContactWizard from '../../components/Contacts/IOContactWizard';
 import PecContactWizard from '../../components/Contacts/PecContactWizard';
 import SercqSendContactWizard from '../../components/Contacts/SercqSendContactWizard';
 import { IOAllowedValues } from '../../models/contacts';
+import { RECAPITI } from '../../navigation/routes.const';
 import { contactsSelectors } from '../../redux/contact/reducers';
 import { useAppSelector } from '../../redux/hooks';
 import { getConfiguration } from '../../services/configuration.service';
@@ -159,8 +160,8 @@ const DigitalContactActivation: React.FC<Props> = ({ isTransferring = false, onG
                 isTransferring ? 'transfer' : 'activation'
               }`
             ),
-            buttonText: t('legal-contacts.sercq-send-wizard.feedback.back-to-contacts'),
-            onClick: () => navigate(-1),
+            buttonText: t('legal-contacts.sercq-send-wizard.feedback.go-to-contacts'),
+            onClick: () => navigate(RECAPITI),
           },
           actions: isEmailSmsStep && hasEmailOrSms ? { justifyContent: 'flex-end' } : {},
         }}

--- a/packages/pn-personafisica-webapp/src/components/Contacts/DigitalContactManagement.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/DigitalContactManagement.tsx
@@ -9,6 +9,7 @@ import { ButtonNaked } from '@pagopa/mui-italia';
 import LegalContactManager, {
   DigitalDomicileManagementAction,
 } from '../../components/Contacts/LegalContactManager';
+import { RECAPITI } from '../../navigation/routes.const';
 import AddSpecialContact, { AddSpecialContactRef } from './AddSpecialContact';
 import DigitalContactActivation from './DigitalContactActivation';
 
@@ -100,8 +101,8 @@ const DigitalContactManagement: React.FC = () => {
         },
         feedback: {
           title: t(`legal-contacts.sercq-send-wizard.feedback.title-transfer`),
-          buttonText: t('legal-contacts.sercq-send-wizard.feedback.back-to-contacts'),
-          onClick: () => navigate(-1),
+          buttonText: t('legal-contacts.sercq-send-wizard.feedback.go-to-contacts'),
+          onClick: () => navigate(RECAPITI),
         },
       }}
     >

--- a/packages/pn-personafisica-webapp/src/components/Contacts/PecContactWizard.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/PecContactWizard.tsx
@@ -15,6 +15,7 @@ import {
   ContactSource,
   SaveDigitalAddressParams,
 } from '../../models/contacts';
+import { RECAPITI } from '../../navigation/routes.const';
 import { createOrUpdateAddress } from '../../redux/contact/actions';
 import { contactsSelectors } from '../../redux/contact/reducers';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
@@ -96,7 +97,7 @@ const PecContactWizard: React.FC<Props> = ({
           res.pecValid && !!defaultSERCQ_SENDAddress
         );
         setOpenCodeModal(false);
-        return isTransferring ? setActiveStep(activeStep + 1) : navigate(-1);
+        return isTransferring ? setActiveStep(activeStep + 1) : navigate(RECAPITI);
       })
       .catch(() => {});
   };
@@ -147,8 +148,8 @@ const PecContactWizard: React.FC<Props> = ({
                     isTransferring ? 'transfer' : 'activation'
                   }`
                 ),
-                buttonText: t('legal-contacts.sercq-send-wizard.feedback.back-to-contacts'),
-                onClick: () => navigate(-1),
+                buttonText: t('legal-contacts.sercq-send-wizard.feedback.go-to-contacts'),
+                onClick: () => navigate(RECAPITI),
               }
             : undefined,
         }}

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/DigitalContactActivation.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/DigitalContactActivation.test.tsx
@@ -12,6 +12,7 @@ import { digitalAddressesSercq, digitalLegalAddresses } from '../../../__mocks__
 import { fireEvent, render, screen, waitFor, within } from '../../../__test__/test-utils';
 import { apiClient } from '../../../api/apiClients';
 import { AddressType, ChannelType, IOAllowedValues } from '../../../models/contacts';
+import { RECAPITI } from '../../../navigation/routes.const';
 import DigitalContactActivation from '../DigitalContactActivation';
 import { fillCodeDialog } from './test-utils';
 
@@ -53,6 +54,7 @@ describe('DigitalContactActivation', () => {
     expect(backButton).toBeInTheDocument();
     fireEvent.click(backButton);
     expect(mockNavigateFn).toHaveBeenCalledTimes(1);
+    expect(mockNavigateFn).toHaveBeenCalledWith(-1);
   });
 
   it('renders pec contact wizard correctly', () => {
@@ -278,10 +280,11 @@ describe('DigitalContactActivation', () => {
     );
     const feedbackButton = getByTestId('wizard-feedback-button');
     expect(feedbackButton).toHaveTextContent(
-      'legal-contacts.sercq-send-wizard.feedback.back-to-contacts'
+      'legal-contacts.sercq-send-wizard.feedback.go-to-contacts'
     );
     fireEvent.click(feedbackButton);
     expect(mockNavigateFn).toHaveBeenCalledTimes(1);
+    expect(mockNavigateFn).toHaveBeenCalledWith(RECAPITI);
   });
 
   it('adds an email correctly (verify skip and confirm buttons)', async () => {
@@ -365,10 +368,11 @@ describe('DigitalContactActivation', () => {
     );
     const feedbackButton = result.getByTestId('wizard-feedback-button');
     expect(feedbackButton).toHaveTextContent(
-      'legal-contacts.sercq-send-wizard.feedback.back-to-contacts'
+      'legal-contacts.sercq-send-wizard.feedback.go-to-contacts'
     );
     fireEvent.click(feedbackButton);
     expect(mockNavigateFn).toHaveBeenCalledTimes(1);
+    expect(mockNavigateFn).toHaveBeenCalledWith(RECAPITI);
   });
 
   it('renders component correctly when transferring', async () => {

--- a/packages/pn-personagiuridica-webapp/public/locales/it/recapiti.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/it/recapiti.json
@@ -96,7 +96,7 @@
       "feedback": {
         "title-activation": "Hai attivato il tuo domicilio digitale",
         "title-transfer": "Hai aggiornato il domicilio digitale della tua impresa",
-        "back-to-contacts": "Torna ai tuoi recapiti"
+        "go-to-contacts": "Vai ai tuoi recapiti"
       }
     },
     "pec-contact-wizard": {

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/DigitalContactActivation.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/DigitalContactActivation.tsx
@@ -8,6 +8,7 @@ import { ButtonNaked } from '@pagopa/mui-italia';
 
 import PecContactWizard from '../../components/Contacts/PecContactWizard';
 import SercqSendContactWizard from '../../components/Contacts/SercqSendContactWizard';
+import { RECAPITI } from '../../navigation/routes.const';
 import { contactsSelectors } from '../../redux/contact/reducers';
 import { useAppSelector } from '../../redux/hooks';
 import { getConfiguration } from '../../services/configuration.service';
@@ -130,8 +131,8 @@ const DigitalContactActivation: React.FC<Props> = ({ isTransferring = false, onG
                 isTransferring ? 'transfer' : 'activation'
               }`
             ),
-            buttonText: t('legal-contacts.sercq-send-wizard.feedback.back-to-contacts'),
-            onClick: () => navigate(-1),
+            buttonText: t('legal-contacts.sercq-send-wizard.feedback.go-to-contacts'),
+            onClick: () => navigate(RECAPITI),
           },
           actions: hasCourtesyContact ? { justifyContent: 'flex-end' } : {},
         }}

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/DigitalContactManagement.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/DigitalContactManagement.tsx
@@ -9,6 +9,7 @@ import { ButtonNaked } from '@pagopa/mui-italia';
 import LegalContactManager, {
   DigitalDomicileManagementAction,
 } from '../../components/Contacts/LegalContactManager';
+import { RECAPITI } from '../../navigation/routes.const';
 import AddSpecialContact, { AddSpecialContactRef } from './AddSpecialContact';
 import DigitalContactActivation from './DigitalContactActivation';
 
@@ -99,8 +100,8 @@ const DigitalContactManagement: React.FC = () => {
         },
         feedback: {
           title: t(`legal-contacts.sercq-send-wizard.feedback.title-transfer`),
-          buttonText: t('legal-contacts.sercq-send-wizard.feedback.back-to-contacts'),
-          onClick: () => navigate(-1),
+          buttonText: t('legal-contacts.sercq-send-wizard.feedback.go-to-contacts'),
+          onClick: () => navigate(RECAPITI),
         },
       }}
     >

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/PecContactWizard.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/PecContactWizard.tsx
@@ -9,6 +9,7 @@ import { PnWizard, PnWizardStep } from '@pagopa-pn/pn-commons';
 import { ButtonNaked } from '@pagopa/mui-italia';
 
 import { AddressType, ChannelType, SaveDigitalAddressParams } from '../../models/contacts';
+import { RECAPITI } from '../../navigation/routes.const';
 import { createOrUpdateAddress } from '../../redux/contact/actions';
 import { contactsSelectors } from '../../redux/contact/reducers';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
@@ -72,7 +73,7 @@ const PecContactWizard: React.FC<Props> = ({
           return;
         }
         setOpenCodeModal(false);
-        return isTransferring ? setActiveStep(activeStep + 1) : navigate(-1);
+        return isTransferring ? setActiveStep(activeStep + 1) : navigate(RECAPITI);
       })
       .catch(() => {});
   };
@@ -123,8 +124,8 @@ const PecContactWizard: React.FC<Props> = ({
                     isTransferring ? 'transfer' : 'activation'
                   }`
                 ),
-                buttonText: t('legal-contacts.sercq-send-wizard.feedback.back-to-contacts'),
-                onClick: () => navigate(-1),
+                buttonText: t('legal-contacts.sercq-send-wizard.feedback.go-to-contacts'),
+                onClick: () => navigate(RECAPITI),
               }
             : undefined,
         }}

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/__test__/DigitalContactActivation.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/__test__/DigitalContactActivation.test.tsx
@@ -12,6 +12,7 @@ import { digitalAddressesSercq, digitalLegalAddresses } from '../../../__mocks__
 import { fireEvent, render, waitFor, within } from '../../../__test__/test-utils';
 import { apiClient } from '../../../api/apiClients';
 import { AddressType, ChannelType } from '../../../models/contacts';
+import { RECAPITI } from '../../../navigation/routes.const';
 import DigitalContactActivation from '../DigitalContactActivation';
 import { fillCodeDialog } from './test-utils';
 
@@ -53,6 +54,7 @@ describe('DigitalContactActivation', () => {
     expect(backButton).toBeInTheDocument();
     fireEvent.click(backButton);
     expect(mockNavigateFn).toHaveBeenCalledTimes(1);
+    expect(mockNavigateFn).toHaveBeenCalledWith(-1);
   });
 
   it('renders pec contact wizard correctly', () => {
@@ -178,10 +180,11 @@ describe('DigitalContactActivation', () => {
     );
     const feedbackButton = getByTestId('wizard-feedback-button');
     expect(feedbackButton).toHaveTextContent(
-      'legal-contacts.sercq-send-wizard.feedback.back-to-contacts'
+      'legal-contacts.sercq-send-wizard.feedback.go-to-contacts'
     );
     fireEvent.click(feedbackButton);
     expect(mockNavigateFn).toHaveBeenCalledTimes(1);
+    expect(mockNavigateFn).toHaveBeenCalledWith(RECAPITI);
   });
 
   it('adds an email correctly (verify skip and confirm buttons)', async () => {
@@ -261,10 +264,11 @@ describe('DigitalContactActivation', () => {
     );
     const feedbackButton = result.getByTestId('wizard-feedback-button');
     expect(feedbackButton).toHaveTextContent(
-      'legal-contacts.sercq-send-wizard.feedback.back-to-contacts'
+      'legal-contacts.sercq-send-wizard.feedback.go-to-contacts'
     );
     fireEvent.click(feedbackButton);
     expect(mockNavigateFn).toHaveBeenCalledTimes(1);
+    expect(mockNavigateFn).toHaveBeenCalledWith(RECAPITI);
   });
 
   it('renders component correctly when transferring', async () => {


### PR DESCRIPTION
## Short description
This PR includes the changes to always redirect the user to the contacts page after successfully completing the digital domicile activation wizard (PF and PG).

## How to test
Run pf and pg webapps and verify the user is always redirected to contacts page after ddom wizard successful completion, regardless of where the process started from (including domicile banner)