### PR TITLE
fix(pn-15747): fixed wrong copy when a courtesy contact linked to a sender is deleted

### DIFF
--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/SpecialContacts.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/SpecialContacts.tsx
@@ -58,7 +58,7 @@ const SpecialContacts: React.FC<{ addressType: AddressType; channelType?: Channe
     channelType: ChannelType.PEC,
   });
 
-  const labelRoot = `legal-contacts`;
+  const labelRoot = `${addressType.toLowerCase()}-contacts`;
   const contactType = currentAddress.current.channelType.toLowerCase();
 
   const handleCodeVerification = (verificationCode?: string) => {


### PR DESCRIPTION
## Short description
Fixed wrong copy when a courtesy contact linked to a sender is deleted

## List of changes proposed in this pull request
- Use address type (legal or courtesy) to choose which copy show when a special contact is deleted

## How to test
Go to PG -> add a special courtesy contact using postman -> delete the contact and check that the success toast shows the correct copy