### PR TITLE
fix(PN-16022): include .well-known folder in tar build

### DIFF
--- a/cra_buildspec.yaml
+++ b/cra_buildspec.yaml
@@ -31,7 +31,7 @@ phases:
       - echo $COMMIT_ID > $SUB_PRJ_NAME/build/commit_id.txt
       - echo gzipping and pushing artifact to s3
       - cd $SUB_PRJ_NAME/build
-      - tar c * | gzip | aws s3 cp - "s3://${CI_ARTIFACT_BUCKET}/${GITHUB_PRJ_NAME}/commits/${COMMIT_ID}/${PACKAGE_NAME}.tar.gz"
+      - tar c --ignore-failed-read .well-known * | gzip | aws s3 cp - "s3://${CI_ARTIFACT_BUCKET}/${GITHUB_PRJ_NAME}/commits/${COMMIT_ID}/${PACKAGE_NAME}.tar.gz"
       - |
         BRANCH_NAME=$(echo $CODEBUILD_WEBHOOK_HEAD_REF | sed 's/refs\/heads\///'); export BRANCH_NAME=${BRANCH_NAME:=$GIT_DEFAULT_BRANCH}
         EVENT_DETAIL="{ \"event_type\": \"BUILD_DONE\", \"project_branch\":\"${BRANCH_NAME}\",\"project_type\":\"FRONTEND\", \"project\":\"pn-frontend\", \"commit_id\": \"${CODEBUILD_RESOLVED_SOURCE_VERSION}\" }"


### PR DESCRIPTION
## Short description
With command `tar c *` hidden files are not included. We need to add .well-known folder.