### PR TITLE
fix(PN-15847, PN-15848): add max length validation to house number and foreignState fields

### DIFF
--- a/packages/pn-pa-webapp/src/components/NewNotification/Recipient.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/Recipient.tsx
@@ -175,7 +175,12 @@ const Recipient: React.FC<Props> = ({
     addressDetails: conditionalPhysicalAddress(
       yup.string().max(1024, tc('too-long-field-error', { maxLength: 1024 }))
     ),
-    houseNumber: conditionalPhysicalAddress(yup.string().required(tc('required-field'))),
+    houseNumber: conditionalPhysicalAddress(
+      yup
+        .string()
+        .required(tc('required-field'))
+        .max(1024, tc('too-long-field-error', { maxLength: 1024 }))
+    ),
     zip: conditionalPhysicalAddress(
       yup
         .string()
@@ -191,7 +196,7 @@ const Recipient: React.FC<Props> = ({
     ),
     municipality: conditionalPhysicalAddress(requiredStringFieldValidation(tc, 256)),
     province: conditionalPhysicalAddress(requiredStringFieldValidation(tc, 256)),
-    foreignState: conditionalPhysicalAddress(requiredStringFieldValidation(tc)),
+    foreignState: conditionalPhysicalAddress(requiredStringFieldValidation(tc, 1024)),
     physicalAddressLookup: yup
       .mixed<PhysicalAddressLookup>()
       .oneOf(Object.values(PhysicalAddressLookup)),


### PR DESCRIPTION
## Short description
Add max length validation to house number and foreignState fields

## List of changes proposed in this pull request
- Fix yup validations

## How to test
- Start PA
- Open new notification form
- On Recipient steps try to insert more than 1024 characters on `houseNumber` (numero civico) and `foreignState` (stato) fields and check that error is displayed 