### PR TITLE
refactor(pn-15400): add recap step for SERCQ activation wizard

### DIFF
--- a/packages/pn-personafisica-webapp/public/locales/it/recapiti.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/recapiti.json
@@ -230,7 +230,7 @@
     "confirmation-modal-io-accept": "Collega SEND a IO",
     "undo-deactivation-io-modal": "Mantieni collegato",
     "confirmation-deactivation-io-modal": "Scollega",
-    "confirmation-modal-email-content": "<0>Senza un indirizzo email o un altro recapito non possiamo informarti quando ricevi una comunicazione a valore legale su SEND.</0><1>Ricorda che se non leggi in tempo una notifica SEND, potresti non essere al corrente di eventuali scadenze e incorrere in sanzioni.</1>"
+    "confirmation-modal-email-content": "<0>Senza un indirizzo email o un altro recapito <strong>non ricevi avvisi quando c’è una comunicazione a valore legale per te su SEND.</strong></0><1>Ricorda che se non leggi in tempo una notifica SEND, potresti non essere al corrente di eventuali scadenze e incorrere in sanzioni.</1>"
   },
   "special-contacts": {
     "select-address": "Tipologia",

--- a/packages/pn-personafisica-webapp/public/locales/it/recapiti.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/recapiti.json
@@ -106,6 +106,28 @@
         "step-title": "Inserisci una email",
         "content": "L’email dove possiamo informarti quando c’è una comunicazione a valore legale per te su SEND."
       },
