### PR TITLE
fix(PN-16362): add contacts to Mixpanel event when adding special contact

### DIFF
--- a/packages/pn-personafisica-webapp/src/components/Contacts/AddSpecialContact.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/AddSpecialContact.tsx
@@ -265,7 +265,11 @@ const AddSpecialContact = forwardRef<AddSpecialContactRef, Props>(
     const sendSuccessEvent = (type: ChannelType) => {
       const eventKey = `SEND_ADD_${type}_UX_SUCCESS`;
       if (isPFEvent(eventKey)) {
-        PFEventStrategyFactory.triggerEvent(PFEventsType[eventKey], formik.values.sender.id);
+        PFEventStrategyFactory.triggerEvent(PFEventsType[eventKey], {
+          sercq_type: type,
+          contacts: addressesData.courtesyAddresses,
+          other_contact: 'yes',
+        });
       }
     };
 

--- a/packages/pn-personafisica-webapp/src/components/Contacts/AddSpecialContact.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/AddSpecialContact.tsx
@@ -19,6 +19,7 @@ import {
   ConsentActionType,
   ConsentType,
   CustomDropdown,
+  EventAction,
   PnAutocomplete,
   SERCQ_SEND_VALUE,
   TosPrivacyConsent,
@@ -300,6 +301,8 @@ const AddSpecialContact = forwardRef<AddSpecialContactRef, Props>(
         PFEventStrategyFactory.triggerEvent(PFEventsType[eventKey], {
           senderId: sender.senderId,
           source: ContactSource.RECAPITI,
+          event_type: EventAction.ACTION,
+          contacts: addressesData.courtesyAddresses,
         });
       }
 

--- a/packages/pn-personafisica-webapp/src/components/Contacts/AddSpecialContact.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/AddSpecialContact.tsx
@@ -263,9 +263,10 @@ const AddSpecialContact = forwardRef<AddSpecialContactRef, Props>(
     const contactType = formik.values.channelType.toLowerCase();
 
     const sendSuccessEvent = (type: ChannelType) => {
-      const eventKey = `SEND_ADD_${type}_UX_SUCCESS`;
-      if (isPFEvent(eventKey)) {
-        PFEventStrategyFactory.triggerEvent(PFEventsType[eventKey], {
+      if (type === ChannelType.PEC) {
+        PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_ADD_PEC_UX_SUCCESS, false);
+      } else {
+        PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_ADD_SERCQ_SEND_UX_SUCCESS, {
           sercq_type: type,
           contacts: addressesData.courtesyAddresses,
           other_contact: 'yes',
@@ -300,11 +301,13 @@ const AddSpecialContact = forwardRef<AddSpecialContactRef, Props>(
       channelType: ChannelType,
       sender: Sender = { senderId: 'default' }
     ) => {
-      const eventKey = `SEND_ADD_${channelType}_START`;
-      if (isPFEvent(eventKey)) {
-        PFEventStrategyFactory.triggerEvent(PFEventsType[eventKey], {
+      if (channelType === ChannelType.PEC) {
+        PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_ADD_PEC_START, {
           senderId: sender.senderId,
           source: ContactSource.RECAPITI,
+        });
+      } else {
+        PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_ADD_SERCQ_SEND_START, {
           event_type: EventAction.ACTION,
           contacts: addressesData.courtesyAddresses,
         });

--- a/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/SendAddSercqUxSuccessStrategy.ts
+++ b/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/SendAddSercqUxSuccessStrategy.ts
@@ -17,6 +17,7 @@ type SendHasAddresses = {
 type Props = {
   sercq_type: ChannelType;
   contacts: Array<DigitalAddress>;
+  other_contact?: 'yes' | 'no';
 };
 
 type Return =
@@ -27,12 +28,12 @@ type Return =
   | SendHasAddresses;
 
 export class SendAddSercqUxSuccessStrategy implements EventStrategy {
-  performComputations({ sercq_type, contacts }: Props): TrackedEvent<Return> {
+  performComputations({ sercq_type, contacts, other_contact = 'no' }: Props): TrackedEvent<Return> {
     return {
       [EventPropertyType.TRACK]: {
         event_category: EventCategory.UX,
         event_type: EventAction.CONFIRM,
-        other_contact: 'no',
+        other_contact,
         contact_details: concatCourtestyContacts(contacts),
       },
       [EventPropertyType.PROFILE]: {


### PR DESCRIPTION
## Short description
Add contacts to Mixpanel event when adding special contact in order to avoid application crash

## List of changes proposed in this pull request
- Add required properties to mixpanel event

## How to test
- Start PF
- Add a PEC as main contact
- Add a special contact with SEND as contact type and check that works correctly 