### PR TITLE
fix(PN-14852): restore label included-costs

### DIFF
--- a/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentF24Item.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentF24Item.tsx
@@ -190,9 +190,22 @@ const NotificationPaymentF24Item: React.FC<Props> = ({
             {getLocalizedOrDefaultLabel('notifications', 'detail.payment.pay-with-f24')}
           </Typography>
         ) : (
-          <Typography variant="sidenav" color="text.primary" sx={{ overflowWrap: 'anywhere' }}>
-            {f24Item.title}
-          </Typography>
+          <>
+            <Typography variant="sidenav" color="text.primary" sx={{ overflowWrap: 'anywhere' }}>
+              {f24Item.title}
+            </Typography>
+            {f24Item.applyCost && (
+              <Typography
+                fontSize="0.625rem"
+                fontWeight="600"
+                lineHeight="0.875rem"
+                color="text.secondary"
+                data-testid="f24-apply-costs-caption"
+              >
+                {getLocalizedOrDefaultLabel('notifications', 'detail.payment.included-costs')}
+              </Typography>
+            )}
+          </>
         )}
         {maxTimeError && (
           <Stack

--- a/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentPagoPAItem.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentPagoPAItem.tsx
@@ -140,6 +140,18 @@ const NotificationPaymentPagoPAStatusElem: React.FC<{
           <Typography variant="h6" color="primary.main" data-testid="payment-amount">
             {formatEurocentToCurrency(pagoPAItem.amount)}
           </Typography>
+
+          {pagoPAItem.applyCost && (
+            <Typography
+              fontSize="0.625rem"
+              fontWeight="600"
+              lineHeight="0.875rem"
+              color="text.secondary"
+              data-testid="apply-costs-caption"
+            >
+              {getLocalizedOrDefaultLabel('notifications', 'detail.payment.included-costs')}
+            </Typography>
+          )}
         </Box>
       )}
       {pagoPAItem.status === PaymentStatus.REQUIRED ? (

--- a/packages/pn-commons/src/components/NotificationDetail/__test__/NotificationPaymentF24Item.test.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/__test__/NotificationPaymentF24Item.test.tsx
@@ -76,7 +76,7 @@ describe('NotificationPaymentF24Item Component', () => {
     attachmentIdx?: number | undefined
   ) => store.dispatch(getSentNotificationPayment({ name, attachmentIdx, downloadStatus }));
 
-  it('renders component - should show title of f24Item', () => {
+  it('renders component - should show title and included cost label of f24Item', () => {
     const item = { ...f24Item, applyCost: true };
     const { container, getByTestId } = render(
       <NotificationPaymentF24Item
@@ -88,8 +88,23 @@ describe('NotificationPaymentF24Item Component', () => {
       />
     );
     expect(container).toHaveTextContent(item.title);
+    expect(container).toHaveTextContent('included-costs');
     const downloadBtn = getByTestId('download-f24-button');
     expect(downloadBtn).toBeInTheDocument();
+  });
+
+  it('renders component - should show label if costs are included', () => {
+    const item = { ...f24Item, applyCost: true };
+    const { container } = render(
+      <NotificationPaymentF24Item
+        f24Item={item}
+        timerF24={TIMERF24}
+        getPaymentAttachmentAction={vi.fn()}
+        disableDownload={false}
+        handleDownload={() => {}}
+      />
+    );
+    expect(container).toHaveTextContent('included-costs');
   });
 
   it('should show the correct label if is a PagoPA attachment', () => {
@@ -130,7 +145,7 @@ describe('NotificationPaymentF24Item Component', () => {
     );
   });
 
-  it('immediatly dowload the attachment', async () => {
+  it('immediatly download the attachment', async () => {
     const item = { ...f24Item, attachmentIdx: 1 };
     const { getByTestId } = render(
       <NotificationPaymentF24Item

--- a/packages/pn-commons/src/components/NotificationDetail/__test__/NotificationPaymentPagoPAItem.test.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/__test__/NotificationPaymentPagoPAItem.test.tsx
@@ -134,6 +134,26 @@ describe('NotificationPaymentPagoPAItem Component', () => {
     );
   });
 
+  it('renders component - should show label if costs are included', () => {
+    const amount = 1000;
+    const item = { ...pagoPAItem, amount, applyCost: true };
+    const { container, getByTestId } = render(
+      <NotificationPaymentPagoPAItem
+        pagoPAItem={item}
+        loading={false}
+        isSelected={false}
+        handleFetchPaymentsInfo={() => void 0}
+        handleDeselectPayment={() => void 0}
+        isCancelled={false}
+      />
+    );
+    expect(container).toHaveTextContent('included-costs');
+    const amountContainer = getByTestId('payment-amount');
+    expect(amountContainer).toHaveTextContent(
+      formatEurocentToCurrency(amount).replace(/\u00a0/g, ' ')
+    );
+  });
+
   it('Should call handleDeselectPayment when radio button is selected and is clicked', async () => {
     const item = { ...pagoPAItem, status: PaymentStatus.REQUIRED };
     const handleDeselectPaymentMk = vi.fn();


### PR DESCRIPTION
## Short description
restore label included-costs

## List of changes proposed in this pull request
- add label included-costs in pagopa payment
- add label included-costs in f24 payment

## How to test
Login as cristoforocolombo and check label is present. Use [these notifications](https://pagopa.atlassian.net/wiki/spaces/PN/pages/1630208256/Esiste+un+utenza+che..) for `dev` 