### PR TITLE
Fix(PN-16259): pass translated label in Header component

### DIFF
--- a/packages/pn-commons/src/components/Header/Header.tsx
+++ b/packages/pn-commons/src/components/Header/Header.tsx
@@ -106,6 +106,11 @@ const Header: React.FC<HeaderProps> = ({
         enableDropdown={enableDropdown}
         userActions={userActions}
         enableAssistanceButton={enableAssistanceButton}
+        translationsMap={{
+          logIn: getLocalizedOrDefaultLabel('common', 'header.login', 'Accedi'),
+          logOut: getLocalizedOrDefaultLabel('common', 'header.logout', 'Esci'),
+          assistance: getLocalizedOrDefaultLabel('common', 'header.assistance', 'Assistenza'),
+        }}
       />
       {enableHeaderProduct && (
         <HeaderProduct

--- a/packages/pn-pa-webapp/public/locales/de/common.json
+++ b/packages/pn-pa-webapp/public/locales/de/common.json
@@ -21,6 +21,8 @@
     "app-status": "Plattformstatus"
   },
   "header": {
+    "assistance": "Hilfe",
+    "login": "Anmelden",
     "logout": "Beenden",
     "pago-pa-link": "Website von PagoPA S.p.A.",
     "reserved-area": "Reservierten Bereich",

--- a/packages/pn-pa-webapp/public/locales/en/common.json
+++ b/packages/pn-pa-webapp/public/locales/en/common.json
@@ -21,6 +21,8 @@
     "app-status": "Platform status"
   },
   "header": {
+    "assistance": "Assistance",
+    "login": "Login",
     "logout": "Exit",
     "pago-pa-link": "PagoPA S.p.A. website",
     "reserved-area": "Reserved Area",

--- a/packages/pn-pa-webapp/public/locales/fr/common.json
+++ b/packages/pn-pa-webapp/public/locales/fr/common.json
@@ -21,6 +21,8 @@
     "app-status": "État de la plateforme"
   },
   "header": {
+    "assistance": "Assistance",
+    "login": "Se connecter",
     "logout": "Sortir",
     "pago-pa-link": "Site de PagoPA S.p.A.",
     "reserved-area": "Espace réservé",

--- a/packages/pn-pa-webapp/public/locales/it/common.json
+++ b/packages/pn-pa-webapp/public/locales/it/common.json
@@ -22,6 +22,8 @@
     "app-status": "Stato della piattaforma"
   },
   "header": {
+    "assistance": "Assistenza",
+    "login": "Accedi",
     "logout": "Esci",
     "pago-pa-link": "Sito di PagoPA S.p.A.",
     "reserved-area": "Area Riservata",

--- a/packages/pn-pa-webapp/public/locales/sl/common.json
+++ b/packages/pn-pa-webapp/public/locales/sl/common.json
@@ -21,6 +21,8 @@
     "app-status": "Stanje platforme"
   },
   "header": {
+    "assistance": "Pomoč",
+    "login": "Prijava",
     "logout": "Izhod",
     "pago-pa-link": "Spletna stran PagoPA S.p.A.",
     "reserved-area": "rezerviranega območja",

--- a/packages/pn-personafisica-webapp/public/locales/de/common.json
+++ b/packages/pn-personafisica-webapp/public/locales/de/common.json
@@ -30,6 +30,8 @@
     "app-status": "Plattformstatus"
   },
   "header": {
+    "assistance": "Hilfe",
+    "login": "Anmelden",
     "logout": "Beenden",
     "pago-pa-link": "Website von PagoPA S.p.A."
   },

--- a/packages/pn-personafisica-webapp/public/locales/en/common.json
+++ b/packages/pn-personafisica-webapp/public/locales/en/common.json
@@ -30,6 +30,8 @@
     "app-status": "Platform status"
   },
   "header": {
+    "assistance": "Assistance",
+    "login": "Login",
     "logout": "Exit",
     "pago-pa-link": "PagoPA S.p.A. website"
   },

--- a/packages/pn-personafisica-webapp/public/locales/fr/common.json
+++ b/packages/pn-personafisica-webapp/public/locales/fr/common.json
@@ -30,6 +30,8 @@
     "app-status": "État de la plateforme"
   },
   "header": {
+    "assistance": "Assistance",
+    "login": "Se connecter",
     "logout": "Sortir",
     "pago-pa-link": "Site de PagoPA S.p.A."
   },

--- a/packages/pn-personafisica-webapp/public/locales/it/common.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/common.json
@@ -35,6 +35,8 @@
     "app-status": "Stato della piattaforma"
   },
   "header": {
+    "assistance": "Assistenza",
+    "login": "Accedi",
     "logout": "Esci",
     "pago-pa-link": "Sito di PagoPA S.p.A.",
     "logout-message": "Confermi di voler uscire da SEND?"

--- a/packages/pn-personafisica-webapp/public/locales/sl/common.json
+++ b/packages/pn-personafisica-webapp/public/locales/sl/common.json
@@ -30,6 +30,8 @@
     "app-status": "Stanje platforme"
   },
   "header": {
+    "assistance": "Pomoč",
+    "login": "Prijava",
     "logout": "Izhod",
     "pago-pa-link": "Spletna stran PagoPA S.p.A."
   },

--- a/packages/pn-personagiuridica-webapp/public/locales/de/common.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/de/common.json
@@ -30,6 +30,8 @@
     "groups": "Gruppen"
   },
   "header": {
+    "assistance": "Hilfe",
+    "login": "Anmelden",
     "product": {
       "organization-dashboard": "Dein Unternehmen",
       "notification-platform": "SEND - Servizio Notifiche Digitali"

--- a/packages/pn-personagiuridica-webapp/public/locales/en/common.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/en/common.json
@@ -30,6 +30,8 @@
     "groups": "Groups"
   },
   "header": {
+    "assistance": "Assistance",
+    "login": "Login",
     "product": {
       "organization-dashboard": "Your company",
       "notification-platform": "SEND - Servizio Notifiche Digitali"

--- a/packages/pn-personagiuridica-webapp/public/locales/fr/common.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/fr/common.json
@@ -30,6 +30,8 @@
     "groups": "Groupes"
   },
   "header": {
+    "assistance": "Assistance",
+    "login": "Se connecter",
     "product": {
       "organization-dashboard": "Votre entreprise",
       "notification-platform": "SEND - Servizio Notifiche Digitali"

--- a/packages/pn-personagiuridica-webapp/public/locales/it/common.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/it/common.json
@@ -40,6 +40,8 @@
     "groups": "Gruppi"
   },
   "header": {
+    "assistance": "Assistenza",
+    "login": "Accedi",
     "product": {
       "organization-dashboard": "La tua impresa",
       "notification-platform": "SEND - Servizio Notifiche Digitali"

--- a/packages/pn-personagiuridica-webapp/public/locales/sl/common.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/sl/common.json
@@ -30,6 +30,8 @@
     "groups": "Skupine"
   },
   "header": {
+    "assistance": "Pomoč",
+    "login": "Prijava",
     "product": {
       "organization-dashboard": "Vaše podjetje",
       "notification-platform": "SEND - Servizio Notifiche Digitali"


### PR DESCRIPTION
## Short description
This PR translates the header labels when the language is changed from the footer.

## List of changes proposed in this pull request
- add string translation for `header.login` and `header.assistance` and pass as prop in mui component [Header](https://github.com/pagopa/mui-italia/blob/develop/src/components/HeaderAccount/HeaderAccount.tsx#L51)

## How to test
Start app PA/PF/PG and login in SEND. Change lang in footer and check that labels in header are translated  