### PR TITLE
fix/PN-14794: do not render component if inactivity handler is disabled

### DIFF
--- a/packages/pn-commons/src/components/InactivityHandler.tsx
+++ b/packages/pn-commons/src/components/InactivityHandler.tsx
@@ -63,6 +63,10 @@ const InactivityHandler: React.FC<Props> = ({ inactivityTimer, onTimerExpired, c
     };
   }, [handleActivity]);
 
+  if (inactivityTimer === 0) {
+    return null;
+  }
+
   return (
     <>
       <PnDialog

--- a/packages/pn-commons/src/components/InactivityHandler.tsx
+++ b/packages/pn-commons/src/components/InactivityHandler.tsx
@@ -63,38 +63,36 @@ const InactivityHandler: React.FC<Props> = ({ inactivityTimer, onTimerExpired, c
     };
   }, [handleActivity]);
 
-  if (inactivityTimer === 0) {
-    return null;
-  }
-
   return (
     <>
-      <PnDialog
-        open={openModal}
-        aria-labelledby="inactivity-dialog-title"
-        aria-describedby="inactivity-dialog-description"
-        data-testid="inactivity-modal"
-      >
-        <DialogTitle id="inactivity-dialog-title">
-          {getLocalizedOrDefaultLabel('common', 'inactivity.title')}
-        </DialogTitle>
-        <PnDialogContent>
-          <DialogContentText id="inactivity-dialog-description">
-            {getLocalizedOrDefaultLabel('common', 'inactivity.body')}
-          </DialogContentText>
-        </PnDialogContent>
-        <PnDialogActions>
-          <Button
-            fullWidth
-            color="primary"
-            variant="outlined"
-            data-testid="inactivity-button"
-            onClick={confirmModal}
-          >
-            {getLocalizedOrDefaultLabel('common', 'inactivity.action')}
-          </Button>
-        </PnDialogActions>
-      </PnDialog>
+      {inactivityTimer > 0 && (
+        <PnDialog
+          open={openModal}
+          aria-labelledby="inactivity-dialog-title"
+          aria-describedby="inactivity-dialog-description"
+          data-testid="inactivity-modal"
+        >
+          <DialogTitle id="inactivity-dialog-title">
+            {getLocalizedOrDefaultLabel('common', 'inactivity.title')}
+          </DialogTitle>
+          <PnDialogContent>
+            <DialogContentText id="inactivity-dialog-description">
+              {getLocalizedOrDefaultLabel('common', 'inactivity.body')}
+            </DialogContentText>
+          </PnDialogContent>
+          <PnDialogActions>
+            <Button
+              fullWidth
+              color="primary"
+              variant="outlined"
+              data-testid="inactivity-button"
+              onClick={confirmModal}
+            >
+              {getLocalizedOrDefaultLabel('common', 'inactivity.action')}
+            </Button>
+          </PnDialogActions>
+        </PnDialog>
+      )}
       {children}
     </>
   );

--- a/packages/pn-personafisica-webapp/src/navigation/SessionGuard.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/SessionGuard.tsx
@@ -116,12 +116,10 @@ const SessionGuard = () => {
       ) : (
         <>
           <SessionModal {...modalData} handleClose={() => exit()} initTimeout />
-          {INACTIVITY_HANDLER_MINUTES && (
-            <InactivityHandler
-              inactivityTimer={INACTIVITY_HANDLER_MINUTES * 60 * 1000}
-              onTimerExpired={() => exit()}
-            />
-          )}
+          <InactivityHandler
+            inactivityTimer={INACTIVITY_HANDLER_MINUTES * 60 * 1000}
+            onTimerExpired={() => exit()}
+          />
           <Outlet />
         </>
       )}


### PR DESCRIPTION
## Short description
If config `INACTIVITY_HANDLER_MINUTES` is `0` pndialog component is not rendered 