### PR TITLE
fix(PN-16109): update maximum length for addressDetails validation to 44 characters

### DIFF
--- a/packages/pn-pa-webapp/src/components/NewNotification/Recipient.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/Recipient.tsx
@@ -173,7 +173,7 @@ const Recipient: React.FC<Props> = ({
       .matches(dataRegex.email, t('pec-error')),
     address: conditionalPhysicalAddress(requiredStringFieldValidation(tc, 1024)),
     addressDetails: conditionalPhysicalAddress(
-      yup.string().max(1024, tc('too-long-field-error', { maxLength: 1024 }))
+      yup.string().max(44, tc('too-long-field-error', { maxLength: 44 }))
     ),
     houseNumber: conditionalPhysicalAddress(
       yup


### PR DESCRIPTION
## Short description
Update maximum length for addressDetails validation to 44 characters

## List of changes proposed in this pull request
- Fix recipient address validation

## How to test
- Start PA
- Go to new notification form
- On Recipient step try to insert more than 44 characters on field `Note Aggiuntive (presso, scala, piano)`

See: https://pagopa.atlassian.net/browse/PN-16109?focusedCommentId=290623