### PR TITLE
fix(pn-15230): move DeliveryMandateNotFoundAppError translation to 'common' ns

### DIFF
--- a/packages/pn-personafisica-webapp/public/locales/it/common.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/common.json
@@ -148,6 +148,10 @@
     "invalid-characters-not-inserted": "I caratteri non validi non sono stati inseriti."
   },
   "errors": {
+    "delivery_mandate_not_found": {
+      "title": "Errore",
+      "message": "Questa delega non è più attiva."
+    },
     "technical-error": {
       "title": "Informazioni errore",
       "copy-to-clipboard": "Copia informazioni errore"

--- a/packages/pn-personafisica-webapp/public/locales/it/deleghe.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/deleghe.json
@@ -107,10 +107,6 @@
       "title": "Errore",
       "message": "Delega non trovata"
     },
-    "delivery_mandate_not_found": {
-      "title": "Errore",
-      "message": "Questa delega non è più attiva."
-    },
     "already_exists": {
       "title": "Delega già presente",
       "message": "La persona che hai indicato ha già una delega. Eliminala e creane una nuova."

--- a/packages/pn-personafisica-webapp/src/utility/AppError/DeliveryMandateNotFoundAppError.ts
+++ b/packages/pn-personafisica-webapp/src/utility/AppError/DeliveryMandateNotFoundAppError.ts
@@ -10,8 +10,8 @@ export class DeliveryMandateNotFoundAppError extends AppError {
 
   getMessage() {
     return {
-      title: this.translateFunction('errors.delivery_mandate_not_found.title', 'deleghe'),
-      content: this.translateFunction('errors.delivery_mandate_not_found.message', 'deleghe'),
+      title: this.translateFunction('errors.delivery_mandate_not_found.title', 'common'),
+      content: this.translateFunction('errors.delivery_mandate_not_found.message', 'common'),
     };
   }
 }

--- a/packages/pn-personafisica-webapp/src/utility/AppError/__test__/DeliveryMandateNotFoundAppError.test.ts
+++ b/packages/pn-personafisica-webapp/src/utility/AppError/__test__/DeliveryMandateNotFoundAppError.test.ts
@@ -8,7 +8,7 @@ describe('Test MandateNotFoundAppError', () => {
   it('Should return not found message', () => {
     const appError = new DeliveryMandateNotFoundAppError({} as ServerResponseError, translateFn);
     const message = appError.getMessage();
-    expect(message.title).toBe('errors.delivery_mandate_not_found.title deleghe');
-    expect(message.content).toBe('errors.delivery_mandate_not_found.message deleghe');
+    expect(message.title).toBe('errors.delivery_mandate_not_found.title common');
+    expect(message.content).toBe('errors.delivery_mandate_not_found.message common');
   });
 });


### PR DESCRIPTION
## Short description
This PR moves the error message translation from ns 'deleghe' to 'common' one for DeliveryMandateNotFoundAppError to allow showing the correct copy outside the mandates page, fixing a bug which was causing showing untranslated error trying to access a notification for which the mandate is expired/revoked.

## List of changes proposed in this pull request
- move translation
- change tests

## How to test
Follow the steps described in the Jira task to replicate the error and verify the bug is fixed