### PR TITLE
Feat/PN-15327: PF call api logout before redirect

### DIFF
--- a/packages/pn-personafisica-webapp/src/App.tsx
+++ b/packages/pn-personafisica-webapp/src/App.tsx
@@ -46,6 +46,7 @@ import { PFAppErrorFactory } from './utility/AppError/PFAppErrorFactory';
 import PFEventStrategyFactory from './utility/MixpanelUtils/PFEventStrategyFactory';
 import showLayoutParts from './utility/layout.utility';
 import './utility/onetrust';
+import { apiLogout } from './redux/auth/actions';
 
 // TODO: get products list from be (?)
 const productsList: Array<ProductEntity> = [
@@ -263,6 +264,14 @@ const App = () => {
     });
   };
 
+  const performLogout = async () => {
+    await dispatch(apiLogout(loggedUser.sessionToken));
+
+    sessionStorage.clear();
+    goToLoginPortal();
+    setOpenModal(false);
+  };
+
   useEffect(() => {
     if (sessionToken !== '') {
       void dispatch(getDigitalAddresses());
@@ -316,11 +325,7 @@ const App = () => {
             <Button
               data-testid="confirm-button"
               variant="contained"
-              onClick={() => {
-                sessionStorage.clear();
-                goToLoginPortal();
-                setOpenModal(false);
-              }}
+              onClick={performLogout}
             >
               {t('header.logout')}
             </Button>

--- a/packages/pn-personafisica-webapp/src/__test__/App.test.tsx
+++ b/packages/pn-personafisica-webapp/src/__test__/App.test.tsx
@@ -13,7 +13,7 @@ import { digitalAddresses } from '../__mocks__/Contacts.mock';
 import { mandatesByDelegate } from '../__mocks__/Delegations.mock';
 import { apiClient } from '../api/apiClients';
 import { LOGOUT } from '../navigation/routes.const';
-import { RenderResult, act, fireEvent, getByText, render, screen, waitFor, within } from './test-utils';
+import { RenderResult, act, fireEvent, render, screen, waitFor, within } from './test-utils';
 
 vi.mock('../pages/Notifiche.page', () => ({ default: () => <div>Generic Page</div> }));
 vi.mock('../pages/Profile.page', () => ({ default: () => <div>Profile Page</div> }));
@@ -139,9 +139,12 @@ describe('App', async () => {
     expect(logoutDialog).toBeInTheDocument();
     const confirmLogoutButton = within(logoutDialog).getByTestId('confirm-button');
     fireEvent.click(confirmLogoutButton);
-    expect(sessionStorage.getItem('user')).toBeNull();
-    expect(mockOpenFn).toHaveBeenCalledTimes(1);
-    expect(mockOpenFn).toHaveBeenCalledWith(`${LOGOUT}`, '_self');
+
+    await waitFor(() => {
+      expect(sessionStorage.getItem('user')).toBeNull();
+      expect(mockOpenFn).toHaveBeenCalledTimes(1);
+      expect(mockOpenFn).toHaveBeenCalledWith(`${LOGOUT}`, '_self');
+    });
   });
 
   it('sidemenu not included if error in API call to fetch TOS and Privacy', async () => {
@@ -219,29 +222,5 @@ describe('App', async () => {
     expect(sideMenuItems).toHaveLength(4);
     const collapsibleMenu = sideMenuItems[0].querySelector('[data-testid=collapsible-menu]');
     expect(collapsibleMenu).not.toBeInTheDocument();
-  });
-
-   it('render component - user logs out', async () => {
-    const clearSpy = vi.spyOn(Storage.prototype, 'clear');
-
-    await act(async () => {
-      result = render(<Component />, { preloadedState: reduxInitialState });
-    });
-
-    const header = result.container.querySelector('header');
-    expect(header).toBeInTheDocument();
-
-    const button = getByText(header!, 'Esci');
-    fireEvent.click(button);
-
-    const modalConfirmButton = await waitFor(() => screen.queryByTestId('confirm-button'));
-    fireEvent.click(modalConfirmButton!);
-
-    await waitFor(() => {
-      expect(mockOpenFn).toHaveBeenCalledTimes(1);
-      const url = `${LOGOUT}`;
-      expect(mockOpenFn).toHaveBeenCalledWith(url, '_self');
-      expect(clearSpy).toHaveBeenCalled();
-    });
   });
 });

--- a/packages/pn-personafisica-webapp/src/__test__/App.test.tsx
+++ b/packages/pn-personafisica-webapp/src/__test__/App.test.tsx
@@ -13,7 +13,7 @@ import { digitalAddresses } from '../__mocks__/Contacts.mock';
 import { mandatesByDelegate } from '../__mocks__/Delegations.mock';
 import { apiClient } from '../api/apiClients';
 import { LOGOUT } from '../navigation/routes.const';
-import { RenderResult, act, fireEvent, render, screen, waitFor, within } from './test-utils';
+import { RenderResult, act, fireEvent, getByText, render, screen, waitFor, within } from './test-utils';
 
 vi.mock('../pages/Notifiche.page', () => ({ default: () => <div>Generic Page</div> }));
 vi.mock('../pages/Profile.page', () => ({ default: () => <div>Profile Page</div> }));
@@ -219,5 +219,29 @@ describe('App', async () => {
     expect(sideMenuItems).toHaveLength(4);
     const collapsibleMenu = sideMenuItems[0].querySelector('[data-testid=collapsible-menu]');
     expect(collapsibleMenu).not.toBeInTheDocument();
+  });
+
+   it('render component - user logs out', async () => {
+    const clearSpy = vi.spyOn(Storage.prototype, 'clear');
+
+    await act(async () => {
+      result = render(<Component />, { preloadedState: reduxInitialState });
+    });
+
+    const header = result.container.querySelector('header');
+    expect(header).toBeInTheDocument();
+
+    const button = getByText(header!, 'Esci');
+    fireEvent.click(button);
+
+    const modalConfirmButton = await waitFor(() => screen.queryByTestId('confirm-button'));
+    fireEvent.click(modalConfirmButton!);
+
+    await waitFor(() => {
+      expect(mockOpenFn).toHaveBeenCalledTimes(1);
+      const url = `${LOGOUT}`;
+      expect(mockOpenFn).toHaveBeenCalledWith(url, '_self');
+      expect(clearSpy).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/pn-personafisica-webapp/src/api/auth/Auth.api.ts
+++ b/packages/pn-personafisica-webapp/src/api/auth/Auth.api.ts
@@ -6,7 +6,7 @@ import {
   paramsToSourceType,
 } from '../../models/User';
 import { authClient } from '../apiClients';
-import { AUTH_TOKEN_EXCHANGE } from './auth.routes';
+import { AUTH_LOGOUT, AUTH_TOKEN_EXCHANGE } from './auth.routes';
 
 export const AuthApi = {
   exchangeToken: async ({ spidToken, rapidAccess }: TokenExchangeRequest): Promise<User> => {
@@ -39,4 +39,6 @@ export const AuthApi = {
     }
     return user;
   },
+  logout: (token: string): Promise<void> =>
+    authClient.post(AUTH_LOGOUT(), null, { headers: { Authorization: `Bearer ${token}` } }),
 };

--- a/packages/pn-personafisica-webapp/src/api/auth/auth.routes.ts
+++ b/packages/pn-personafisica-webapp/src/api/auth/auth.routes.ts
@@ -2,11 +2,19 @@ import { compileRoute } from '@pagopa-pn/pn-commons';
 
 // Segments
 const API_AUTH_TOKEN_EXCHANGE = 'token-exchange';
+const API_AUTH_LOGOUT = 'logout';
 
 // APIs
 export function AUTH_TOKEN_EXCHANGE() {
   return compileRoute({
     prefix: '',
     path: API_AUTH_TOKEN_EXCHANGE,
+  });
+}
+
+export function AUTH_LOGOUT() {
+  return compileRoute({
+    prefix: '',
+    path: API_AUTH_LOGOUT,
   });
 }

--- a/packages/pn-personafisica-webapp/src/redux/auth/actions.ts
+++ b/packages/pn-personafisica-webapp/src/redux/auth/actions.ts
@@ -30,6 +30,20 @@ export const exchangeToken = createAsyncThunk<User, TokenExchangeRequest>(
 );
 
 /**
+ * Call api logout to invalidate access token.
+ */
+export const apiLogout = createAsyncThunk<void, string>(
+  'apiLogout',
+  async (token) => {
+    try {
+      return await AuthApi.logout(token);
+    } catch (e: any) {
+      console.log('Error during logout', e);
+    }
+  }
+);
+
+/**
  * Logout action
  * Clears sessionStorage, clears state
  */


### PR DESCRIPTION
## Short description
API logout to invalidate token

## List of changes proposed in this pull request
- Call api /auth/logout

## How to test
Login in PF and logout