### PR TITLE
fix(PN-16180): Remove amount and paymentExpirationDate on NotificationDetail (PF, PG, PA)

### DIFF
--- a/packages/pn-pa-webapp/src/components/Notifications/NotificationDetailTableSender.tsx
+++ b/packages/pn-pa-webapp/src/components/Notifications/NotificationDetailTableSender.tsx
@@ -10,7 +10,6 @@ import {
   TimelineCategory,
   dataRegex,
   formatDate,
-  formatEurocentToCurrency,
   useHasPermissions,
   useIsCancelled,
 } from '@pagopa-pn/pn-commons';
@@ -87,26 +86,6 @@ const NotificationDetailTableSender: React.FC<Props> = ({ notification, onCancel
       label: t('detail.date', { ns: 'notifiche' }),
       rawValue: formatDate(notification.sentAt),
       value: <Box fontWeight={600}>{formatDate(notification.sentAt)}</Box>,
-    },
-    {
-      label: t('detail.payment-terms', { ns: 'notifiche' }),
-      rawValue: notification.paymentExpirationDate,
-      value: (
-        <Box fontWeight={600} display="inline">
-          {notification.paymentExpirationDate}
-        </Box>
-      ),
-    },
-    {
-      label: t('detail.amount', { ns: 'notifiche' }),
-      rawValue: notification.amount
-        ? formatEurocentToCurrency(notification.amount).toString()
-        : undefined,
-      value: (
-        <Box fontWeight={600}>
-          {notification.amount && formatEurocentToCurrency(notification.amount)}
-        </Box>
-      ),
     },
     {
       label: t('detail.iun', { ns: 'notifiche' }),

--- a/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
@@ -115,11 +115,6 @@ const NotificationDetail: React.FC = () => {
       value: <Box fontWeight={600}>{formatDate(notification.sentAt)}</Box>,
     },
     {
-      label: t('detail.payment-terms', { ns: 'notifiche' }),
-      rawValue: notification.paymentExpirationDate,
-      value: <Box fontWeight={600}>{notification.paymentExpirationDate}</Box>,
-    },
-    {
       label: t('detail.iun', { ns: 'notifiche' }),
       rawValue: notification.iun,
       value: <Box fontWeight={600}>{notification.iun}</Box>,

--- a/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
@@ -36,10 +36,10 @@ import {
 
 import DomicileBanner from '../components/DomicileBanner/DomicileBanner';
 import LoadingPageWrapper from '../components/LoadingPageWrapper/LoadingPageWrapper';
+import { PNRole } from '../models/User';
 import { ContactSource } from '../models/contacts';
 import * as routes from '../navigation/routes.const';
 import { getDowntimeLegalFact } from '../redux/appStatus/actions';
-import { PNRole } from '../models/User';
 import { useAppDispatch, useAppSelector } from '../redux/hooks';
 import {
   NOTIFICATION_ACTIONS,
@@ -112,11 +112,6 @@ const NotificationDetail = () => {
       label: t('detail.date', { ns: 'notifiche' }),
       rawValue: formatDate(notification.sentAt),
       value: <Box fontWeight={600}>{formatDate(notification.sentAt)}</Box>,
-    },
-    {
-      label: t('detail.payment-terms', { ns: 'notifiche' }),
-      rawValue: notification.paymentExpirationDate,
-      value: <Box fontWeight={600}>{notification.paymentExpirationDate}</Box>,
     },
     {
       label: t('detail.iun', { ns: 'notifiche' }),


### PR DESCRIPTION
## Short description
This PR includes the changes needed to remove the `amount` and `paymentExpirationDate` fields from `NotificationDetail` component.

## How to test
PF:
- user: garibaldi - env: TEST
- IUN: PQKM-EGNQ-QKZG-202509-N-1

PA:
- user: grossini/Test 2 (Comune di Sappada) - env: TEST
- IUN: same as above

PG:
- user: Dante Alighieri / Divina Commedia) - env: TEST (create a new mandate if the current one has already expired)
- IUN: same as above