### PR TITLE
rework/PN-15398 - Rework on SERCQ wizard navigation buttons

### DIFF
--- a/packages/pn-commons/src/components/PnWizard/PnWizard.tsx
+++ b/packages/pn-commons/src/components/PnWizard/PnWizard.tsx
@@ -23,7 +23,7 @@ type Props = {
   setActiveStep: (step: number) => void;
   title: ReactNode;
   children: ReactNode;
-  onExit: () => void;
+  onExit?: () => void;
   slots?: {
     nextButton?: JSXElementConstructor<ButtonProps>;
     prevButton?: JSXElementConstructor<ButtonProps>;
@@ -90,6 +90,7 @@ const PnWizard: React.FC<Props> = ({
   };
 
   if (activeStep >= childrens.length && slotsProps?.feedback) {
+    const feedback = slotsProps?.feedback;
     return (
       <Box
         sx={{ minHeight: '350px', height: '100%', display: 'flex' }}
@@ -103,15 +104,15 @@ const PnWizard: React.FC<Props> = ({
             color="text.primary"
             sx={{ margin: '20px 0 10px 0' }}
           >
-            {slotsProps?.feedback?.title}
+            {feedback.title}
           </Typography>
           <Button
             data-testid="wizard-feedback-button"
             variant="contained"
             sx={{ marginTop: '30px' }}
-            onClick={slotsProps?.feedback?.onClick}
+            onClick={feedback.onClick}
           >
-            {slotsProps?.feedback?.buttonText}
+            {feedback.buttonText}
           </Button>
         </Box>
       </Box>
@@ -121,16 +122,17 @@ const PnWizard: React.FC<Props> = ({
   return (
     <Stack display="flex" alignItems="center" justifyContent="center" {...slotsProps?.container}>
       <Box p={3}>
-        <ButtonNaked
-          type="button"
-          size="medium"
-          color="primary"
-          startIcon={<ArrowBackIcon />}
-          onClick={onExit}
-        >
-          {getLocalizedOrDefaultLabel('common', 'button.exit', 'Esci')}
-        </ButtonNaked>
-
+        {onExit && (
+          <ButtonNaked
+            type="button"
+            size="medium"
+            color="primary"
+            startIcon={<ArrowBackIcon />}
+            onClick={onExit}
+          >
+            {getLocalizedOrDefaultLabel('common', 'button.exit', 'Esci')}
+          </ButtonNaked>
+        )}
         <Box sx={{ mt: 2, mb: 3 }} data-testid="wizard-title">
           {title}
         </Box>

--- a/packages/pn-personafisica-webapp/src/components/Contacts/DigitalContactActivation.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/DigitalContactActivation.tsx
@@ -1,9 +1,9 @@
 import React, { useMemo, useState } from 'react';
-import { Trans, useTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 
-import { Button, DialogContentText, Typography } from '@mui/material';
-import { ConfirmationModal, PnWizard, PnWizardStep } from '@pagopa-pn/pn-commons';
+import { Button, Typography } from '@mui/material';
+import { PnWizard, PnWizardStep } from '@pagopa-pn/pn-commons';
 import { ButtonNaked } from '@pagopa/mui-italia';
 
 import IOContactWizard from '../../components/Contacts/IOContactWizard';
@@ -21,17 +21,6 @@ type Props = {
   onGoBack?: () => void;
 };
 
-enum ActiveStep {
-  IO = 'IO',
-  EMAIL = 'EMAIL',
-}
-
-type ModalType = {
-  open: boolean;
-  step?: ActiveStep;
-  exit?: boolean;
-};
-
 const DigitalContactActivation: React.FC<Props> = ({ isTransferring = false, onGoBack }) => {
   const { t } = useTranslation(['recapiti', 'common']);
   const navigate = useNavigate();
@@ -39,7 +28,6 @@ const DigitalContactActivation: React.FC<Props> = ({ isTransferring = false, onG
   const { defaultAPPIOAddress, defaultSMSAddress, defaultEMAILAddress, defaultSERCQ_SENDAddress } =
     useAppSelector(contactsSelectors.selectAddresses);
 
-  const [modal, setModal] = useState<ModalType>({ open: false });
   const [activeStep, setActiveStep] = useState(0);
   const [showPecWizard, setShowPecWizard] = useState(!!defaultSERCQ_SENDAddress || !IS_DOD_ENABLED);
 
@@ -47,52 +35,20 @@ const DigitalContactActivation: React.FC<Props> = ({ isTransferring = false, onG
     () => defaultAPPIOAddress && defaultAPPIOAddress.value === IOAllowedValues.DISABLED,
     []
   );
-  const showEmailStep = useMemo(() => !(defaultSMSAddress || defaultEMAILAddress), []);
 
-  const hasEmailOrSms = defaultEMAILAddress || defaultSMSAddress;
+  const hasEmailOrSms = !!(defaultEMAILAddress || defaultSMSAddress);
 
   const isEmailSmsStep = (activeStep === 1 && !showIOStep) || activeStep === 2;
-
-  const hasCourtesyContact =
-    defaultAPPIOAddress?.value === IOAllowedValues.ENABLED || hasEmailOrSms;
 
   const goToNextStep = () => {
     setActiveStep((step) => step + 1);
   };
 
-  const goToEnd = () => {
-    setActiveStep(3); // set the current step greater than the number of steps to go to the thankyou page
+  const goToPreviousStep = () => {
+    setActiveStep((step) => step - 1);
   };
 
-  const handleConfirmationModalAccept = () => {
-    setModal({ open: false });
-  };
-
-  const handleConfirmationModalDecline = () => {
-    if (modal.exit) {
-      goToEnd();
-    } else {
-      goToNextStep();
-    }
-    setModal({ open: false });
-  };
-
-  const handleSkipOrExitClick = (exit?: boolean) => {
-    if (activeStep === 0) {
-      navigate(-1);
-    } else if (hasCourtesyContact) {
-      goToEnd();
-    } else {
-      showConfirmationModal(exit);
-    }
-  };
-
-  const showConfirmationModal = (exit?: boolean) => {
-    const step = activeStep === 1 && showIOStep ? ActiveStep.IO : ActiveStep.EMAIL;
-    setModal({ open: true, step, exit });
-  };
-
-  const getNextButton = () => {
+  const getPreviousButton = () => {
     if (activeStep === 0) {
       return (
         <ButtonNaked
@@ -104,29 +60,37 @@ const DigitalContactActivation: React.FC<Props> = ({ isTransferring = false, onG
           {t('button.annulla', { ns: 'common' })}
         </ButtonNaked>
       );
-    }
-    if (isEmailSmsStep && hasEmailOrSms) {
+    } else {
       return (
-        <Button variant="contained" onClick={goToNextStep} color="primary" size="medium">
+        <ButtonNaked
+          onClick={goToPreviousStep}
+          color="primary"
+          size="medium"
+          data-testid="prev-button"
+          sx={{ mt: { xs: 2, lg: 0 } }}
+        >
+          {t('button.indietro', { ns: 'common' })}
+        </ButtonNaked>
+      );
+    }
+  };
+
+  const getNextButton = () => {
+    if (isEmailSmsStep) {
+      return (
+        <Button
+          variant="contained"
+          onClick={goToNextStep}
+          color="primary"
+          size="medium"
+          sx={{ width: { xs: '100%', md: 'auto' } }}
+        >
           {t('button.conferma', { ns: 'common' })}
         </Button>
       );
     }
 
-    if (activeStep > 0 && (showIOStep || showEmailStep)) {
-      return (
-        <ButtonNaked
-          onClick={() => handleSkipOrExitClick()}
-          color="primary"
-          size="medium"
-          sx={{ mx: 'auto' }}
-        >
-          {t('button.not-now', { ns: 'common' })}
-        </ButtonNaked>
-      );
-    }
-
-    return null;
+    return <></>;
   };
 
   if (showPecWizard) {
@@ -139,84 +103,43 @@ const DigitalContactActivation: React.FC<Props> = ({ isTransferring = false, onG
     );
   }
   return (
-    <>
-      <PnWizard
-        title={
-          <Typography fontSize="28px" fontWeight={700}>
-            {t(`legal-contacts.sercq-send-wizard.title${isTransferring ? '-transfer' : ''}`)}
-          </Typography>
-        }
-        activeStep={activeStep}
-        setActiveStep={setActiveStep}
-        onExit={() => handleSkipOrExitClick(true)}
-        slots={{
-          nextButton: getNextButton,
-          prevButton: () => <></>,
-        }}
-        slotsProps={{
-          feedback: {
-            title: t(
-              `legal-contacts.sercq-send-wizard.feedback.title-${
-                isTransferring ? 'transfer' : 'activation'
-              }`
-            ),
-            buttonText: t('legal-contacts.sercq-send-wizard.feedback.go-to-contacts'),
-            onClick: () => navigate(RECAPITI),
-          },
-          actions: isEmailSmsStep && hasEmailOrSms ? { justifyContent: 'flex-end' } : {},
-        }}
-      >
-        <PnWizardStep label={t('legal-contacts.sercq-send-wizard.step_1.title')}>
-          <SercqSendContactWizard goToNextStep={goToNextStep} setShowPecWizard={setShowPecWizard} />
+    <PnWizard
+      title={
+        <Typography fontSize="28px" fontWeight={700}>
+          {t(`legal-contacts.sercq-send-wizard.title${isTransferring ? '-transfer' : ''}`)}
+        </Typography>
+      }
+      activeStep={activeStep}
+      setActiveStep={setActiveStep}
+      slots={{
+        prevButton: getPreviousButton,
+        nextButton: getNextButton,
+      }}
+      slotsProps={{
+        feedback: {
+          title: t(
+            `legal-contacts.sercq-send-wizard.feedback.title-${
+              isTransferring ? 'transfer' : 'activation'
+            }`
+          ),
+          buttonText: t('legal-contacts.sercq-send-wizard.feedback.go-to-contacts'),
+          onClick: () => navigate(RECAPITI),
+        },
+        actions: isEmailSmsStep && hasEmailOrSms ? { justifyContent: 'flex-end' } : {},
+      }}
+    >
+      <PnWizardStep label={t('legal-contacts.sercq-send-wizard.step_1.title')}>
+        <SercqSendContactWizard goToNextStep={goToNextStep} setShowPecWizard={setShowPecWizard} />
+      </PnWizardStep>
+      {showIOStep && (
+        <PnWizardStep label={t('legal-contacts.sercq-send-wizard.step_2.title')}>
+          <IOContactWizard goToNextStep={goToNextStep} />
         </PnWizardStep>
-        {showIOStep && (
-          <PnWizardStep label={t('legal-contacts.sercq-send-wizard.step_2.title')}>
-            <IOContactWizard goToNextStep={goToNextStep} />
-          </PnWizardStep>
-        )}
-        {showEmailStep && (
-          <PnWizardStep label={t('legal-contacts.sercq-send-wizard.step_3.step-title')}>
-            <EmailSmsContactWizard />
-          </PnWizardStep>
-        )}
-      </PnWizard>
-      {modal.step && (
-        <ConfirmationModal
-          open={modal.open}
-          title={t('courtesy-contacts.confirmation-modal-title')}
-          slots={{
-            confirmButton: Button,
-            closeButton: Button,
-          }}
-          slotsProps={{
-            closeButton: {
-              onClick: handleConfirmationModalAccept,
-              children: t(
-                `courtesy-contacts.confirmation-modal-${modal.step.toLowerCase()}-accept`
-              ),
-            },
-            confirmButton: {
-              onClick: handleConfirmationModalDecline,
-              children: t('button.do-later', { ns: 'common' }),
-            },
-          }}
-        >
-          <Trans
-            ns="recapiti"
-            i18nKey={`courtesy-contacts.confirmation-modal-${modal.step.toLowerCase()}-content`}
-            components={[
-              <DialogContentText key="paragraph1" id="dialog-description" color="text.primary" />,
-              <DialogContentText
-                key="paragraph2"
-                id="dialog-description"
-                color="text.primary"
-                mt={2}
-              />,
-            ]}
-          />
-        </ConfirmationModal>
       )}
-    </>
+      <PnWizardStep label={t('legal-contacts.sercq-send-wizard.step_3.step-title')}>
+        <EmailSmsContactWizard />
+      </PnWizardStep>
+    </PnWizard>
   );
 };
 

--- a/packages/pn-personafisica-webapp/src/components/Contacts/DigitalContactManagement.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/DigitalContactManagement.tsx
@@ -84,7 +84,6 @@ const DigitalContactManagement: React.FC = () => {
       }
       activeStep={activeStep}
       setActiveStep={setActiveStep}
-      onExit={() => navigate(-1)}
       slots={{
         prevButton: getPreviouButton,
         nextButton:

--- a/packages/pn-personafisica-webapp/src/components/Contacts/PecContactWizard.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/PecContactWizard.tsx
@@ -130,7 +130,6 @@ const PecContactWizard: React.FC<Props> = ({
         }
         activeStep={activeStep}
         setActiveStep={setActiveStep}
-        onExit={() => navigate(-1)}
         slots={{
           prevButton: () => (
             <ButtonNaked

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/DigitalContactActivation.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/DigitalContactActivation.tsx
@@ -1,9 +1,9 @@
-import React, { useMemo, useState } from 'react';
-import { Trans, useTranslation } from 'react-i18next';
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 
-import { Button, DialogContentText, Typography } from '@mui/material';
-import { ConfirmationModal, PnWizard, PnWizardStep } from '@pagopa-pn/pn-commons';
+import { Button, Typography } from '@mui/material';
+import { PnWizard, PnWizardStep } from '@pagopa-pn/pn-commons';
 import { ButtonNaked } from '@pagopa/mui-italia';
 
 import PecContactWizard from '../../components/Contacts/PecContactWizard';
@@ -19,10 +19,6 @@ type Props = {
   onGoBack?: () => void;
 };
 
-type ModalType = {
-  open: boolean;
-};
-
 const DigitalContactActivation: React.FC<Props> = ({ isTransferring = false, onGoBack }) => {
   const { t } = useTranslation(['recapiti', 'common']);
   const navigate = useNavigate();
@@ -31,42 +27,22 @@ const DigitalContactActivation: React.FC<Props> = ({ isTransferring = false, onG
     contactsSelectors.selectAddresses
   );
 
-  const [modal, setModal] = useState<ModalType>({ open: false });
   const [activeStep, setActiveStep] = useState(0);
   const [showPecWizard, setShowPecWizard] = useState(!!defaultSERCQ_SENDAddress || !IS_DOD_ENABLED);
 
-  const showEmailStep = useMemo(() => !(defaultSMSAddress || defaultEMAILAddress), []);
+  const hasEmailOrSms = !!(defaultEMAILAddress || defaultSMSAddress);
 
-  const hasCourtesyContact = defaultEMAILAddress || defaultSMSAddress;
+  const isEmailSmsStep = activeStep === 1;
 
   const goToNextStep = () => {
     setActiveStep((step) => step + 1);
   };
 
-  const handleConfirmationModalAccept = () => {
-    setModal({ open: false });
+  const goToPreviousStep = () => {
+    setActiveStep((step) => step - 1);
   };
 
-  const handleConfirmationModalDecline = () => {
-    setModal({ open: false });
-    goToNextStep();
-  };
-
-  const showConfirmationModal = () => {
-    setModal({ open: true });
-  };
-
-  const handleExit = () => {
-    if (activeStep === 0) {
-      navigate(-1);
-    } else if (hasCourtesyContact) {
-      goToNextStep();
-    } else {
-      showConfirmationModal();
-    }
-  };
-
-  const getNextButton = () => {
+  const getPreviousButton = () => {
     if (activeStep === 0) {
       return (
         <ButtonNaked
@@ -78,25 +54,37 @@ const DigitalContactActivation: React.FC<Props> = ({ isTransferring = false, onG
           {t('button.annulla', { ns: 'common' })}
         </ButtonNaked>
       );
-    }
-    if (hasCourtesyContact) {
+    } else {
       return (
-        <Button variant="contained" onClick={goToNextStep} color="primary" size="medium">
+        <ButtonNaked
+          onClick={goToPreviousStep}
+          color="primary"
+          size="medium"
+          data-testid="prev-button"
+          sx={{ mt: { xs: 2, lg: 0 } }}
+        >
+          {t('button.indietro', { ns: 'common' })}
+        </ButtonNaked>
+      );
+    }
+  };
+
+  const getNextButton = () => {
+    if (isEmailSmsStep) {
+      return (
+        <Button
+          variant="contained"
+          onClick={goToNextStep}
+          color="primary"
+          size="medium"
+          sx={{ width: { xs: '100%', md: 'auto' } }}
+        >
           {t('button.conferma', { ns: 'common' })}
         </Button>
       );
     }
 
-    return (
-      <ButtonNaked
-        onClick={showConfirmationModal}
-        color="primary"
-        size="medium"
-        sx={{ mx: 'auto' }}
-      >
-        {t('button.not-now', { ns: 'common' })}
-      </ButtonNaked>
-    );
+    return <></>;
   };
 
   if (showPecWizard) {
@@ -110,75 +98,38 @@ const DigitalContactActivation: React.FC<Props> = ({ isTransferring = false, onG
   }
 
   return (
-    <>
-      <PnWizard
-        title={
-          <Typography fontSize="28px" fontWeight={700}>
-            {t(`legal-contacts.sercq-send-wizard.title${isTransferring ? '-transfer' : ''}`)}
-          </Typography>
-        }
-        activeStep={activeStep}
-        setActiveStep={setActiveStep}
-        onExit={handleExit}
-        slots={{
-          nextButton: getNextButton,
-          prevButton: () => <></>,
-        }}
-        slotsProps={{
-          feedback: {
-            title: t(
-              `legal-contacts.sercq-send-wizard.feedback.title-${
-                isTransferring ? 'transfer' : 'activation'
-              }`
-            ),
-            buttonText: t('legal-contacts.sercq-send-wizard.feedback.go-to-contacts'),
-            onClick: () => navigate(RECAPITI),
-          },
-          actions: hasCourtesyContact ? { justifyContent: 'flex-end' } : {},
-        }}
-      >
-        <PnWizardStep label={t('legal-contacts.sercq-send-wizard.step_1.title')}>
-          <SercqSendContactWizard goToNextStep={goToNextStep} setShowPecWizard={setShowPecWizard} />
-        </PnWizardStep>
-        {showEmailStep && (
-          <PnWizardStep label={t('legal-contacts.sercq-send-wizard.step_2.step-title')}>
-            <EmailSmsContactWizard />
-          </PnWizardStep>
-        )}
-      </PnWizard>
-      <ConfirmationModal
-        open={modal.open}
-        title={t('courtesy-contacts.confirmation-modal-title')}
-        slots={{
-          confirmButton: Button,
-          closeButton: Button,
-        }}
-        slotsProps={{
-          closeButton: {
-            onClick: handleConfirmationModalAccept,
-            children: t(`courtesy-contacts.confirmation-modal-accept`),
-          },
-          confirmButton: {
-            onClick: handleConfirmationModalDecline,
-            children: t('button.do-later', { ns: 'common' }),
-          },
-        }}
-      >
-        <Trans
-          ns={'recapiti'}
-          i18nKey={modal ? `courtesy-contacts.confirmation-modal-content` : ''}
-          components={[
-            <DialogContentText key="paragraph1" id="dialog-description" color="text.primary" />,
-            <DialogContentText
-              key="paragraph2"
-              id="dialog-description"
-              color="text.primary"
-              mt={2}
-            />,
-          ]}
-        />
-      </ConfirmationModal>
-    </>
+    <PnWizard
+      title={
+        <Typography fontSize="28px" fontWeight={700}>
+          {t(`legal-contacts.sercq-send-wizard.title${isTransferring ? '-transfer' : ''}`)}
+        </Typography>
+      }
+      activeStep={activeStep}
+      setActiveStep={setActiveStep}
+      slots={{
+        prevButton: getPreviousButton,
+        nextButton: getNextButton,
+      }}
+      slotsProps={{
+        feedback: {
+          title: t(
+            `legal-contacts.sercq-send-wizard.feedback.title-${
+              isTransferring ? 'transfer' : 'activation'
+            }`
+          ),
+          buttonText: t('legal-contacts.sercq-send-wizard.feedback.go-to-contacts'),
+          onClick: () => navigate(RECAPITI),
+        },
+        actions: isEmailSmsStep && hasEmailOrSms ? { justifyContent: 'flex-end' } : {},
+      }}
+    >
+      <PnWizardStep label={t('legal-contacts.sercq-send-wizard.step_1.title')}>
+        <SercqSendContactWizard goToNextStep={goToNextStep} setShowPecWizard={setShowPecWizard} />
+      </PnWizardStep>
+      <PnWizardStep label={t('legal-contacts.sercq-send-wizard.step_2.step-title')}>
+        <EmailSmsContactWizard />
+      </PnWizardStep>
+    </PnWizard>
   );
 };
 

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/DigitalContactManagement.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/DigitalContactManagement.tsx
@@ -83,7 +83,6 @@ const DigitalContactManagement: React.FC = () => {
       }
       activeStep={activeStep}
       setActiveStep={setActiveStep}
-      onExit={() => navigate(-1)}
       slots={{
         prevButton: getPreviouButton,
         nextButton:

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/PecContactWizard.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/PecContactWizard.tsx
@@ -106,7 +106,6 @@ const PecContactWizard: React.FC<Props> = ({
         }
         activeStep={activeStep}
         setActiveStep={setActiveStep}
-        onExit={() => navigate(-1)}
         slots={{
           prevButton: () => (
             <ButtonNaked


### PR DESCRIPTION
## Short description
This PR makes the following changes on SERCQ activation/transfer wizard:

## List of changes proposed in this pull request
- change PnWizard making exit button optional
- change DigitalContactActivation component removing ConfirmationModal on IO and email/sms steps
- change DigitalContactActivation component to always show email/sms steps
- change DigitalContactActivation, DigitalContactManagement and PecContactWizard removing exit button
- change DigitalContactActivation to show back button
- fix tests for DigitalContactActivation component