### PR TITLE
feat(PN-18982): adapt UI for support users by hiding routes and actions

### DIFF
--- a/packages/pn-commons/src/components/Header/Header.tsx
+++ b/packages/pn-commons/src/components/Header/Header.tsx
@@ -38,6 +38,8 @@ type HeaderProps = {
   isLogged?: boolean;
   /** Enable assistance button */
   enableAssistanceButton?: boolean;
+  /** Flag that indicate if logged user is a support user */
+  isSupportUser?: boolean;
 };
 
 const Header: React.FC<HeaderProps> = ({
@@ -53,6 +55,7 @@ const Header: React.FC<HeaderProps> = ({
   onAssistanceClick,
   isLogged,
   enableAssistanceButton,
+  isSupportUser = false,
 }) => {
   const pagoPAHeaderLink: RootLinkType = {
     ...pagoPALink(),
@@ -119,6 +122,10 @@ const Header: React.FC<HeaderProps> = ({
           partyId={partyId}
           productsList={productsList}
           partyList={partyList}
+          chipLabel={
+            isSupportUser ? getLocalizedOrDefaultLabel('common', 'header.support') : undefined
+          }
+          // chipSize="medium"
           onSelectedProduct={handleProductSelection}
           onSelectedParty={(party) => handlePartySelection(party as PartyEntityWithUrl)}
         />

--- a/packages/pn-commons/src/components/Header/Header.tsx
+++ b/packages/pn-commons/src/components/Header/Header.tsx
@@ -38,8 +38,8 @@ type HeaderProps = {
   isLogged?: boolean;
   /** Enable assistance button */
   enableAssistanceButton?: boolean;
-  /** Flag that indicate if logged user is a support user */
-  isSupportUser?: boolean;
+  /** Label of the chip displayed next to product switch */
+  chipLabel?: string;
 };
 
 const Header: React.FC<HeaderProps> = ({
@@ -55,7 +55,7 @@ const Header: React.FC<HeaderProps> = ({
   onAssistanceClick,
   isLogged,
   enableAssistanceButton,
-  isSupportUser = false,
+  chipLabel,
 }) => {
   const pagoPAHeaderLink: RootLinkType = {
     ...pagoPALink(),
@@ -122,10 +122,7 @@ const Header: React.FC<HeaderProps> = ({
           partyId={partyId}
           productsList={productsList}
           partyList={partyList}
-          chipLabel={
-            isSupportUser ? getLocalizedOrDefaultLabel('common', 'header.support') : undefined
-          }
-          // chipSize="medium"
+          chipLabel={chipLabel}
           onSelectedProduct={handleProductSelection}
           onSelectedParty={(party) => handlePartySelection(party as PartyEntityWithUrl)}
         />

--- a/packages/pn-commons/src/components/Header/__test__/Header.test.tsx
+++ b/packages/pn-commons/src/components/Header/__test__/Header.test.tsx
@@ -330,6 +330,19 @@ describe('Header Component', () => {
     expect(window.location.href).toBe('');
   });
 
+  it('renders chip with "Supporto" label when isSupportUser is true', () => {
+    render(
+      <Header
+        productsList={productsList}
+        loggedUser={loggedUser}
+        productId={productsList[0].id}
+        isSupportUser
+      />
+    );
+    const chip = screen.getByText('header.support');
+    expect(chip).toBeInTheDocument();
+  });
+
   it('clicks on exit with default value', async () => {
     const { container } = render(
       <Header

--- a/packages/pn-commons/src/components/Header/__test__/Header.test.tsx
+++ b/packages/pn-commons/src/components/Header/__test__/Header.test.tsx
@@ -330,16 +330,16 @@ describe('Header Component', () => {
     expect(window.location.href).toBe('');
   });
 
-  it('renders chip with "Supporto" label when isSupportUser is true', () => {
+  it('renders chip with label when chipLabel is defined', () => {
     render(
       <Header
         productsList={productsList}
         loggedUser={loggedUser}
         productId={productsList[0].id}
-        isSupportUser
+        chipLabel="test-label"
       />
     );
-    const chip = screen.getByText('header.support');
+    const chip = screen.getByText('test-label');
     expect(chip).toBeInTheDocument();
   });
 

--- a/packages/pn-commons/src/components/Layout/Layout.tsx
+++ b/packages/pn-commons/src/components/Layout/Layout.tsx
@@ -57,8 +57,8 @@ type Props = {
   accessibilityLink: string;
   /** Enable assistance button */
   enableAssistanceButton?: boolean;
-  /** Flag that indicate if logged user is a support user */
-  isSupportUser?: boolean;
+  /** Label of the chip displayed next to product switch */
+  chipLabel?: string;
   slotsProps?: {
     content?: Partial<StackProps>;
     main?: Partial<BoxOwnProps>;
@@ -91,7 +91,7 @@ const Layout: React.FC<Props> = ({
   termsOfServiceHref,
   accessibilityLink,
   enableAssistanceButton = true,
-  isSupportUser = false,
+  chipLabel,
   slotsProps,
 }) => (
   <ErrorBoundary
@@ -119,7 +119,7 @@ const Layout: React.FC<Props> = ({
             onAssistanceClick={onAssistanceClick}
             isLogged={isLogged}
             enableAssistanceButton={enableAssistanceButton}
-            isSupportUser={isSupportUser}
+            chipLabel={chipLabel}
           />
         )}
         <Stack

--- a/packages/pn-commons/src/components/Layout/Layout.tsx
+++ b/packages/pn-commons/src/components/Layout/Layout.tsx
@@ -57,6 +57,8 @@ type Props = {
   accessibilityLink: string;
   /** Enable assistance button */
   enableAssistanceButton?: boolean;
+  /** Flag that indicate if logged user is a support user */
+  isSupportUser?: boolean;
   slotsProps?: {
     content?: Partial<StackProps>;
     main?: Partial<BoxOwnProps>;
@@ -89,6 +91,7 @@ const Layout: React.FC<Props> = ({
   termsOfServiceHref,
   accessibilityLink,
   enableAssistanceButton = true,
+  isSupportUser = false,
   slotsProps,
 }) => (
   <ErrorBoundary
@@ -116,6 +119,7 @@ const Layout: React.FC<Props> = ({
             onAssistanceClick={onAssistanceClick}
             isLogged={isLogged}
             enableAssistanceButton={enableAssistanceButton}
+            isSupportUser={isSupportUser}
           />
         )}
         <Stack

--- a/packages/pn-pa-webapp/public/locales/de/common.json
+++ b/packages/pn-pa-webapp/public/locales/de/common.json
@@ -26,7 +26,8 @@
     "logout": "Beenden",
     "pago-pa-link": "Website von PagoPA S.p.A.",
     "reserved-area": "Reservierten Bereich",
-    "notification-platform": "SEND - Servizio Notifiche Digitali"
+    "notification-platform": "SEND - Servizio Notifiche Digitali",
+    "support": "Support"
   },
   "tos": {
     "title": "SEND - Servizio Notifiche Digitali",

--- a/packages/pn-pa-webapp/public/locales/en/common.json
+++ b/packages/pn-pa-webapp/public/locales/en/common.json
@@ -26,7 +26,8 @@
     "logout": "Exit",
     "pago-pa-link": "PagoPA S.p.A. website",
     "reserved-area": "Reserved Area",
-    "notification-platform": "SEND - Servizio Notifiche Digitali"
+    "notification-platform": "SEND - Servizio Notifiche Digitali",
+    "support": "Support"
   },
   "tos": {
     "title": "SEND - Servizio Notifiche Digitali",

--- a/packages/pn-pa-webapp/public/locales/fr/common.json
+++ b/packages/pn-pa-webapp/public/locales/fr/common.json
@@ -26,7 +26,8 @@
     "logout": "Sortir",
     "pago-pa-link": "Site de PagoPA S.p.A.",
     "reserved-area": "Espace réservé",
-    "notification-platform": "SEND - Servizio Notifiche Digitali"
+    "notification-platform": "SEND - Servizio Notifiche Digitali",
+    "support": "Assistance"
   },
   "tos": {
     "title": "SEND - Servizio Notifiche Digitali",

--- a/packages/pn-pa-webapp/public/locales/it/common.json
+++ b/packages/pn-pa-webapp/public/locales/it/common.json
@@ -28,7 +28,8 @@
     "pago-pa-link": "Sito di PagoPA S.p.A.",
     "reserved-area": "Area Riservata",
     "notification-platform": "SEND - Servizio Notifiche Digitali",
-    "logout-message": "Confermi di voler uscire da Area Riservata?"
+    "logout-message": "Confermi di voler uscire da Area Riservata?",
+    "support": "Supporto"
   },
   "tos": {
     "title": "SEND - Servizio Notifiche Digitali",

--- a/packages/pn-pa-webapp/public/locales/sl/common.json
+++ b/packages/pn-pa-webapp/public/locales/sl/common.json
@@ -26,7 +26,8 @@
     "logout": "Izhod",
     "pago-pa-link": "Spletna stran PagoPA S.p.A.",
     "reserved-area": "rezerviranega območja",
-    "notification-platform": "SEND - Servizio Notifiche Digitali"
+    "notification-platform": "SEND - Servizio Notifiche Digitali",
+    "support": "Podpora"
   },
   "tos": {
     "title": "SEND - Servizio Notifiche Digitali",

--- a/packages/pn-pa-webapp/src/App.tsx
+++ b/packages/pn-pa-webapp/src/App.tsx
@@ -14,6 +14,7 @@ import {
   APP_VERSION,
   AppMessage,
   AppResponseMessage,
+  ConsentUser,
   Layout,
   LoadingOverlay,
   PnDialog,
@@ -40,7 +41,7 @@ import {
   getInstitutions,
   getProductsOfInstitution,
 } from './redux/auth/actions';
-import { resetState } from './redux/auth/reducers';
+import { authSelectors, resetState } from './redux/auth/reducers';
 import { useAppDispatch, useAppSelector } from './redux/hooks';
 import { RootState } from './redux/store';
 import { getConfiguration } from './services/configuration.service';
@@ -72,6 +73,32 @@ const App = () => {
   return isInitialized ? <ActualApp /> : <div />;
 };
 
+type ShowSideMenuParams = {
+  isPrivacyPage: boolean;
+  isSupportUser: boolean;
+  sessionToken?: string;
+  tosConsent?: ConsentUser;
+  privacyConsent?: ConsentUser;
+};
+
+const canShowSideMenu = ({
+  sessionToken,
+  tosConsent,
+  privacyConsent,
+  isPrivacyPage,
+  isSupportUser,
+}: ShowSideMenuParams): boolean => {
+  if (!sessionToken || isPrivacyPage) {
+    return false;
+  }
+
+  if (isSupportUser) {
+    return true;
+  }
+
+  return !!(tosConsent?.accepted && privacyConsent?.accepted);
+};
+
 const ActualApp = () => {
   const loggedUser = useAppSelector((state: RootState) => state.userState.user);
   const loggedUserOrganizationParty = loggedUser.organization;
@@ -86,6 +113,7 @@ const ActualApp = () => {
   const products = useAppSelector((state: RootState) => state.userState.productsOfInstitution);
   const institutions = useAppSelector((state: RootState) => state.userState.institutions);
   const lastError = useAppSelector((state: RootState) => state.appState.lastError);
+  const isSupportUser = useAppSelector(authSelectors.selectIsSupportUser);
   const dispatch = useAppDispatch();
   const { t, i18n } = useTranslation(['common', 'notifiche']);
 
@@ -116,10 +144,12 @@ const ActualApp = () => {
         ];
 
   const productId = products.length > 0 ? SELFCARE_SEND_PROD_ID : '0';
-  const institutionsList = institutions.map((institution) => ({
-    ...institution,
-    productRole: t(`roles.${institution.productRole}`),
-  }));
+  const institutionsList = institutions
+    .filter((institution) => !isSupportUser || institution.id === idOrganization)
+    .map((institution) => ({
+      ...institution,
+      productRole: t(`roles.${institution.productRole}`),
+    }));
 
   const sessionToken = loggedUser.sessionToken;
 
@@ -186,9 +216,9 @@ const ActualApp = () => {
 
   const jwtUser = useMemo(
     () => ({
-      id: loggedUser.fiscal_number ?? '',
-      name: loggedUser.name ?? '',
-      surname: loggedUser.family_name ?? '',
+      id: loggedUser.fiscal_number ?? loggedUser.uid,
+      name: loggedUser.name,
+      surname: loggedUser.family_name,
     }),
     [loggedUser]
   );
@@ -196,15 +226,21 @@ const ActualApp = () => {
   useTracking(configuration.MIXPANEL_TOKEN, process.env.NODE_ENV);
 
   useEffect(() => {
-    if (sessionToken) {
-      void dispatch(getCurrentAppStatus());
-      void dispatch(getInstitutions());
+    if (!sessionToken) {
+      return;
+    }
+
+    void dispatch(getCurrentAppStatus());
+    void dispatch(getInstitutions());
+
+    if (!isSupportUser) {
       void dispatch(getAdditionalLanguages());
     }
+
     if (idOrganization) {
       void dispatch(getProductsOfInstitution());
     }
-  }, [sessionToken, getCurrentAppStatus, idOrganization]);
+  }, [sessionToken, getCurrentAppStatus, idOrganization, isSupportUser]);
 
   const { pathname } = useLocation();
   const path = pathname.split('/');
@@ -241,7 +277,7 @@ const ActualApp = () => {
   const performLogout = async () => {
     await dispatch(apiLogout(loggedUser.sessionToken));
     dispatch(resetState());
-    goToSelfcareLogout();
+    goToSelfcareLogout(isSupportUser);
     setOpenModal(false);
   };
 
@@ -258,14 +294,13 @@ const ActualApp = () => {
             <SideMenu menuItems={menuItems.menuItems} selfCareItems={menuItems.selfCareItems} />
           )
         }
-        showSideMenu={
-          !!sessionToken &&
-          tosConsent &&
-          tosConsent.accepted &&
-          privacyConsent &&
-          privacyConsent.accepted &&
-          !isPrivacyPage
-        }
+        showSideMenu={canShowSideMenu({
+          sessionToken,
+          tosConsent,
+          privacyConsent,
+          isPrivacyPage,
+          isSupportUser,
+        })}
         productsList={productsList}
         productId={productId}
         partyId={idOrganization}
@@ -273,9 +308,11 @@ const ActualApp = () => {
         loggedUser={jwtUser}
         currentLanguage={i18n.language}
         onLanguageChanged={changeLanguageHandler}
+        enableAssistanceButton={!isSupportUser}
         onAssistanceClick={handleAssistanceClick}
         isLogged={!!sessionToken}
         accessibilityLink={ACCESSIBILITY_LINK}
+        isSupportUser={isSupportUser}
       >
         <PnDialog open={openModal}>
           <DialogTitle sx={{ mb: 2 }}>{t('header.logout-message')}</DialogTitle>

--- a/packages/pn-pa-webapp/src/App.tsx
+++ b/packages/pn-pa-webapp/src/App.tsx
@@ -312,7 +312,7 @@ const ActualApp = () => {
         onAssistanceClick={handleAssistanceClick}
         isLogged={!!sessionToken}
         accessibilityLink={ACCESSIBILITY_LINK}
-        isSupportUser={isSupportUser}
+        chipLabel={isSupportUser ? t('header.support') : undefined}
       >
         <PnDialog open={openModal}>
           <DialogTitle sx={{ mb: 2 }}>{t('header.logout-message')}</DialogTitle>

--- a/packages/pn-pa-webapp/src/__test__/App.test.tsx
+++ b/packages/pn-pa-webapp/src/__test__/App.test.tsx
@@ -5,11 +5,15 @@ import { ThemeProvider, createTheme } from '@mui/material';
 
 import App from '../App';
 import { currentStatusDTO } from '../__mocks__/AppStatus.mock';
-import { userResponse } from '../__mocks__/Auth.mock';
+import { supportUserResponse, userResponse } from '../__mocks__/Auth.mock';
 import { tosPrivacyConsentMock } from '../__mocks__/Consents.mock';
 import { institutionsDTO, productsDTO } from '../__mocks__/User.mock';
 import { apiClient, authClient } from '../api/apiClients';
-import { SELFCARE_LOGIN_PATH, SELFCARE_LOGOUT_PATH } from '../navigation/routes.const';
+import {
+  SELFCARE_LOGIN_PATH,
+  SELFCARE_LOGOUT_GOOGLE_PATH,
+  SELFCARE_LOGOUT_PATH,
+} from '../navigation/routes.const';
 import { getConfiguration } from '../services/configuration.service';
 import { RenderResult, act, fireEvent, getByText, render, screen, waitFor } from './test-utils';
 
@@ -169,6 +173,41 @@ describe('App', async () => {
     await waitFor(() => {
       expect(mockOpenFn).toHaveBeenCalledTimes(1);
       const url = `${getConfiguration().SELFCARE_BASE_URL}${SELFCARE_LOGOUT_PATH}`;
+      expect(mockOpenFn).toHaveBeenCalledWith(url, '_self');
+      expect(clearSpy).toHaveBeenCalled();
+      expect(mockAuth.history.post.length).toBe(1);
+    });
+  });
+
+  it('render component - support user logs out', async () => {
+    mockAuth.onPost('/logout').reply(200);
+
+    const clearSpy = vi.spyOn(Storage.prototype, 'clear');
+
+    await act(async () => {
+      result = render(<Component />, {
+        preloadedState: {
+          ...reduxInitialState,
+          userState: {
+            ...reduxInitialState.userState,
+            user: supportUserResponse,
+          },
+        },
+      });
+    });
+
+    const header = result.container.querySelector('header');
+    expect(header).toBeInTheDocument();
+
+    const button = getByText(header!, 'Esci');
+    fireEvent.click(button);
+
+    const modalConfirmButton = await waitFor(() => screen.queryByTestId('confirm-button'));
+    fireEvent.click(modalConfirmButton!);
+
+    await waitFor(() => {
+      expect(mockOpenFn).toHaveBeenCalledTimes(1);
+      const url = `${getConfiguration().SELFCARE_BASE_URL}${SELFCARE_LOGOUT_GOOGLE_PATH}`;
       expect(mockOpenFn).toHaveBeenCalledWith(url, '_self');
       expect(clearSpy).toHaveBeenCalled();
       expect(mockAuth.history.post.length).toBe(1);

--- a/packages/pn-pa-webapp/src/api/auth/Auth.api.ts
+++ b/packages/pn-pa-webapp/src/api/auth/Auth.api.ts
@@ -1,36 +1,38 @@
 import { removeNullProperties } from '@pagopa-pn/pn-commons';
 
-import { User } from '../../models/user';
+import { PNRole, PartyRole, User } from '../../models/user';
 import { authClient } from '../apiClients';
 import { AUTH_LOGOUT, AUTH_TOKEN_EXCHANGE } from './auth.routes';
 
-// const supportOrganization = {
-//   id: '5b994d4a-0fa8-47ac-9c7b-354f1d44a1ce',
-//   name: 'Comune di Palermo',
-//   roles: [
-//     {
-//       partyRole: PartyRole.SUPPORT,
-//       role: PNRole.SUPPORT,
-//     },
-//   ],
-//   fiscal_code: '80016350821',
-//   ipaCode: 'c_g273',
-// };
-
-// // eslint-disable-next-line functional/immutable-data
-// response.data = {
-//   uid: '4253a451-4b19-476f-8f8f-baa10f9934de',
-//   email: 'f.bianchi@codermine.com',
-//   organization: supportOrganization,
-//   desired_exp: response.data.desired_exp,
-//   sessionToken: response.data.sessionToken,
-// };
+const supportOrganization = {
+  id: '5b994d4a-0fa8-47ac-9c7b-354f1d44a1ce',
+  name: 'Comune di Palermo',
+  roles: [
+    {
+      partyRole: PartyRole.SUPPORT,
+      role: PNRole.SUPPORT,
+    },
+  ],
+  fiscal_code: '80016350821',
+  ipaCode: 'c_g273',
+};
 
 export const AuthApi = {
   exchangeToken: (selfCareToken: string): Promise<User> =>
-    authClient.post<User>(AUTH_TOKEN_EXCHANGE(), { authorizationToken: selfCareToken }).then(
-      (response): User =>
-        removeNullProperties<User>({
+    authClient
+      .post<User>(AUTH_TOKEN_EXCHANGE(), { authorizationToken: selfCareToken })
+      .then((response): User => {
+        // eslint-disable-next-line functional/immutable-data
+        // response.data = {
+        //   uid: '4253a451-4b19-476f-8f8f-baa10f9934de',
+        //   email: 'f.bianchi@codermine.com',
+        //   organization: supportOrganization,
+        //   desired_exp: response.data.desired_exp,
+        //   sessionToken: response.data.sessionToken,
+        // };
+        console.log(response, supportOrganization);
+
+        return removeNullProperties<User>({
           desired_exp: response.data.desired_exp,
           email: response.data.email,
           name: response.data.name,
@@ -39,8 +41,8 @@ export const AuthApi = {
           organization: response.data.organization,
           sessionToken: response.data.sessionToken,
           uid: response.data.uid,
-        })
-    ),
+        });
+      }),
   logout: (token: string): Promise<void> =>
     authClient.post(AUTH_LOGOUT(), null, { headers: { Authorization: `Bearer ${token}` } }),
 };

--- a/packages/pn-pa-webapp/src/api/auth/Auth.api.ts
+++ b/packages/pn-pa-webapp/src/api/auth/Auth.api.ts
@@ -1,38 +1,14 @@
 import { removeNullProperties } from '@pagopa-pn/pn-commons';
 
-import { PNRole, PartyRole, User } from '../../models/user';
+import { User } from '../../models/user';
 import { authClient } from '../apiClients';
 import { AUTH_LOGOUT, AUTH_TOKEN_EXCHANGE } from './auth.routes';
 
-const supportOrganization = {
-  id: '5b994d4a-0fa8-47ac-9c7b-354f1d44a1ce',
-  name: 'Comune di Palermo',
-  roles: [
-    {
-      partyRole: PartyRole.SUPPORT,
-      role: PNRole.SUPPORT,
-    },
-  ],
-  fiscal_code: '80016350821',
-  ipaCode: 'c_g273',
-};
-
 export const AuthApi = {
   exchangeToken: (selfCareToken: string): Promise<User> =>
-    authClient
-      .post<User>(AUTH_TOKEN_EXCHANGE(), { authorizationToken: selfCareToken })
-      .then((response): User => {
-        // eslint-disable-next-line functional/immutable-data
-        response.data = {
-          uid: '4253a451-4b19-476f-8f8f-baa10f9934de',
-          email: 'f.bianchi@codermine.com',
-          organization: supportOrganization,
-          desired_exp: response.data.desired_exp,
-          sessionToken: response.data.sessionToken,
-        };
-        console.log(response, supportOrganization);
-
-        return removeNullProperties<User>({
+    authClient.post<User>(AUTH_TOKEN_EXCHANGE(), { authorizationToken: selfCareToken }).then(
+      (response): User =>
+        removeNullProperties<User>({
           desired_exp: response.data.desired_exp,
           email: response.data.email,
           name: response.data.name,
@@ -41,8 +17,8 @@ export const AuthApi = {
           organization: response.data.organization,
           sessionToken: response.data.sessionToken,
           uid: response.data.uid,
-        });
-      }),
+        })
+    ),
   logout: (token: string): Promise<void> =>
     authClient.post(AUTH_LOGOUT(), null, { headers: { Authorization: `Bearer ${token}` } }),
 };

--- a/packages/pn-pa-webapp/src/api/auth/Auth.api.ts
+++ b/packages/pn-pa-webapp/src/api/auth/Auth.api.ts
@@ -23,13 +23,13 @@ export const AuthApi = {
       .post<User>(AUTH_TOKEN_EXCHANGE(), { authorizationToken: selfCareToken })
       .then((response): User => {
         // eslint-disable-next-line functional/immutable-data
-        // response.data = {
-        //   uid: '4253a451-4b19-476f-8f8f-baa10f9934de',
-        //   email: 'f.bianchi@codermine.com',
-        //   organization: supportOrganization,
-        //   desired_exp: response.data.desired_exp,
-        //   sessionToken: response.data.sessionToken,
-        // };
+        response.data = {
+          uid: '4253a451-4b19-476f-8f8f-baa10f9934de',
+          email: 'f.bianchi@codermine.com',
+          organization: supportOrganization,
+          desired_exp: response.data.desired_exp,
+          sessionToken: response.data.sessionToken,
+        };
         console.log(response, supportOrganization);
 
         return removeNullProperties<User>({

--- a/packages/pn-pa-webapp/src/components/Notifications/__test__/NotificationDetailTableSender.test.tsx
+++ b/packages/pn-pa-webapp/src/components/Notifications/__test__/NotificationDetailTableSender.test.tsx
@@ -75,4 +75,26 @@ describe('NotificationDetailTableSender Component', () => {
     const cancelNotificationBtn = queryByTestId('cancelNotificationBtn');
     expect(cancelNotificationBtn).not.toBeInTheDocument();
   });
+
+  it('renders component - no cancel notification button with support role', () => {
+    const { queryByTestId } = render(
+      <NotificationDetailTableSender
+        notification={notificationDTO}
+        onCancelNotification={mockCancelHandler}
+      />,
+      {
+        preloadedState: {
+          userState: {
+            user: {
+              organization: {
+                roles: [{ role: PNRole.SUPPORT }],
+              },
+            },
+          },
+        },
+      }
+    );
+    const cancelNotificationBtn = queryByTestId('cancelNotificationBtn');
+    expect(cancelNotificationBtn).not.toBeInTheDocument();
+  });
 });

--- a/packages/pn-pa-webapp/src/navigation/SessionGuard.tsx
+++ b/packages/pn-pa-webapp/src/navigation/SessionGuard.tsx
@@ -14,7 +14,7 @@ import {
 } from '@pagopa-pn/pn-commons';
 
 import { apiLogout, exchangeToken } from '../redux/auth/actions';
-import { resetState } from '../redux/auth/reducers';
+import { authSelectors, resetState } from '../redux/auth/reducers';
 import { useAppDispatch, useAppSelector } from '../redux/hooks';
 import { RootState } from '../redux/store';
 import { getConfiguration } from '../services/configuration.service';
@@ -27,6 +27,7 @@ const SessionGuard = () => {
     (state: RootState) => state.userState.user
   );
   const { loading } = useAppSelector((state: RootState) => state.userState);
+  const isSupportUser = useAppSelector(authSelectors.selectIsSupportUser);
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
   const sessionCheck = useSessionCheck(200, () => sessionCheckCallback());
@@ -93,7 +94,7 @@ const SessionGuard = () => {
       await dispatch(apiLogout(sessionToken));
     }
     dispatch(resetState());
-    goToSelfcareLogout();
+    goToSelfcareLogout(isSupportUser);
   };
 
   useEffect(() => {

--- a/packages/pn-pa-webapp/src/navigation/ToSGuard.tsx
+++ b/packages/pn-pa-webapp/src/navigation/ToSGuard.tsx
@@ -6,6 +6,7 @@ import { LoadingPage, SessionModal } from '@pagopa-pn/pn-commons';
 
 import ToSAcceptancePage from '../pages/ToSAcceptance.page';
 import { getTosPrivacyApproval } from '../redux/auth/actions';
+import { authSelectors } from '../redux/auth/reducers';
 import { useAppDispatch, useAppSelector } from '../redux/hooks';
 import { RootState } from '../redux/store';
 import { goToSelfcareLogin } from './navigation.utility';
@@ -14,14 +15,19 @@ const ToSGuard = () => {
   const dispatch = useAppDispatch();
   const { tosConsent, privacyConsent, fetchedTos, fetchedPrivacy, tosPrivacyApiError } =
     useAppSelector((state: RootState) => state.userState);
+  const isSupportUser = useAppSelector(authSelectors.selectIsSupportUser);
   const { sessionToken } = useAppSelector((state: RootState) => state.userState.user);
   const { t } = useTranslation(['common']);
 
   useEffect(() => {
-    if (sessionToken) {
+    if (sessionToken && !isSupportUser) {
       void dispatch(getTosPrivacyApproval());
     }
-  }, [sessionToken]);
+  }, [sessionToken, isSupportUser]);
+
+  if (isSupportUser) {
+    return <Outlet />;
+  }
 
   if (tosPrivacyApiError || !fetchedTos || !fetchedPrivacy) {
     return (

--- a/packages/pn-pa-webapp/src/navigation/__test__/ToSGuard.test.tsx
+++ b/packages/pn-pa-webapp/src/navigation/__test__/ToSGuard.test.tsx
@@ -1,7 +1,7 @@
 import MockAdapter from 'axios-mock-adapter';
 import { Route, Routes } from 'react-router-dom';
 
-import { userResponse } from '../../__mocks__/Auth.mock';
+import { supportUserResponse, userResponse } from '../../__mocks__/Auth.mock';
 import { tosPrivacyConsentMock } from '../../__mocks__/Consents.mock';
 import { act, render, screen } from '../../__test__/test-utils';
 import { apiClient } from '../../api/apiClients';
@@ -111,5 +111,25 @@ describe('Tests the ToSGuard component', async () => {
     expect(tosComponent).toBeNull();
     expect(genericPage).toBeTruthy();
     expect(mock.history.get).toHaveLength(1);
+  });
+
+  it('does not call tos-privacy API when logged user has role SUPPORT', async () => {
+    const supportReduxState = {
+      userState: {
+        ...reduxState.userState,
+        user: supportUserResponse,
+      },
+    };
+
+    await act(async () => {
+      render(<Guard />, { preloadedState: supportReduxState });
+    });
+    const pageComponent = screen.queryByTestId('loading-skeleton');
+    const tosComponent = screen.queryByTestId('tos-acceptance-page');
+    const genericPage = screen.queryByText('Generic Page');
+    expect(pageComponent).toBeNull();
+    expect(tosComponent).toBeNull();
+    expect(genericPage).toBeTruthy();
+    expect(mock.history.get).toHaveLength(0);
   });
 });

--- a/packages/pn-pa-webapp/src/navigation/__test__/navigation.utility.test.ts
+++ b/packages/pn-pa-webapp/src/navigation/__test__/navigation.utility.test.ts
@@ -2,7 +2,11 @@ import { vi } from 'vitest';
 
 import { getConfiguration } from '../../services/configuration.service';
 import { goToSelfcareLogin, goToSelfcareLogout } from '../navigation.utility';
-import { SELFCARE_LOGIN_PATH, SELFCARE_LOGOUT_PATH } from '../routes.const';
+import {
+  SELFCARE_LOGIN_PATH,
+  SELFCARE_LOGOUT_GOOGLE_PATH,
+  SELFCARE_LOGOUT_PATH,
+} from '../routes.const';
 
 const mockOpenFn = vi.fn();
 
@@ -27,14 +31,21 @@ describe('Tests notification.utility', () => {
   it('goToSelfcareLogin', () => {
     goToSelfcareLogin();
     expect(mockOpenFn).toHaveBeenCalledTimes(1);
-    const url = `${getConfiguration().SELFCARE_BASE_URL}${SELFCARE_LOGIN_PATH}`
+    const url = `${getConfiguration().SELFCARE_BASE_URL}${SELFCARE_LOGIN_PATH}`;
     expect(mockOpenFn).toHaveBeenCalledWith(url, '_self');
   });
-  
-  it('goToSelfcareLogout', () => {
-    goToSelfcareLogout();
+
+  it('goToSelfcareLogout - basic user', () => {
+    goToSelfcareLogout(false);
     expect(mockOpenFn).toHaveBeenCalledTimes(1);
-    const url = `${getConfiguration().SELFCARE_BASE_URL}${SELFCARE_LOGOUT_PATH}`
+    const url = `${getConfiguration().SELFCARE_BASE_URL}${SELFCARE_LOGOUT_PATH}`;
+    expect(mockOpenFn).toHaveBeenCalledWith(url, '_self');
+  });
+
+  it('goToSelfcareLogout - support user', () => {
+    goToSelfcareLogout(true);
+    expect(mockOpenFn).toHaveBeenCalledTimes(1);
+    const url = `${getConfiguration().SELFCARE_BASE_URL}${SELFCARE_LOGOUT_GOOGLE_PATH}`;
     expect(mockOpenFn).toHaveBeenCalledWith(url, '_self');
   });
 });

--- a/packages/pn-pa-webapp/src/navigation/navigation.utility.ts
+++ b/packages/pn-pa-webapp/src/navigation/navigation.utility.ts
@@ -1,12 +1,17 @@
 import { getConfiguration } from '../services/configuration.service';
-import { SELFCARE_LOGIN_PATH, SELFCARE_LOGOUT_PATH } from './routes.const';
+import {
+  SELFCARE_LOGIN_PATH,
+  SELFCARE_LOGOUT_GOOGLE_PATH,
+  SELFCARE_LOGOUT_PATH,
+} from './routes.const';
 
 export function goToSelfcareLogin(): void {
   const { SELFCARE_BASE_URL } = getConfiguration();
-  window.open( `${SELFCARE_BASE_URL}${SELFCARE_LOGIN_PATH}`, '_self');
+  window.open(`${SELFCARE_BASE_URL}${SELFCARE_LOGIN_PATH}`, '_self');
 }
 
-export function goToSelfcareLogout(): void {
+export function goToSelfcareLogout(isSupportUser: boolean): void {
   const { SELFCARE_BASE_URL } = getConfiguration();
-  window.open(`${SELFCARE_BASE_URL}${SELFCARE_LOGOUT_PATH}`, '_self');
+  const logoutPath = isSupportUser ? SELFCARE_LOGOUT_GOOGLE_PATH : SELFCARE_LOGOUT_PATH;
+  window.open(`${SELFCARE_BASE_URL}${logoutPath}`, '_self');
 }

--- a/packages/pn-pa-webapp/src/navigation/routes.const.ts
+++ b/packages/pn-pa-webapp/src/navigation/routes.const.ts
@@ -38,3 +38,4 @@ export const NOT_ACCESSIBLE = '/non-accessibile';
 
 export const SELFCARE_LOGIN_PATH = '/auth/login';
 export const SELFCARE_LOGOUT_PATH = '/auth/logout';
+export const SELFCARE_LOGOUT_GOOGLE_PATH = `${SELFCARE_LOGOUT_PATH}/google`;

--- a/packages/pn-pa-webapp/src/navigation/routes.tsx
+++ b/packages/pn-pa-webapp/src/navigation/routes.tsx
@@ -29,18 +29,22 @@ const Router: React.FC = () => {
     <Routes>
       <Route element={<SessionGuard />}>
         {/* protected routes */}
-        <Route element={<RouteGuard roles={[PNRole.ADMIN, PNRole.OPERATOR]} />}>
+        <Route element={<RouteGuard roles={[PNRole.ADMIN, PNRole.OPERATOR, PNRole.SUPPORT]} />}>
           <Route element={<ToSGuard />}>
             <Route path={routes.DASHBOARD} element={<Dashboard />} />
             {IS_STATISTICS_ENABLED && <Route path={routes.STATISTICHE} element={<Statistics />} />}
             <Route path={routes.DETTAGLIO_NOTIFICA} element={<NotificationDetail />} />
-            {getConfiguration().IS_MANUAL_SEND_ENABLED && (
-              <Route path={routes.NUOVA_NOTIFICA} element={<NewNotification />} />
-            )}
             <Route path={routes.APP_STATUS} element={<AppStatus />} />
-            <Route path={routes.API_KEYS} element={<ApiKeys />} />
-            <Route path={routes.NUOVA_API_KEY} element={<NewApiKey />} />
             <Route path="/" element={<Navigate to={routes.DASHBOARD} />} />
+
+            {/* rotte non accessibili al ruolo SUPPORT */}
+            <Route element={<RouteGuard roles={[PNRole.ADMIN, PNRole.OPERATOR]} />}>
+              <Route path={routes.API_KEYS} element={<ApiKeys />} />
+              <Route path={routes.NUOVA_API_KEY} element={<NewApiKey />} />
+              {getConfiguration().IS_MANUAL_SEND_ENABLED && (
+                <Route path={routes.NUOVA_NOTIFICA} element={<NewNotification />} />
+              )}
+            </Route>
           </Route>
         </Route>
       </Route>

--- a/packages/pn-pa-webapp/src/pages/Dashboard.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/Dashboard.page.tsx
@@ -22,6 +22,7 @@ import FilterNotifications from '../components/Notifications/FilterNotifications
 import MobileNotifications from '../components/Notifications/MobileNotifications';
 import NotificationSettingsDrawer from '../components/Notifications/NotificationSettingsDrawer';
 import * as routes from '../navigation/routes.const';
+import { authSelectors } from '../redux/auth/reducers';
 import { DASHBOARD_ACTIONS, getSentNotifications } from '../redux/dashboard/actions';
 import { setPagination } from '../redux/dashboard/reducers';
 import { useAppDispatch, useAppSelector } from '../redux/hooks';
@@ -36,6 +37,7 @@ const Dashboard = () => {
   const sort = useAppSelector((state: RootState) => state.dashboardState.sort);
   const pagination = useAppSelector((state: RootState) => state.dashboardState.pagination);
   const loading = useAppSelector((state: RootState) => state.appState.loading.result);
+  const isSupportUser = useAppSelector(authSelectors.selectIsSupportUser);
   const navigate = useNavigate();
   const isMobile = useIsMobile();
   const { t } = useTranslation(['notifiche']);
@@ -77,6 +79,37 @@ const Dashboard = () => {
   // route to API keys
   const handleRouteApiKeys = () => {
     navigate(routes.API_KEYS);
+  };
+
+  const getTitleButtonContent = () => {
+    if (isSupportUser) {
+      return undefined;
+    }
+
+    return IS_MANUAL_SEND_ENABLED ? (
+      <Box display="flex" gap={5}>
+        <NotificationSettingsDrawer />
+        <Button
+          id="new-notification-btn"
+          variant="contained"
+          onClick={handleRouteManualSend}
+          data-testid="newNotificationBtn"
+        >
+          {t('new-notification-button')}
+        </Button>
+      </Box>
+    ) : (
+      <Alert
+        severity="warning"
+        action={
+          <ButtonNaked color="inherit" size="small" onClick={() => navigate(routes.APP_STATUS)}>
+            {t('manual-send-disabled-action')}
+          </ButtonNaked>
+        }
+      >
+        {t('manual-send-disabled-message')}
+      </Alert>
+    );
   };
 
   const fetchNotifications = useCallback(() => {
@@ -148,38 +181,7 @@ const Dashboard = () => {
           flexWrap: 'wrap',
           gap: 3,
         }}
-        titleButton={
-          <>
-            {IS_MANUAL_SEND_ENABLED ? (
-              <Box display="flex" gap={5}>
-                <NotificationSettingsDrawer />
-                <Button
-                  id="new-notification-btn"
-                  variant="contained"
-                  onClick={handleRouteManualSend}
-                  data-testid="newNotificationBtn"
-                >
-                  {t('new-notification-button')}
-                </Button>
-              </Box>
-            ) : (
-              <Alert
-                severity="warning"
-                action={
-                  <ButtonNaked
-                    color="inherit"
-                    size="small"
-                    onClick={() => navigate(routes.APP_STATUS)}
-                  >
-                    {t('manual-send-disabled-action')}
-                  </ButtonNaked>
-                }
-              >
-                {t('manual-send-disabled-message')}
-              </Alert>
-            )}
-          </>
-        }
+        titleButton={getTitleButtonContent()}
         subTitle={
           <Box
             display={isMobile ? 'block' : 'flex'}

--- a/packages/pn-pa-webapp/src/pages/__test__/Dashboard.page.test.tsx
+++ b/packages/pn-pa-webapp/src/pages/__test__/Dashboard.page.test.tsx
@@ -21,6 +21,7 @@ import {
   waitFor,
 } from '../../__test__/test-utils';
 import { apiClient } from '../../api/apiClients';
+import { PNRole } from '../../models/user';
 import * as routes from '../../navigation/routes.const';
 import { DASHBOARD_ACTIONS } from '../../redux/dashboard/actions';
 import { ServerResponseErrorCode } from '../../utility/AppError/types';
@@ -357,5 +358,26 @@ describe('Dashboard Page', async () => {
     await waitFor(() => {
       expect(screen.queryByTestId('filter-form')).not.toBeInTheDocument();
     });
+  });
+
+  it('should not display new notification and language settings buttons if user has role support', async () => {
+    await act(async () => {
+      result = render(<Dashboard />, {
+        preloadedState: {
+          userState: {
+            user: {
+              organization: {
+                roles: [{ role: PNRole.SUPPORT }],
+              },
+            },
+          },
+        },
+      });
+    });
+
+    const newNotificationBtn = result.queryByTestId('newNotificationBtn');
+    const settingsLangBtn = result.queryByTestId('settingsLangBtn');
+    expect(newNotificationBtn).not.toBeInTheDocument();
+    expect(settingsLangBtn).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Short description

Adapt the UI for support users by hiding the following routes: `/api-keys`, `/api-keys/nuova-api-key`, and `/dashboard/nuova-notifica`. Also hide certain actions, such as the "New Notification" button, language settings, and the "Cancel Notification" button.

Additionally, prevent the ToS privacy fetch, redirect the user to a specific logout route, and disable the party switch.

## List of changes proposed in this pull request

- Adapt the UI
- Update unit tests

## How to test

- In `Auth.api.ts`, uncomment the mocked response
- Start PA
- Verify that the user cannot see:
  - the API key page
  - the "New Notification" button
  - the "Cancel Notification" button
  - the party switch  
- Also verify that a chip labeled "Supporto" is displayed next to the product switch