### PR TITLE
fix(PN-16621): SessionGuard: avoid call api logout if token is expired

### DIFF
--- a/packages/pn-commons/src/hooks/index.ts
+++ b/packages/pn-commons/src/hooks/index.ts
@@ -6,12 +6,13 @@ import { useIsMobile } from './useIsMobile';
 import { useMobileOS } from './useMobileOS';
 import { useMultiEvent } from './useMultiEvent';
 import { useProcess } from './useProcess';
-import { useSessionCheck } from './useSessionCheck';
+import { isJwtExpired, useSessionCheck } from './useSessionCheck';
 import { useTracking } from './useTracking';
 import { useUnload } from './useUnload';
 
 export {
   downloadDocument,
+  isJwtExpired,
   useErrors,
   useHasPermissions,
   useIsCancelled,

--- a/packages/pn-commons/src/hooks/useSessionCheck.ts
+++ b/packages/pn-commons/src/hooks/useSessionCheck.ts
@@ -10,11 +10,7 @@ export const useSessionCheck = (timer: number, sessionExpiredCbk: () => void) =>
     }
     if (expt) {
       interval = setInterval(() => {
-        const now = new Date();
-        // expt is in epoch format
-        const expireAt = new Date(0); // The 0 there is the key, which sets the date to the epoch
-        expireAt.setUTCSeconds(expt);
-        if (now.getTime() >= expireAt.getTime()) {
+        if (isJwtExpired(expt)) {
           sessionExpiredCbk();
           clearInterval(interval);
         }
@@ -34,4 +30,12 @@ export const useSessionCheck = (timer: number, sessionExpiredCbk: () => void) =>
   );
 
   return initSessionCheck;
+};
+
+// exp in seconds (from JWT standard)
+export const isJwtExpired = (exp: number) => {
+  const now = new Date();
+  const expireAt = new Date(0);
+  expireAt.setUTCSeconds(exp);
+  return now.getTime() >= expireAt.getTime();
 };

--- a/packages/pn-pa-webapp/src/navigation/SessionGuard.tsx
+++ b/packages/pn-pa-webapp/src/navigation/SessionGuard.tsx
@@ -8,6 +8,7 @@ import {
   LoadingPage,
   SessionModal,
   adaptedTokenExchangeError,
+  isJwtExpired,
   useErrors,
   useSessionCheck,
 } from '@pagopa-pn/pn-commons';
@@ -78,7 +79,7 @@ const SessionGuard = () => {
   };
 
   const exit = async () => {
-    if (sessionToken) {
+    if (sessionToken && !isJwtExpired(expDate)) {
       await dispatch(apiLogout(sessionToken));
     }
     dispatch(resetState());

--- a/packages/pn-pa-webapp/src/navigation/__test__/SessionGuard.test.tsx
+++ b/packages/pn-pa-webapp/src/navigation/__test__/SessionGuard.test.tsx
@@ -166,5 +166,13 @@ describe('SessionGuard Component', async () => {
       const logoutTitleComponent = screen.queryByText('leaving-app.title');
       expect(logoutTitleComponent).toBeTruthy();
     });
+
+    // No call api logout because the token is expired
+    vi.useFakeTimers();
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+      expect(mock.history.post).toHaveLength(0);
+    });
+    vi.useRealTimers();
   });
 });

--- a/packages/pn-personafisica-webapp/src/navigation/SessionGuard.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/SessionGuard.tsx
@@ -9,6 +9,7 @@ import {
   LoadingPage,
   SessionModal,
   adaptedTokenExchangeError,
+  isJwtExpired,
   useErrors,
   useSessionCheck,
 } from '@pagopa-pn/pn-commons';
@@ -80,7 +81,7 @@ const SessionGuard = () => {
   };
 
   const exit = async () => {
-    if (sessionToken) {
+    if (sessionToken && !isJwtExpired(exp)) {
       await dispatch(apiLogout(sessionToken));
     }
 

--- a/packages/pn-personafisica-webapp/src/navigation/__test__/SessionGuard.test.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/__test__/SessionGuard.test.tsx
@@ -186,5 +186,14 @@ describe('SessionGuard Component', async () => {
       const logoutTitleComponent = screen.queryByText('leaving-app.title');
       expect(logoutTitleComponent).toBeTruthy();
     });
+
+    // No call api logout because the token is expired
+    vi.useFakeTimers();
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+      expect(mock.history.post).toHaveLength(0);
+    });
+    vi.useRealTimers();
   });
+
 });

--- a/packages/pn-personagiuridica-webapp/src/navigation/SessionGuard.tsx
+++ b/packages/pn-personagiuridica-webapp/src/navigation/SessionGuard.tsx
@@ -9,6 +9,7 @@ import {
   LoadingPage,
   SessionModal,
   adaptedTokenExchangeError,
+  isJwtExpired,
   sanitizeString,
   useErrors,
   useSessionCheck,
@@ -82,7 +83,7 @@ const SessionGuard = () => {
   };
 
   const exit = async () => {
-    if (sessionToken) {
+    if (sessionToken && !isJwtExpired(expDate)) {
       await dispatch(apiLogout(sessionToken));
     }
     dispatch(resetState());

--- a/packages/pn-personagiuridica-webapp/src/navigation/__test__/SessionGuard.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/navigation/__test__/SessionGuard.test.tsx
@@ -228,5 +228,13 @@ describe('SessionGuard Component', async () => {
       const logoutTitleComponent = screen.queryByText('leaving-app.title');
       expect(logoutTitleComponent).toBeTruthy();
     });
+
+    // No call api logout because the token is expired
+    vi.useFakeTimers();
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+      expect(mock.history.post).toHaveLength(0);
+    });
+    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
## Short description
In SessionGuard component, if token is expired do not call api logout.

## List of changes proposed in this pull request


## How to test
Start PF/PA/PG and login. Wait for token expiration and make sure the API logout isn’t triggered.