### PR TITLE
feat(PN-14807): add copy for CAD/ARCAD in timeline

### DIFF
--- a/packages/pn-pa-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/it/notifiche.json
@@ -302,6 +302,8 @@
         "23I": "Ricevuta di consegna",
         "Plico": "Scansione del plico",
         "23L": "Avviso di ricevimento",
+        "CAD": "Il plico della raccomandata che contiene la comunicazione di avvenuto deposito (CAD) è stato dematerializzato.",
+        "ARCAD": "L’avviso di ricevimento della raccomandata che contiene la comunicazione di avvenuto deposito (CAD) è stato dematerializzato.",
         "Indagine": "Scansione dell'indagine",
         "generic": "Documento allegato"
       },

--- a/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
@@ -321,6 +321,8 @@
         "23I": "Ricevuta di consegna",
         "Plico": "Scansione del plico",
         "23L": "Avviso di ricevimento",
+        "CAD": "Il plico della raccomandata che contiene la comunicazione di avvenuto deposito (CAD) è stato dematerializzato.",
+        "ARCAD": "L’avviso di ricevimento della raccomandata che contiene la comunicazione di avvenuto deposito (CAD) è stato dematerializzato.",
         "Indagine": "Scansione dell'indagine",
         "generic": "Documento allegato"
       },

--- a/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
@@ -322,6 +322,8 @@
         "23I": "Ricevuta di consegna",
         "Plico": "Scansione del plico",
         "23L": "Avviso di ricevimento",
+        "CAD": "Il plico della raccomandata che contiene la comunicazione di avvenuto deposito (CAD) è stato dematerializzato.",
+        "ARCAD": "L’avviso di ricevimento della raccomandata che contiene la comunicazione di avvenuto deposito (CAD) è stato dematerializzato.",
         "Indagine": "Scansione dell'indagine",
         "generic": "Documento allegato"
       },


### PR DESCRIPTION
## Short description
This PR includes the changes required for CAD/ARCAD attachment in timeline

## How to test
Environment: DEV
PA: Login as grossini (Sappada) and access notifications having IUN 'TWJP-NWPW-MQTU-202505-L-1' and 'VGHR-VJPD-AGUZ-202505-L-1'. Verify the timeline shows the CAD/ARCAD attachment as expected.
PF: login using the notifications' recipient and search for the same IUN. Verify the timeline.
PG: Create a new mandate and verify the feature works properly for PG too