### PR TITLE
fix(pn-14941): restored disclaimer on digital domicile

### DIFF
--- a/packages/pn-commons/src/components/CustomDropdown.tsx
+++ b/packages/pn-commons/src/components/CustomDropdown.tsx
@@ -67,6 +67,7 @@ const CustomDropdown: React.FC<Props> = ({
           error={error}
           helperText={helperText}
           disabled={disabled}
+          required={required}
         >
           {!required && (
             <MenuItem key={emptyItemKey} value={emptyItemValue}>

--- a/packages/pn-personafisica-webapp/public/locales/de/recapiti.json
+++ b/packages/pn-personafisica-webapp/public/locales/de/recapiti.json
@@ -97,13 +97,11 @@
     "sercq_send": "Digitales Domizil SEND",
     "link-pec-label": "Deine PEC",
     "link-sercq-label": "Dein digitales Domizil SEND",
-    "contact-to-add": "Adresse",
     "contact-to-add-description": "Verknüpfe eine Adresse mit einer bestimmten Körperschaft, um die Mitteilungen nach Empfänger zu personalisieren.",
     "contact-already-exists": "Die gewählte Körperschaft ist bereits mit dieser Adresse verknüpft. Wenn du „Verknüpfen“ drückst, wird sie durch die hier eingegebene ersetzt.",
     "fetch-party-error": "Wir konnten die Daten, die benötigt werden, um eine neue Adresse zu erstellen, nicht wiederherstellen.",
     "modal-title": "Personalisiere die mit einer Körperschaft verknüpfte Adresse",
     "card-title": "Personalisiert",
-    "sender": "Körperschaft",
     "remove-special-title": "Möchtest du {{contactValue}} entfernen?",
     "remove-special-description": "Die Benachrichtigungen der Zustellungen der verknüpften Körperschaften werden nicht mehr an diese Adresse geschickt, sondern an die Hauptadresse."
   },

--- a/packages/pn-personafisica-webapp/public/locales/en/recapiti.json
+++ b/packages/pn-personafisica-webapp/public/locales/en/recapiti.json
@@ -97,13 +97,11 @@
     "sercq_send": "SEND digital domicile",
     "link-pec-label": "Your PEC",
     "link-sercq-label": "Your SEND Digital Domicile",
-    "contact-to-add": "Address",
     "contact-to-add-description": "Associate an address with a specific institution to customize the communications you receive based on the sender.",
     "contact-already-exists": "The selected institution is already associated with this address. If you press \"Associate\", it will be replaced by the one you indicated here.",
     "fetch-party-error": "We were unable to retrieve the data needed to create a new address.",
     "modal-title": "Customize the address associated with an institution",
     "card-title": "Customized",
-    "sender": "Institution",
     "remove-special-title": "Do you want to delete {{contactValue}}?",
     "remove-special-description": "The notifications related to the notifications of the associated institutions will no longer be sent to this address, but to the main one."
   },

--- a/packages/pn-personafisica-webapp/public/locales/fr/recapiti.json
+++ b/packages/pn-personafisica-webapp/public/locales/fr/recapiti.json
@@ -97,13 +97,11 @@
     "sercq_send": "Domicile Numérique SEND",
     "link-pec-label": "Votre PEC",
     "link-sercq-label": "Votre Domicile Numérique SEND",
-    "contact-to-add": "Adresse",
     "contact-to-add-description": "Associez une adresse à un organisme spécifique pour personnaliser les communications que vous recevez en fonction de l’expéditeur.",
     "contact-already-exists": "L’organisme sélectionné est déjà associé à cette adresse. Si vous appuyez sur « Associer », elle sera remplacée par celle que avez indiquer ici.",
     "fetch-party-error": "Nous n’avons pas pu récupérer les données dont nous avions besoin pour créer une nouvelle adresse.",
     "modal-title": "Personnaliser l’adresse associée à un organisme",
     "card-title": "Personnalisées",
-    "sender": "Organisme",
     "remove-special-title": "Vous souhaitez supprimer {{contactValue}}?",
     "remove-special-description": "Les avis sur les notifications des organismes associés ne seront plus envoyés à cette adresse mais à l’adresse principale."
   },

--- a/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
@@ -30,7 +30,7 @@
   "empty-state": {
     "filtered": "Non abbiamo trovato risultati: prova con dei filtri diversi. <0>Rimuovi filtri</0>.",
     "delegate": "{{name}} non ha ricevuto nessuna notifica.",
-    "no-notifications": "Non hai ricevuto nessuna notifica. <0>Vai ai tuoi recapiti</0> e inserisci uno più recapiti di cortesia: così, se riceverai una notifica, te lo comunicheremo.",
+    "no-notifications": "Non hai ancora ricevuto notifiche. Inserisci un domicilio digitale, uno o più recapiti di cortesia o attiva il servizio <strong>SEND - Notifiche Digitali</strong> sull’app IO nella sezione <strong>I tuoi recapiti</strong>: così, se riceverai una notifica, te lo comunicheremo. <0>Vai ai tuoi recapiti</0>",
     "aria-label-remove-filters": "Rimuovi filtri",
     "aria-label-route-contacts": "Vai ai tuoi recapiti"
   },

--- a/packages/pn-personafisica-webapp/public/locales/it/recapiti.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/recapiti.json
@@ -1,6 +1,6 @@
 {
   "title": "I tuoi recapiti",
-  "subtitle": "Gestisci i recapiti digitali su cui ricevere le comunicazioni a valore legale di SEND.",
+  "subtitle": "Gestisci i recapiti digitali su cui ricevere le comunicazioni a valore legale di SEND e/o i relativi messaggi di cortesia.",
   "insert-code": "Inserisci codice",
   "status": {
     "active": "Attivo",
@@ -15,6 +15,7 @@
       "dod-disabled-message": "Fino al termine del processo non sarà possibile modificare i recapiti a valore legale.",
       "parties-list": "La piattaforma SEND resterà il tuo domicilio digitale per {{list}} fino al completamento della validazione."
     },
+    "pec-disclaimer": "Questo è l'indirizzo principale che verrà utilizzato per inviarti le notifiche in via digitale. Inserendolo, non riceverai più raccomandate cartacee.",
     "pec-description": "Quando un ente ti invia una notifica SEND, ricevi l’avviso a valore legale sulla PEC che hai scelto.",
     "link-pec-placeholder": "La tua PEC",
     "valid-pec": "Indirizzo PEC non valido",
@@ -117,8 +118,8 @@
       "content-title": "Inserisci la tua PEC",
       "content-description": "Quando un ente ti invia una notifica SEND, ricevi l’avviso a valore legale sulla PEC che hai scelto.",
       "input-label": "Indirizzo PEC",
-      "input-placeholder": "La tua PEC",
-      "sercq-info-alert": "La PEC sostituirà la piattaforma SEND come tuo domicilio digitale."
+      "sercq-info-alert": "La PEC sostituirà la piattaforma SEND come tuo domicilio digitale.",
+      "disclaimer": "Compilando il campo e premendo <strong>Conferma</strong> accetti che l’indirizzo PEC che hai scelto sia utilizzato da SEND per l’invio delle notifiche, in via prioritaria rispetto a un eventuale domicilio digitale eletto presso un ente mittente o presente nei pubblici registri."
     },
     "digital-domicile-management": {
       "title": "Gestisci il tuo domicilio digitale",
@@ -204,23 +205,21 @@
     "add-sender": "Ente mittente",
     "pec": "Indirizzo PEC",
     "sercq_send": "Domicilio Digitale SEND",
-    "pec-to-add": "Indirizzo PEC",
-    "link-pec-label": "La tua PEC",
+    "link-pec-label": "Indirizzo PEC",
     "link-sercq-label": "Il tuo Domicilio Digitale SEND",
-    "contact-to-add": "Domicilio Digitale",
     "contact-to-add-description": "Il domicilio digitale personalizzato dove riceverai le notifiche SEND che ti invia un ente specifico",
     "contact-already-exists": "L'ente selezionato è già associato a questo recapito. Se premi “Associa”, verrà sostituito da quello che hai indicato qui.",
     "validating-pec": "Per l’ente selezionato non è possibile associare il domicilio digitale SEND perchè la PEC è in validazione.",
     "fetch-party-error": "Non siamo riusciti a recuperare i dati che servono per poter creare un nuovo recapito.",
     "add-title": "Inserisci l’ente e il recapito da associare",
     "card-title": "PERSONALIZZATI PER ENTE",
-    "sender": "Ente",
     "remove-special-title": "Vuoi eliminare {{contactValue}}?",
     "remove-special-description": "Gli avvisi relativi alle notifiche degli enti associati non saranno più inviati a questo recapito, ma a quello principale.",
     "legal-association-title": "Conferma modifica recapito",
     "legal-association-description": "Hai già selezionato in precedenza un recapito a valore legale per <strong>{{senderName}}</strong>. Confermi che per le notifiche inviate da <strong>{{senderName}}</strong> il tuo recapito a valore legale sarà <strong>{{newAddress}}</strong> invece che <strong>{{oldAddress}}</strong>.",
     "legal-association-title-block": "Recapito già inserito precedentemente",
-    "legal-association-description-block": "Ti comunichiamo che le notifiche inviate da <strong>{{senderName}}</strong> sono già inoltrate al recapito a valore legale <strong>{{oldAddress}}</strong> inserito in precedenza."
+    "legal-association-description-block": "Ti comunichiamo che le notifiche inviate da <strong>{{senderName}}</strong> sono già inoltrate al recapito a valore legale <strong>{{oldAddress}}</strong> inserito in precedenza.",
+    "pec-disclaimer": "Compilando il campo e premendo <strong>Conferma</strong> accetti che l’indirizzo PEC che hai scelto sia utilizzato da SEND per l’invio delle notifiche di questo specifico ente mittente, in via prioritaria rispetto al  domicilio digitale di piattaforma, a un eventuale domicilio digitale eletto presso lo stesso ente mittente o presente nei pubblici registri."
   },
   "common": {
     "duplicate-contact-title": "Recapito già presente",

--- a/packages/pn-personafisica-webapp/public/locales/sl/recapiti.json
+++ b/packages/pn-personafisica-webapp/public/locales/sl/recapiti.json
@@ -97,13 +97,11 @@
     "sercq_send": "Digitalno prebivališče SEND",
     "link-pec-label": "Vaš PEC",
     "link-sercq-label": "Vaše digitalno prebivališče je SEND",
-    "contact-to-add": "Kontaktni podatki",
     "contact-to-add-description": "Povežite naslov z določeno organizacijo, da prilagodite sporočila, ki jih prejmete glede na pošiljatelja.",
     "contact-already-exists": "Izbrana organizacija je že povezana s tem naslovom. Če pritisnete »Poveži«, ga bo nadomestil tisti, ki ste ga pravkar navedli.",
     "fetch-party-error": "Podatkov, potrebnih za ustvarjanje novega kontaktnega podatka, ni bilo mogoče pridobiti.",
     "modal-title": "Prilagodite naslov, povezan z organizacijo",
     "card-title": "Prilagojeno",
-    "sender": "Organizacija",
     "remove-special-title": "Ali želite izbrisati {{contactValue}}?",
     "remove-special-description": "Opozorila v zvezi z obvestili povezanih organizacij se ne bodo več pošiljala na ta naslov, temveč na glavnega."
   },

--- a/packages/pn-personafisica-webapp/src/components/Contacts/AddSpecialContact.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/AddSpecialContact.tsx
@@ -1,9 +1,19 @@
 import { useFormik } from 'formik';
 import { ChangeEvent, forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import * as yup from 'yup';
 
-import { Alert, MenuItem, Paper, TextField, Typography } from '@mui/material';
+import {
+  Alert,
+  Checkbox,
+  FormControl,
+  FormControlLabel,
+  FormHelperText,
+  MenuItem,
+  Paper,
+  TextField,
+  Typography,
+} from '@mui/material';
 import {
   ApiErrorWrapper,
   ConsentActionType,
@@ -195,12 +205,17 @@ const AddSpecialContact = forwardRef<AddSpecialContactRef, Props>(
           is: ChannelType.SERCQ_SEND,
           then: yup.string().nullable(),
         }),
+      s_disclaimer: yup.bool().when('channelType', {
+        is: ChannelType.PEC,
+        then: yup.bool().isTrue(t('required-field')),
+      }),
     });
 
     const initialValues: {
       sender: { id: string; name: string };
       channelType: ChannelType | '';
       s_value: string;
+      s_disclaimer: boolean;
     } = {
       sender: {
         id: '',
@@ -208,6 +223,7 @@ const AddSpecialContact = forwardRef<AddSpecialContactRef, Props>(
       },
       channelType: mandatoryChannelType,
       s_value: '',
+      s_disclaimer: false,
     };
 
     const formik = useFormik({
@@ -465,8 +481,14 @@ const AddSpecialContact = forwardRef<AddSpecialContactRef, Props>(
             {t(`special-contacts.contact-to-add-description`, { ns: 'recapiti' })}
           </Typography>
 
-          <Typography variant="caption-semibold" mb={2} display="block">
-            {t(`special-contacts.sender`, { ns: 'recapiti' })}
+          <Typography
+            variant="body2"
+            mb={2}
+            fontWeight={400}
+            fontSize="14px"
+            color="text.secondary"
+          >
+            {t(`required-fields`)}
           </Typography>
           <ApiErrorWrapper
             apiId={CONTACT_ACTIONS.GET_ALL_ACTIVATED_PARTIES}
@@ -507,48 +529,40 @@ const AddSpecialContact = forwardRef<AddSpecialContactRef, Props>(
                     formik.touched.sender &&
                     (formik.errors.sender?.name || formik.errors.sender?.id)
                   }
+                  required
                 />
               )}
-              sx={{ flexGrow: 1, flexBasis: 0 }}
+              sx={{ flexGrow: 1, flexBasis: 0, mb: 2 }}
             />
           </ApiErrorWrapper>
           {!mandatoryChannelType && (
-            <>
-              <Typography variant="caption-semibold" my={2} display="block">
-                {t(`special-contacts.contact-to-add`, { ns: 'recapiti' })}
-              </Typography>
-              <CustomDropdown
-                id="channelType"
-                name="channelType"
-                value={formik.values.channelType}
-                onChange={addressTypeChangeHandler}
-                size="small"
-                sx={{ flexGrow: 1, flexBasis: 0 }}
-                label={t('special-contacts.select-address', { ns: 'recapiti' })}
-                fullWidth
-                error={formik.touched.channelType && Boolean(formik.errors.channelType)}
-                helperText={formik.touched.channelType && formik.errors.channelType}
-              >
-                {addressTypes.map((a) => (
-                  <MenuItem
-                    id={`dropdown-${a.id}`}
-                    key={a.id}
-                    value={a.id}
-                    sx={{ display: 'flex', flexDirection: 'column', alignItems: 'start' }}
-                  >
-                    {t(`special-contacts.${a.id.toLowerCase()}`, { ns: 'recapiti' })}
-                  </MenuItem>
-                ))}
-              </CustomDropdown>
-            </>
+            <CustomDropdown
+              id="channelType"
+              name="channelType"
+              value={formik.values.channelType}
+              onChange={addressTypeChangeHandler}
+              size="small"
+              sx={{ flexGrow: 1, flexBasis: 0, mb: 2 }}
+              label={t('special-contacts.select-address', { ns: 'recapiti' })}
+              fullWidth
+              error={formik.touched.channelType && Boolean(formik.errors.channelType)}
+              helperText={formik.touched.channelType && formik.errors.channelType}
+              required
+            >
+              {addressTypes.map((a) => (
+                <MenuItem
+                  id={`dropdown-${a.id}`}
+                  key={a.id}
+                  value={a.id}
+                  sx={{ display: 'flex', flexDirection: 'column', alignItems: 'start' }}
+                >
+                  {t(`special-contacts.${a.id.toLowerCase()}`, { ns: 'recapiti' })}
+                </MenuItem>
+              ))}
+            </CustomDropdown>
           )}
           {formik.values.channelType === ChannelType.PEC && (
             <>
-              <Typography variant="caption-semibold" my={2} display="block">
-                {t(`special-contacts.${formik.values.channelType.toLowerCase()}-to-add`, {
-                  ns: 'recapiti',
-                })}
-              </Typography>
               <TextField
                 size="small"
                 fullWidth
@@ -561,7 +575,33 @@ const AddSpecialContact = forwardRef<AddSpecialContactRef, Props>(
                 onChange={handleChangeTouched}
                 error={formik.touched.s_value && Boolean(formik.errors.s_value)}
                 helperText={formik.touched.s_value && formik.errors.s_value}
+                required
               />
+              <FormControl>
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      name="s_disclaimer"
+                      id="s_disclaimer"
+                      required
+                      onChange={handleChangeTouched}
+                      inputProps={{
+                        'aria-describedby': 's_disclaimer-helper-text',
+                        'aria-invalid':
+                          formik.touched.s_disclaimer && Boolean(formik.errors.s_disclaimer),
+                      }}
+                    />
+                  }
+                  label={<Trans ns="recapiti" i18nKey="special-contacts.pec-disclaimer" />}
+                  sx={{ mt: 2 }}
+                  value={formik.values.s_disclaimer}
+                />
+                {formik.touched.s_disclaimer && Boolean(formik.errors.s_disclaimer) && (
+                  <FormHelperText id="s_disclaimer-helper-text" error>
+                    {formik.errors.s_disclaimer}
+                  </FormHelperText>
+                )}
+              </FormControl>
             </>
           )}
         </form>

--- a/packages/pn-personafisica-webapp/src/components/Contacts/LegalContacts.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/LegalContacts.tsx
@@ -7,7 +7,7 @@ import LaptopChromebookIcon from '@mui/icons-material/LaptopChromebook';
 import PowerSettingsNewIcon from '@mui/icons-material/PowerSettingsNew';
 import SavingsIcon from '@mui/icons-material/Savings';
 import TouchAppIcon from '@mui/icons-material/TouchApp';
-import { Box, Button, Chip, ChipOwnProps, Stack, Typography } from '@mui/material';
+import { Alert, Box, Button, Chip, ChipOwnProps, Stack, Typography } from '@mui/material';
 import { PnInfoCard, appStateActions, useIsMobile } from '@pagopa-pn/pn-commons';
 
 import { PFEventsType } from '../../models/PFEventsType';
@@ -211,6 +211,11 @@ const LegalContacts = () => {
         <Typography variant="body1" mt={2} fontSize={{ xs: '14px', lg: '16px' }}>
           {t(`legal-contacts.${channelType.toLowerCase()}-description`, { ns: 'recapiti' })}
         </Typography>
+      )}
+      {(isValidatingPec || hasPecActive) && (
+        <Alert severity="info" sx={{ mt: 2 }}>
+          {t(`legal-contacts.pec-disclaimer`, { ns: 'recapiti' })}
+        </Alert>
       )}
       {showSpecialContactsSection && <SpecialContacts />}
       <DeleteDialog

--- a/packages/pn-personafisica-webapp/src/components/Contacts/PecContactWizard.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/PecContactWizard.tsx
@@ -1,10 +1,18 @@
 import { useFormik } from 'formik';
 import React, { ChangeEvent, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import * as yup from 'yup';
 
-import { Alert, TextField, Typography } from '@mui/material';
+import {
+  Alert,
+  Checkbox,
+  FormControl,
+  FormControlLabel,
+  FormHelperText,
+  TextField,
+  Typography,
+} from '@mui/material';
 import { PnWizard, PnWizardStep } from '@pagopa-pn/pn-commons';
 import { ButtonNaked } from '@pagopa/mui-italia';
 
@@ -47,11 +55,13 @@ const PecContactWizard: React.FC<Props> = ({
 
   const validationSchema = yup.object().shape({
     pec: pecValidationSchema(t),
+    disclaimer: yup.bool().isTrue(t('required-field', { ns: 'common' })),
   });
 
   const formik = useFormik({
     initialValues: {
       pec: '',
+      disclaimer: false,
     },
     validationSchema,
     validateOnMount: true,
@@ -159,7 +169,7 @@ const PecContactWizard: React.FC<Props> = ({
             {t('legal-contacts.pec-contact-wizard.content-title')}
           </Typography>
 
-          <Typography variant="body2" mb={defaultSERCQ_SENDAddress ? { xs: 2, lg: 3 } : 4}>
+          <Typography variant="body2" mb={defaultSERCQ_SENDAddress ? { xs: 2, lg: 3 } : 3}>
             {t('legal-contacts.pec-contact-wizard.content-description')}
           </Typography>
 
@@ -169,14 +179,20 @@ const PecContactWizard: React.FC<Props> = ({
             </Alert>
           )}
 
-          <Typography fontSize="18px" fontWeight={600} mb={2}>
-            {t('legal-contacts.pec-contact-wizard.input-label')}
+          <Typography
+            fontSize="14px"
+            fontWeight={400}
+            mb={2}
+            variant="body2"
+            color="text.secondary"
+          >
+            {t('required-fields', { ns: 'common' })}
           </Typography>
 
           <TextField
             id="pec"
             name="pec"
-            placeholder={t('legal-contacts.pec-contact-wizard.input-placeholder')}
+            label={t('legal-contacts.pec-contact-wizard.input-label')}
             size="small"
             fullWidth
             sx={{ flexBasis: { xs: 'unset', lg: '66.66%' } }}
@@ -185,7 +201,33 @@ const PecContactWizard: React.FC<Props> = ({
             error={formik.touched.pec && Boolean(formik.errors.pec)}
             helperText={formik.touched.pec && formik.errors.pec}
             data-testid="pec-wizard-input"
+            required
           />
+
+          <FormControl>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  name="disclaimer"
+                  id="disclaimer"
+                  required
+                  onChange={handleChangeTouched}
+                  inputProps={{
+                    'aria-describedby': 'disclaimer-helper-text',
+                    'aria-invalid': formik.touched.disclaimer && Boolean(formik.errors.disclaimer),
+                  }}
+                />
+              }
+              label={<Trans ns="recapiti" i18nKey="legal-contacts.pec-contact-wizard.disclaimer" />}
+              sx={{ mt: 2 }}
+              value={formik.values.disclaimer}
+            />
+            {formik.touched.disclaimer && Boolean(formik.errors.disclaimer) && (
+              <FormHelperText id="disclaimer-helper-text" error>
+                {formik.errors.disclaimer}
+              </FormHelperText>
+            )}
+          </FormControl>
         </PnWizardStep>
       </PnWizard>
 

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/AddSpecialContact.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/AddSpecialContact.test.tsx
@@ -97,8 +97,6 @@ describe('test AddSpecialContact', () => {
     expect(title).toBeInTheDocument();
     const description = getByText('special-contacts.contact-to-add-description');
     expect(description).toBeInTheDocument();
-    const senderCaption = getByText('special-contacts.sender');
-    expect(senderCaption).toBeInTheDocument();
     const senderLabel = getById(container, 'sender-label');
     expect(senderLabel).toBeInTheDocument();
     expect(senderLabel).toHaveTextContent('special-contacts.add-sender');
@@ -107,8 +105,6 @@ describe('test AddSpecialContact', () => {
     expect(senderInput).toHaveValue('');
     const senderAutoComplete = getByTestId('sender');
     expect(senderAutoComplete).toBeInTheDocument();
-    const channelTypeCaption = getByText('special-contacts.contact-to-add');
-    expect(channelTypeCaption).toBeInTheDocument();
     const channelTypeLabel = getById(container, 'channelType-label');
     expect(channelTypeLabel).toBeInTheDocument();
     expect(channelTypeLabel).toHaveTextContent('special-contacts.select-address');
@@ -160,7 +156,7 @@ describe('test AddSpecialContact', () => {
     await waitFor(() => {
       expect(input).toHaveValue('invalid value');
     });
-    const errorMessage = getById(result.container, `s_value-helper-text`);
+    let errorMessage = getById(result.container, `s_value-helper-text`);
     expect(errorMessage).toBeInTheDocument();
 
     // fill with valid value
@@ -178,6 +174,19 @@ describe('test AddSpecialContact', () => {
     fireEvent.click(discardButton);
     await waitFor(() => {
       expect(handleContactDiscardMock).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.click(confirmButton);
+
+    const disclaimerCheckbox = result.container.querySelector('[name="s_disclaimer"]');
+
+    // check disclaimer error
+    errorMessage = getById(result.container, `s_disclaimer-helper-text`);
+    expect(errorMessage).toBeInTheDocument();
+
+    fireEvent.click(disclaimerCheckbox!);
+    await waitFor(() => {
+      expect(errorMessage).not.toBeInTheDocument();
     });
 
     fireEvent.click(confirmButton);
@@ -303,6 +312,9 @@ describe('test AddSpecialContact', () => {
       expect(input).toHaveValue('test@test.it');
     });
 
+    const disclaimerCheckbox = container.querySelector('[name="s_disclaimer"]');
+    fireEvent.click(disclaimerCheckbox!);
+
     const confirmButton = getByRole('button', { name: 'conferma' });
 
     fireEvent.click(confirmButton);
@@ -341,7 +353,7 @@ describe('test AddSpecialContact', () => {
   it('should show PEC input if SERCQ is default address', async () => {
     mock.onGet('/bff/v1/pa-list').reply(200, parties);
     // render component
-    const { container, getByTestId, getByText, queryByText } = render(
+    const { container, getByTestId, queryByText } = render(
       <AddSpecialContactWrapper handleSpecialContactAdded={handleContactAddedMock} />,
       {
         preloadedState: { contactsState: { digitalAddresses: digitalAddressesSercq } },
@@ -362,8 +374,6 @@ describe('test AddSpecialContact', () => {
     const channelTypeLabel = queryById(container, 'channelType-label');
     expect(channelTypeLabel).not.toBeInTheDocument();
 
-    const pecCaption = getByText('special-contacts.pec-to-add');
-    expect(pecCaption).toBeInTheDocument();
     const pecLabel = getById(container, 's_value-label');
     expect(pecLabel).toBeInTheDocument();
     expect(pecLabel).toHaveTextContent('special-contacts.link-pec-label');

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/PecContactWizard.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/PecContactWizard.test.tsx
@@ -66,6 +66,28 @@ describe('PecContactWizard', () => {
     });
   });
 
+  it('validates PEC input field and shows an error on disclaimer not accepted', async () => {
+    const { container, getByTestId } = render(
+      <PecContactWizard setShowPecWizard={setShowPecWizardMock} />
+    );
+
+    const pecInput = container.querySelector('[name="pec"]');
+    fireEvent.change(pecInput!, { target: { value: VALID_PEC } });
+
+    await waitFor(() => {
+      expect(pecInput).toHaveValue(VALID_PEC);
+    });
+    const confirmButton = getByTestId('next-button');
+    expect(confirmButton).toBeEnabled();
+    fireEvent.click(confirmButton);
+    const errorMessage = await waitFor(() => container.querySelector(`#disclaimer-helper-text`));
+    expect(errorMessage).toBeInTheDocument();
+    fireEvent.click(confirmButton);
+    await waitFor(() => {
+      expect(mock.history.post).toHaveLength(0);
+    });
+  });
+
   it('should show alert when SERCQ SEND is enabled', async () => {
     const { getByTestId } = render(<PecContactWizard setShowPecWizard={setShowPecWizardMock} />, {
       preloadedState: {
@@ -102,6 +124,9 @@ describe('PecContactWizard', () => {
 
     const pecInput = container.querySelector('[name="pec"]');
     fireEvent.change(pecInput!, { target: { value: VALID_PEC } });
+
+    const disclaimerCheckbox = container.querySelector('[name="disclaimer"]');
+    fireEvent.click(disclaimerCheckbox!);
 
     const nextButton = getByTestId('next-button');
     fireEvent.click(nextButton);
@@ -147,6 +172,9 @@ describe('PecContactWizard', () => {
 
     const pecInput = container.querySelector('[name="pec"]');
     fireEvent.change(pecInput!, { target: { value: VALID_PEC } });
+
+    const disclaimerCheckbox = container.querySelector('[name="disclaimer"]');
+    fireEvent.click(disclaimerCheckbox!);
 
     const nextButton = getByTestId('next-button');
     fireEvent.click(nextButton);

--- a/packages/pn-personagiuridica-webapp/public/locales/it/recapiti.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/it/recapiti.json
@@ -1,6 +1,6 @@
 {
   "title": "Recapiti",
-  "subtitle": "Gestisci i recapiti digitali su cui ricevere le comunicazioni a valore legale di SEND per <0>la tua impresa</0>.",
+  "subtitle": "Gestisci i recapiti digitali su cui ricevere le comunicazioni a valore legale di SEND e/o i relativi messaggi di cortesia per la <0>tua impresa</0>.",
   "insert-code": "Inserisci codice",
   "status": {
     "active": "Attivo",
@@ -15,6 +15,7 @@
       "dod-disabled-message": "Fino al termine del processo non sarà possibile modificare i recapiti a valore legale.",
       "parties-list": "La piattaforma SEND resterà il tuo domicilio digitale per {{list}} fino al completamento della validazione."
     },
+    "pec-disclaimer": "Questo è l'indirizzo principale che verrà utilizzato per inviare le notifiche dell'impresa in digitale. Inserendolo, l'impresa non riceverà più raccomandate cartacee.",
     "pec-description": "Quando un ente invia alla tua impresa una notifica SEND, viene recapitata in modo sicuro e con valore legale sulla PEC che hai scelto.",
     "link-pec-placeholder": "Indirizzo PEC",
     "valid-pec": "Indirizzo PEC non valido",
@@ -105,8 +106,8 @@
       "content-title": "Inserisci la tua PEC",
       "content-description": "Quando un ente invia una notifica su SEND alla tua impresa, ricevi l’avviso a valore legale sulla PEC che hai scelto. ",
       "input-label": "Indirizzo PEC",
-      "input-placeholder": "La tua PEC",
-      "sercq-info-alert": "La PEC aziendale sostituirà la piattaforma SEND come tuo domicilio digitale. "
+      "sercq-info-alert": "La PEC aziendale sostituirà la piattaforma SEND come tuo domicilio digitale. ",
+      "disclaimer": "Compilando il campo e premendo <strong>Conferma</strong> accetti che l’indirizzo PEC che hai scelto sia utilizzato da SEND per l’invio delle notifiche, in via prioritaria rispetto a un eventuale domicilio digitale eletto presso un ente mittente o presente nei pubblici registri."
     },
     "digital-domicile-management": {
       "title": "Gestisci domicilio digitale",
@@ -172,23 +173,21 @@
     "add-sender": "Ente mittente",
     "pec": "Indirizzo PEC",
     "sercq_send": "Domicilio Digitale SEND",
-    "pec-to-add": "Indirizzo PEC",
-    "link-pec-label": "La tua PEC",
+    "link-pec-label": "Indirizzo PEC",
     "link-sercq-label": "Il tuo Domicilio Digitale SEND",
-    "contact-to-add": "Domicilio Digitale",
     "contact-to-add-description": "Il domicilio digitale personalizzato dove riceverai le notifiche SEND per la tua impresa che ti invia un ente specifico.",
     "contact-already-exists": "L'ente selezionato è già associato a questo recapito. Se premi “Associa”, verrà sostituito da quello che hai indicato qui.",
     "validating-pec": "Per l’ente selezionato non è possibile associare il domicilio digitale SEND perchè la PEC è in validazione.",
     "fetch-party-error": "Non siamo riusciti a recuperare i dati che servono per poter creare un nuovo recapito.",
     "add-title": "Inserisci l’ente e il recapito da associare",
     "card-title": "PERSONALIZZATI PER ENTE",
-    "sender": "Ente",
     "remove-special-title": "Vuoi eliminare {{contactValue}}?",
     "remove-special-description": "Gli avvisi relativi alle notifiche degli enti associati non saranno più inviati a questo recapito, ma a quello principale.",
     "legal-association-title": "Conferma modifica recapito",
     "legal-association-description": "Hai già selezionato in precedenza un recapito a valore legale per <strong>{{senderName}}</strong>. Confermi che per le notifiche inviate da <strong>{{senderName}}</strong> il tuo recapito a valore legale sarà <strong>{{newAddress}}</strong> invece che <strong>{{oldAddress}}</strong>.",
     "legal-association-title-block": "Recapito già inserito precedentemente",
-    "legal-association-description-block": "Ti comunichiamo che le notifiche inviate da <strong>{{senderName}}</strong> sono già inoltrate al recapito a valore legale <strong>{{oldAddress}}</strong> inserito in precedenza."
+    "legal-association-description-block": "Ti comunichiamo che le notifiche inviate da <strong>{{senderName}}</strong> sono già inoltrate al recapito a valore legale <strong>{{oldAddress}}</strong> inserito in precedenza.",
+    "pec-disclaimer": "Compilando il campo e premendo <strong>Conferma</strong> accetti che l’indirizzo PEC che hai scelto sia utilizzato da SEND per l’invio delle notifiche di questo specifico ente mittente, in via prioritaria rispetto al  domicilio digitale di piattaforma, a un eventuale domicilio digitale eletto presso lo stesso ente mittente o presente nei pubblici registri."
   },
   "common": {
     "duplicate-contact-title": "Recapito già presente",

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/AddSpecialContact.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/AddSpecialContact.tsx
@@ -1,9 +1,19 @@
 import { useFormik } from 'formik';
 import { ChangeEvent, forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import * as yup from 'yup';
 
-import { Alert, MenuItem, Paper, TextField, Typography } from '@mui/material';
+import {
+  Alert,
+  Checkbox,
+  FormControl,
+  FormControlLabel,
+  FormHelperText,
+  MenuItem,
+  Paper,
+  TextField,
+  Typography,
+} from '@mui/material';
 import {
   ApiErrorWrapper,
   ConsentActionType,
@@ -186,12 +196,17 @@ const AddSpecialContact = forwardRef<AddSpecialContactRef, Props>(
           is: ChannelType.SERCQ_SEND,
           then: yup.string().nullable(),
         }),
+      s_disclaimer: yup.bool().when('channelType', {
+        is: ChannelType.PEC,
+        then: yup.bool().isTrue(t('required-field')),
+      }),
     });
 
     const initialValues: {
       sender: { id: string; name: string };
       channelType: ChannelType | '';
       s_value: string;
+      s_disclaimer: boolean;
     } = {
       sender: {
         id: '',
@@ -199,6 +214,7 @@ const AddSpecialContact = forwardRef<AddSpecialContactRef, Props>(
       },
       channelType: mandatoryChannelType,
       s_value: '',
+      s_disclaimer: false,
     };
 
     const formik = useFormik({
@@ -424,9 +440,16 @@ const AddSpecialContact = forwardRef<AddSpecialContactRef, Props>(
             {t(`special-contacts.contact-to-add-description`, { ns: 'recapiti' })}
           </Typography>
 
-          <Typography variant="caption-semibold" mb={2} display="block">
-            {t(`special-contacts.sender`, { ns: 'recapiti' })}
+          <Typography
+            variant="body2"
+            mb={2}
+            fontWeight={400}
+            fontSize="14px"
+            color="text.secondary"
+          >
+            {t(`required-fields`)}
           </Typography>
+
           <ApiErrorWrapper
             apiId={CONTACT_ACTIONS.GET_ALL_ACTIVATED_PARTIES}
             mainText={t('special-contacts.fetch-party-error', { ns: 'recapiti' })}
@@ -466,48 +489,40 @@ const AddSpecialContact = forwardRef<AddSpecialContactRef, Props>(
                     formik.touched.sender &&
                     (formik.errors.sender?.name || formik.errors.sender?.id)
                   }
+                  required
                 />
               )}
-              sx={{ flexGrow: 1, flexBasis: 0 }}
+              sx={{ flexGrow: 1, flexBasis: 0, mb: 2 }}
             />
           </ApiErrorWrapper>
           {!mandatoryChannelType && (
-            <>
-              <Typography variant="caption-semibold" my={2} display="block">
-                {t(`special-contacts.contact-to-add`, { ns: 'recapiti' })}
-              </Typography>
-              <CustomDropdown
-                id="channelType"
-                name="channelType"
-                value={formik.values.channelType}
-                onChange={addressTypeChangeHandler}
-                size="small"
-                sx={{ flexGrow: 1, flexBasis: 0 }}
-                label={t('special-contacts.select-address', { ns: 'recapiti' })}
-                fullWidth
-                error={formik.touched.channelType && Boolean(formik.errors.channelType)}
-                helperText={formik.touched.channelType && formik.errors.channelType}
-              >
-                {addressTypes.map((a) => (
-                  <MenuItem
-                    id={`dropdown-${a.id}`}
-                    key={a.id}
-                    value={a.id}
-                    sx={{ display: 'flex', flexDirection: 'column', alignItems: 'start' }}
-                  >
-                    {t(`special-contacts.${a.id.toLowerCase()}`, { ns: 'recapiti' })}
-                  </MenuItem>
-                ))}
-              </CustomDropdown>
-            </>
+            <CustomDropdown
+              id="channelType"
+              name="channelType"
+              value={formik.values.channelType}
+              onChange={addressTypeChangeHandler}
+              size="small"
+              sx={{ flexGrow: 1, flexBasis: 0, mb: 2 }}
+              label={t('special-contacts.select-address', { ns: 'recapiti' })}
+              fullWidth
+              error={formik.touched.channelType && Boolean(formik.errors.channelType)}
+              helperText={formik.touched.channelType && formik.errors.channelType}
+              required
+            >
+              {addressTypes.map((a) => (
+                <MenuItem
+                  id={`dropdown-${a.id}`}
+                  key={a.id}
+                  value={a.id}
+                  sx={{ display: 'flex', flexDirection: 'column', alignItems: 'start' }}
+                >
+                  {t(`special-contacts.${a.id.toLowerCase()}`, { ns: 'recapiti' })}
+                </MenuItem>
+              ))}
+            </CustomDropdown>
           )}
           {formik.values.channelType === ChannelType.PEC && (
             <>
-              <Typography variant="caption-semibold" my={2} display="block">
-                {t(`special-contacts.${formik.values.channelType.toLowerCase()}-to-add`, {
-                  ns: 'recapiti',
-                })}
-              </Typography>
               <TextField
                 size="small"
                 fullWidth
@@ -520,7 +535,33 @@ const AddSpecialContact = forwardRef<AddSpecialContactRef, Props>(
                 onChange={handleChangeTouched}
                 error={formik.touched.s_value && Boolean(formik.errors.s_value)}
                 helperText={formik.touched.s_value && formik.errors.s_value}
+                required
               />
+              <FormControl>
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      name="s_disclaimer"
+                      id="s_disclaimer"
+                      required
+                      onChange={handleChangeTouched}
+                      inputProps={{
+                        'aria-describedby': 's_disclaimer-helper-text',
+                        'aria-invalid':
+                          formik.touched.s_disclaimer && Boolean(formik.errors.s_disclaimer),
+                      }}
+                    />
+                  }
+                  label={<Trans ns="recapiti" i18nKey="special-contacts.pec-disclaimer" />}
+                  sx={{ mt: 2 }}
+                  value={formik.values.s_disclaimer}
+                />
+                {formik.touched.s_disclaimer && Boolean(formik.errors.s_disclaimer) && (
+                  <FormHelperText id="s_disclaimer-helper-text" error>
+                    {formik.errors.s_disclaimer}
+                  </FormHelperText>
+                )}
+              </FormControl>
             </>
           )}
         </form>

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/LegalContacts.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/LegalContacts.tsx
@@ -7,7 +7,7 @@ import LaptopChromebookIcon from '@mui/icons-material/LaptopChromebook';
 import PowerSettingsNewIcon from '@mui/icons-material/PowerSettingsNew';
 import SavingsIcon from '@mui/icons-material/Savings';
 import TouchAppIcon from '@mui/icons-material/TouchApp';
-import { Box, Button, Chip, ChipOwnProps, Stack, Typography } from '@mui/material';
+import { Alert, Box, Button, Chip, ChipOwnProps, Stack, Typography } from '@mui/material';
 import { PnInfoCard, appStateActions, useIsMobile } from '@pagopa-pn/pn-commons';
 
 import { AddressType, ChannelType } from '../../models/contacts';
@@ -206,6 +206,11 @@ const LegalContacts = () => {
         <Typography variant="body1" mt={2} fontSize={{ xs: '14px', lg: '16px' }}>
           {t(`legal-contacts.${channelType.toLowerCase()}-description`, { ns: 'recapiti' })}
         </Typography>
+      )}
+      {(isValidatingPec || hasPecActive) && (
+        <Alert severity="info" sx={{ mt: 2 }}>
+          {t(`legal-contacts.pec-disclaimer`, { ns: 'recapiti' })}
+        </Alert>
       )}
       {showSpecialContactsSection && <SpecialContacts />}
       <DeleteDialog

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/PecContactWizard.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/PecContactWizard.tsx
@@ -1,10 +1,18 @@
 import { useFormik } from 'formik';
 import React, { ChangeEvent, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import * as yup from 'yup';
 
-import { Alert, TextField, Typography } from '@mui/material';
+import {
+  Alert,
+  Checkbox,
+  FormControl,
+  FormControlLabel,
+  FormHelperText,
+  TextField,
+  Typography,
+} from '@mui/material';
 import { PnWizard, PnWizardStep } from '@pagopa-pn/pn-commons';
 import { ButtonNaked } from '@pagopa/mui-italia';
 
@@ -38,11 +46,13 @@ const PecContactWizard: React.FC<Props> = ({
 
   const validationSchema = yup.object().shape({
     pec: pecValidationSchema(t),
+    disclaimer: yup.bool().isTrue(t('required-field', { ns: 'common' })),
   });
 
   const formik = useFormik({
     initialValues: {
       pec: '',
+      disclaimer: false,
     },
     validationSchema,
     validateOnMount: true,
@@ -135,24 +145,30 @@ const PecContactWizard: React.FC<Props> = ({
             {t('legal-contacts.pec-contact-wizard.content-title')}
           </Typography>
 
-          <Typography variant="body2" mb={defaultSERCQ_SENDAddress ? { xs: 2, lg: 3 } : 4}>
+          <Typography variant="body2" mb={defaultSERCQ_SENDAddress ? { xs: 2, lg: 3 } : 3}>
             {t('legal-contacts.pec-contact-wizard.content-description')}
           </Typography>
 
           {defaultSERCQ_SENDAddress && (
-            <Alert severity="info" sx={{ mb: 4 }} data-testid="sercq-info-alert">
+            <Alert severity="info" sx={{ mb: 3 }} data-testid="sercq-info-alert">
               {t('legal-contacts.pec-contact-wizard.sercq-info-alert')}
             </Alert>
           )}
 
-          <Typography fontSize="18px" fontWeight={600} mb={2}>
-            {t('legal-contacts.pec-contact-wizard.input-label')}
+          <Typography
+            fontSize="14px"
+            fontWeight={400}
+            mb={2}
+            variant="body2"
+            color="text.secondary"
+          >
+            {t('required-fields', { ns: 'common' })}
           </Typography>
 
           <TextField
             id="pec"
             name="pec"
-            placeholder={t('legal-contacts.pec-contact-wizard.input-placeholder')}
+            label={t('legal-contacts.pec-contact-wizard.input-label')}
             size="small"
             fullWidth
             sx={{ flexBasis: { xs: 'unset', lg: '66.66%' } }}
@@ -161,7 +177,33 @@ const PecContactWizard: React.FC<Props> = ({
             error={formik.touched.pec && Boolean(formik.errors.pec)}
             helperText={formik.touched.pec && formik.errors.pec}
             data-testid="pec-wizard-input"
+            required
           />
+
+          <FormControl>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  name="disclaimer"
+                  id="disclaimer"
+                  required
+                  onChange={handleChangeTouched}
+                  inputProps={{
+                    'aria-describedby': 'disclaimer-helper-text',
+                    'aria-invalid': formik.touched.disclaimer && Boolean(formik.errors.disclaimer),
+                  }}
+                />
+              }
+              label={<Trans ns="recapiti" i18nKey="legal-contacts.pec-contact-wizard.disclaimer" />}
+              sx={{ mt: 2 }}
+              value={formik.values.disclaimer}
+            />
+            {formik.touched.disclaimer && Boolean(formik.errors.disclaimer) && (
+              <FormHelperText id="disclaimer-helper-text" error>
+                {formik.errors.disclaimer}
+              </FormHelperText>
+            )}
+          </FormControl>
         </PnWizardStep>
       </PnWizard>
 

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/__test__/AddSpecialContact.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/__test__/AddSpecialContact.test.tsx
@@ -97,8 +97,6 @@ describe('test AddSpecialContact', () => {
     expect(title).toBeInTheDocument();
     const description = getByText('special-contacts.contact-to-add-description');
     expect(description).toBeInTheDocument();
-    const senderCaption = getByText('special-contacts.sender');
-    expect(senderCaption).toBeInTheDocument();
     const senderLabel = getById(container, 'sender-label');
     expect(senderLabel).toBeInTheDocument();
     expect(senderLabel).toHaveTextContent('special-contacts.add-sender');
@@ -107,8 +105,6 @@ describe('test AddSpecialContact', () => {
     expect(senderInput).toHaveValue('');
     const senderAutoComplete = getByTestId('sender');
     expect(senderAutoComplete).toBeInTheDocument();
-    const channelTypeCaption = getByText('special-contacts.contact-to-add');
-    expect(channelTypeCaption).toBeInTheDocument();
     const channelTypeLabel = getById(container, 'channelType-label');
     expect(channelTypeLabel).toBeInTheDocument();
     expect(channelTypeLabel).toHaveTextContent('special-contacts.select-address');
@@ -160,7 +156,7 @@ describe('test AddSpecialContact', () => {
     await waitFor(() => {
       expect(input).toHaveValue('invalid value');
     });
-    const errorMessage = getById(result.container, `s_value-helper-text`);
+    let errorMessage = getById(result.container, `s_value-helper-text`);
     expect(errorMessage).toBeInTheDocument();
 
     // fill with valid value
@@ -178,6 +174,21 @@ describe('test AddSpecialContact', () => {
     fireEvent.click(discardButton);
     await waitFor(() => {
       expect(handleContactDiscardMock).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.click(confirmButton);
+
+    fireEvent.click(confirmButton);
+
+    const disclaimerCheckbox = result.container.querySelector('[name="s_disclaimer"]');
+
+    // check disclaimer error
+    errorMessage = getById(result.container, `s_disclaimer-helper-text`);
+    expect(errorMessage).toBeInTheDocument();
+
+    fireEvent.click(disclaimerCheckbox!);
+    await waitFor(() => {
+      expect(errorMessage).not.toBeInTheDocument();
     });
 
     fireEvent.click(confirmButton);
@@ -303,6 +314,9 @@ describe('test AddSpecialContact', () => {
       expect(input).toHaveValue('test@test.it');
     });
 
+    const disclaimerCheckbox = container.querySelector('[name="s_disclaimer"]');
+    fireEvent.click(disclaimerCheckbox!);
+
     const confirmButton = getByRole('button', { name: 'conferma' });
 
     fireEvent.click(confirmButton);
@@ -341,7 +355,7 @@ describe('test AddSpecialContact', () => {
   it('should show PEC input if SERCQ is default address', async () => {
     mock.onGet('/bff/v1/pa-list').reply(200, parties);
     // render component
-    const { container, getByTestId, getByText, queryByText } = render(
+    const { container, getByTestId, queryByText } = render(
       <AddSpecialContactWrapper handleSpecialContactAdded={handleContactAddedMock} />,
       {
         preloadedState: { contactsState: { digitalAddresses: digitalAddressesSercq } },
@@ -362,8 +376,6 @@ describe('test AddSpecialContact', () => {
     const channelTypeLabel = queryById(container, 'channelType-label');
     expect(channelTypeLabel).not.toBeInTheDocument();
 
-    const pecCaption = getByText('special-contacts.pec-to-add');
-    expect(pecCaption).toBeInTheDocument();
     const pecLabel = getById(container, 's_value-label');
     expect(pecLabel).toBeInTheDocument();
     expect(pecLabel).toHaveTextContent('special-contacts.link-pec-label');

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/__test__/PecContactWizard.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/__test__/PecContactWizard.test.tsx
@@ -66,6 +66,28 @@ describe('PecContactWizard', () => {
     });
   });
 
+  it('validates PEC input field and shows an error on disclaimer not accepted', async () => {
+    const { container, getByTestId } = render(
+      <PecContactWizard setShowPecWizard={setShowPecWizardMock} />
+    );
+
+    const pecInput = container.querySelector('[name="pec"]');
+    fireEvent.change(pecInput!, { target: { value: VALID_PEC } });
+
+    await waitFor(() => {
+      expect(pecInput).toHaveValue(VALID_PEC);
+    });
+    const confirmButton = getByTestId('next-button');
+    expect(confirmButton).toBeEnabled();
+    fireEvent.click(confirmButton);
+    const errorMessage = await waitFor(() => container.querySelector(`#disclaimer-helper-text`));
+    expect(errorMessage).toBeInTheDocument();
+    fireEvent.click(confirmButton);
+    await waitFor(() => {
+      expect(mock.history.post).toHaveLength(0);
+    });
+  });
+
   it('should show alert when SERCQ SEND is enabled', async () => {
     const { getByTestId } = render(<PecContactWizard setShowPecWizard={setShowPecWizardMock} />, {
       preloadedState: {
@@ -102,6 +124,9 @@ describe('PecContactWizard', () => {
 
     const pecInput = container.querySelector('[name="pec"]');
     fireEvent.change(pecInput!, { target: { value: VALID_PEC } });
+
+    const disclaimerCheckbox = container.querySelector('[name="disclaimer"]');
+    fireEvent.click(disclaimerCheckbox!);
 
     const nextButton = getByTestId('next-button');
     fireEvent.click(nextButton);
@@ -147,6 +172,9 @@ describe('PecContactWizard', () => {
 
     const pecInput = container.querySelector('[name="pec"]');
     fireEvent.change(pecInput!, { target: { value: VALID_PEC } });
+
+    const disclaimerCheckbox = container.querySelector('[name="disclaimer"]');
+    fireEvent.click(disclaimerCheckbox!);
 
     const nextButton = getByTestId('next-button');
     fireEvent.click(nextButton);


### PR DESCRIPTION
## Short description
Restored disclaimer for pec.

## List of changes proposed in this pull request
- Added new control during the PEC insertion
- Added new disclaimer in the main section of the domicile contacts
- Updated tests

## How to test
Login with pf -> go to contacts page -> add a PEC as a legal contact and check that the user must to confirm a disclaimer -> after check that a disclaimer is shown in the main section of the domicile contacts
Login with pf -> go to contacts page -> add a PEC as a legal contact linked to a specific sender and check that the user must to confirm a disclaimer
Login with pg -> do the same tests done for the pf