### PR TITLE
fix/PN-13210: add autofocus on PnDialog

### DIFF
--- a/packages/pn-commons/src/components/CodeModal/CodeModal.tsx
+++ b/packages/pn-commons/src/components/CodeModal/CodeModal.tsx
@@ -174,6 +174,7 @@ const CodeModal = forwardRef<ModalHandle, Props>(
                 sx={{ mt: 1.5 }}
                 value={initialValues.join('')}
                 tooltipTitle={getLocalizedOrDefaultLabel('delegations', 'deleghe.code_copied')}
+                autoFocus
               />
             )}
           </Box>
@@ -203,6 +204,7 @@ const CodeModal = forwardRef<ModalHandle, Props>(
               color={internalHasError ? 'error' : 'primary'}
               data-testid="codeConfirmButton"
               onClick={confirmHandler}
+              autoFocus={!isReadOnly}
             >
               {confirmLabel}
             </Button>

--- a/packages/pn-commons/src/components/ConfirmationModal.tsx
+++ b/packages/pn-commons/src/components/ConfirmationModal.tsx
@@ -57,6 +57,7 @@ const ConfirmationModal: React.FC<Props> = ({
           variant="contained"
           data-testid="confirmButton"
           {...slotsProps?.confirmButton}
+          autoFocus={!slotsProps?.closeButton?.autoFocus}
         />
       </PnDialogActions>
     </PnDialog>

--- a/packages/pn-commons/src/components/DisclaimerModal.tsx
+++ b/packages/pn-commons/src/components/DisclaimerModal.tsx
@@ -60,6 +60,7 @@ const DisclaimerModal: React.FC<Props> = ({
                 />
               }
               label={checkboxLabel}
+              autoFocus
             />
           </Box>
         )}

--- a/packages/pn-commons/src/components/InactivityHandler.tsx
+++ b/packages/pn-commons/src/components/InactivityHandler.tsx
@@ -67,6 +67,7 @@ const InactivityHandler: React.FC<Props> = ({ inactivityTimer, onTimerExpired, c
             variant="outlined"
             data-testid="inactivity-button"
             onClick={resetTimer}
+            autoFocus
           >
             {getLocalizedOrDefaultLabel('common', 'inactivity.action')}
           </Button>

--- a/packages/pn-commons/src/components/SessionModal.tsx
+++ b/packages/pn-commons/src/components/SessionModal.tsx
@@ -75,7 +75,14 @@ const SessionModal: React.FC<Props> = ({
       </PnDialogContent>
       {onConfirm && (
         <PnDialogActions>
-          <Button sx={{ width: '100%' }} color="primary" variant="contained" data-testid='buttonOfSessionModal' onClick={onConfirm}>
+          <Button
+            sx={{ width: '100%' }}
+            color="primary"
+            variant="contained"
+            data-testid="buttonOfSessionModal"
+            onClick={onConfirm}
+            autoFocus
+          >
             {onConfirmLabel}
           </Button>
         </PnDialogActions>

--- a/packages/pn-pa-webapp/src/App.tsx
+++ b/packages/pn-pa-webapp/src/App.tsx
@@ -278,7 +278,12 @@ const ActualApp = () => {
             <Button id="cancelButton" variant="outlined" onClick={() => setOpenModal(false)}>
               {t('button.annulla')}
             </Button>
-            <Button data-testid="confirm-button" variant="contained" onClick={performLogout}>
+            <Button
+              data-testid="confirm-button"
+              variant="contained"
+              onClick={performLogout}
+              autoFocus
+            >
               {t('header.logout')}
             </Button>
           </PnDialogActions>

--- a/packages/pn-pa-webapp/src/components/ApiKeys/ApiKeyModal.tsx
+++ b/packages/pn-pa-webapp/src/components/ApiKeys/ApiKeyModal.tsx
@@ -59,6 +59,7 @@ const ApiKeyModal = ({
           data-testid="action-modal-button"
           variant="contained"
           onClick={actionHandler}
+          autoFocus
         >
           {actionButtonLabel}
         </Button>

--- a/packages/pn-pa-webapp/src/components/Notifications/ConfirmCancellationDialog.tsx
+++ b/packages/pn-pa-webapp/src/components/Notifications/ConfirmCancellationDialog.tsx
@@ -56,6 +56,7 @@ const ConfirmCancellationDialog: React.FC<Props> = ({ showModal, onClose, onConf
                   data-testid="checkbox"
                   checked={checked}
                   onChange={handleChange}
+                  autoFocus
                 ></Checkbox>
               }
               label={t('detail.cancel-notification-modal.i-understand')}
@@ -73,6 +74,7 @@ const ConfirmCancellationDialog: React.FC<Props> = ({ showModal, onClose, onConf
           disabled={payment ? !checked : false}
           variant="contained"
           data-testid="modalCloseAndProceedBtnId"
+          autoFocus={!payment}
         >
           {t('detail.cancel-notification')}
         </Button>

--- a/packages/pn-pa-webapp/src/components/Notifications/NotificationPaymentF24.tsx
+++ b/packages/pn-pa-webapp/src/components/Notifications/NotificationPaymentF24.tsx
@@ -42,7 +42,12 @@ const NotificationPaymentF24: React.FC<Props> = ({ iun, payments }) => {
           ))}
         </PnDialogContent>
         <PnDialogActions>
-          <Button variant="outlined" onClick={() => setOpen(false)} data-testid="close-dialog">
+          <Button
+            variant="outlined"
+            onClick={() => setOpen(false)}
+            data-testid="close-dialog"
+            autoFocus
+          >
             {t('button.close', { ns: 'common' })}
           </Button>
         </PnDialogActions>

--- a/packages/pn-pa-webapp/src/components/Notifications/NotificationRecipientsDetail.tsx
+++ b/packages/pn-pa-webapp/src/components/Notifications/NotificationRecipientsDetail.tsx
@@ -52,7 +52,10 @@ const NotificationRecipientsDetail: React.FC<Props> = ({ recipients, iun }) => {
                 </Box>
               </Grid>
               <Grid item xs="auto">
-                <CopyToClipboardButton value={`${recipient.denomination} - ${recipient.taxId}`} />
+                <CopyToClipboardButton
+                  value={`${recipient.denomination} - ${recipient.taxId}`}
+                  autoFocus
+                />
               </Grid>
             </Grid>
           ))}

--- a/packages/pn-personafisica-webapp/src/App.tsx
+++ b/packages/pn-personafisica-webapp/src/App.tsx
@@ -322,7 +322,12 @@ const App = () => {
             <Button id="cancelButton" variant="outlined" onClick={() => setOpenModal(false)}>
               {t('button.annulla')}
             </Button>
-            <Button data-testid="confirm-button" variant="contained" onClick={performLogout}>
+            <Button
+              data-testid="confirm-button"
+              variant="contained"
+              onClick={performLogout}
+              autoFocus
+            >
               {t('header.logout')}
             </Button>
           </PnDialogActions>

--- a/packages/pn-personafisica-webapp/src/components/Contacts/CancelVerificationModal.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/CancelVerificationModal.tsx
@@ -37,7 +37,7 @@ const CancelVerificationModal: React.FC<Props> = ({ open, senderId = 'default', 
         <Button onClick={handleClose} variant="outlined">
           {t('button.annulla')}
         </Button>
-        <Button onClick={handleConfirm} variant="contained">
+        <Button onClick={handleConfirm} variant="contained" autoFocus>
           {t('button.conferma')}
         </Button>
       </PnDialogActions>

--- a/packages/pn-personafisica-webapp/src/components/Contacts/DeleteDialog.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/DeleteDialog.tsx
@@ -29,7 +29,7 @@ const DeleteDialog: React.FC<DialogProps> = ({
   const { t } = useTranslation(['common']);
 
   const deleteModalActions = blockDelete ? (
-    <Button id="buttonClose" onClick={handleModalClose} variant="contained">
+    <Button id="buttonClose" onClick={handleModalClose} variant="contained" autoFocus>
       {t('button.understand')}
     </Button>
   ) : (
@@ -48,6 +48,7 @@ const DeleteDialog: React.FC<DialogProps> = ({
         key="confirm"
         onClick={confirmHandler}
         variant="contained"
+        autoFocus
         {...slotsProps?.primaryButton}
       >
         {slotsProps?.primaryButton?.label ?? t('button.conferma')}

--- a/packages/pn-personafisica-webapp/src/components/Contacts/InformativeDialog.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/InformativeDialog.tsx
@@ -88,6 +88,7 @@ const InformativeDialog: React.FC<DialogProps> = ({
           onClick={onConfirm}
           variant="contained"
           data-testid="understandButton"
+          autoFocus
         >
           {t('button.understand')}
         </Button>

--- a/packages/pn-personafisica-webapp/src/components/Contacts/PecVerificationDialog.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/PecVerificationDialog.tsx
@@ -28,7 +28,7 @@ const PecVerificationDialog: React.FC<Props> = ({ open = false, handleConfirm })
         </DialogContentText>
       </PnDialogContent>
       <PnDialogActions>
-        <Button id="confirmDialog" onClick={handleConfirm} variant="contained">
+        <Button id="confirmDialog" onClick={handleConfirm} variant="contained" autoFocus>
           {t('button.conferma')}
         </Button>
       </PnDialogActions>

--- a/packages/pn-personafisica-webapp/src/components/Contacts/SercqSendIODialog.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/SercqSendIODialog.tsx
@@ -96,7 +96,7 @@ const SercqSendIODialog: React.FC<Props> = ({ open, onDiscard }) => {
         <Button onClick={onDiscard} variant="naked">
           {t('button.not-now')}
         </Button>
-        <Button onClick={handleConfirm} variant="contained">
+        <Button onClick={handleConfirm} variant="contained" autoFocus>
           {t('button.attiva')}
         </Button>
       </PnDialogActions>

--- a/packages/pn-personagiuridica-webapp/src/App.tsx
+++ b/packages/pn-personagiuridica-webapp/src/App.tsx
@@ -307,7 +307,12 @@ const ActualApp = () => {
             <Button id="cancelButton" variant="outlined" onClick={() => setOpenModal(false)}>
               {t('button.annulla')}
             </Button>
-            <Button data-testid="confirm-button" variant="contained" onClick={performLogout}>
+            <Button
+              data-testid="confirm-button"
+              variant="contained"
+              onClick={performLogout}
+              autoFocus
+            >
               {t('header.logout')}
             </Button>
           </PnDialogActions>

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/CancelVerificationModal.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/CancelVerificationModal.tsx
@@ -37,7 +37,7 @@ const CancelVerificationModal: React.FC<Props> = ({ open, senderId = 'default', 
         <Button onClick={handleClose} variant="outlined">
           {t('button.annulla')}
         </Button>
-        <Button onClick={handleConfirm} variant="contained">
+        <Button onClick={handleConfirm} variant="contained" autoFocus>
           {t('button.conferma')}
         </Button>
       </PnDialogActions>

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/DeleteDialog.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/DeleteDialog.tsx
@@ -29,7 +29,7 @@ const DeleteDialog: React.FC<Props> = ({
   const { t } = useTranslation(['common']);
 
   const deleteModalActions = blockDelete ? (
-    <Button id="buttonClose" onClick={handleModalClose} variant="contained">
+    <Button id="buttonClose" onClick={handleModalClose} variant="contained" autoFocus>
       {t('button.understand')}
     </Button>
   ) : (
@@ -48,6 +48,7 @@ const DeleteDialog: React.FC<Props> = ({
         key="confirm"
         onClick={confirmHandler}
         variant="contained"
+        autoFocus
         {...slotsProps?.primaryButton}
       >
         {slotsProps?.primaryButton?.label ?? t('button.conferma')}

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/InformativeDialog.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/InformativeDialog.tsx
@@ -54,6 +54,7 @@ const InformativeDialog: React.FC<DialogProps> = ({
           onClick={onConfirm}
           variant="contained"
           data-testid="understandButton"
+          autoFocus
         >
           {t('button.understand')}
         </Button>

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/PecVerificationDialog.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/PecVerificationDialog.tsx
@@ -27,7 +27,7 @@ const PecVerificationDialog: React.FC<Props> = ({ open = false, handleConfirm })
         </DialogContentText>
       </PnDialogContent>
       <PnDialogActions>
-        <Button id="confirmDialog" onClick={handleConfirm} variant="contained">
+        <Button id="confirmDialog" onClick={handleConfirm} variant="contained" autoFocus>
           {t('button.conferma')}
         </Button>
       </PnDialogActions>

--- a/packages/pn-personagiuridica-webapp/src/components/Deleghe/AcceptDelegationModal.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Deleghe/AcceptDelegationModal.tsx
@@ -260,6 +260,7 @@ const AcceptDelegationModal: React.FC<Props> = ({
           data-testid="groupConfirmButton"
           onClick={() => handleConfirm(code, groupForm.value)}
           disabled={groupForm.value.length === 0 && associateGroup}
+          autoFocus
         >
           {t('button.conferma', { ns: 'common' })}
         </Button>

--- a/packages/pn-personagiuridica-webapp/src/components/IntegrazioneApi/ApiKeyModal.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/IntegrazioneApi/ApiKeyModal.tsx
@@ -47,6 +47,7 @@ const ApiKeyModal = ({
         data-testid="close-modal-button"
         variant={closeButtonVariant}
         onClick={closeModalHandler}
+        autoFocus={!actionButtonLabel}
       >
         {closeButtonLabel}
       </Button>
@@ -58,6 +59,7 @@ const ApiKeyModal = ({
           onClick={actionHandler}
           color={hasDeleteButton ? 'error' : 'primary'}
           sx={hasDeleteButton ? { color: 'white' } : null}
+          autoFocus
         >
           {buttonIcon}
           {actionButtonLabel}


### PR DESCRIPTION
## Short description
Add prop `autoFocus` on relevant component in every dialog

## List of changes proposed in this pull request

## How to test
Start all app and check that screen readers (Nvda, Voice Reader) don't read dialog title on close 