### PR TITLE
fix(PN-14877): add RETURNED_TO_SENDER status on statistics page and rename some types

### DIFF
--- a/packages/pn-pa-webapp/public/locales/it/statistics.json
+++ b/packages/pn-pa-webapp/public/locales/it/statistics.json
@@ -45,7 +45,8 @@
     "viewed": "Avvenuto accesso",
     "effective_date": "Perfezionata per\ndecorrenza termini",
     "canceled": "Annullata",
-    "unreachable": "Destinatario\nirreperibile"
+    "unreachable": "Destinatario\nirreperibile",
+    "returned_to_sender": "Resa al mittente"
   },
   "delivery_mode": {
     "title": "Notifiche consegnate per modalità di invio",

--- a/packages/pn-pa-webapp/src/__mocks__/Statistics.mock.ts
+++ b/packages/pn-pa-webapp/src/__mocks__/Statistics.mock.ts
@@ -1,15 +1,14 @@
-import { oneMonthAgo, threeMonthsAgo, today } from '@pagopa-pn/pn-commons';
+import { NotificationStatus, oneMonthAgo, threeMonthsAgo, today } from '@pagopa-pn/pn-commons';
 
 import {
-  DeliveryMode,
   DigitaErrorTypes,
-  NotificationStatus,
-  ResponseStatus,
   SelectedStatisticsFilter,
   StatisticsDataTypes,
+  StatisticsDeliveryMode,
   StatisticsFilter,
   StatisticsParsedResponse,
   StatisticsResponse,
+  StatisticsResponseStatus,
 } from '../models/Statistics';
 
 const baseDate = threeMonthsAgo.toISOString();
@@ -26,8 +25,8 @@ export const rawResponseMock: StatisticsResponse = {
       notification_send_date: `${dateYearMonth}-15`,
       notification_request_status: NotificationStatus.ACCEPTED,
       notification_status: NotificationStatus.DELIVERED,
-      notification_type: DeliveryMode.ANALOG,
-      status_digital_delivery: ResponseStatus.UNKNOWN,
+      notification_type: StatisticsDeliveryMode.ANALOG,
+      status_digital_delivery: StatisticsResponseStatus.UNKNOWN,
       notification_delivered: 'SI',
       notification_viewed: 'NO',
       notification_refined: 'NO',
@@ -42,8 +41,8 @@ export const rawResponseMock: StatisticsResponse = {
       notification_send_date: `${dateYearMonth}-15`,
       notification_request_status: NotificationStatus.ACCEPTED,
       notification_status: NotificationStatus.DELIVERED,
-      notification_type: DeliveryMode.ANALOG,
-      status_digital_delivery: ResponseStatus.UNKNOWN,
+      notification_type: StatisticsDeliveryMode.ANALOG,
+      status_digital_delivery: StatisticsResponseStatus.UNKNOWN,
       notification_delivered: 'NO',
       notification_viewed: 'NO',
       notification_refined: 'NO',
@@ -58,8 +57,8 @@ export const rawResponseMock: StatisticsResponse = {
       notification_send_date: `${dateYearMonth}-15`,
       notification_request_status: NotificationStatus.ACCEPTED,
       notification_status: NotificationStatus.DELIVERING,
-      notification_type: DeliveryMode.ANALOG,
-      status_digital_delivery: ResponseStatus.UNKNOWN,
+      notification_type: StatisticsDeliveryMode.ANALOG,
+      status_digital_delivery: StatisticsResponseStatus.UNKNOWN,
       notification_delivered: 'NO',
       notification_viewed: 'NO',
       notification_refined: 'NO',
@@ -74,8 +73,8 @@ export const rawResponseMock: StatisticsResponse = {
       notification_send_date: `${dateYearMonth}-15`,
       notification_request_status: NotificationStatus.ACCEPTED,
       notification_status: NotificationStatus.EFFECTIVE_DATE,
-      notification_type: DeliveryMode.ANALOG,
-      status_digital_delivery: ResponseStatus.UNKNOWN,
+      notification_type: StatisticsDeliveryMode.ANALOG,
+      status_digital_delivery: StatisticsResponseStatus.UNKNOWN,
       notification_delivered: 'SI',
       notification_viewed: 'NO',
       notification_refined: 'SI',
@@ -90,8 +89,8 @@ export const rawResponseMock: StatisticsResponse = {
       notification_send_date: `${dateYearMonth}-15`,
       notification_request_status: NotificationStatus.ACCEPTED,
       notification_status: NotificationStatus.EFFECTIVE_DATE,
-      notification_type: DeliveryMode.ANALOG,
-      status_digital_delivery: ResponseStatus.UNKNOWN,
+      notification_type: StatisticsDeliveryMode.ANALOG,
+      status_digital_delivery: StatisticsResponseStatus.UNKNOWN,
       notification_delivered: 'NO',
       notification_viewed: 'NO',
       notification_refined: 'SI',
@@ -106,8 +105,8 @@ export const rawResponseMock: StatisticsResponse = {
       notification_send_date: `${dateYearMonth}-15`,
       notification_request_status: NotificationStatus.ACCEPTED,
       notification_status: NotificationStatus.VIEWED,
-      notification_type: DeliveryMode.DIGITAL,
-      status_digital_delivery: ResponseStatus.OK,
+      notification_type: StatisticsDeliveryMode.DIGITAL,
+      status_digital_delivery: StatisticsResponseStatus.OK,
       notification_delivered: 'SI',
       notification_viewed: 'SI',
       notification_refined: 'SI',
@@ -122,8 +121,8 @@ export const rawResponseMock: StatisticsResponse = {
       notification_send_date: `${dateYearMonth}-18`,
       notification_request_status: NotificationStatus.ACCEPTED,
       notification_status: NotificationStatus.DELIVERED,
-      notification_type: DeliveryMode.ANALOG,
-      status_digital_delivery: ResponseStatus.UNKNOWN,
+      notification_type: StatisticsDeliveryMode.ANALOG,
+      status_digital_delivery: StatisticsResponseStatus.UNKNOWN,
       notification_delivered: 'SI',
       notification_viewed: 'NO',
       notification_refined: 'NO',
@@ -138,8 +137,8 @@ export const rawResponseMock: StatisticsResponse = {
       notification_send_date: `${dateYearMonth}-18`,
       notification_request_status: NotificationStatus.ACCEPTED,
       notification_status: NotificationStatus.DELIVERING,
-      notification_type: DeliveryMode.ANALOG,
-      status_digital_delivery: ResponseStatus.UNKNOWN,
+      notification_type: StatisticsDeliveryMode.ANALOG,
+      status_digital_delivery: StatisticsResponseStatus.UNKNOWN,
       notification_delivered: 'NO',
       notification_viewed: 'NO',
       notification_refined: 'NO',
@@ -154,8 +153,8 @@ export const rawResponseMock: StatisticsResponse = {
       notification_send_date: `${dateYearMonth}-18`,
       notification_request_status: NotificationStatus.ACCEPTED,
       notification_status: NotificationStatus.EFFECTIVE_DATE,
-      notification_type: DeliveryMode.ANALOG,
-      status_digital_delivery: ResponseStatus.UNKNOWN,
+      notification_type: StatisticsDeliveryMode.ANALOG,
+      status_digital_delivery: StatisticsResponseStatus.UNKNOWN,
       notification_delivered: 'SI',
       notification_viewed: 'NO',
       notification_refined: 'SI',
@@ -170,8 +169,8 @@ export const rawResponseMock: StatisticsResponse = {
       notification_send_date: `${dateYearMonth}-18`,
       notification_request_status: NotificationStatus.ACCEPTED,
       notification_status: NotificationStatus.EFFECTIVE_DATE,
-      notification_type: DeliveryMode.ANALOG,
-      status_digital_delivery: ResponseStatus.UNKNOWN,
+      notification_type: StatisticsDeliveryMode.ANALOG,
+      status_digital_delivery: StatisticsResponseStatus.UNKNOWN,
       notification_delivered: 'NO',
       notification_viewed: 'NO',
       notification_refined: 'SI',
@@ -186,8 +185,8 @@ export const rawResponseMock: StatisticsResponse = {
       notification_send_date: `${dateYearMonth}-18`,
       notification_request_status: NotificationStatus.ACCEPTED,
       notification_status: NotificationStatus.EFFECTIVE_DATE,
-      notification_type: DeliveryMode.DIGITAL,
-      status_digital_delivery: ResponseStatus.OK,
+      notification_type: StatisticsDeliveryMode.DIGITAL,
+      status_digital_delivery: StatisticsResponseStatus.OK,
       notification_delivered: 'SI',
       notification_viewed: 'NO',
       notification_refined: 'SI',
@@ -258,32 +257,33 @@ export const parsedResponseMock: StatisticsParsedResponse = {
       [NotificationStatus.EFFECTIVE_DATE]: 1484,
       [NotificationStatus.CANCELLED]: 0,
       [NotificationStatus.UNREACHABLE]: 0,
+      [NotificationStatus.RETURNED_TO_SENDER]: 0,
     },
     [StatisticsDataTypes.DeliveryModeStatistics]: {
-      [DeliveryMode.ANALOG]: {
+      [StatisticsDeliveryMode.ANALOG]: {
         count: 1591,
         details: [
           { send_date: `${dateYearMonth}-15`, count: 788 },
           { send_date: `${dateYearMonth}-18`, count: 803 },
         ],
       },
-      [DeliveryMode.DIGITAL]: {
+      [StatisticsDeliveryMode.DIGITAL]: {
         count: 211,
         details: [
           { send_date: `${dateYearMonth}-15`, count: 132 },
           { send_date: `${dateYearMonth}-18`, count: 79 },
         ],
       },
-      [DeliveryMode.UNKNOWN]: {
+      [StatisticsDeliveryMode.UNKNOWN]: {
         count: 0,
         details: [],
       },
     },
     [StatisticsDataTypes.DigitalStateStatistics]: {
-      [ResponseStatus.OK]: 211,
-      [ResponseStatus.KO]: 0,
-      [ResponseStatus.PROGRESS]: 0,
-      [ResponseStatus.UNKNOWN]: 0,
+      [StatisticsResponseStatus.OK]: 211,
+      [StatisticsResponseStatus.KO]: 0,
+      [StatisticsResponseStatus.PROGRESS]: 0,
+      [StatisticsResponseStatus.UNKNOWN]: 0,
     },
     [StatisticsDataTypes.DigitalMeanTimeStatistics]: {
       delivered: { count: 211, time: 45.67 },
@@ -322,26 +322,27 @@ export const parsedEmptyResponseMock: StatisticsParsedResponse = {
       [NotificationStatus.EFFECTIVE_DATE]: 0,
       [NotificationStatus.CANCELLED]: 0,
       [NotificationStatus.UNREACHABLE]: 0,
+      [NotificationStatus.RETURNED_TO_SENDER]: 0,
     },
     [StatisticsDataTypes.DeliveryModeStatistics]: {
-      [DeliveryMode.ANALOG]: {
+      [StatisticsDeliveryMode.ANALOG]: {
         count: 0,
         details: [],
       },
-      [DeliveryMode.DIGITAL]: {
+      [StatisticsDeliveryMode.DIGITAL]: {
         count: 0,
         details: [],
       },
-      [DeliveryMode.UNKNOWN]: {
+      [StatisticsDeliveryMode.UNKNOWN]: {
         count: 0,
         details: [],
       },
     },
     [StatisticsDataTypes.DigitalStateStatistics]: {
-      [ResponseStatus.OK]: 0,
-      [ResponseStatus.KO]: 0,
-      [ResponseStatus.PROGRESS]: 0,
-      [ResponseStatus.UNKNOWN]: 0,
+      [StatisticsResponseStatus.OK]: 0,
+      [StatisticsResponseStatus.KO]: 0,
+      [StatisticsResponseStatus.PROGRESS]: 0,
+      [StatisticsResponseStatus.UNKNOWN]: 0,
     },
     [StatisticsDataTypes.DigitalMeanTimeStatistics]: {
       delivered: { count: 0, time: 0 },
@@ -490,10 +491,10 @@ export const digitalStateDataMock = {
 
 export const digitalStateEmptyDataMock = {
   data: {
-    [ResponseStatus.OK]: 0,
-    [ResponseStatus.KO]: 0,
-    [ResponseStatus.PROGRESS]: 0,
-    [ResponseStatus.UNKNOWN]: 0,
+    [StatisticsResponseStatus.OK]: 0,
+    [StatisticsResponseStatus.KO]: 0,
+    [StatisticsResponseStatus.PROGRESS]: 0,
+    [StatisticsResponseStatus.UNKNOWN]: 0,
   },
 };
 
@@ -514,6 +515,7 @@ export const lastStateEmptyDataMock = {
   [NotificationStatus.EFFECTIVE_DATE]: 0,
   [NotificationStatus.CANCELLED]: 0,
   [NotificationStatus.UNREACHABLE]: 0,
+  [NotificationStatus.RETURNED_TO_SENDER]: 0,
 };
 
 export const trendDataMocked = {

--- a/packages/pn-pa-webapp/src/components/Statistics/DeliveryModeStatistics.tsx
+++ b/packages/pn-pa-webapp/src/components/Statistics/DeliveryModeStatistics.tsx
@@ -5,7 +5,11 @@ import { useTranslation } from 'react-i18next';
 import { Paper, SxProps, Typography } from '@mui/material';
 import { PnEChartsProps } from '@pagopa-pn/pn-data-viz';
 
-import { DeliveryMode, GraphColors, IDeliveryModeStatistics } from '../../models/Statistics';
+import {
+  GraphColors,
+  IDeliveryModeStatistics,
+  StatisticsDeliveryMode,
+} from '../../models/Statistics';
 import AggregateAndTrendStatistics, { AggregateAndTrendData } from './AggregateAndTrendStatistics';
 
 type Props = {
@@ -21,16 +25,16 @@ const DeliveryModeStatistics: React.FC<Props> = ({
   data: statisticsData,
   sx,
 }) => {
-  const digital = statisticsData[DeliveryMode.DIGITAL];
-  const analog = statisticsData[DeliveryMode.ANALOG];
+  const digital = statisticsData[StatisticsDeliveryMode.DIGITAL];
+  const analog = statisticsData[StatisticsDeliveryMode.ANALOG];
 
   const { t } = useTranslation(['statistics']);
 
   const digitalText = t('delivery_mode.digital');
   const analogText = t('delivery_mode.analog');
 
-  const digitalSum = statisticsData[DeliveryMode.DIGITAL].count;
-  const analogSum = statisticsData[DeliveryMode.ANALOG].count;
+  const digitalSum = statisticsData[StatisticsDeliveryMode.DIGITAL].count;
+  const analogSum = statisticsData[StatisticsDeliveryMode.ANALOG].count;
 
   const data: Array<AggregateAndTrendData> = [
     {

--- a/packages/pn-pa-webapp/src/components/Statistics/DigitalStateStatistics.tsx
+++ b/packages/pn-pa-webapp/src/components/Statistics/DigitalStateStatistics.tsx
@@ -6,7 +6,11 @@ import { useTranslation } from 'react-i18next';
 import { Paper, SxProps, Typography } from '@mui/material';
 import { PnECharts, PnEChartsProps } from '@pagopa-pn/pn-data-viz';
 
-import { GraphColors, IDigitalStateStatistics, ResponseStatus } from '../../models/Statistics';
+import {
+  GraphColors,
+  IDigitalStateStatistics,
+  StatisticsResponseStatus,
+} from '../../models/Statistics';
 import EmptyStatistics from './EmptyStatistics';
 
 type Props = {
@@ -34,15 +38,15 @@ const DigitalStateStatistics: React.FC<Props> = (props) => {
 
   const statuses = [
     {
-      value: props.data[ResponseStatus.OK],
+      value: props.data[StatisticsResponseStatus.OK],
       color: GraphColors.blue,
     },
     {
-      value: props.data[ResponseStatus.KO],
+      value: props.data[StatisticsResponseStatus.KO],
       color: GraphColors.azure,
     },
     {
-      value: props.data[ResponseStatus.PROGRESS],
+      value: props.data[StatisticsResponseStatus.PROGRESS],
       color: GraphColors.lightGrey,
     },
   ];

--- a/packages/pn-pa-webapp/src/components/Statistics/FiledNotificationsStatistics.tsx
+++ b/packages/pn-pa-webapp/src/components/Statistics/FiledNotificationsStatistics.tsx
@@ -3,10 +3,10 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Grid, Paper, Typography } from '@mui/material';
-import { useIsMobile } from '@pagopa-pn/pn-commons';
+import { NotificationStatus, useIsMobile } from '@pagopa-pn/pn-commons';
 import { PnEChartsProps } from '@pagopa-pn/pn-data-viz';
 
-import { GraphColors, IFiledStatistics, NotificationStatus } from '../../models/Statistics';
+import { GraphColors, IFiledStatistics } from '../../models/Statistics';
 import AggregateAndTrendStatistics, { AggregateAndTrendData } from './AggregateAndTrendStatistics';
 
 type Props = {

--- a/packages/pn-pa-webapp/src/components/Statistics/LastStateStatistics.tsx
+++ b/packages/pn-pa-webapp/src/components/Statistics/LastStateStatistics.tsx
@@ -4,9 +4,10 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Paper, SxProps, Typography } from '@mui/material';
+import { NotificationStatus } from '@pagopa-pn/pn-commons';
 import { PnECharts, PnEChartsProps } from '@pagopa-pn/pn-data-viz';
 
-import { GraphColors, ILastStateStatistics, NotificationStatus } from '../../models/Statistics';
+import { GraphColors, ILastStateStatistics } from '../../models/Statistics';
 import EmptyStatistics from './EmptyStatistics';
 
 type Props = {
@@ -41,6 +42,10 @@ const LastStateStatistics: React.FC<Props> = (props) => {
     {
       value: props.data[NotificationStatus.UNREACHABLE],
       color: GraphColors.lightRed,
+    },
+    {
+      value: props.data[NotificationStatus.RETURNED_TO_SENDER],
+      color: GraphColors.pink,
     },
   ];
 
@@ -86,6 +91,7 @@ const LastStateStatistics: React.FC<Props> = (props) => {
         t('last_state.effective_date'),
         t('last_state.canceled'),
         t('last_state.unreachable'),
+        t('last_state.returned_to_sender'),
       ],
     },
     yAxis: {

--- a/packages/pn-pa-webapp/src/components/Statistics/__test__/DeliveryModeStatistics.test.tsx
+++ b/packages/pn-pa-webapp/src/components/Statistics/__test__/DeliveryModeStatistics.test.tsx
@@ -2,7 +2,7 @@ import { vi } from 'vitest';
 
 import { deliveryModeDataMock } from '../../../__mocks__/Statistics.mock';
 import { render } from '../../../__test__/test-utils';
-import { DeliveryMode, GraphColors } from '../../../models/Statistics';
+import { GraphColors, StatisticsDeliveryMode } from '../../../models/Statistics';
 import DeliveryModeStatistics from '../DeliveryModeStatistics';
 
 const mockInput = vi.fn();
@@ -65,13 +65,13 @@ describe('DeliveryModeStatistics component tests', () => {
       data: [
         {
           title: 'delivery_mode.digital',
-          total: deliveryModeDataMock.data[DeliveryMode.DIGITAL].count,
-          details: deliveryModeDataMock.data[DeliveryMode.DIGITAL].details,
+          total: deliveryModeDataMock.data[StatisticsDeliveryMode.DIGITAL].count,
+          details: deliveryModeDataMock.data[StatisticsDeliveryMode.DIGITAL].details,
         },
         {
           title: 'delivery_mode.analog',
-          total: deliveryModeDataMock.data[DeliveryMode.ANALOG].count,
-          details: deliveryModeDataMock.data[DeliveryMode.ANALOG].details,
+          total: deliveryModeDataMock.data[StatisticsDeliveryMode.ANALOG].count,
+          details: deliveryModeDataMock.data[StatisticsDeliveryMode.ANALOG].details,
         },
       ],
       options: { color: [GraphColors.blue, GraphColors.turquoise] },

--- a/packages/pn-pa-webapp/src/components/Statistics/__test__/DigitalStateStatistics.test.tsx
+++ b/packages/pn-pa-webapp/src/components/Statistics/__test__/DigitalStateStatistics.test.tsx
@@ -5,7 +5,7 @@ import {
   digitalStateEmptyDataMock,
 } from '../../../__mocks__/Statistics.mock';
 import { render } from '../../../__test__/test-utils';
-import { GraphColors, ResponseStatus } from '../../../models/Statistics';
+import { GraphColors, StatisticsResponseStatus } from '../../../models/Statistics';
 import DigitalStateStatistics from '../DigitalStateStatistics';
 
 const mockInput = vi.fn();
@@ -65,15 +65,15 @@ describe('DigitaStateStatistics component tests', () => {
 
     expect(mockInput).toHaveBeenCalledWith([
       {
-        value: digitalStateDataMock.data[ResponseStatus.OK],
+        value: digitalStateDataMock.data[StatisticsResponseStatus.OK],
         itemStyle: { color: GraphColors.blue },
       },
       {
-        value: digitalStateDataMock.data[ResponseStatus.KO],
+        value: digitalStateDataMock.data[StatisticsResponseStatus.KO],
         itemStyle: { color: GraphColors.azure },
       },
       {
-        value: digitalStateDataMock.data[ResponseStatus.PROGRESS],
+        value: digitalStateDataMock.data[StatisticsResponseStatus.PROGRESS],
         itemStyle: { color: GraphColors.lightGrey },
       },
     ]);

--- a/packages/pn-pa-webapp/src/components/Statistics/__test__/FiledNotificationsStatistics.test.tsx
+++ b/packages/pn-pa-webapp/src/components/Statistics/__test__/FiledNotificationsStatistics.test.tsx
@@ -1,8 +1,10 @@
 import { vi } from 'vitest';
 
+import { NotificationStatus } from '@pagopa-pn/pn-commons';
+
 import { filedNotificationsDataMock } from '../../../__mocks__/Statistics.mock';
 import { render } from '../../../__test__/test-utils';
-import { GraphColors, NotificationStatus } from '../../../models/Statistics';
+import { GraphColors } from '../../../models/Statistics';
 import FiledNotificationsStatistics from '../FiledNotificationsStatistics';
 
 const mockInput = vi.fn();

--- a/packages/pn-pa-webapp/src/components/Statistics/__test__/LastStateStatistics.test.tsx
+++ b/packages/pn-pa-webapp/src/components/Statistics/__test__/LastStateStatistics.test.tsx
@@ -1,8 +1,10 @@
 import { vi } from 'vitest';
 
+import { NotificationStatus } from '@pagopa-pn/pn-commons';
+
 import { lastStateDataMock, lastStateEmptyDataMock } from '../../../__mocks__/Statistics.mock';
 import { render } from '../../../__test__/test-utils';
-import { GraphColors, NotificationStatus } from '../../../models/Statistics';
+import { GraphColors } from '../../../models/Statistics';
 import LastStateStatistics from '../LastStateStatistics';
 
 const mockInput = vi.fn();
@@ -84,6 +86,10 @@ describe('DigitalMeanTimeStatistics component tests', () => {
       {
         value: lastStateDataMock[NotificationStatus.UNREACHABLE],
         itemStyle: { color: GraphColors.lightRed },
+      },
+      {
+        value: lastStateDataMock[NotificationStatus.RETURNED_TO_SENDER],
+        itemStyle: { color: GraphColors.pink },
       },
     ]);
   });

--- a/packages/pn-pa-webapp/src/models/Statistics.ts
+++ b/packages/pn-pa-webapp/src/models/Statistics.ts
@@ -1,16 +1,4 @@
-export enum NotificationStatus {
-  ACCEPTED = 'ACCEPTED',
-  DELIVERING = 'DELIVERING',
-  DELIVERED = 'DELIVERED',
-  VIEWED = 'VIEWED',
-  EFFECTIVE_DATE = 'EFFECTIVE_DATE',
-  UNREACHABLE = 'UNREACHABLE',
-  CANCELLED = 'CANCELLED',
-  REFUSED = 'REFUSED',
-  IN_VALIDATION = 'IN_VALIDATION',
-  PAID = 'PAID',
-  CANCELLATION_IN_PROGRESS = 'CANCELLATION_IN_PROGRESS',
-}
+import { NotificationStatus } from '@pagopa-pn/pn-commons';
 
 export enum GraphColors {
   navy = '#0073E6',
@@ -38,13 +26,13 @@ export enum CxType {
   PG = 'PG',
 }
 
-export enum DeliveryMode { // export from pn-commons/../NotificationDetail.ts???
+export enum StatisticsDeliveryMode {
   DIGITAL = 'DIGITAL',
   ANALOG = 'ANALOGIC',
   UNKNOWN = '-',
 }
 
-export enum ResponseStatus { // EXPORT FROM pn-commons/../NotificationDetail.ts???
+export enum StatisticsResponseStatus {
   OK = 'OK',
   PROGRESS = 'IN_CORSO',
   UNKNOWN = '-',
@@ -73,12 +61,12 @@ export enum StatisticsDataTypes {
 
 export interface NotificationOverview {
   notification_send_date: string;
-  notification_request_status: 'ACCEPTED' | 'REFUSED';
+  notification_request_status: 'ACCEPTED' | 'REFUSED' | '-';
   notification_status: NotificationStatus; // openapi definition does not include the following: IN_VALIDATION, PAID
-  notification_type: DeliveryMode;
-  status_digital_delivery: ResponseStatus;
-  notification_delivered: 'SI' | 'NO';
-  notification_viewed: 'SI' | 'NO';
+  notification_type: StatisticsDeliveryMode;
+  status_digital_delivery: StatisticsResponseStatus;
+  notification_delivered: 'SI' | 'NO' | '-';
+  notification_viewed: 'SI' | 'NO' | '-';
   notification_refined: 'SI' | 'NO';
   attempt_count_per_digital_notification: string | number;
   notifications_count: string | number;
@@ -136,19 +124,20 @@ export interface ILastStateStatistics {
   [NotificationStatus.UNREACHABLE]: number;
   [NotificationStatus.CANCELLED]: number;
   [NotificationStatus.REFUSED]: number;
+  [NotificationStatus.RETURNED_TO_SENDER]: number;
 }
 
 export interface IDeliveryModeStatistics {
-  [DeliveryMode.ANALOG]: IStatisticsTrendData;
-  [DeliveryMode.DIGITAL]: IStatisticsTrendData;
-  [DeliveryMode.UNKNOWN]: IStatisticsTrendData;
+  [StatisticsDeliveryMode.ANALOG]: IStatisticsTrendData;
+  [StatisticsDeliveryMode.DIGITAL]: IStatisticsTrendData;
+  [StatisticsDeliveryMode.UNKNOWN]: IStatisticsTrendData;
 }
 
 export interface IDigitalStateStatistics {
-  [ResponseStatus.OK]: number;
-  [ResponseStatus.KO]: number;
-  [ResponseStatus.PROGRESS]: number;
-  [ResponseStatus.UNKNOWN]: number;
+  [StatisticsResponseStatus.OK]: number;
+  [StatisticsResponseStatus.KO]: number;
+  [StatisticsResponseStatus.PROGRESS]: number;
+  [StatisticsResponseStatus.UNKNOWN]: number;
 }
 
 interface IProcessTimeStatistics {

--- a/packages/pn-pa-webapp/src/redux/statistics/reducers.ts
+++ b/packages/pn-pa-webapp/src/redux/statistics/reducers.ts
@@ -1,9 +1,8 @@
 /* eslint-disable functional/immutable-data */
-import { today, twelveMonthsAgo } from '@pagopa-pn/pn-commons';
+import { NotificationStatus, today, twelveMonthsAgo } from '@pagopa-pn/pn-commons';
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
 import {
-  NotificationStatus,
   SelectedStatisticsFilter,
   StatisticsDataTypes,
   StatisticsFilter,

--- a/packages/pn-pa-webapp/src/utility/StatisticsData/DeliveryModeStatisticsData.ts
+++ b/packages/pn-pa-webapp/src/utility/StatisticsData/DeliveryModeStatisticsData.ts
@@ -1,10 +1,10 @@
 /* eslint-disable functional/immutable-data */
 import {
-  DeliveryMode,
   DigitalNotificationFocus,
   IDeliveryModeStatistics,
   NotificationOverview,
   StatisticsDataTypes,
+  StatisticsDeliveryMode,
   StatisticsResponse,
 } from '../../models/Statistics';
 import StatisticsData from './StatisticsData';
@@ -19,15 +19,15 @@ import StatisticsData from './StatisticsData';
  */
 export class DeliveryModeStatisticsData extends StatisticsData {
   data: IDeliveryModeStatistics = {
-    [DeliveryMode.ANALOG]: {
+    [StatisticsDeliveryMode.ANALOG]: {
       count: 0,
       details: [],
     },
-    [DeliveryMode.DIGITAL]: {
+    [StatisticsDeliveryMode.DIGITAL]: {
       count: 0,
       details: [],
     },
-    [DeliveryMode.UNKNOWN]: {
+    [StatisticsDeliveryMode.UNKNOWN]: {
       count: 0,
       details: [],
     },
@@ -68,15 +68,15 @@ export class DeliveryModeStatisticsData extends StatisticsData {
 
   resetData(): void {
     this.data = {
-      [DeliveryMode.ANALOG]: {
+      [StatisticsDeliveryMode.ANALOG]: {
         count: 0,
         details: [],
       },
-      [DeliveryMode.DIGITAL]: {
+      [StatisticsDeliveryMode.DIGITAL]: {
         count: 0,
         details: [],
       },
-      [DeliveryMode.UNKNOWN]: {
+      [StatisticsDeliveryMode.UNKNOWN]: {
         count: 0,
         details: [],
       },

--- a/packages/pn-pa-webapp/src/utility/StatisticsData/DigitalMeanTimeStatisticsData.ts
+++ b/packages/pn-pa-webapp/src/utility/StatisticsData/DigitalMeanTimeStatisticsData.ts
@@ -1,10 +1,10 @@
 /* eslint-disable functional/immutable-data */
 import {
-  DeliveryMode,
   DigitalNotificationFocus,
   IDigitalMeanTimeStatistics,
   NotificationOverview,
   StatisticsDataTypes,
+  StatisticsDeliveryMode,
   StatisticsResponse,
 } from '../../models/Statistics';
 import StatisticsData from './StatisticsData';
@@ -32,7 +32,7 @@ export class DigitalMeanTimeStatisticsData extends StatisticsData {
     const notifications_overview = rawData.notificationsOverview;
 
     const digital_notifications = notifications_overview.filter(
-      (item) => item.notification_type === DeliveryMode.DIGITAL
+      (item) => item.notification_type === StatisticsDeliveryMode.DIGITAL
     );
 
     digital_notifications.forEach((element) => {
@@ -43,7 +43,10 @@ export class DigitalMeanTimeStatisticsData extends StatisticsData {
 
   parseChunk(chunk: NotificationOverview | DigitalNotificationFocus) {
     // parse only if chunk is a NotificationOverview
-    if ('notification_status' in chunk && chunk.notification_type === DeliveryMode.DIGITAL) {
+    if (
+      'notification_status' in chunk &&
+      chunk.notification_type === StatisticsDeliveryMode.DIGITAL
+    ) {
       const count = +chunk.notifications_count;
       if (chunk.notification_delivered === 'SI') {
         this.data.delivered.count += count;

--- a/packages/pn-pa-webapp/src/utility/StatisticsData/DigitalStateStatisticsData.ts
+++ b/packages/pn-pa-webapp/src/utility/StatisticsData/DigitalStateStatisticsData.ts
@@ -1,12 +1,12 @@
 /* eslint-disable functional/immutable-data */
 import {
-  DeliveryMode,
   DigitalNotificationFocus,
   IDigitalStateStatistics,
   NotificationOverview,
-  ResponseStatus,
   StatisticsDataTypes,
+  StatisticsDeliveryMode,
   StatisticsResponse,
+  StatisticsResponseStatus,
 } from '../../models/Statistics';
 import StatisticsData from './StatisticsData';
 
@@ -20,10 +20,10 @@ import StatisticsData from './StatisticsData';
  */
 export class DigitalStateStatisticsData extends StatisticsData {
   data: IDigitalStateStatistics = {
-    [ResponseStatus.OK]: 0,
-    [ResponseStatus.KO]: 0,
-    [ResponseStatus.PROGRESS]: 0,
-    [ResponseStatus.UNKNOWN]: 0,
+    [StatisticsResponseStatus.OK]: 0,
+    [StatisticsResponseStatus.KO]: 0,
+    [StatisticsResponseStatus.PROGRESS]: 0,
+    [StatisticsResponseStatus.UNKNOWN]: 0,
   };
 
   public getName(): StatisticsDataTypes {
@@ -34,7 +34,7 @@ export class DigitalStateStatisticsData extends StatisticsData {
     const notifications_overview = rawData.notificationsOverview;
 
     const digital_notifications = notifications_overview.filter(
-      (item) => item.notification_type === DeliveryMode.DIGITAL
+      (item) => item.notification_type === StatisticsDeliveryMode.DIGITAL
     );
 
     digital_notifications.forEach((element) => {
@@ -45,7 +45,10 @@ export class DigitalStateStatisticsData extends StatisticsData {
 
   parseChunk(chunk: NotificationOverview | DigitalNotificationFocus) {
     // parse only if chunk is a NotificationOverview
-    if ('notification_status' in chunk && chunk.notification_type === DeliveryMode.DIGITAL) {
+    if (
+      'notification_status' in chunk &&
+      chunk.notification_type === StatisticsDeliveryMode.DIGITAL
+    ) {
       const status = chunk.status_digital_delivery;
       const count = +chunk.notifications_count;
 
@@ -55,10 +58,10 @@ export class DigitalStateStatisticsData extends StatisticsData {
 
   resetData(): void {
     this.data = {
-      [ResponseStatus.OK]: 0,
-      [ResponseStatus.KO]: 0,
-      [ResponseStatus.PROGRESS]: 0,
-      [ResponseStatus.UNKNOWN]: 0,
+      [StatisticsResponseStatus.OK]: 0,
+      [StatisticsResponseStatus.KO]: 0,
+      [StatisticsResponseStatus.PROGRESS]: 0,
+      [StatisticsResponseStatus.UNKNOWN]: 0,
     };
   }
 }

--- a/packages/pn-pa-webapp/src/utility/StatisticsData/FiledStatisticsData.ts
+++ b/packages/pn-pa-webapp/src/utility/StatisticsData/FiledStatisticsData.ts
@@ -1,11 +1,12 @@
 /* eslint-disable functional/immutable-data */
 
 /* eslint-disable functional/no-let */
+import { NotificationStatus } from '@pagopa-pn/pn-commons';
+
 import {
   DigitalNotificationFocus,
   IFiledStatistics,
   NotificationOverview,
-  NotificationStatus,
   StatisticsDataTypes,
   StatisticsResponse,
 } from '../../models/Statistics';
@@ -48,6 +49,9 @@ export class FiledStatisticsData extends StatisticsData {
     // parse only if chunk is a NotificationOverview
     if ('notification_status' in chunk) {
       const status = chunk.notification_request_status;
+      if (status === '-') {
+        return;
+      }
       const send_date = chunk.notification_send_date;
       const count = +chunk.notifications_count;
       this.data[status].count += count;

--- a/packages/pn-pa-webapp/src/utility/StatisticsData/LastStateStatisticsData.ts
+++ b/packages/pn-pa-webapp/src/utility/StatisticsData/LastStateStatisticsData.ts
@@ -1,9 +1,10 @@
 /* eslint-disable functional/immutable-data */
+import { NotificationStatus } from '@pagopa-pn/pn-commons';
+
 import {
   DigitalNotificationFocus,
   ILastStateStatistics,
   NotificationOverview,
-  NotificationStatus,
   StatisticsDataTypes,
   StatisticsResponse,
 } from '../../models/Statistics';
@@ -27,6 +28,7 @@ export class LastStateStatisticsData extends StatisticsData {
     [NotificationStatus.EFFECTIVE_DATE]: 0,
     [NotificationStatus.CANCELLED]: 0,
     [NotificationStatus.UNREACHABLE]: 0,
+    [NotificationStatus.RETURNED_TO_SENDER]: 0,
   };
 
   public getName(): StatisticsDataTypes {
@@ -61,6 +63,7 @@ export class LastStateStatisticsData extends StatisticsData {
       [NotificationStatus.EFFECTIVE_DATE]: 0,
       [NotificationStatus.CANCELLED]: 0,
       [NotificationStatus.UNREACHABLE]: 0,
+      [NotificationStatus.RETURNED_TO_SENDER]: 0,
     };
   }
 }


### PR DESCRIPTION
## Short description
Added `RETURNED_TO_SENDER` notification status to the statistics page. Also handled unknown values (`-`) for `notification_request_status`, `notification_delivered`, and `notification_viewed`.  
Additionally, renamed some types by adding a `Statistics` prefix.

## List of changes proposed in this pull request
- Fixed missing notification status and handled unknown values
- Renamed types

## How to test
- Start PA and log in with `grossini` - `Comune di Palermo`
- Use Netify to mock this endpoint: `https://webapi.dev.notifichedigitali.it/bff/v1/sender-dashboard/dashboard-data-request/PA/5b994d4a-0fa8-47ac-9c7b-354f1d44a1ce?startDate=2024-05-08&endDate=2025-05-07` and return the JSON attached to the JIRA bug
- Verify that the page doesn't crash and that `Returned to sender` is shown on the `Notifiche inviate per stato` chart