### PR TITLE
fix(PN-15517): use actual expiry token date from api response

### DIFF
--- a/packages/pn-personafisica-webapp/src/navigation/SessionGuard.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/SessionGuard.tsx
@@ -49,8 +49,8 @@ const SessionGuard = () => {
   const performExchangeToken = async (token: TokenExchangeRequest) => {
     AppResponsePublisher.error.subscribe('exchangeToken', manageUnforbiddenError);
     try {
-      await dispatch(exchangeToken(token)).unwrap();
-      sessionCheck(exp);
+      const user = await dispatch(exchangeToken(token)).unwrap();
+      sessionCheck(user.exp);
     } catch (error) {
       const adaptedError = adaptedTokenExchangeError(error);
       if (adaptedError.response.status === 451 || WORK_IN_PROGRESS) {


### PR DESCRIPTION
## Short description
Use `exp` token date value from api response instead of `exp` value from redux that it's not ready.