### PR TITLE
fix/pn(14794): handle user inactivity

### DIFF
--- a/packages/pn-commons/src/components/InactivityHandler.tsx
+++ b/packages/pn-commons/src/components/InactivityHandler.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable functional/immutable-data */
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { Button, DialogContentText, DialogTitle } from '@mui/material';
 
@@ -29,12 +29,12 @@ const InactivityHandler: React.FC<Props> = ({ inactivityTimer, onTimerExpired, c
     setOpenModal(false);
   };
 
-  const handleActivity = (() => {
+  const handleActivity = useCallback(() => {
     if (openModal) {
       return;
     }
     lastActivityRef.current = Date.now();
-  });
+  }, [openModal]);
 
   useEffect(() => {
     if (inactivityTimer === 0) {

--- a/packages/pn-commons/src/components/InactivityHandler.tsx
+++ b/packages/pn-commons/src/components/InactivityHandler.tsx
@@ -23,7 +23,6 @@ const events = ['mousemove', 'keydown', 'scroll', 'click', 'touchstart'];
 const InactivityHandler: React.FC<Props> = ({ inactivityTimer, onTimerExpired, children }) => {
   const [openModal, setOpenModal] = useState(false);
   const lastActivityRef = useRef(Date.now());
-  const intervalRef = useRef(0);
 
   const confirmModal = () => {
     lastActivityRef.current = Date.now();
@@ -42,10 +41,7 @@ const InactivityHandler: React.FC<Props> = ({ inactivityTimer, onTimerExpired, c
       return;
     }
 
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current);
-    }
-    intervalRef.current = window.setInterval(() => {
+    const interval = window.setInterval(() => {
       const diffMs = Date.now() - lastActivityRef.current;
       if (inactivityTimer > warningTimer && diffMs >= inactivityTimer - warningTimer) {
         setOpenModal(true);
@@ -60,7 +56,7 @@ const InactivityHandler: React.FC<Props> = ({ inactivityTimer, onTimerExpired, c
     });
 
     return () => {
-      clearInterval(intervalRef.current);
+      clearInterval(interval);
       events.forEach((event) => {
         window.removeEventListener(event, handleActivity);
       });

--- a/packages/pn-commons/src/components/InactivityHandler.tsx
+++ b/packages/pn-commons/src/components/InactivityHandler.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable functional/immutable-data */
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { Button, DialogContentText, DialogTitle } from '@mui/material';
 

--- a/packages/pn-commons/src/components/InactivityHandler.tsx
+++ b/packages/pn-commons/src/components/InactivityHandler.tsx
@@ -30,8 +30,7 @@ const InactivityHandler: React.FC<Props> = ({ inactivityTimer, onTimerExpired, c
     setOpenModal(false);
   };
 
-  const handleActivity = useCallback((e:any) => {
-    console.log('handleActivity', e);
+  const handleActivity = useCallback(() => {
     if (openModal) {
       return;
     }

--- a/packages/pn-commons/src/components/InactivityHandler.tsx
+++ b/packages/pn-commons/src/components/InactivityHandler.tsx
@@ -29,12 +29,12 @@ const InactivityHandler: React.FC<Props> = ({ inactivityTimer, onTimerExpired, c
     setOpenModal(false);
   };
 
-  const handleActivity = useCallback(() => {
+  const handleActivity = (() => {
     if (openModal) {
       return;
     }
     lastActivityRef.current = Date.now();
-  }, [openModal]);
+  });
 
   useEffect(() => {
     if (inactivityTimer === 0) {

--- a/packages/pn-commons/src/components/InactivityHandler.tsx
+++ b/packages/pn-commons/src/components/InactivityHandler.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react';
+/* eslint-disable functional/immutable-data */
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { Button, DialogContentText, DialogTitle } from '@mui/material';
 
@@ -6,6 +7,8 @@ import { getLocalizedOrDefaultLabel } from '../utility/localization.utility';
 import PnDialog from './PnDialog/PnDialog';
 import PnDialogActions from './PnDialog/PnDialogActions';
 import PnDialogContent from './PnDialog/PnDialogContent';
+
+const warningTimer = 30 * 1000; // 30 seconds before inactivityTimer user will be warned
 
 type Props = {
   /** Inactivity timer (in milliseconds), if 0 the inactivity timer is disabled */
@@ -15,34 +18,55 @@ type Props = {
   children?: React.ReactNode;
 };
 
+const events = ['mousemove', 'keydown', 'scroll', 'click', 'touchstart'];
+
 const InactivityHandler: React.FC<Props> = ({ inactivityTimer, onTimerExpired, children }) => {
-  const [initTimeout, setInitTimeout] = useState(true);
   const [openModal, setOpenModal] = useState(false);
-  const resetTimer = () => setInitTimeout(!initTimeout);
+  const lastActivityRef = useRef(Date.now());
+  const intervalRef = useRef(0);
 
-  // init timer
-  useEffect(() => {
-    if (inactivityTimer) {
-      // this is the timer after wich the inactivity modal is shown
-      const inactivityWarningTimer = inactivityTimer - 30 * 1000;
-      // init timer
-      const timer = setTimeout(() => {
-        onTimerExpired();
-      }, inactivityTimer);
+  const confirmModal = () => {
+    lastActivityRef.current = Date.now();
+    setOpenModal(false);
+  };
 
-      const warningTimer = setTimeout(() => {
-        setOpenModal(true);
-      }, inactivityWarningTimer);
-
-      // cleanup function
-      return () => {
-        setOpenModal(false);
-        clearTimeout(timer);
-        clearTimeout(warningTimer);
-      };
+  const handleActivity = useCallback((e:any) => {
+    console.log('handleActivity', e);
+    if (openModal) {
+      return;
     }
-    return () => {};
-  }, [initTimeout]);
+    lastActivityRef.current = Date.now();
+  }, [openModal]);
+
+  useEffect(() => {
+    if (inactivityTimer === 0) {
+      return;
+    }
+
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+    }
+    intervalRef.current = window.setInterval(() => {
+      const diffMs = Date.now() - lastActivityRef.current;
+      if (inactivityTimer > warningTimer && diffMs >= inactivityTimer - warningTimer) {
+        setOpenModal(true);
+      }
+      if (diffMs >= inactivityTimer) {
+        onTimerExpired();
+      }
+    }, 1000);
+
+    events.forEach((event) => {
+      window.addEventListener(event, handleActivity);
+    });
+
+    return () => {
+      clearInterval(intervalRef.current);
+      events.forEach((event) => {
+        window.removeEventListener(event, handleActivity);
+      });
+    };
+  }, [handleActivity]);
 
   return (
     <>
@@ -66,7 +90,7 @@ const InactivityHandler: React.FC<Props> = ({ inactivityTimer, onTimerExpired, c
             color="primary"
             variant="outlined"
             data-testid="inactivity-button"
-            onClick={resetTimer}
+            onClick={confirmModal}
           >
             {getLocalizedOrDefaultLabel('common', 'inactivity.action')}
           </Button>

--- a/packages/pn-commons/src/components/InactivityHandler.tsx
+++ b/packages/pn-commons/src/components/InactivityHandler.tsx
@@ -8,7 +8,7 @@ import PnDialog from './PnDialog/PnDialog';
 import PnDialogActions from './PnDialog/PnDialogActions';
 import PnDialogContent from './PnDialog/PnDialogContent';
 
-const warningTimer = 30 * 1000; // 30 seconds before inactivityTimer user will be warned
+export const warningTimer = 30 * 1000; // 30 seconds before inactivityTimer user will be warned
 
 type Props = {
   /** Inactivity timer (in milliseconds), if 0 the inactivity timer is disabled */

--- a/packages/pn-commons/src/components/__test__/InactivityHandler.test.tsx
+++ b/packages/pn-commons/src/components/__test__/InactivityHandler.test.tsx
@@ -1,7 +1,7 @@
 import { vi } from 'vitest';
 
 import { act, fireEvent, render, within } from '../../test-utils';
-import InactivityHandler from '../InactivityHandler';
+import InactivityHandler, { warningTimer } from '../InactivityHandler';
 
 const timerExpiredHandler = vi.fn();
 const inactivityTimer = 60 * 1000;
@@ -34,14 +34,30 @@ describe('InactivityHandler Component', () => {
     expect(timerExpiredHandler).toHaveBeenCalledTimes(1);
   });
 
-  it('test user interaction', async () => {
-    // render component
+  it('test user interaction in warning modal', async () => {
+    let fakeNow = 0;
+    vi.setSystemTime(fakeNow);
     const { getByTestId } = render(<Component />);
-    await act(() => vi.advanceTimersByTime(inactivityTimer - 30 * 1000));
+
+    // Step for warning modal
+    await act(async () => {
+      fakeNow += inactivityTimer - warningTimer;
+      vi.setSystemTime(fakeNow);
+      vi.advanceTimersByTime(inactivityTimer - warningTimer);
+    });
+
     const inactivityDialog = getByTestId('inactivity-modal');
     expect(inactivityDialog).toBeInTheDocument();
     const inactivityButton = within(inactivityDialog).getByTestId('inactivity-button');
     fireEvent.click(inactivityButton);
-    expect(timerExpiredHandler).toHaveBeenCalledTimes(0);
+
+    // Step 1sec for interval callback
+    await act(async () => {
+      fakeNow += 1000;
+      vi.setSystemTime(fakeNow);
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(timerExpiredHandler).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/pn-pa-webapp/public/conf/config-dev.json
+++ b/packages/pn-pa-webapp/public/conf/config-dev.json
@@ -2,7 +2,7 @@
   "PAGOPA_HELP_EMAIL": "enti-send@assistenza.pagopa.it",
   "SELFCARE_BASE_URL": "https://uat.selfcare.pagopa.it",
   "API_BASE_URL": "https://webapi.dev.notifichedigitali.it/",
-  "IS_INACTIVITY_HANDLER_ENABLED": false,
+  "INACTIVITY_HANDLER_MINUTES": 0,
   "OT_DOMAIN_ID": "62ebb6a0-1a65-48a4-8ca0-837de03b1199-test",
   "MIXPANEL_TOKEN": "aef0b0d89c3355510e9cdfdb18e7d0b5",
   "ONE_TRUST_DRAFT_MODE": true,

--- a/packages/pn-pa-webapp/src/navigation/SessionGuard.tsx
+++ b/packages/pn-pa-webapp/src/navigation/SessionGuard.tsx
@@ -32,8 +32,6 @@ const INITIALIZATION_SEQUENCE = [
   INITIALIZATION_STEPS.SESSION_CHECK,
 ];
 
-const inactivityTimer = 5 * 60 * 1000;
-
 const manageUnforbiddenError = (e: any) => {
   if (e.status === 451) {
     // error toast must not be shown
@@ -56,7 +54,7 @@ const SessionGuardRender = () => {
   );
   const { t } = useTranslation(['common']);
   const { hasApiErrors } = useErrors();
-  const { IS_INACTIVITY_HANDLER_ENABLED } = getConfiguration();
+  const { INACTIVITY_HANDLER_MINUTES } = getConfiguration();
 
   const isAnonymousUser = !isUnauthorizedUser && !sessionToken;
   const hasTosPrivacyApiErrors = hasApiErrors(AUTH_ACTIONS.GET_TOS_PRIVACY_APPROVAL);
@@ -92,7 +90,7 @@ const SessionGuardRender = () => {
     }
     return (
       <InactivityHandler
-        inactivityTimer={isAnonymousUser || !IS_INACTIVITY_HANDLER_ENABLED ? 0 : inactivityTimer}
+        inactivityTimer={isAnonymousUser || (INACTIVITY_HANDLER_MINUTES * 60 * 1000)}
         onTimerExpired={() => {
           sessionStorage.clear();
           goToSelfcareLogin();

--- a/packages/pn-pa-webapp/src/services/configuration.service.ts
+++ b/packages/pn-pa-webapp/src/services/configuration.service.ts
@@ -12,7 +12,7 @@ export interface PaConfiguration {
   ONE_TRUST_PP: string;
   ONE_TRUST_TOS: string;
   PAGOPA_HELP_EMAIL: string;
-  IS_INACTIVITY_HANDLER_ENABLED: boolean;
+  INACTIVITY_HANDLER_MINUTES: number;
   IS_PAYMENT_ENABLED: boolean;
   MIXPANEL_TOKEN: string;
   WORK_IN_PROGRESS: boolean;
@@ -38,7 +38,7 @@ class PaConfigurationValidator extends Validator<PaConfiguration> {
     this.ruleFor('ONE_TRUST_PP').isString().isRequired().matches(dataRegex.token);
     this.ruleFor('ONE_TRUST_TOS').isString().isRequired().matches(dataRegex.token);
     this.ruleFor('PAGOPA_HELP_EMAIL').isString().isRequired().matches(dataRegex.email);
-    this.ruleFor('IS_INACTIVITY_HANDLER_ENABLED').isBoolean();
+    this.ruleFor('INACTIVITY_HANDLER_MINUTES').isNumber().isRequired();
     this.ruleFor('IS_PAYMENT_ENABLED').isBoolean();
     this.ruleFor('MIXPANEL_TOKEN').isString().isRequired();
     this.ruleFor('WORK_IN_PROGRESS').isBoolean();

--- a/packages/pn-pa-webapp/src/setupTests.tsx
+++ b/packages/pn-pa-webapp/src/setupTests.tsx
@@ -10,14 +10,14 @@ import { Configuration } from '@pagopa-pn/pn-commons';
 import '@testing-library/jest-dom';
 
 import { initAxiosClients } from './api/apiClients';
+import { PhysicalAddressLookupConfig } from './models/NewNotification';
 import { initStore } from './redux/store';
 import { PaConfiguration } from './services/configuration.service';
-import { PhysicalAddressLookupConfig } from './models/NewNotification';
 
 beforeAll(() => {
   Configuration.setForTest<PaConfiguration>({
     API_BASE_URL: 'https://mock-api-base-url',
-    IS_INACTIVITY_HANDLER_ENABLED: false,
+    INACTIVITY_HANDLER_MINUTES: 0,
     ONE_TRUST_DRAFT_MODE: true,
     ONE_TRUST_PP: '365c84c5-9329-4ec5-89f5-e53572eda132',
     ONE_TRUST_TOS: 'b0da531e-8370-4373-8bd2-61ddc89e7fa6',

--- a/packages/pn-personafisica-webapp/public/conf/config-dev.json
+++ b/packages/pn-personafisica-webapp/public/conf/config-dev.json
@@ -1,6 +1,6 @@
 {
   "API_BASE_URL": "https://webapi.dev.notifichedigitali.it/",
-  "IS_INACTIVITY_HANDLER_ENABLED": false,
+  "INACTIVITY_HANDLER_MINUTES": 0,
   "MIXPANEL_TOKEN": "ba1f5101fe34a61bb125cbfe587780d8",
   "ONE_TRUST_DRAFT_MODE": true,
   "ONE_TRUST_PARTICIPATING_ENTITIES": "ffb2a640-8165-4d5f-94c2-6259e21bee51",

--- a/packages/pn-personafisica-webapp/src/navigation/SessionGuard.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/SessionGuard.tsx
@@ -15,7 +15,7 @@ import {
 
 import { useRapidAccessParam } from '../hooks/useRapidAccessParam';
 import { TokenExchangeRequest } from '../models/User';
-import { exchangeToken } from '../redux/auth/actions';
+import { apiLogout, exchangeToken } from '../redux/auth/actions';
 import { resetState } from '../redux/auth/reducers';
 import { useAppDispatch, useAppSelector } from '../redux/hooks';
 import { RootState } from '../redux/store';
@@ -95,11 +95,15 @@ const SessionGuard = () => {
 
   useEffect(() => {
     if (hasAnyForbiddenError) {
-      exit();
+      void exit();
     }
   }, [hasAnyForbiddenError]);
 
-  const exit = () => {
+  const exit = async () => {
+    if (sessionToken) {
+      await dispatch(apiLogout(sessionToken));
+    }
+
     sessionStorage.clear();
     dispatch(resetState());
     goToLoginPortal();

--- a/packages/pn-personafisica-webapp/src/navigation/SessionGuard.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/SessionGuard.tsx
@@ -23,8 +23,6 @@ import { getConfiguration } from '../services/configuration.service';
 import { goToLoginPortal } from './navigation.utility';
 import * as routes from './routes.const';
 
-const inactivityTimer = 5 * 60 * 1000;
-
 const SessionGuard = () => {
   const location = useLocation();
   const dispatch = useAppDispatch();
@@ -32,7 +30,7 @@ const SessionGuard = () => {
   const { loading } = useAppSelector((state: RootState) => state.userState);
   const { sessionToken, exp } = useAppSelector((state: RootState) => state.userState.user);
   const navigate = useNavigate();
-  const { WORK_IN_PROGRESS, IS_INACTIVITY_HANDLER_ENABLED } = getConfiguration();
+  const { WORK_IN_PROGRESS, INACTIVITY_HANDLER_MINUTES } = getConfiguration();
   const sessionCheck = useSessionCheck(200, () => sessionCheckCallback());
   const { t } = useTranslation(['common']);
   const { hasSpecificStatusError } = useErrors();
@@ -114,8 +112,11 @@ const SessionGuard = () => {
       ) : (
         <>
           <SessionModal {...modalData} handleClose={() => exit()} initTimeout />
-          {IS_INACTIVITY_HANDLER_ENABLED && (
-            <InactivityHandler inactivityTimer={inactivityTimer} onTimerExpired={() => exit()} />
+          {INACTIVITY_HANDLER_MINUTES && (
+            <InactivityHandler
+              inactivityTimer={INACTIVITY_HANDLER_MINUTES * 60 * 1000}
+              onTimerExpired={() => exit()}
+            />
           )}
           <Outlet />
         </>

--- a/packages/pn-personafisica-webapp/src/services/configuration.service.ts
+++ b/packages/pn-personafisica-webapp/src/services/configuration.service.ts
@@ -3,7 +3,7 @@ import { Validator } from '@pagopa-pn/pn-validator';
 
 export interface PfConfiguration {
   API_BASE_URL: string;
-  IS_INACTIVITY_HANDLER_ENABLED: boolean;
+  INACTIVITY_HANDLER_MINUTES: number;
   MIXPANEL_TOKEN: string;
   ONE_TRUST_DRAFT_MODE: boolean;
   ONE_TRUST_PARTICIPATING_ENTITIES: string;
@@ -30,7 +30,7 @@ class PfConfigurationValidator extends Validator<PfConfiguration> {
   constructor() {
     super();
     this.ruleFor('API_BASE_URL').isString().isRequired().matches(dataRegex.htmlPageUrl);
-    this.ruleFor('IS_INACTIVITY_HANDLER_ENABLED').isBoolean();
+    this.ruleFor('INACTIVITY_HANDLER_MINUTES').isNumber().isRequired();
     this.ruleFor('MIXPANEL_TOKEN').isString().isRequired();
     this.ruleFor('ONE_TRUST_DRAFT_MODE').isBoolean();
     this.ruleFor('ONE_TRUST_PARTICIPATING_ENTITIES')

--- a/packages/pn-personafisica-webapp/src/setupTests.tsx
+++ b/packages/pn-personafisica-webapp/src/setupTests.tsx
@@ -16,7 +16,7 @@ window.getComputedStyle = (elt) => getComputedStyle(elt);
 beforeAll(() => {
   Configuration.setForTest<PfConfiguration>({
     API_BASE_URL: 'https://webapi.test.notifichedigitali.it/',
-    IS_INACTIVITY_HANDLER_ENABLED: false,
+    INACTIVITY_HANDLER_MINUTES: 0,
     ONE_TRUST_DRAFT_MODE: false,
     ONE_TRUST_PARTICIPATING_ENTITIES: 'mocked-id',
     ONE_TRUST_PP: 'mocked-id',

--- a/packages/pn-personagiuridica-webapp/public/conf/config-dev.json
+++ b/packages/pn-personagiuridica-webapp/public/conf/config-dev.json
@@ -1,6 +1,6 @@
 {
   "API_BASE_URL": "https://webapi.dev.notifichedigitali.it/",
-  "IS_INACTIVITY_HANDLER_ENABLED": false,
+  "INACTIVITY_HANDLER_MINUTES": 0,
   "MIXPANEL_TOKEN": "41f1a1ad6abcc5fc5ed5809b9a9d5761",
   "ONE_TRUST_DRAFT_MODE": true,
   "ONE_TRUST_PP": "9d7b7236-956b-4669-8943-5284fba6a815",

--- a/packages/pn-personagiuridica-webapp/src/navigation/SessionGuard.tsx
+++ b/packages/pn-personagiuridica-webapp/src/navigation/SessionGuard.tsx
@@ -34,8 +34,6 @@ const INITIALIZATION_SEQUENCE = [
   INITIALIZATION_STEPS.SESSION_CHECK,
 ];
 
-const inactivityTimer = 5 * 60 * 1000;
-
 const manageUnforbiddenError = (e: any) => {
   if (e.status === 451) {
     // error toast must not be shown
@@ -56,7 +54,7 @@ const manageUnforbiddenError = (e: any) => {
  */
 const SessionGuardRender = () => {
   const [params] = useSearchParams();
-  const { IS_INACTIVITY_HANDLER_ENABLED } = getConfiguration();
+  const { INACTIVITY_HANDLER_MINUTES } = getConfiguration();
 
   const isInitialized = useAppSelector((state: RootState) => state.appState.isInitialized);
   const { sessionToken } = useAppSelector((state: RootState) => state.userState.user);
@@ -109,7 +107,7 @@ const SessionGuardRender = () => {
     }
     return (
       <InactivityHandler
-        inactivityTimer={isAnonymousUser || !IS_INACTIVITY_HANDLER_ENABLED ? 0 : inactivityTimer}
+        inactivityTimer={isAnonymousUser || (INACTIVITY_HANDLER_MINUTES * 60 * 1000)}
         onTimerExpired={() => {
           sessionStorage.clear();
           goToLoginPortal();

--- a/packages/pn-personagiuridica-webapp/src/services/configuration.service.ts
+++ b/packages/pn-personagiuridica-webapp/src/services/configuration.service.ts
@@ -3,7 +3,7 @@ import { Validator } from '@pagopa-pn/pn-validator';
 
 export interface PgConfiguration {
   API_BASE_URL: string;
-  IS_INACTIVITY_HANDLER_ENABLED: boolean;
+  INACTIVITY_HANDLER_MINUTES: number;
   MIXPANEL_TOKEN: string;
   ONE_TRUST_DRAFT_MODE: boolean;
   ONE_TRUST_PP: string;
@@ -29,7 +29,7 @@ class PgConfigurationValidator extends Validator<PgConfiguration> {
   constructor() {
     super();
     this.ruleFor('API_BASE_URL').isString().isRequired().matches(dataRegex.htmlPageUrl);
-    this.ruleFor('IS_INACTIVITY_HANDLER_ENABLED').isBoolean();
+    this.ruleFor('INACTIVITY_HANDLER_MINUTES').isNumber().isRequired();
     this.ruleFor('MIXPANEL_TOKEN').isString().isRequired();
     this.ruleFor('ONE_TRUST_DRAFT_MODE').isBoolean();
     this.ruleFor('ONE_TRUST_PP').isString().isRequired().matches(dataRegex.lettersNumbersAndDashs);

--- a/packages/pn-personagiuridica-webapp/src/setupTests.tsx
+++ b/packages/pn-personagiuridica-webapp/src/setupTests.tsx
@@ -20,7 +20,7 @@ window.getComputedStyle = (elt) => getComputedStyle(elt);
 beforeAll(async () => {
   Configuration.setForTest<PgConfiguration>({
     API_BASE_URL: 'https://webapi.test.notifichedigitali.it/',
-    IS_INACTIVITY_HANDLER_ENABLED: false,
+    INACTIVITY_HANDLER_MINUTES: 0,
     ONE_TRUST_DRAFT_MODE: false,
     ONE_TRUST_PP: 'mocked-id',
     ONE_TRUST_TOS: 'mocked-id',


### PR DESCRIPTION
## Short description
With this PR, user inactivity is handled for a time (in minutes) specified in the configurations. For screen readers, the focus event is used.

## List of changes proposed in this pull request
- Add INACTIVITY_HANDLER_MINUTES in config 

## How to test
Add `INACTIVITY_HANDLER_MINUTES` config. Start the app and remain inactive for the configured number of minutes.