### PR TITLE
feat(PN-14807) - CAD/ARCAD new copy and fix wrong text alignment for timeline attachments

### DIFF
--- a/packages/pn-commons/src/components/NotificationDetail/NotificationDetailTimelineStep.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationDetailTimelineStep.tsx
@@ -288,11 +288,15 @@ const NotificationDetailTimelineStep = ({
                 s.legalFactsIds.map((lf) => (
                   <ButtonNaked
                     fontSize={14}
-                    color='primary'
+                    color="primary"
                     onClick={() => clickHandler(lf)}
                     disabled={disableDownloads}
                     key={lf.key}
                     data-testid="download-legalfact-micro"
+                    sx={{
+                      justifyContent: 'flex-start',
+                      textAlign: 'left',
+                    }}
                   >
                     {getLegalFactLabel(s, lf.category, lf.key || '')}
                   </ButtonNaked>

--- a/packages/pn-pa-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/it/notifiche.json
@@ -302,8 +302,8 @@
         "23I": "Ricevuta di consegna",
         "Plico": "Scansione del plico",
         "23L": "Avviso di ricevimento",
-        "CAD": "Il plico della raccomandata che contiene la comunicazione di avvenuto deposito (CAD) è stato dematerializzato.",
-        "ARCAD": "L’avviso di ricevimento della raccomandata che contiene la comunicazione di avvenuto deposito (CAD) è stato dematerializzato.",
+        "CAD": "È disponibile la dematerializzazione della raccomandata che contiene la comunicazione di avvenuto deposito",
+        "ARCAD": "È disponibile la dematerializzazione dell'avviso di ricevimento della raccomandata che contiene la comunicazione di avvenuto deposito",
         "Indagine": "Scansione dell'indagine",
         "generic": "Documento allegato"
       },

--- a/packages/pn-pa-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/it/notifiche.json
@@ -302,6 +302,8 @@
         "23I": "Ricevuta di consegna",
         "Plico": "Scansione del plico",
         "23L": "Avviso di ricevimento",
+        "CAD": "Il plico della raccomandata che contiene la comunicazione di avvenuto deposito (CAD) è stato dematerializzato.",
+        "ARCAD": "L’avviso di ricevimento della raccomandata che contiene la comunicazione di avvenuto deposito (CAD) è stato dematerializzato.",
         "Indagine": "Scansione dell'indagine",
         "generic": "Documento allegato"
       },

--- a/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
@@ -321,6 +321,8 @@
         "23I": "Ricevuta di consegna",
         "Plico": "Scansione del plico",
         "23L": "Avviso di ricevimento",
+        "CAD": "Il plico della raccomandata che contiene la comunicazione di avvenuto deposito (CAD) è stato dematerializzato.",
+        "ARCAD": "L’avviso di ricevimento della raccomandata che contiene la comunicazione di avvenuto deposito (CAD) è stato dematerializzato.",
         "Indagine": "Scansione dell'indagine",
         "generic": "Documento allegato"
       },

--- a/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
@@ -322,6 +322,8 @@
         "23I": "Ricevuta di consegna",
         "Plico": "Scansione del plico",
         "23L": "Avviso di ricevimento",
+        "CAD": "Il plico della raccomandata che contiene la comunicazione di avvenuto deposito (CAD) è stato dematerializzato.",
+        "ARCAD": "L’avviso di ricevimento della raccomandata che contiene la comunicazione di avvenuto deposito (CAD) è stato dematerializzato.",
         "Indagine": "Scansione dell'indagine",
         "generic": "Documento allegato"
       },


### PR DESCRIPTION
## Short description
This PR fixes a bug showing the text for the timeline attachments centered if it's too long and goes on a new line.
It also provides an updated text for CAD/ARCAD timeline attachments

## How to test
Environment: DEV
PA: Login as grossini (Sappada) and access notifications having IUN 'TWJP-NWPW-MQTU-202505-L-1' and 'VGHR-VJPD-AGUZ-202505-L-1'. Verify the timeline shows the CAD/ARCAD attachment as expected.
PF: login using the notifications' recipient and search for the same IUN. Verify the timeline.
PG: Create a new mandate and verify the feature works properly for PG too