### PR TITLE
feat(PN-14928): Changes Support page to forward technical data to zendesk-auth

### DIFF
--- a/packages/pn-commons/src/utility/__test__/redux.utility.test.ts
+++ b/packages/pn-commons/src/utility/__test__/redux.utility.test.ts
@@ -6,6 +6,7 @@ describe('parseError', () => {
       response: {
         data: {
           message: 'An error occurred',
+          traceId: 'custom-trace-id',
         },
         status: 404,
         headers: {
@@ -27,7 +28,7 @@ describe('parseError', () => {
     });
   });
 
-  it('should use traceId from data if present', () => {
+  it('should use traceId from data if not present in headers', () => {
     const error = {
       response: {
         data: {
@@ -35,9 +36,6 @@ describe('parseError', () => {
           traceId: 'custom-trace-id',
         },
         status: 400,
-        headers: {
-          'x-amzn-trace-id': '1-67891233-abcdef1234567890abcdef',
-        },
       },
     };
 

--- a/packages/pn-commons/src/utility/__test__/support.utility.test.ts
+++ b/packages/pn-commons/src/utility/__test__/support.utility.test.ts
@@ -1,0 +1,22 @@
+import { extractRootTraceId } from '../support.utility';
+
+describe('support utility', () => {
+  describe('extractRootTraceId test', () => {
+    it('should return undefined if has no Root element', () => {
+      expect(extractRootTraceId(undefined)).toBeUndefined();
+      expect(extractRootTraceId(null)).toBeUndefined();
+      expect(extractRootTraceId('')).toBeUndefined();
+      expect(extractRootTraceId('Key1=val1;Key2=val2')).toBeUndefined();
+    });
+
+    it('should extract Root value', () => {
+      expect(extractRootTraceId('Root=atTheBeginning;Key2=val2')).toBe('atTheBeginning');
+      expect(extractRootTraceId('Key1=val1;Root=inTheMiddle;Key3=val3')).toBe('inTheMiddle');
+      expect(extractRootTraceId('Key1=val1;Key2=val2;Root=atTheEnd')).toBe('atTheEnd');
+    });
+
+    it('should not match similar keys', () => {
+      expect(extractRootTraceId('Key1=val1;NonRoot=Root;Rooty=123;Key2=val2')).toBeUndefined();
+    });
+  });
+});

--- a/packages/pn-commons/src/utility/index.ts
+++ b/packages/pn-commons/src/utility/index.ts
@@ -66,6 +66,7 @@ import { searchStringLimitReachedText, useSearchStringChangeInput } from './sear
 import { storageOpsBuilder } from './storage.utility';
 import { dataRegex, formatFiscalCode, fromStringToBase64, sanitizeString } from './string.utility';
 import { buttonNakedInheritStyle } from './styles.utility';
+import { extractRootTraceId } from './support.utility';
 import {
   adaptedTokenExchangeError,
   basicInitialUserData,
@@ -159,4 +160,5 @@ export {
   IS_DEVELOP,
   APP_VERSION,
   getRapidAccessParam,
+  extractRootTraceId,
 };

--- a/packages/pn-commons/src/utility/redux.utility.ts
+++ b/packages/pn-commons/src/utility/redux.utility.ts
@@ -2,28 +2,15 @@
 This function removes from error object all those informations that are not used by the application.
 This is needed because redux, when recives an action, does a serializability check and, if the obeject is not serializable, it launchs a warning 
 */
-function extractRootTraceId(input: string | undefined | null): string | undefined {
-  if (!input) {
-    return undefined;
-  }
-
-  // Match "Root=..." and only return its value
-  const match = input.match(/(?:^|;)Root=([^;]+)/);
-  return match?.[1];
-}
-
 export function parseError(e: any) {
   if (e.response) {
     const { data, status, headers } = e.response;
-
-    const headerTraceId = extractRootTraceId(headers?.['x-amzn-trace-id']);
-    const dataTraceId = extractRootTraceId(data?.traceId);
 
     return {
       response: {
         data: {
           ...data,
-          traceId: headerTraceId || dataTraceId || '',
+          traceId: headers?.['x-amzn-trace-id'] || data?.traceId || '',
         },
         status: status || 500,
       },

--- a/packages/pn-commons/src/utility/redux.utility.ts
+++ b/packages/pn-commons/src/utility/redux.utility.ts
@@ -2,14 +2,28 @@
 This function removes from error object all those informations that are not used by the application.
 This is needed because redux, when recives an action, does a serializability check and, if the obeject is not serializable, it launchs a warning 
 */
+function extractRootTraceId(input: string | undefined | null): string | undefined {
+  if (!input) {
+    return undefined;
+  }
+
+  // Match "Root=..." and only return its value
+  const match = input.match(/(?:^|;)Root=([^;]+)/);
+  return match?.[1];
+}
+
 export function parseError(e: any) {
   if (e.response) {
     const { data, status, headers } = e.response;
+
+    const headerTraceId = extractRootTraceId(headers?.['x-amzn-trace-id']);
+    const dataTraceId = extractRootTraceId(data?.traceId);
+
     return {
       response: {
         data: {
           ...data,
-          traceId: data?.traceId || headers?.['x-amzn-trace-id'] || '',
+          traceId: headerTraceId || dataTraceId || '',
         },
         status: status || 500,
       },

--- a/packages/pn-commons/src/utility/support.utility.ts
+++ b/packages/pn-commons/src/utility/support.utility.ts
@@ -1,0 +1,9 @@
+export function extractRootTraceId(input: string | undefined | null): string | undefined {
+  if (!input) {
+    return undefined;
+  }
+
+  // Match "Root=..." and only return its value
+  const match = input.match(/(?:^|;)Root=([^;]+)/);
+  return match?.[1];
+}

--- a/packages/pn-personafisica-webapp/src/api/support/Support.api.ts
+++ b/packages/pn-personafisica-webapp/src/api/support/Support.api.ts
@@ -1,10 +1,10 @@
-import { ZendeskAuthorizationDTO } from '../../models/Support';
+import { ZendeskAuthorizationDTO, ZendeskAuthorizationRequest } from '../../models/Support';
 import { apiClient } from '../apiClients';
 import { ZENDESK_AUTHORIZATION } from './support.routes';
 
 export const SupportApi = {
-  zendeskAuthorization: (params: string): Promise<ZendeskAuthorizationDTO> =>
+  zendeskAuthorization: (params: ZendeskAuthorizationRequest): Promise<ZendeskAuthorizationDTO> =>
     apiClient
-      .post<ZendeskAuthorizationDTO>(ZENDESK_AUTHORIZATION(), { email: params })
+      .post<ZendeskAuthorizationDTO>(ZENDESK_AUTHORIZATION(), params)
       .then((response) => response.data),
 };

--- a/packages/pn-personafisica-webapp/src/api/support/__test__/Support.api.test.ts
+++ b/packages/pn-personafisica-webapp/src/api/support/__test__/Support.api.test.ts
@@ -22,16 +22,36 @@ describe('Support api tests', () => {
     mock.restore();
   });
 
-  it('zendeskAuthorization', async () => {
-    const mail = 'mail@di-prova.it';
+  it('zendeskAuthorization without technical data', async () => {
+    const params = {
+      email: 'mail@di-prova.it',
+    };
     const response = {
       action: 'https://zendesk-url.com',
       jwt: 'zendesk-jwt',
       return_to: 'https://suuport-url.com',
     };
 
-    mock.onPost(ZENDESK_AUTHORIZATION(), { email: mail }).reply(200, response);
-    const res = await SupportApi.zendeskAuthorization(mail);
+    mock.onPost(ZENDESK_AUTHORIZATION(), params).reply(200, response);
+    const res = await SupportApi.zendeskAuthorization(params);
+    expect(res).toStrictEqual(response);
+  });
+
+  it('zendeskAuthorization with technical data', async () => {
+    const params = {
+      email: 'mail@di-prova.it',
+      data: {
+        traceId: 'fake-traceId',
+      },
+    };
+    const response = {
+      action: 'https://zendesk-url.com',
+      jwt: 'zendesk-jwt',
+      return_to: 'https://suuport-url.com',
+    };
+
+    mock.onPost(ZENDESK_AUTHORIZATION(), params).reply(200, response);
+    const res = await SupportApi.zendeskAuthorization(params);
     expect(res).toStrictEqual(response);
   });
 });

--- a/packages/pn-personafisica-webapp/src/models/Support.ts
+++ b/packages/pn-personafisica-webapp/src/models/Support.ts
@@ -8,3 +8,10 @@ export interface ZendeskAuthorizationDTO {
   jwt: string;
   return_to: string;
 }
+
+export interface ZendeskAuthorizationRequest {
+  email: string;
+  data?: {
+    traceId: string;
+  };
+}

--- a/packages/pn-personafisica-webapp/src/pages/Support.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/Support.page.tsx
@@ -1,6 +1,6 @@
 import { useReducer, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { Box, Button, Paper, Stack, TextField, Typography } from '@mui/material';
 import { Prompt, TitleBox } from '@pagopa-pn/pn-commons';
@@ -74,6 +74,9 @@ const SupportPPButton: React.FC<{ children?: React.ReactNode }> = ({ children })
 
 const SupportPage: React.FC = () => {
   const { t } = useTranslation(['support', 'common']);
+  const [params] = useSearchParams();
+  const rawData = params.get('data');
+  const data = rawData !== null ? JSON.parse(decodeURIComponent(rawData)) : null;
   const [formData, formDispatch] = useReducer(reducer, {
     email: {
       value: '',
@@ -106,7 +109,11 @@ const SupportPage: React.FC = () => {
 
   const handleConfirm = () => {
     if (!formData.errors) {
-      dispatch(zendeskAuthorization(formData.email.value))
+      dispatch(
+        zendeskAuthorization(
+          data ? { email: formData.email.value, data } : { email: formData.email.value }
+        )
+      )
         .unwrap()
         .then((response) => {
           setZendeskAuthData(response);

--- a/packages/pn-personafisica-webapp/src/redux/support/actions.ts
+++ b/packages/pn-personafisica-webapp/src/redux/support/actions.ts
@@ -2,15 +2,15 @@ import { parseError } from '@pagopa-pn/pn-commons';
 import { createAsyncThunk } from '@reduxjs/toolkit';
 
 import { SupportApi } from '../../api/support/Support.api';
-import { ZendeskAuthorizationDTO } from '../../models/Support';
+import { ZendeskAuthorizationDTO, ZendeskAuthorizationRequest } from '../../models/Support';
 
-export const zendeskAuthorization = createAsyncThunk<ZendeskAuthorizationDTO, string>(
-  'zendeskAuthorization',
-  async (params, { rejectWithValue }) => {
-    try {
-      return await SupportApi.zendeskAuthorization(params);
-    } catch (e: any) {
-      return rejectWithValue(parseError(e));
-    }
+export const zendeskAuthorization = createAsyncThunk<
+  ZendeskAuthorizationDTO,
+  ZendeskAuthorizationRequest
+>('zendeskAuthorization', async (params, { rejectWithValue }) => {
+  try {
+    return await SupportApi.zendeskAuthorization(params);
+  } catch (e: any) {
+    return rejectWithValue(parseError(e));
   }
-);
+});


### PR DESCRIPTION
## Short description
This PR includes some changes needed to manage the incoming data param in the form of a json object, forwarding it to zendesk-auth lamdba.

## List of changes proposed in this pull request
- change the strategy to choose the traceId in parseError method
- add extractRootTraceId helper function to extract the traceId of the Root element
- change the zendesk-auth api call to send the data object in addition to the email when available
- change the Support.page to receive the new data query param, forwarding it inside the body request made to zendesk-auth
- test: change tests

## How to test
For PF only, call the assistance page adding the following query string containing the data param:
?data=%7B%22traceId%22%3A%221-68307663-7659cbbe32741178290d23fb%22%2C%22errorCode%22%3A%22PN_DELIVERY_NOTIFICATIONWITHOUTPAYMENTATTACHMENT%22%7D
then fill the email field and send the request. Verify the request body contains both email and data params as expected

Verify that the default behaviour still works: call the assistance url without the data param (only the base url), fill in the form and send the request and verify the email param is properly sent.