+      "step_4": {
+        "title": "Stai attivando il tuo domicilio digitale su SEND",
+        "step-title": "Riepilogo",
+        "content": "Le tue comunicazioni a valore legale saranno recapitate a:",
+        "digital-domicile": "Domicilio digitale",
+        "send": "Send",
+        "info-list": [
+          {
+            "title": "Indirizzo email",
+            "description": "Aggiungi email"
+          },
+          {
+            "title": "App IO",
+            "description": "Collega SEND a IO"
+          },
+          {
+            "title": "Numero di cellulare",
+            "description": "Aggiungi numero di cellulare"
+          }
+        ],
+        "disclaimer": "Premendo “Attiva domicilio digitale” dichiari di aver letto la <0>Informativa privacy</0> e di accettare i <1>Termini del servizio</1>"
+      },
       "feedback": {
         "title-activation": "Hai attivato il tuo domicilio digitale",
         "title-transfer": "Hai aggiornato il tuo domicilio digitale",

--- a/packages/pn-personafisica-webapp/public/locales/it/recapiti.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/recapiti.json
@@ -65,7 +65,7 @@
     "sercq-send-io-description": "Attiva SEND - Notifiche Digitali su IO per<strong> ricevere direttamente in app</strong> le comunicazioni inviate al tuo Domicilio Digitale SEND.",
     "sercq-send-io-advantages": "Su IO",
     "sercq-send-wizard": {
-      "title": "Attiva domicilio digitale",
+      "title": "Attiva domicilio digitale su SEND",
       "title-transfer": "Trasferisci il domicilio digitale sulla piattaforma SEND",
       "step_1": {
         "title": "Come funziona",
@@ -106,7 +106,7 @@
       },
       "step_3": {
         "title": "La tua mail per ricevere aggiornamenti",
-        "step-title": "Inserisci una email",
+        "step-title": "Inserisci un recapito",
         "content": "L’email dove possiamo informarti quando c’è una comunicazione a valore legale per te su SEND."
       },
       "step_4": {
@@ -116,22 +116,23 @@
         "digital-domicile": "Domicilio digitale",
         "send": "SEND",
         "courtesy-content": "Hai scelto di ricevere un messaggio su:",
-        "contacts-list": [
-          {
+        "contacts-list": {
+          "email": {
             "title": "Indirizzo email",
             "textDisabled": "Aggiungi email"
           },
-          {
+          "io": {
             "title": "App IO",
             "textDisabled": "Collega SEND a IO",
             "textEnabled": "Servizio SEND attivato"
           },
-          {
+          "sms": {
             "title": "Numero di cellulare",
             "textDisabled": "Aggiungi numero di cellulare"
           }
-        ],
-        "disclaimer": "Premendo “Attiva domicilio digitale” dichiari di aver letto la <0>Informativa privacy</0> e di accettare i <1>Termini del servizio</1>"
+        },
+        "disclaimer": "Premendo “Attiva domicilio digitale” dichiari di aver letto la <0>Informativa privacy</0> e di accettare i <1>Termini del servizio</1>",
+        "enable": "Attiva domicilio digitale"
       },
       "feedback": {
         "title-pec-activation": "Hai attivato il tuo domicilio digitale su PEC",

--- a/packages/pn-personafisica-webapp/public/locales/it/recapiti.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/recapiti.json
@@ -111,19 +111,21 @@
         "step-title": "Riepilogo",
         "content": "Le tue comunicazioni a valore legale saranno recapitate a:",
         "digital-domicile": "Domicilio digitale",
-        "send": "Send",
-        "info-list": [
+        "send": "SEND",
+        "courtesy-content": "Hai scelto di ricevere un messaggio su:",
+        "contacts-list": [
           {
             "title": "Indirizzo email",
-            "description": "Aggiungi email"
+            "textDisabled": "Aggiungi email"
           },
           {
             "title": "App IO",
-            "description": "Collega SEND a IO"
+            "textDisabled": "Collega SEND a IO",
+            "textEnabled": "Servizio SEND attivato"
           },
           {
             "title": "Numero di cellulare",
-            "description": "Aggiungi numero di cellulare"
+            "textDisabled": "Aggiungi numero di cellulare"
           }
         ],
         "disclaimer": "Premendo “Attiva domicilio digitale” dichiari di aver letto la <0>Informativa privacy</0> e di accettare i <1>Termini del servizio</1>"

--- a/packages/pn-personafisica-webapp/src/components/Contacts/DigitalContactActivation.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/DigitalContactActivation.tsx
@@ -15,6 +15,7 @@ import { useAppSelector } from '../../redux/hooks';
 import { getConfiguration } from '../../services/configuration.service';
 import EmailSmsContactWizard from './EmailSmsContactWizard';
 import HowItWorksContactWizard from './HowItWorksContactWizard';
+import SercqSendContactWizard from './SercqSendContactWizard';
 
 type Props = {
   isTransferring?: boolean;
@@ -39,7 +40,7 @@ const DigitalContactActivation: React.FC<Props> = ({ isTransferring = false, onG
 
   // const hasEmailOrSms = !!(defaultEMAILAddress || defaultSMSAddress);
 
-  const isEmailSmsStep = (activeStep === 1 && !showIOStep) || activeStep === 2;
+  const isEmailSmsStep = !showIOStep ? activeStep === 1 : activeStep === 2;
 
   const goToNextStep = () => {
     setActiveStep((step) => step + 1);
@@ -77,7 +78,9 @@ const DigitalContactActivation: React.FC<Props> = ({ isTransferring = false, onG
   };
 
   const getNextButton = () => {
+    console.log(`Step attivo: '${activeStep}'`);
     if (isEmailSmsStep) {
+      console.log('isEmailSmsStep');
       return (
         <Button
           variant="contained"
@@ -91,6 +94,7 @@ const DigitalContactActivation: React.FC<Props> = ({ isTransferring = false, onG
       );
     }
 
+    console.log('!isEmailSmsStep');
     return <></>;
   };
 
@@ -140,6 +144,9 @@ const DigitalContactActivation: React.FC<Props> = ({ isTransferring = false, onG
       )}
       <PnWizardStep label={t('legal-contacts.sercq-send-wizard.step_3.step-title')}>
         <EmailSmsContactWizard />
+      </PnWizardStep>
+      <PnWizardStep label={t('legal-contacts.sercq-send-wizard.step_4.step-title')}>
+        <SercqSendContactWizard goToNextStep={goToNextStep} />
       </PnWizardStep>
     </PnWizard>
   );

--- a/packages/pn-personafisica-webapp/src/components/Contacts/DigitalContactActivation.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/DigitalContactActivation.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 
@@ -30,18 +30,15 @@ const DigitalContactActivation: React.FC<Props> = ({ isTransferring = false, onG
   const { IS_DOD_ENABLED } = getConfiguration();
   const { defaultEMAILAddress, defaultSMSAddress, defaultAPPIOAddress, defaultSERCQ_SENDAddress } =
     useAppSelector(contactsSelectors.selectAddresses);
-  const loading = useAppSelector(contactsSelectors.selectLoading);
 
   const [activeStep, setActiveStep] = useState(0);
   const [showConfirmationModal, setShowConfirmationModal] = useState(false);
   const [showPecWizard, setShowPecWizard] = useState(!!defaultSERCQ_SENDAddress || !IS_DOD_ENABLED);
-  const [showIOStep, setShowIOStep] = useState(false);
 
-  useEffect(() => {
-    if (!loading && defaultAPPIOAddress?.value === IOAllowedValues.DISABLED) {
-      setShowIOStep(true);
-    }
-  }, [loading, defaultAPPIOAddress]);
+  const showIOStep = useMemo(
+    () => defaultAPPIOAddress && defaultAPPIOAddress.value === IOAllowedValues.DISABLED,
+    []
+  );
 
   const hasEmailOrSms = !!(defaultEMAILAddress || defaultSMSAddress);
 
@@ -119,10 +116,6 @@ const DigitalContactActivation: React.FC<Props> = ({ isTransferring = false, onG
 
     return <></>;
   };
-
-  if (loading) {
-    return null;
-  }
 
   if (showPecWizard) {
     return (

--- a/packages/pn-personafisica-webapp/src/components/Contacts/DigitalContactActivation.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/DigitalContactActivation.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 
@@ -30,15 +30,18 @@ const DigitalContactActivation: React.FC<Props> = ({ isTransferring = false, onG
   const { IS_DOD_ENABLED } = getConfiguration();
   const { defaultEMAILAddress, defaultSMSAddress, defaultAPPIOAddress, defaultSERCQ_SENDAddress } =
     useAppSelector(contactsSelectors.selectAddresses);
+  const loading = useAppSelector(contactsSelectors.selectLoading);
 
   const [activeStep, setActiveStep] = useState(0);
   const [showConfirmationModal, setShowConfirmationModal] = useState(false);
   const [showPecWizard, setShowPecWizard] = useState(!!defaultSERCQ_SENDAddress || !IS_DOD_ENABLED);
+  const [showIOStep, setShowIOStep] = useState(false);
 
-  const showIOStep = useMemo(
-    () => !!(defaultAPPIOAddress && defaultAPPIOAddress.value === IOAllowedValues.DISABLED),
-    []
-  );
+  useEffect(() => {
+    if (!loading && defaultAPPIOAddress?.value === IOAllowedValues.DISABLED) {
+      setShowIOStep(true);
+    }
+  }, [loading, defaultAPPIOAddress]);
 
   const hasEmailOrSms = !!(defaultEMAILAddress || defaultSMSAddress);
 
@@ -116,6 +119,10 @@ const DigitalContactActivation: React.FC<Props> = ({ isTransferring = false, onG
 
     return <></>;
   };
+
+  if (loading) {
+    return null;
+  }
 
   if (showPecWizard) {
     return (

--- a/packages/pn-personafisica-webapp/src/components/Contacts/DigitalContactActivation.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/DigitalContactActivation.tsx
@@ -22,6 +22,8 @@ type Props = {
   onGoBack?: () => void;
 };
 
+const MAX_STEPS_NUMBER = 4;
+
 const DigitalContactActivation: React.FC<Props> = ({ isTransferring = false, onGoBack }) => {
   const { t } = useTranslation(['recapiti', 'common']);
   const navigate = useNavigate();
@@ -34,7 +36,7 @@ const DigitalContactActivation: React.FC<Props> = ({ isTransferring = false, onG
   const [showPecWizard, setShowPecWizard] = useState(!!defaultSERCQ_SENDAddress || !IS_DOD_ENABLED);
 
   const showIOStep = useMemo(
-    () => defaultAPPIOAddress && defaultAPPIOAddress.value === IOAllowedValues.DISABLED,
+    () => !!(defaultAPPIOAddress && defaultAPPIOAddress.value === IOAllowedValues.DISABLED),
     []
   );
 
@@ -48,6 +50,13 @@ const DigitalContactActivation: React.FC<Props> = ({ isTransferring = false, onG
 
   const goToPreviousStep = () => {
     setActiveStep((step) => step - 1);
+  };
+
+  const goToStep = (step: number) => {
+    if (step >= 0 && step <= MAX_STEPS_NUMBER) {
+      return setActiveStep(step);
+    }
+    return goToNextStep();
   };
 
   const getPreviousButton = () => {
@@ -78,9 +87,7 @@ const DigitalContactActivation: React.FC<Props> = ({ isTransferring = false, onG
   };
 
   const getNextButton = () => {
-    console.log(`Step attivo: '${activeStep}'`);
     if (isEmailSmsStep) {
-      console.log('isEmailSmsStep');
       return (
         <Button
           variant="contained"
@@ -94,7 +101,6 @@ const DigitalContactActivation: React.FC<Props> = ({ isTransferring = false, onG
       );
     }
 
-    console.log('!isEmailSmsStep');
     return <></>;
   };
 
@@ -146,7 +152,7 @@ const DigitalContactActivation: React.FC<Props> = ({ isTransferring = false, onG
         <EmailSmsContactWizard />
       </PnWizardStep>
       <PnWizardStep label={t('legal-contacts.sercq-send-wizard.step_4.step-title')}>
-        <SercqSendContactWizard goToNextStep={goToNextStep} />
+        <SercqSendContactWizard showIOStep={showIOStep} goToStep={goToStep} />
       </PnWizardStep>
     </PnWizard>
   );

--- a/packages/pn-personafisica-webapp/src/components/Contacts/SercqSendContactWizard.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/SercqSendContactWizard.tsx
@@ -27,6 +27,7 @@ import {
   TosPrivacyConsent,
   appStateActions,
 } from '@pagopa-pn/pn-commons';
+import { theme } from '@pagopa/mui-italia';
 
 import { PFEventsType } from '../../models/PFEventsType';
 import {
@@ -297,6 +298,12 @@ const SercqSendContactWizard: React.FC<Props> = ({ goToStep, showIOStep }) => {
               inputProps={{
                 'aria-describedby': 'disclaimer-helper-text',
                 'aria-invalid': formik.touched.disclaimer && Boolean(formik.errors.disclaimer),
+              }}
+              sx={{
+                color:
+                  formik.touched.disclaimer && Boolean(formik.errors.disclaimer)
+                    ? theme.palette.error.dark
+                    : theme.palette.text.secondary,
               }}
             />
           }

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/DigitalContactActivation.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/DigitalContactActivation.test.tsx
@@ -1,8 +1,13 @@
 import MockAdapter from 'axios-mock-adapter';
 import { vi } from 'vitest';
 
+import { ConsentType, SERCQ_SEND_VALUE } from '@pagopa-pn/pn-commons';
 import { getById } from '@pagopa-pn/pn-commons/src/test-utils';
 
+import {
+  acceptTosPrivacyConsentBodyMock,
+  sercqSendTosPrivacyConsentMock,
+} from '../../../__mocks__/Consents.mock';
 import { digitalAddressesSercq, digitalLegalAddresses } from '../../../__mocks__/Contacts.mock';
 import { fireEvent, render, waitFor, within } from '../../../__test__/test-utils';
 import { apiClient } from '../../../api/apiClients';
@@ -200,6 +205,7 @@ describe('DigitalContactActivation', () => {
 
   it('adds an email correctly', async () => {
     const mailValue = 'nome.utente@mail.it';
+    // mock new email api calls
     mock.onPost('/bff/v1/addresses/COURTESY/default/EMAIL', { value: mailValue }).reply(200, {
       result: 'CODE_VERIFICATION_REQUIRED',
     });
@@ -209,19 +215,20 @@ describe('DigitalContactActivation', () => {
         verificationCode: '01234',
       })
       .reply(204);
-    // uncomment the following snippet to mock sercq activation api call once the final step is created
-    // mock
-    //   .onPost('/bff/v1/addresses/LEGAL/default/SERCQ_SEND', {
-    //     value: SERCQ_SEND_VALUE,
-    //   })
-    //   .reply(204);
-    // mock.onGet(/\/bff\/v2\/tos-privacy.*/).reply(200, sercqSendTosPrivacyConsentMock(false, false));
-    // mock
-    //   .onPut(
-    //     '/bff/v2/tos-privacy',
-    //     acceptTosPrivacyConsentBodyMock(ConsentType.TOS_SERCQ, ConsentType.DATAPRIVACY_SERCQ)
-    //   )
-    //   .reply(200);
+
+    // mock SERCQ activation api call
+    mock
+      .onPost('/bff/v1/addresses/LEGAL/default/SERCQ_SEND', {
+        value: SERCQ_SEND_VALUE,
+      })
+      .reply(204);
+    mock.onGet(/\/bff\/v2\/tos-privacy.*/).reply(200, sercqSendTosPrivacyConsentMock(false, false));
+    mock
+      .onPut(
+        '/bff/v2/tos-privacy',
+        acceptTosPrivacyConsentBodyMock(ConsentType.TOS_SERCQ, ConsentType.DATAPRIVACY_SERCQ)
+      )
+      .reply(200);
 
     const result = render(<DigitalContactActivation />, {
       preloadedState: {
@@ -282,9 +289,23 @@ describe('DigitalContactActivation', () => {
 
     fireEvent.click(confirmButton);
 
-    // thankyou page
-    const feedbackStep = result.getByTestId('wizard-feedback-step');
-    expect(feedbackStep).toBeInTheDocument();
+    // recap step: check disclaimer and press button to enable sercq
+    const enableSercqStepTitle = result.getByText(`${labelPrefix}.step_4.title`);
+    expect(enableSercqStepTitle).toBeInTheDocument();
+
+    const disclaimerCkb = getById(result.container, 'disclaimer');
+    expect(disclaimerCkb).not.toBeChecked();
+
+    fireEvent.click(disclaimerCkb);
+
+    const enableSercqButton = result.getByTestId('activateButton');
+    fireEvent.click(enableSercqButton);
+
+    // feedback step
+    await waitFor(() => {
+      const feedbackStep = result.getByTestId('wizard-feedback-step');
+      expect(feedbackStep).toBeInTheDocument();
+    });
 
     const feedbackTitle = result.getByTestId('wizard-feedback-title');
     expect(feedbackTitle).toHaveTextContent(`${labelPrefix}.feedback.title-sercq_send-activation`);
@@ -300,21 +321,21 @@ describe('DigitalContactActivation', () => {
   });
 
   it('renders component correctly when transferring', async () => {
-    // uncomment the following snippet to mock sercq activation api call once the final step is created
-    // mock
-    //   .onPost('/bff/v1/addresses/LEGAL/default/SERCQ_SEND', {
-    //     value: SERCQ_SEND_VALUE,
-    //   })
-    //   .reply(204);
-    // mock.onGet(/\/bff\/v2\/tos-privacy.*/).reply(200, sercqSendTosPrivacyConsentMock(false, false));
-    // mock
-    //   .onPut(
-    //     '/bff/v2/tos-privacy',
-    //     acceptTosPrivacyConsentBodyMock(ConsentType.TOS_SERCQ, ConsentType.DATAPRIVACY_SERCQ)
-    //   )
-    //   .reply(200);
+    // mock SERCQ activation api call
+    mock
+      .onPost('/bff/v1/addresses/LEGAL/default/SERCQ_SEND', {
+        value: SERCQ_SEND_VALUE,
+      })
+      .reply(204);
+    mock.onGet(/\/bff\/v2\/tos-privacy.*/).reply(200, sercqSendTosPrivacyConsentMock(false, false));
+    mock
+      .onPut(
+        '/bff/v2/tos-privacy',
+        acceptTosPrivacyConsentBodyMock(ConsentType.TOS_SERCQ, ConsentType.DATAPRIVACY_SERCQ)
+      )
+      .reply(200);
 
-    const { getByTestId, queryByTestId, getByText } = render(
+    const { container, getByTestId, queryByTestId, getByText } = render(
       <DigitalContactActivation isTransferring />,
       {
         preloadedState: {
@@ -353,8 +374,20 @@ describe('DigitalContactActivation', () => {
     expect(confirmButton).toBeEnabled();
     fireEvent.click(confirmButton);
 
-    const feedbackStep = getByTestId('wizard-feedback-step');
-    expect(feedbackStep).toBeInTheDocument();
+    // recap step: check disclaimer and press button to enable sercq
+    const disclaimerCkb = getById(container, 'disclaimer');
+    expect(disclaimerCkb).not.toBeChecked();
+
+    fireEvent.click(disclaimerCkb);
+
+    const enableSercqButton = getByTestId('activateButton');
+    fireEvent.click(enableSercqButton);
+
+    // feedback step
+    await waitFor(() => {
+      const feedbackStep = getByTestId('wizard-feedback-step');
+      expect(feedbackStep).toBeInTheDocument();
+    });
 
     const feedbackTitle = getByTestId('wizard-feedback-title');
     expect(feedbackTitle).toHaveTextContent(`${labelPrefix}.feedback.title-sercq_send-transfer`);

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/SercqSendContactWizard.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/SercqSendContactWizard.test.tsx
@@ -27,12 +27,11 @@ describe('SercqSendContactWizard', () => {
     mock.restore();
   });
 
-  const goToNextStep = vi.fn();
-  const setShowPecWizard = vi.fn();
+  const goToStep = vi.fn();
 
   it('render components', async () => {
     const { getByText, getByTestId } = render(
-      <SercqSendContactWizard goToNextStep={goToNextStep} setShowPecWizard={setShowPecWizard} />
+      <SercqSendContactWizard goToStep={goToStep} showIOStep />
     );
 
     expect(getByText('legal-contacts.sercq-send-wizard.step_1.title')).toBeInTheDocument();
@@ -47,7 +46,7 @@ describe('SercqSendContactWizard', () => {
 
   it('should not show pec section if default pec address is present', async () => {
     const { getByTestId, queryByTestId } = render(
-      <SercqSendContactWizard goToNextStep={goToNextStep} setShowPecWizard={setShowPecWizard} />,
+      <SercqSendContactWizard goToStep={goToStep} showIOStep />,
       {
         preloadedState: {
           contactsState: {
@@ -88,9 +87,7 @@ describe('SercqSendContactWizard', () => {
       )
       .reply(200);
     // render component
-    const { getByTestId } = render(
-      <SercqSendContactWizard goToNextStep={goToNextStep} setShowPecWizard={setShowPecWizard} />
-    );
+    const { getByTestId } = render(<SercqSendContactWizard goToStep={goToStep} showIOStep />);
     const activateButton = getByTestId('activateButton');
     fireEvent.click(activateButton);
 
@@ -103,6 +100,7 @@ describe('SercqSendContactWizard', () => {
       });
     });
 
-    expect(goToNextStep).toHaveBeenCalledTimes(1);
+    expect(goToStep).toHaveBeenCalledTimes(1);
+    expect(goToStep).toHaveBeenCalledWith(4);
   });
 });

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/SercqSendContactWizard.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/SercqSendContactWizard.test.tsx
@@ -2,78 +2,265 @@ import MockAdapter from 'axios-mock-adapter';
 import { vi } from 'vitest';
 
 import { ConsentType, SERCQ_SEND_VALUE } from '@pagopa-pn/pn-commons';
+import { getById } from '@pagopa-pn/pn-commons/src/test-utils';
 
 import {
   acceptTosPrivacyConsentBodyMock,
   sercqSendTosPrivacyConsentMock,
 } from '../../../__mocks__/Consents.mock';
+import { digitalAddresses } from '../../../__mocks__/Contacts.mock';
 import { fireEvent, render, waitFor } from '../../../__test__/test-utils';
 import { apiClient } from '../../../api/apiClients';
-import { AddressType, ChannelType } from '../../../models/contacts';
+import { AddressType, ChannelType, IOAllowedValues } from '../../../models/contacts';
 import SercqSendContactWizard from '../SercqSendContactWizard';
+
+const labelPrefix = 'legal-contacts.sercq-send-wizard.step_4';
 
 describe('SercqSendContactWizard', () => {
   let mock: MockAdapter;
+  let goToStep = vi.fn();
 
   beforeAll(() => {
     mock = new MockAdapter(apiClient);
   });
 
-  afterEach(() => {
+  beforeEach(() => {
     mock.reset();
+    vi.restoreAllMocks();
   });
 
   afterAll(() => {
     mock.restore();
   });
 
-  const goToStep = vi.fn();
-
-  it('render components', async () => {
-    const { getByText, getByTestId } = render(
-      <SercqSendContactWizard goToStep={goToStep} showIOStep />
+  it('render component', async () => {
+    const initialAddresses = digitalAddresses.filter(
+      (addr) => addr.addressType === AddressType.COURTESY
     );
-
-    expect(getByText('legal-contacts.sercq-send-wizard.step_1.title')).toBeInTheDocument();
-    expect(getByTestId('sercq-send-info-list')).toBeInTheDocument();
-    const activateButton = getByTestId('activateButton');
-    expect(activateButton).toBeInTheDocument();
-    expect(activateButton).toHaveTextContent('button.enable');
-    expect(activateButton).toBeEnabled();
-    const pecSection = getByTestId('pec-section');
-    expect(pecSection).toBeInTheDocument();
-  });
-
-  it('should not show pec section if default pec address is present', async () => {
-    const { getByTestId, queryByTestId } = render(
+    const { container, getByTestId, getByText } = render(
       <SercqSendContactWizard goToStep={goToStep} showIOStep />,
       {
         preloadedState: {
           contactsState: {
-            digitalAddresses: [
-              {
-                addressType: AddressType.LEGAL,
-                senderId: 'default',
-                channelType: ChannelType.PEC,
-                value: 'pec@test.it',
-                pecValid: true,
-                codeValid: true,
-              },
-            ],
+            digitalAddresses: initialAddresses,
           },
         },
       }
     );
 
-    const pecSection = queryByTestId('pec-section');
-    expect(pecSection).not.toBeInTheDocument();
+    expect(getByText(`${labelPrefix}.title`)).toBeInTheDocument();
+    expect(getByText(`${labelPrefix}.content`)).toBeInTheDocument();
+    expect(getByText(`${labelPrefix}.digital-domicile`)).toBeInTheDocument();
+    expect(getByText(`${labelPrefix}.send`)).toBeInTheDocument();
+    expect(getByText(`${labelPrefix}.courtesy-content`)).toBeInTheDocument();
+
+    expect(getByText(`${labelPrefix}.contacts-list.email.title`)).toBeInTheDocument();
+    expect(getByText(initialAddresses[0].value));
+
+    expect(getByText(`${labelPrefix}.contacts-list.io.title`)).toBeInTheDocument();
+    const ioLink = getByTestId('backToContactStep');
+    expect(ioLink).toHaveTextContent(`${labelPrefix}.contacts-list.io.textDisabled`);
+
+    expect(getByText(`${labelPrefix}.contacts-list.sms.title`)).toBeInTheDocument();
+    expect(getByText(initialAddresses[1].value));
+
+    const icons = container.querySelectorAll(
+      'svg[data-testid="CheckCircleIcon"], svg[data-testid="ErrorIcon"]'
+    );
+    expect(icons.length).toBe(3);
+    const emailIcon = icons[0];
+    const ioIcon = icons[1];
+    const smsIcon = icons[2];
+
+    expect(emailIcon).toHaveAttribute('data-testid', 'CheckCircleIcon');
+    expect(ioIcon).toHaveAttribute('data-testid', 'ErrorIcon');
+    expect(smsIcon).toHaveAttribute('data-testid', 'CheckCircleIcon');
+
+    const disclaimerCkb = getById(container, 'disclaimer');
+    expect(disclaimerCkb).not.toBeChecked();
+    expect(getByText(`${labelPrefix}.disclaimer`)).toBeInTheDocument();
+
     const activateButton = getByTestId('activateButton');
     expect(activateButton).toBeInTheDocument();
-    const alertMessage = getByTestId('default-pec-info');
-    expect(alertMessage).toBeInTheDocument();
+    expect(activateButton).toHaveTextContent(`${labelPrefix}.enable`);
+  });
+
+  it('should not show IO when user does not have app IO installed', async () => {
+    const initialAddresses = [
+      {
+        addressType: AddressType.COURTESY,
+        senderId: 'default',
+        channelType: ChannelType.EMAIL,
+        value: 'nome.utente@mail.it',
+      },
+    ];
+
+    // render component
+    const { container, getByTestId, getByText, queryByText } = render(
+      <SercqSendContactWizard goToStep={goToStep} />,
+      {
+        preloadedState: {
+          contactsState: {
+            digitalAddresses: initialAddresses,
+          },
+        },
+      }
+    );
+
+    expect(getByText(`${labelPrefix}.contacts-list.email.title`)).toBeInTheDocument();
+    expect(getByText(initialAddresses[0].value));
+
+    expect(queryByText(`${labelPrefix}.contacts-list.io.title`)).not.toBeInTheDocument();
+    expect(queryByText(`${labelPrefix}.contacts-list.io.textDisabled`)).not.toBeInTheDocument();
+    expect(queryByText(`${labelPrefix}.contacts-list.io.textEnabled`)).not.toBeInTheDocument();
+
+    expect(getByText(`${labelPrefix}.contacts-list.sms.title`)).toBeInTheDocument();
+    const smsLink = getByTestId('backToContactStep');
+    expect(smsLink).toHaveTextContent(`${labelPrefix}.contacts-list.sms.textDisabled`);
+
+    const icons = container.querySelectorAll(
+      'svg[data-testid="CheckCircleIcon"], svg[data-testid="ErrorIcon"]'
+    );
+    expect(icons.length).toBe(2);
+    const emailIcon = icons[0];
+    const smsIcon = icons[1];
+
+    expect(emailIcon).toHaveAttribute('data-testid', 'CheckCircleIcon');
+    expect(smsIcon).toHaveAttribute('data-testid', 'ErrorIcon');
+
+    fireEvent.click(smsLink);
+
+    expect(goToStep).toHaveBeenCalledTimes(1);
+    expect(goToStep).toHaveBeenCalledWith(1);
+  });
+
+  it('should show links to relative steps - IO disabled and no email', async () => {
+    const initialAddresses = [
+      {
+        addressType: AddressType.COURTESY,
+        senderId: 'default',
+        channelType: ChannelType.SMS,
+        value: '+393333333333',
+      },
+      {
+        addressType: AddressType.COURTESY,
+        senderId: 'default',
+        channelType: ChannelType.IOMSG,
+        value: IOAllowedValues.DISABLED,
+      },
+    ];
+
+    // render component
+    const { container, getByText } = render(
+      <SercqSendContactWizard goToStep={goToStep} showIOStep />,
+      {
+        preloadedState: {
+          contactsState: {
+            digitalAddresses: initialAddresses,
+          },
+        },
+      }
+    );
+
+    expect(getByText(`${labelPrefix}.contacts-list.email.title`)).toBeInTheDocument();
+    const emailLink = getByText(`${labelPrefix}.contacts-list.email.textDisabled`, {
+      selector: 'a',
+    });
+
+    expect(getByText(`${labelPrefix}.contacts-list.io.title`)).toBeInTheDocument();
+    const ioLink = getByText(`${labelPrefix}.contacts-list.io.textDisabled`, {
+      selector: 'a',
+    });
+
+    expect(getByText(`${labelPrefix}.contacts-list.sms.title`)).toBeInTheDocument();
+    expect(getByText(initialAddresses[0].value));
+
+    const icons = container.querySelectorAll(
+      'svg[data-testid="CheckCircleIcon"], svg[data-testid="ErrorIcon"]'
+    );
+    expect(icons.length).toBe(3);
+    const emailIcon = icons[0];
+    const ioIcon = icons[1];
+    const smsIcon = icons[2];
+
+    expect(emailIcon).toHaveAttribute('data-testid', 'ErrorIcon');
+    expect(ioIcon).toHaveAttribute('data-testid', 'ErrorIcon');
+    expect(smsIcon).toHaveAttribute('data-testid', 'CheckCircleIcon');
+
+    fireEvent.click(emailLink);
+    fireEvent.click(ioLink);
+
+    expect(goToStep).toHaveBeenCalledTimes(2);
+    expect(goToStep.mock.calls).toEqual([[2], [1]]);
+  });
+
+  it('should show links to relative steps - no sms', async () => {
+    const initialAddresses = [
+      {
+        addressType: AddressType.COURTESY,
+        senderId: 'default',
+        channelType: ChannelType.EMAIL,
+        value: 'nome.utente@mail.it',
+      },
+      {
+        addressType: AddressType.COURTESY,
+        senderId: 'default',
+        channelType: ChannelType.IOMSG,
+        value: IOAllowedValues.ENABLED,
+      },
+    ];
+
+    // render component
+    const { container, getByText } = render(<SercqSendContactWizard goToStep={goToStep} />, {
+      preloadedState: {
+        contactsState: {
+          digitalAddresses: initialAddresses,
+        },
+      },
+    });
+
+    expect(getByText(`${labelPrefix}.contacts-list.email.title`)).toBeInTheDocument();
+    expect(getByText(initialAddresses[0].value));
+
+    expect(getByText(`${labelPrefix}.contacts-list.sms.title`)).toBeInTheDocument();
+    const smsLink = getByText(`${labelPrefix}.contacts-list.sms.textDisabled`, {
+      selector: 'a',
+    });
+
+    const icons = container.querySelectorAll(
+      'svg[data-testid="CheckCircleIcon"], svg[data-testid="ErrorIcon"]'
+    );
+    expect(icons.length).toBe(3);
+    const emailIcon = icons[0];
+    const ioIcon = icons[1];
+    const smsIcon = icons[2];
+
+    expect(emailIcon).toHaveAttribute('data-testid', 'CheckCircleIcon');
+    expect(ioIcon).toHaveAttribute('data-testid', 'CheckCircleIcon');
+    expect(smsIcon).toHaveAttribute('data-testid', 'ErrorIcon');
+
+    fireEvent.click(smsLink);
+
+    expect(goToStep).toHaveBeenCalledTimes(1);
+    expect(goToStep).toHaveBeenCalledWith(1);
   });
 
   it('should activate sercq send', async () => {
+    const initialAddresses = [
+      {
+        addressType: AddressType.COURTESY,
+        senderId: 'default',
+        channelType: ChannelType.EMAIL,
+        value: 'nome.utente@mail.it',
+      },
+      {
+        addressType: AddressType.COURTESY,
+        senderId: 'default',
+        channelType: ChannelType.IOMSG,
+        value: IOAllowedValues.ENABLED,
+      },
+    ];
+
     mock
       .onPost('/bff/v1/addresses/LEGAL/default/SERCQ_SEND', {
         value: SERCQ_SEND_VALUE,
@@ -86,9 +273,50 @@ describe('SercqSendContactWizard', () => {
         acceptTosPrivacyConsentBodyMock(ConsentType.TOS_SERCQ, ConsentType.DATAPRIVACY_SERCQ)
       )
       .reply(200);
+
     // render component
-    const { getByTestId } = render(<SercqSendContactWizard goToStep={goToStep} showIOStep />);
+    const { container, findByText, getByTestId, getByText, queryByText } = render(
+      <SercqSendContactWizard goToStep={goToStep} showIOStep />,
+      {
+        preloadedState: {
+          contactsState: {
+            digitalAddresses: initialAddresses,
+          },
+        },
+      }
+    );
+
+    expect(getByText(`${labelPrefix}.contacts-list.io.title`)).toBeInTheDocument();
+    expect(getByText(`${labelPrefix}.contacts-list.io.textEnabled`)).toBeInTheDocument();
+
+    const icons = container.querySelectorAll(
+      'svg[data-testid="CheckCircleIcon"], svg[data-testid="ErrorIcon"]'
+    );
+    expect(icons.length).toBe(3);
+    const emailIcon = icons[0];
+    const ioIcon = icons[1];
+    const smsIcon = icons[2];
+
+    expect(emailIcon).toHaveAttribute('data-testid', 'CheckCircleIcon');
+    expect(ioIcon).toHaveAttribute('data-testid', 'CheckCircleIcon');
+    expect(smsIcon).toHaveAttribute('data-testid', 'ErrorIcon');
+
     const activateButton = getByTestId('activateButton');
+    let errorMsg = queryByText('required-field');
+    expect(errorMsg).not.toBeInTheDocument();
+
+    fireEvent.click(activateButton);
+
+    errorMsg = await findByText('required-field');
+    expect(errorMsg).toBeInTheDocument();
+
+    const disclaimerCkb = getById(container, 'disclaimer');
+    expect(disclaimerCkb).not.toBeChecked();
+
+    fireEvent.click(disclaimerCkb);
+
+    expect(disclaimerCkb).toBeChecked();
+
     fireEvent.click(activateButton);
 
     await waitFor(() => {

--- a/packages/pn-personafisica-webapp/src/pages/DigitalContact.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/DigitalContact.page.tsx
@@ -3,15 +3,25 @@ import { Outlet } from 'react-router-dom';
 import { Box } from '@mui/material';
 
 import LoadingPageWrapper from '../components/LoadingPageWrapper/LoadingPageWrapper';
+import { contactsSelectors } from '../redux/contact/reducers';
+import { useAppSelector } from '../redux/hooks';
 
-const DigitalContact: React.FC = () => (
-  <LoadingPageWrapper isInitialized={true}>
-    <Box display="flex" justifyContent="center">
-      <Box sx={{ width: { xs: '100%', lg: '760px' } }}>
-        <Outlet />
+const DigitalContact: React.FC = () => {
+  const loading = useAppSelector(contactsSelectors.selectLoading);
+
+  if (loading) {
+    return <></>;
+  }
+
+  return (
+    <LoadingPageWrapper isInitialized={true}>
+      <Box display="flex" justifyContent="center">
+        <Box sx={{ width: { xs: '100%', lg: '760px' } }}>
+          <Outlet />
+        </Box>
       </Box>
-    </Box>
-  </LoadingPageWrapper>
-);
+    </LoadingPageWrapper>
+  );
+};
 
 export default DigitalContact;

--- a/packages/pn-personafisica-webapp/src/redux/contact/__test__/reducers.test.ts
+++ b/packages/pn-personafisica-webapp/src/redux/contact/__test__/reducers.test.ts
@@ -320,4 +320,39 @@ describe('Contacts redux state tests', () => {
     const state = store.getState().contactsState;
     expect(state.event).toEqual(initialState.event);
   });
+
+  it('should handle loading state during fetch digital addresses', async () => {
+    const testStore = createMockedStore({
+      contactsState: initialState,
+    });
+
+    mock.onGet('/bff/v1/addresses').reply(() => {
+      // verify loading is true before response
+      const stateBefore = testStore.getState().contactsState;
+      expect(stateBefore.loading).toBe(true);
+      return [200, digitalAddresses];
+    });
+
+    const action = await testStore.dispatch(getDigitalAddresses());
+
+    // after response
+    const stateAfter = testStore.getState().contactsState;
+    expect(stateAfter.loading).toBe(false);
+    expect(stateAfter.digitalAddresses).toEqual(digitalAddresses);
+    expect(action.type).toBe('getDigitalAddresses/fulfilled');
+  });
+
+  it('should reset loading state if fetch fails', async () => {
+    const testStore = createMockedStore({
+      contactsState: initialState,
+    });
+
+    mock.onGet('/bff/v1/addresses').reply(500);
+
+    const action = await testStore.dispatch(getDigitalAddresses());
+
+    const state = testStore.getState().contactsState;
+    expect(state.loading).toBe(false);
+    expect(action.type).toBe('getDigitalAddresses/rejected');
+  });
 });

--- a/packages/pn-personafisica-webapp/src/redux/contact/reducers.ts
+++ b/packages/pn-personafisica-webapp/src/redux/contact/reducers.ts
@@ -54,8 +54,15 @@ const contactsSlice = createSlice({
     },
   },
   extraReducers: (builder) => {
+    builder.addCase(getDigitalAddresses.pending, (state) => {
+      state.loading = true;
+    });
     builder.addCase(getDigitalAddresses.fulfilled, (state, action) => {
       state.digitalAddresses = action.payload;
+      state.loading = false;
+    });
+    builder.addCase(getDigitalAddresses.rejected, (state) => {
+      state.loading = false;
     });
     builder.addCase(createOrUpdateAddress.fulfilled, (state, action) => {
       if (action.payload) {
@@ -111,6 +118,8 @@ const digitalAddresses = createSelector(
   (contactsState) => contactsState.digitalAddresses
 );
 
+const loading = createSelector([contactState], (contactsState) => contactsState.loading);
+
 export type SelectedAddresses = {
   addresses: Array<DigitalAddress>;
   legalAddresses: Array<DigitalAddress>;
@@ -151,6 +160,7 @@ const memoizedSelectAddresses = createSelector([digitalAddresses], (digitalAddre
 
 export const contactsSelectors = {
   selectAddresses: memoizedSelectAddresses,
+  selectLoading: loading,
 };
 // END: SELECTORS
 

--- a/packages/pn-personagiuridica-webapp/public/locales/it/recapiti.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/it/recapiti.json
@@ -94,6 +94,25 @@
         "step-title": "Inserisci una email",
         "content": "L’email dove possiamo informarti quando c’è una comunicazione a valore legale per te su SEND."
       },
+      "step_3": {
+        "title": "Stai attivando il domicilio digitale su SEND",
+        "step-title": "Riepilogo",
+        "content": "Le comunicazioni a valore legale per l’impresa saranno recapitate a:",
+        "digital-domicile": "Domicilio digitale",
+        "send": "SEND",
+        "courtesy-content": "Hai scelto di ricevere un messaggio su:",
+        "contacts-list": [
+          {
+            "title": "Indirizzo email",
+            "textDisabled": "Aggiungi email"
+          },
+          {
+            "title": "Numero di cellulare",
+            "textDisabled": "Aggiungi numero di cellulare"
+          }
+        ],
+        "disclaimer": "Premendo “Attiva domicilio digitale” dichiari di aver letto la <0>Informativa privacy</0> e di accettare i <1>Termini del servizio</1>"
+      },
       "feedback": {
         "title-activation": "Hai attivato il tuo domicilio digitale",
         "title-transfer": "Hai aggiornato il domicilio digitale della tua impresa",

--- a/packages/pn-personagiuridica-webapp/public/locales/it/recapiti.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/it/recapiti.json
@@ -63,7 +63,7 @@
     "block-remove-digital-domicile-message": "Per procedere, devi prima disattivare i domicili digitali personalizzati per ente.",
     "sercq_send-removed-successfully": "Domicilio Digitale disattivato correttamente",
     "sercq-send-wizard": {
-      "title": "Attiva domicilio digitale",
+      "title": "Attiva domicilio digitale su SEND",
       "title-transfer": "Trasferisci il domicilio digitale sulla piattaforma SEND",
       "step_1": {
         "title": "Come funziona",
@@ -91,7 +91,7 @@
       },
       "step_2": {
         "title": "La tua mail per ricevere aggiornamenti",
-        "step-title": "Inserisci una email",
+        "step-title": "Inserisci un recapito",
         "content": "L’email dove possiamo informarti quando c’è una comunicazione a valore legale per te su SEND."
       },
       "step_3": {
@@ -101,17 +101,18 @@
         "digital-domicile": "Domicilio digitale",
         "send": "SEND",
         "courtesy-content": "Hai scelto di ricevere un messaggio su:",
-        "contacts-list": [
-          {
-            "title": "Indirizzo email",
+        "contacts-list": {
+          "email": {
+            "title": "Email aziendale",
             "textDisabled": "Aggiungi email"
           },
-          {
+          "sms": {
             "title": "Numero di cellulare",
             "textDisabled": "Aggiungi numero di cellulare"
           }
-        ],
-        "disclaimer": "Premendo “Attiva domicilio digitale” dichiari di aver letto la <0>Informativa privacy</0> e di accettare i <1>Termini del servizio</1>"
+        },
+        "disclaimer": "Premendo “Attiva domicilio digitale” dichiari di aver letto la <0>Informativa privacy</0> e di accettare i <1>Termini del servizio</1>",
+        "enable": "Attiva domicilio digitale"
       },
       "feedback": {
         "title-pec-activation": "Hai attivato il domicilio digitale della tua impresa su PEC",

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/DigitalContactActivation.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/DigitalContactActivation.tsx
@@ -29,7 +29,6 @@ const DigitalContactActivation: React.FC<Props> = ({ isTransferring = false, onG
   const { defaultEMAILAddress, defaultSMSAddress, defaultSERCQ_SENDAddress } = useAppSelector(
     contactsSelectors.selectAddresses
   );
-  const loading = useAppSelector(contactsSelectors.selectLoading);
 
   const [activeStep, setActiveStep] = useState(0);
   const [showConfirmationModal, setShowConfirmationModal] = useState(false);
@@ -111,10 +110,6 @@ const DigitalContactActivation: React.FC<Props> = ({ isTransferring = false, onG
 
     return <></>;
   };
-
-  if (loading) {
-    return null;
-  }
 
   if (showPecWizard) {
     return (

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/DigitalContactActivation.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/DigitalContactActivation.tsx
@@ -13,11 +13,14 @@ import { useAppSelector } from '../../redux/hooks';
 import { getConfiguration } from '../../services/configuration.service';
 import EmailSmsContactWizard from './EmailSmsContactWizard';
 import HowItWorksContactWizard from './HowItWorksContactWizard';
+import SercqSendContactWizard from './SercqSendContactWizard';
 
 type Props = {
   isTransferring?: boolean;
   onGoBack?: () => void;
 };
+
+const MAX_STEPS_NUMBER = 3;
 
 const DigitalContactActivation: React.FC<Props> = ({ isTransferring = false, onGoBack }) => {
   const { t } = useTranslation(['recapiti', 'common']);
@@ -38,6 +41,13 @@ const DigitalContactActivation: React.FC<Props> = ({ isTransferring = false, onG
 
   const goToPreviousStep = () => {
     setActiveStep((step) => step - 1);
+  };
+
+  const goToStep = (step: number) => {
+    if (step >= 0 && step <= MAX_STEPS_NUMBER) {
+      return setActiveStep(step);
+    }
+    return goToNextStep();
   };
 
   const getPreviousButton = () => {
@@ -127,6 +137,9 @@ const DigitalContactActivation: React.FC<Props> = ({ isTransferring = false, onG
       </PnWizardStep>
       <PnWizardStep label={t('legal-contacts.sercq-send-wizard.step_2.step-title')}>
         <EmailSmsContactWizard />
+      </PnWizardStep>
+      <PnWizardStep label={t('legal-contacts.sercq-send-wizard.step_3.step-title')}>
+        <SercqSendContactWizard goToStep={goToStep} />
       </PnWizardStep>
     </PnWizard>
   );

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/DigitalContactActivation.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/DigitalContactActivation.tsx
@@ -29,6 +29,7 @@ const DigitalContactActivation: React.FC<Props> = ({ isTransferring = false, onG
   const { defaultEMAILAddress, defaultSMSAddress, defaultSERCQ_SENDAddress } = useAppSelector(
     contactsSelectors.selectAddresses
   );
+  const loading = useAppSelector(contactsSelectors.selectLoading);
 
   const [activeStep, setActiveStep] = useState(0);
   const [showConfirmationModal, setShowConfirmationModal] = useState(false);
@@ -110,6 +111,10 @@ const DigitalContactActivation: React.FC<Props> = ({ isTransferring = false, onG
 
     return <></>;
   };
+
+  if (loading) {
+    return null;
+  }
 
   if (showPecWizard) {
     return (

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/SercqSendContactWizard.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/SercqSendContactWizard.tsx
@@ -27,6 +27,7 @@ import {
   TosPrivacyConsent,
   appStateActions,
 } from '@pagopa-pn/pn-commons';
+import { theme } from '@pagopa/mui-italia';
 
 import { AddressType, ChannelType, SaveDigitalAddressParams } from '../../models/contacts';
 import { PRIVACY_POLICY, TERMS_OF_SERVICE_SERCQ_SEND } from '../../navigation/routes.const';
@@ -254,6 +255,12 @@ const SercqSendContactWizard: React.FC<Props> = ({ goToStep }) => {
               inputProps={{
                 'aria-describedby': 'disclaimer-helper-text',
                 'aria-invalid': formik.touched.disclaimer && Boolean(formik.errors.disclaimer),
+              }}
+              sx={{
+                color:
+                  formik.touched.disclaimer && Boolean(formik.errors.disclaimer)
+                    ? theme.palette.error.dark
+                    : theme.palette.text.secondary,
               }}
             />
           }

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/SercqSendContactWizard.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/SercqSendContactWizard.tsx
@@ -1,5 +1,5 @@
 import { useFormik } from 'formik';
-import React, { ChangeEvent, useRef } from 'react';
+import React, { ChangeEvent, useMemo, useRef } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import * as yup from 'yup';
 
@@ -13,7 +13,6 @@ import {
   FormControl,
   FormControlLabel,
   FormHelperText,
-  IconButton,
   Link,
   List,
   ListItem,
@@ -60,12 +59,14 @@ const SercqSendContactWizard: React.FC<Props> = ({ goToStep }) => {
   const dispatch = useAppDispatch();
 
   const tosPrivacy = useRef<Array<TosPrivacyConsent>>();
-  const { defaultPECAddress, defaultEMAILAddress, defaultSMSAddress } = useAppSelector(
+  const { defaultEMAILAddress, defaultSMSAddress } = useAppSelector(
     contactsSelectors.selectAddresses
   );
 
   const emailSmsStep = 1;
   const thankYouStep = 3;
+
+  const labelPrefix = 'legal-contacts.sercq-send-wizard.step_3.contacts-list';
 
   const validationSchema = yup.object().shape({
     disclaimer: yup.bool().isTrue(t('required-field', { ns: 'common' })),
@@ -84,32 +85,27 @@ const SercqSendContactWizard: React.FC<Props> = ({ goToStep }) => {
     },
   });
 
-  const sercqSendContactsList: Array<{ title: string; textDisabled: string }> = t(
-    'legal-contacts.sercq-send-wizard.step_3.contacts-list',
-    {
-      returnObjects: true,
-      defaultValue: [],
-    }
+  const contactsRecapData: Array<ContactRecapData> = useMemo(
+    () => [
+      {
+        title: t(`${labelPrefix}.email.title`),
+        value: defaultEMAILAddress?.value,
+        cta: {
+          text: t(`${labelPrefix}.email.textDisabled`),
+          action: () => goToStep(emailSmsStep),
+        },
+      },
+      {
+        title: t(`${labelPrefix}.sms.title`),
+        value: defaultSMSAddress?.value,
+        cta: {
+          text: t(`${labelPrefix}.sms.textDisabled`),
+          action: () => goToStep(emailSmsStep),
+        },
+      },
+    ],
+    [defaultEMAILAddress?.value, defaultSMSAddress?.value, t]
   );
-
-  const getContactsRecapData = (): Array<ContactRecapData> => [
-    {
-      title: sercqSendContactsList[0].title,
-      value: defaultEMAILAddress?.value,
-      cta: {
-        text: sercqSendContactsList[0].textDisabled,
-        action: () => goToStep(emailSmsStep),
-      },
-    },
-    {
-      title: sercqSendContactsList[1].title,
-      value: defaultSMSAddress?.value,
-      cta: {
-        text: sercqSendContactsList[1].textDisabled,
-        action: () => goToStep(emailSmsStep),
-      },
-    },
-  ];
 
   const handleActivation = () => {
     dispatch(getSercqSendTosPrivacyApproval())
@@ -212,7 +208,7 @@ const SercqSendContactWizard: React.FC<Props> = ({ goToStep }) => {
       </Typography>
 
       <List dense sx={{ p: 0 }} data-testid="sercq-send-contacts-list">
-        {getContactsRecapData().map((item) => (
+        {contactsRecapData.map((item) => (
           <ListItem key={item.title} sx={{ px: 0, py: 1 }} divider>
             <Stack width="100%">
               <Typography variant="body1" fontWeight={600}>
@@ -230,18 +226,17 @@ const SercqSendContactWizard: React.FC<Props> = ({ goToStep }) => {
                         fontWeight: 'bold',
                       }}
                       onClick={item.cta.action}
+                      data-testid="backToContactStep"
                     >
                       {item.cta.text}
                     </Link>
                   )}
                 </ListItemText>
-                <IconButton size="small">
-                  {item.value ? (
-                    <CheckCircleIcon fontSize="small" color="success" />
-                  ) : (
-                    <ErrorIcon fontSize="small" color="warning" />
-                  )}
-                </IconButton>
+                {item.value ? (
+                  <CheckCircleIcon fontSize="small" color="success" aria-hidden="true" />
+                ) : (
+                  <ErrorIcon fontSize="small" color="warning" aria-hidden="true" />
+                )}
               </Box>
             </Stack>
           </ListItem>
@@ -308,10 +303,9 @@ const SercqSendContactWizard: React.FC<Props> = ({ goToStep }) => {
         variant="contained"
         color="primary"
         onClick={() => formik.submitForm()}
-        sx={{ textTransform: 'none', mb: !defaultPECAddress ? 4 : 0 }}
         data-testid="activateButton"
       >
-        {t('button.enable', { ns: 'common' })}
+        {t('legal-contacts.sercq-send-wizard.step_3.enable', { ns: 'recapiti' })}
       </Button>
     </Box>
   );

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/__test__/DigitalContactActivation.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/__test__/DigitalContactActivation.test.tsx
@@ -1,8 +1,13 @@
 import MockAdapter from 'axios-mock-adapter';
 import { vi } from 'vitest';
 
+import { ConsentType, SERCQ_SEND_VALUE } from '@pagopa-pn/pn-commons';
 import { getById } from '@pagopa-pn/pn-commons/src/test-utils';
 
+import {
+  acceptTosPrivacyConsentBodyMock,
+  sercqSendTosPrivacyConsentMock,
+} from '../../../__mocks__/Consents.mock';
 import { digitalAddressesSercq, digitalLegalAddresses } from '../../../__mocks__/Contacts.mock';
 import { fireEvent, render, waitFor, within } from '../../../__test__/test-utils';
 import { apiClient } from '../../../api/apiClients';
@@ -114,21 +119,23 @@ describe('DigitalContactActivation', () => {
   });
 
   it('renders the feedback step correctly', async () => {
-    // uncomment the following snippet to mock sercq activation api call once the final step is created
-    // mock.
-    //   onPost('/bff/v1/addresses/LEGAL/default/SERCQ_SEND', {
-    //     value: SERCQ_SEND_VALUE,
-    //   })
-    //   .reply(204);
-    // mock.onGet(/\/bff\/v2\/tos-privacy.*/).reply(200, sercqSendTosPrivacyConsentMock(false, false));
-    // mock
-    //   .onPut(
-    //     '/bff/v2/tos-privacy',
-    //     acceptTosPrivacyConsentBodyMock(ConsentType.TOS_SERCQ, ConsentType.DATAPRIVACY_SERCQ)
-    //   )
-    //   .reply(200);
+    // mock SERCQ activation api call
+    mock
+      .onPost('/bff/v1/addresses/LEGAL/default/SERCQ_SEND', {
+        value: SERCQ_SEND_VALUE,
+      })
+      .reply(204);
+    mock
+      .onGet(/\/bff\/v1\/pg\/tos-privacy.*/)
+      .reply(200, sercqSendTosPrivacyConsentMock(false, false));
+    mock
+      .onPut(
+        '/bff/v1/pg/tos-privacy',
+        acceptTosPrivacyConsentBodyMock(ConsentType.TOS_SERCQ, ConsentType.DATAPRIVACY_SERCQ)
+      )
+      .reply(200);
 
-    const { getByTestId, getByText } = render(<DigitalContactActivation />, {
+    const { container, getByTestId, getByText } = render(<DigitalContactActivation />, {
       preloadedState: {
         contactsState: {
           digitalAddresses: [
@@ -150,8 +157,21 @@ describe('DigitalContactActivation', () => {
     expect(confirmButton).toBeEnabled();
     fireEvent.click(confirmButton);
 
-    const feedbackStep = getByTestId('wizard-feedback-step');
-    expect(feedbackStep).toBeInTheDocument();
+    // recap step: check disclaimer and press button to enable sercq
+    const disclaimerCkb = getById(container, 'disclaimer');
+    expect(disclaimerCkb).not.toBeChecked();
+
+    fireEvent.click(disclaimerCkb);
+
+    expect(disclaimerCkb).toBeChecked();
+    const enableSercqButton = getByTestId('activateButton');
+    fireEvent.click(enableSercqButton);
+
+    // feedback step
+    await waitFor(() => {
+      const feedbackStep = getByTestId('wizard-feedback-step');
+      expect(feedbackStep).toBeInTheDocument();
+    });
 
     const feedbackTitle = getByTestId('wizard-feedback-title');
     expect(feedbackTitle).toHaveTextContent(`${labelPrefix}.feedback.title-sercq_send-activation`);
@@ -168,20 +188,21 @@ describe('DigitalContactActivation', () => {
   });
 
   it('adds an email correctly', async () => {
-    // uncomment the following snippet to mock sercq activation api call once the final step is created
-    // use the following commented code once the recap step is created to mock sercq activation api call
-    // mock.
-    //   onPost('/bff/v1/addresses/LEGAL/default/SERCQ_SEND', {
-    //     value: SERCQ_SEND_VALUE,
-    //   })
-    //   .reply(204);
-    // mock.onGet(/\/bff\/v2\/tos-privacy.*/).reply(200, sercqSendTosPrivacyConsentMock(false, false));
-    // mock
-    //   .onPut(
-    //     '/bff/v2/tos-privacy',
-    //     acceptTosPrivacyConsentBodyMock(ConsentType.TOS_SERCQ, ConsentType.DATAPRIVACY_SERCQ)
-    //   )
-    //   .reply(200);
+    // mock SERCQ activation api call
+    mock
+      .onPost('/bff/v1/addresses/LEGAL/default/SERCQ_SEND', {
+        value: SERCQ_SEND_VALUE,
+      })
+      .reply(204);
+    mock
+      .onGet(/\/bff\/v1\/pg\/tos-privacy.*/)
+      .reply(200, sercqSendTosPrivacyConsentMock(false, false));
+    mock
+      .onPut(
+        '/bff/v1/pg/tos-privacy',
+        acceptTosPrivacyConsentBodyMock(ConsentType.TOS_SERCQ, ConsentType.DATAPRIVACY_SERCQ)
+      )
+      .reply(200);
 
     const mailValue = 'nome.utente@mail.it';
     mock.onPost('/bff/v1/addresses/COURTESY/default/EMAIL', { value: mailValue }).reply(200, {
@@ -240,9 +261,21 @@ describe('DigitalContactActivation', () => {
 
     fireEvent.click(confirmButton);
 
-    // thankyou page
-    const feedbackStep = result.getByTestId('wizard-feedback-step');
-    expect(feedbackStep).toBeInTheDocument();
+    // recap step: check disclaimer and press button to enable sercq
+    const disclaimerCkb = getById(result.container, 'disclaimer');
+    expect(disclaimerCkb).not.toBeChecked();
+
+    fireEvent.click(disclaimerCkb);
+
+    expect(disclaimerCkb).toBeChecked();
+    const enableSercqButton = result.getByTestId('activateButton');
+    fireEvent.click(enableSercqButton);
+
+    // feedback step
+    await waitFor(() => {
+      const feedbackStep = result.getByTestId('wizard-feedback-step');
+      expect(feedbackStep).toBeInTheDocument();
+    });
 
     const feedbackTitle = result.getByTestId('wizard-feedback-title');
     expect(feedbackTitle).toHaveTextContent(`${labelPrefix}.feedback.title-sercq_send-activation`);
@@ -258,22 +291,23 @@ describe('DigitalContactActivation', () => {
   });
 
   it('renders component correctly when transferring', async () => {
-    // uncomment the following snippet to mock sercq activation api call once the final step is created
-    // use the following commented code once the recap step is created to mock sercq activation api call
-    // mock.
-    //   onPost('/bff/v1/addresses/LEGAL/default/SERCQ_SEND', {
-    //     value: SERCQ_SEND_VALUE,
-    //   })
-    //   .reply(204);
-    // mock.onGet(/\/bff\/v2\/tos-privacy.*/).reply(200, sercqSendTosPrivacyConsentMock(false, false));
-    // mock
-    //   .onPut(
-    //     '/bff/v2/tos-privacy',
-    //     acceptTosPrivacyConsentBodyMock(ConsentType.TOS_SERCQ, ConsentType.DATAPRIVACY_SERCQ)
-    //   )
-    //   .reply(200);
+    /// mock SERCQ activation api call
+    mock
+      .onPost('/bff/v1/addresses/LEGAL/default/SERCQ_SEND', {
+        value: SERCQ_SEND_VALUE,
+      })
+      .reply(204);
+    mock
+      .onGet(/\/bff\/v1\/pg\/tos-privacy.*/)
+      .reply(200, sercqSendTosPrivacyConsentMock(false, false));
+    mock
+      .onPut(
+        '/bff/v1/pg/tos-privacy',
+        acceptTosPrivacyConsentBodyMock(ConsentType.TOS_SERCQ, ConsentType.DATAPRIVACY_SERCQ)
+      )
+      .reply(200);
 
-    const { getByTestId, queryByTestId, getByText } = render(
+    const { container, getByTestId, queryByTestId, getByText } = render(
       <DigitalContactActivation isTransferring />,
       {
         preloadedState: {
@@ -306,9 +340,21 @@ describe('DigitalContactActivation', () => {
     expect(confirmButton).toBeEnabled();
     fireEvent.click(confirmButton);
 
-    // Thank-you page
-    const feedbackStep = getByTestId('wizard-feedback-step');
-    expect(feedbackStep).toBeInTheDocument();
+    // recap step: check disclaimer and press button to enable sercq
+    const disclaimerCkb = getById(container, 'disclaimer');
+    expect(disclaimerCkb).not.toBeChecked();
+
+    fireEvent.click(disclaimerCkb);
+
+    expect(disclaimerCkb).toBeChecked();
+    const enableSercqButton = getByTestId('activateButton');
+    fireEvent.click(enableSercqButton);
+
+    // feedback step
+    await waitFor(() => {
+      const feedbackStep = getByTestId('wizard-feedback-step');
+      expect(feedbackStep).toBeInTheDocument();
+    });
 
     const feedbackTitle = getByTestId('wizard-feedback-title');
     expect(feedbackTitle).toHaveTextContent(`${labelPrefix}.feedback.title-sercq_send-transfer`);

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/__test__/SercqSendContactWizard.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/__test__/SercqSendContactWizard.test.tsx
@@ -27,13 +27,10 @@ describe('SercqSendContactWizard', () => {
     mock.restore();
   });
 
-  const goToNextStep = vi.fn();
-  const setShowPecWizard = vi.fn();
+  const goToStep = vi.fn();
 
   it('render components', async () => {
-    const { getByText, getByTestId } = render(
-      <SercqSendContactWizard goToNextStep={goToNextStep} setShowPecWizard={setShowPecWizard} />
-    );
+    const { getByText, getByTestId } = render(<SercqSendContactWizard goToStep={goToStep} />);
 
     expect(getByText('legal-contacts.sercq-send-wizard.step_1.title')).toBeInTheDocument();
     expect(getByTestId('sercq-send-info-list')).toBeInTheDocument();
@@ -46,25 +43,22 @@ describe('SercqSendContactWizard', () => {
   });
 
   it('should not show pec section if default pec address is present', async () => {
-    const { getByTestId, queryByTestId } = render(
-      <SercqSendContactWizard goToNextStep={goToNextStep} setShowPecWizard={setShowPecWizard} />,
-      {
-        preloadedState: {
-          contactsState: {
-            digitalAddresses: [
-              {
-                addressType: AddressType.LEGAL,
-                senderId: 'default',
-                channelType: ChannelType.PEC,
-                value: 'pec@test.it',
-                pecValid: true,
-                codeValid: true,
-              },
-            ],
-          },
+    const { getByTestId, queryByTestId } = render(<SercqSendContactWizard goToStep={goToStep} />, {
+      preloadedState: {
+        contactsState: {
+          digitalAddresses: [
+            {
+              addressType: AddressType.LEGAL,
+              senderId: 'default',
+              channelType: ChannelType.PEC,
+              value: 'pec@test.it',
+              pecValid: true,
+              codeValid: true,
+            },
+          ],
         },
-      }
-    );
+      },
+    });
 
     const pecSection = queryByTestId('pec-section');
     expect(pecSection).not.toBeInTheDocument();
@@ -90,9 +84,7 @@ describe('SercqSendContactWizard', () => {
       )
       .reply(200);
     // render component
-    const { getByTestId } = render(
-      <SercqSendContactWizard goToNextStep={goToNextStep} setShowPecWizard={setShowPecWizard} />
-    );
+    const { getByTestId } = render(<SercqSendContactWizard goToStep={goToStep} />);
     const activateButton = getByTestId('activateButton');
     fireEvent.click(activateButton);
 
@@ -105,6 +97,7 @@ describe('SercqSendContactWizard', () => {
       });
     });
 
-    expect(goToNextStep).toHaveBeenCalledTimes(1);
+    expect(goToStep).toHaveBeenCalledTimes(1);
+    expect(goToStep).toHaveBeenCalledWith(3);
   });
 });

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/__test__/SercqSendContactWizard.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/__test__/SercqSendContactWizard.test.tsx
@@ -2,73 +2,176 @@ import MockAdapter from 'axios-mock-adapter';
 import { vi } from 'vitest';
 
 import { ConsentType, SERCQ_SEND_VALUE } from '@pagopa-pn/pn-commons';
+import { getById } from '@pagopa-pn/pn-commons/src/test-utils';
 
 import {
   acceptTosPrivacyConsentBodyMock,
   sercqSendTosPrivacyConsentMock,
 } from '../../../__mocks__/Consents.mock';
+import { digitalAddresses } from '../../../__mocks__/Contacts.mock';
 import { fireEvent, render, waitFor } from '../../../__test__/test-utils';
 import { apiClient } from '../../../api/apiClients';
 import { AddressType, ChannelType } from '../../../models/contacts';
 import SercqSendContactWizard from '../SercqSendContactWizard';
 
+const labelPrefix = 'legal-contacts.sercq-send-wizard.step_3';
+
 describe('SercqSendContactWizard', () => {
   let mock: MockAdapter;
+  let goToStep = vi.fn();
 
   beforeAll(() => {
     mock = new MockAdapter(apiClient);
   });
 
-  afterEach(() => {
+  beforeEach(() => {
     mock.reset();
+    vi.restoreAllMocks();
   });
 
   afterAll(() => {
     mock.restore();
   });
 
-  const goToStep = vi.fn();
-
   it('render components', async () => {
-    const { getByText, getByTestId } = render(<SercqSendContactWizard goToStep={goToStep} />);
+    const initialAddresses = digitalAddresses.filter(
+      (addr) => addr.addressType === AddressType.COURTESY
+    );
+    const { container, getByText, getByTestId } = render(
+      <SercqSendContactWizard goToStep={goToStep} />,
+      {
+        preloadedState: {
+          contactsState: {
+            digitalAddresses: initialAddresses,
+          },
+        },
+      }
+    );
 
-    expect(getByText('legal-contacts.sercq-send-wizard.step_1.title')).toBeInTheDocument();
-    expect(getByTestId('sercq-send-info-list')).toBeInTheDocument();
+    expect(getByText(`${labelPrefix}.title`)).toBeInTheDocument();
+    expect(getByText(`${labelPrefix}.content`)).toBeInTheDocument();
+    expect(getByText(`${labelPrefix}.digital-domicile`)).toBeInTheDocument();
+    expect(getByText(`${labelPrefix}.send`)).toBeInTheDocument();
+    expect(getByText(`${labelPrefix}.courtesy-content`)).toBeInTheDocument();
+
+    expect(getByText(`${labelPrefix}.contacts-list.email.title`)).toBeInTheDocument();
+    expect(getByText(initialAddresses[0].value));
+
+    expect(getByText(`${labelPrefix}.contacts-list.sms.title`)).toBeInTheDocument();
+    expect(getByText(initialAddresses[1].value));
+
+    const icons = container.querySelectorAll(
+      'svg[data-testid="CheckCircleIcon"], svg[data-testid="ErrorIcon"]'
+    );
+
+    const emailIcon = icons[0];
+    const smsIcon = icons[1];
+    expect(emailIcon).toHaveAttribute('data-testid', 'CheckCircleIcon');
+    expect(smsIcon).toHaveAttribute('data-testid', 'CheckCircleIcon');
+
+    const disclaimerCkb = getById(container, 'disclaimer');
+    expect(disclaimerCkb).not.toBeChecked();
+    expect(getByText(`${labelPrefix}.disclaimer`)).toBeInTheDocument();
+
     const activateButton = getByTestId('activateButton');
     expect(activateButton).toBeInTheDocument();
-    expect(activateButton).toHaveTextContent('button.enable');
-    expect(activateButton).toBeEnabled();
-    const pecSection = getByTestId('pec-section');
-    expect(pecSection).toBeInTheDocument();
+    expect(activateButton).toHaveTextContent(`${labelPrefix}.enable`);
   });
 
-  it('should not show pec section if default pec address is present', async () => {
-    const { getByTestId, queryByTestId } = render(<SercqSendContactWizard goToStep={goToStep} />, {
+  it('should show links to relative steps - no email', async () => {
+    const initialAddresses = [
+      {
+        addressType: AddressType.COURTESY,
+        senderId: 'default',
+        channelType: ChannelType.SMS,
+        value: '+393333333333',
+      },
+    ];
+
+    // render component
+    const { container, getByText } = render(<SercqSendContactWizard goToStep={goToStep} />, {
       preloadedState: {
         contactsState: {
-          digitalAddresses: [
-            {
-              addressType: AddressType.LEGAL,
-              senderId: 'default',
-              channelType: ChannelType.PEC,
-              value: 'pec@test.it',
-              pecValid: true,
-              codeValid: true,
-            },
-          ],
+          digitalAddresses: initialAddresses,
         },
       },
     });
 
-    const pecSection = queryByTestId('pec-section');
-    expect(pecSection).not.toBeInTheDocument();
-    const activateButton = getByTestId('activateButton');
-    expect(activateButton).toBeInTheDocument();
-    const alertMessage = getByTestId('default-pec-info');
-    expect(alertMessage).toBeInTheDocument();
+    expect(getByText(`${labelPrefix}.contacts-list.email.title`)).toBeInTheDocument();
+    const emailLink = getByText(`${labelPrefix}.contacts-list.email.textDisabled`, {
+      selector: 'a',
+    });
+
+    expect(getByText(`${labelPrefix}.contacts-list.sms.title`)).toBeInTheDocument();
+    expect(getByText(initialAddresses[0].value));
+
+    const icons = container.querySelectorAll(
+      'svg[data-testid="CheckCircleIcon"], svg[data-testid="ErrorIcon"]'
+    );
+    expect(icons.length).toBe(2);
+    const emailIcon = icons[0];
+    const smsIcon = icons[1];
+    expect(emailIcon).toHaveAttribute('data-testid', 'ErrorIcon');
+    expect(smsIcon).toHaveAttribute('data-testid', 'CheckCircleIcon');
+
+    fireEvent.click(emailLink);
+
+    expect(goToStep).toHaveBeenCalledTimes(1);
+    expect(goToStep).toHaveBeenCalledWith(1);
+  });
+
+  it('should show links to relative steps - no sms', async () => {
+    const initialAddresses = [
+      {
+        addressType: AddressType.COURTESY,
+        senderId: 'default',
+        channelType: ChannelType.EMAIL,
+        value: 'nome.utente@mail.it',
+      },
+    ];
+
+    // render component
+    const { container, getByText } = render(<SercqSendContactWizard goToStep={goToStep} />, {
+      preloadedState: {
+        contactsState: {
+          digitalAddresses: initialAddresses,
+        },
+      },
+    });
+
+    expect(getByText(`${labelPrefix}.contacts-list.email.title`)).toBeInTheDocument();
+    expect(getByText(initialAddresses[0].value));
+
+    expect(getByText(`${labelPrefix}.contacts-list.sms.title`)).toBeInTheDocument();
+    const smsLink = getByText(`${labelPrefix}.contacts-list.sms.textDisabled`, {
+      selector: 'a',
+    });
+
+    const icons = container.querySelectorAll(
+      'svg[data-testid="CheckCircleIcon"], svg[data-testid="ErrorIcon"]'
+    );
+    expect(icons.length).toBe(2);
+    const emailIcon = icons[0];
+    const smsIcon = icons[1];
+    expect(emailIcon).toHaveAttribute('data-testid', 'CheckCircleIcon');
+    expect(smsIcon).toHaveAttribute('data-testid', 'ErrorIcon');
+
+    fireEvent.click(smsLink);
+
+    expect(goToStep).toHaveBeenCalledTimes(1);
+    expect(goToStep).toHaveBeenCalledWith(1);
   });
 
   it('should activate sercq send', async () => {
+    const initialAddresses = [
+      {
+        addressType: AddressType.COURTESY,
+        senderId: 'default',
+        channelType: ChannelType.EMAIL,
+        value: 'nome.utente@mail.it',
+      },
+    ];
+
     mock
       .onPost('/bff/v1/addresses/LEGAL/default/SERCQ_SEND', {
         value: SERCQ_SEND_VALUE,
@@ -83,9 +186,44 @@ describe('SercqSendContactWizard', () => {
         acceptTosPrivacyConsentBodyMock(ConsentType.TOS_SERCQ, ConsentType.DATAPRIVACY_SERCQ)
       )
       .reply(200);
+
     // render component
-    const { getByTestId } = render(<SercqSendContactWizard goToStep={goToStep} />);
+    const { container, findByText, getByTestId, queryByText } = render(
+      <SercqSendContactWizard goToStep={goToStep} />,
+      {
+        preloadedState: {
+          contactsState: {
+            digitalAddresses: initialAddresses,
+          },
+        },
+      }
+    );
+
+    const icons = container.querySelectorAll(
+      'svg[data-testid="CheckCircleIcon"], svg[data-testid="ErrorIcon"]'
+    );
+    expect(icons.length).toBe(2);
+    const emailIcon = icons[0];
+    const smsIcon = icons[1];
+    expect(emailIcon).toHaveAttribute('data-testid', 'CheckCircleIcon');
+    expect(smsIcon).toHaveAttribute('data-testid', 'ErrorIcon');
+
     const activateButton = getByTestId('activateButton');
+    let errorMsg = queryByText('required-field');
+    expect(errorMsg).not.toBeInTheDocument();
+
+    fireEvent.click(activateButton);
+
+    errorMsg = await findByText('required-field');
+    expect(errorMsg).toBeInTheDocument();
+
+    const disclaimerCkb = getById(container, 'disclaimer');
+    expect(disclaimerCkb).not.toBeChecked();
+
+    fireEvent.click(disclaimerCkb);
+
+    expect(disclaimerCkb).toBeChecked();
+
     fireEvent.click(activateButton);
 
     await waitFor(() => {

--- a/packages/pn-personagiuridica-webapp/src/pages/DigitalContact.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/DigitalContact.page.tsx
@@ -3,15 +3,25 @@ import { Outlet } from 'react-router-dom';
 import { Box } from '@mui/material';
 
 import LoadingPageWrapper from '../components/LoadingPageWrapper/LoadingPageWrapper';
+import { contactsSelectors } from '../redux/contact/reducers';
+import { useAppSelector } from '../redux/hooks';
 
-const DigitalContact: React.FC = () => (
-  <LoadingPageWrapper isInitialized={true}>
-    <Box display="flex" justifyContent="center">
-      <Box sx={{ width: { xs: '100%', lg: '760px' } }}>
-        <Outlet />
+const DigitalContact: React.FC = () => {
+  const loading = useAppSelector(contactsSelectors.selectLoading);
+
+  if (loading) {
+    return <></>;
+  }
+
+  return (
+    <LoadingPageWrapper isInitialized={true}>
+      <Box display="flex" justifyContent="center">
+        <Box sx={{ width: { xs: '100%', lg: '760px' } }}>
+          <Outlet />
+        </Box>
       </Box>
-    </Box>
-  </LoadingPageWrapper>
-);
+    </LoadingPageWrapper>
+  );
+};
 
 export default DigitalContact;

--- a/packages/pn-personagiuridica-webapp/src/redux/contact/__test__/reducers.test.ts
+++ b/packages/pn-personagiuridica-webapp/src/redux/contact/__test__/reducers.test.ts
@@ -260,4 +260,39 @@ describe('Contacts redux state tests', () => {
       );
     }
   });
+
+  it('should handle loading state during fetch digital addresses', async () => {
+    const testStore = createMockedStore({
+      contactsState: initialState,
+    });
+
+    mock.onGet('/bff/v1/addresses').reply(() => {
+      // verify loading is true before response
+      const stateBefore = testStore.getState().contactsState;
+      expect(stateBefore.loading).toBe(true);
+      return [200, digitalAddresses];
+    });
+
+    const action = await testStore.dispatch(getDigitalAddresses());
+
+    // after response
+    const stateAfter = testStore.getState().contactsState;
+    expect(stateAfter.loading).toBe(false);
+    expect(stateAfter.digitalAddresses).toEqual(digitalAddresses);
+    expect(action.type).toBe('getDigitalAddresses/fulfilled');
+  });
+
+  it('should reset loading state if fetch fails', async () => {
+    const testStore = createMockedStore({
+      contactsState: initialState,
+    });
+
+    mock.onGet('/bff/v1/addresses').reply(500);
+
+    const action = await testStore.dispatch(getDigitalAddresses());
+
+    const state = testStore.getState().contactsState;
+    expect(state.loading).toBe(false);
+    expect(action.type).toBe('getDigitalAddresses/rejected');
+  });
 });

--- a/packages/pn-personagiuridica-webapp/src/redux/contact/reducers.ts
+++ b/packages/pn-personagiuridica-webapp/src/redux/contact/reducers.ts
@@ -46,8 +46,15 @@ const contactsSlice = createSlice({
     },
   },
   extraReducers: (builder) => {
+    builder.addCase(getDigitalAddresses.pending, (state) => {
+      state.loading = true;
+    });
     builder.addCase(getDigitalAddresses.fulfilled, (state, action) => {
       state.digitalAddresses = action.payload;
+      state.loading = false;
+    });
+    builder.addCase(getDigitalAddresses.rejected, (state) => {
+      state.loading = false;
     });
     builder.addCase(createOrUpdateAddress.fulfilled, (state, action) => {
       if (action.payload) {
@@ -84,6 +91,8 @@ const digitalAddresses = createSelector(
   [contactState],
   (contactsState) => contactsState.digitalAddresses
 );
+
+const loading = createSelector([contactState], (contactsState) => contactsState.loading);
 
 export type SelectedAddresses = {
   addresses: Array<DigitalAddress>;
@@ -125,6 +134,7 @@ const memoizedSelectAddresses = createSelector([digitalAddresses], (digitalAddre
 
 export const contactsSelectors = {
   selectAddresses: memoizedSelectAddresses,
+  selectLoading: loading,
 };
 // END: SELECTORS
 


### PR DESCRIPTION
## Short description
This PR adds the last step of SERCQ activation/transfer wizard

## List of changes proposed in this pull request
- DigitalContactActivation.tsx: add logic to manage the new step and change the way showIOStep is calculated to avoid inconsistent state on refresh
- SercqSendContactWizard.tsx: add contacts recap list and the disclaimer checkbox
- DigitalContactActivation.test.tsx and SercqSendContactWizard.test.tsx: add/refactor tests to verify the new features work correctly
- redux/contact/reducers.ts: add code to update the 'loading' state. This state is used to grant the contacts have been loaded inside DigitalContactActivation component and prevent inconsistent behaviour, expecially when used to calculate the 'showIOStep' value. Added tests to check new code.
- recapiti.json: add/edit localization text

## How to test
Run both PF and PG webapps and verify it works as expected