### PR TITLE
fix(PN-18940): improve notification detail table layout for long values

### DIFF
--- a/packages/pn-commons/src/components/NotificationDetail/NotificationDetailTable.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationDetailTable.tsx
@@ -1,4 +1,13 @@
-import { Paper, Table, TableBody, TableCell, TableContainer, TableRow } from '@mui/material';
+import {
+  Paper,
+  SxProps,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableRow,
+} from '@mui/material';
+import { Theme } from '@mui/material/styles';
 
 import { NotificationDetailTableRow } from '../../models/NotificationDetail';
 import { getLocalizedOrDefaultLabel } from '../../utility/localization.utility';
@@ -6,6 +15,26 @@ import { getLocalizedOrDefaultLabel } from '../../utility/localization.utility';
 type Props = {
   rows: Array<NotificationDetailTableRow>;
   children?: React.ReactNode;
+};
+
+const rowSx: SxProps<Theme> = {
+  '& td': { border: 'none' },
+  verticalAlign: 'top',
+  display: { xs: 'flex', lg: 'table-row' },
+  flexDirection: { xs: 'column', lg: 'row' },
+};
+
+const cellLabelSx: SxProps<Theme> = {
+  py: { xs: 0, lg: 1 },
+  width: { lg: 180 },
+  pr: { lg: 4 },
+  whiteSpace: 'nowrap',
+};
+
+const cellValueSx: SxProps<Theme> = {
+  pb: 1,
+  pt: { xs: 0, lg: 1 },
+  overflowWrap: 'anywhere',
 };
 
 /**
@@ -31,24 +60,11 @@ const NotificationDetailTable: React.FC<Props> = ({ children, rows }) => (
     >
       <TableBody>
         {rows.map((row) => (
-          <TableRow
-            key={row.id}
-            sx={{
-              '& td': { border: 'none' },
-              verticalAlign: 'top',
-              display: { xs: 'flex', lg: 'table-row' },
-              flexDirection: { xs: 'column', lg: 'row' },
-            }}
-            data-testid="notificationDetailTableRow"
-          >
-            <TableCell id={`row-label-${row.id}`} padding="none" sx={{ py: { xs: 0, lg: 1 } }}>
+          <TableRow key={row.id} sx={rowSx} data-testid="notificationDetailTableRow">
+            <TableCell id={`row-label-${row.id}`} padding="none" sx={cellLabelSx}>
               {row.label}
             </TableCell>
-            <TableCell
-              id={`row-value-${row.id}`}
-              padding="none"
-              sx={{ pb: 1, pt: { xs: 0, lg: 1 } }}
-            >
+            <TableCell id={`row-value-${row.id}`} padding="none" sx={cellValueSx}>
               {row.value}
             </TableCell>
           </TableRow>


### PR DESCRIPTION
## Short description
Improve the notification detail table layout to better handle long labels and long values without visual overlap.
This fix resolves both PN-18940 and PN-19055.

## List of changes proposed in this pull request
- add a fixed-width label column with spacing from the value column
- improve wrapping behavior for long values in notification detail rows
- extract table row and cell styles into `sx` constants to keep the JSX as lean as possible

## How to test
Open a notification detail page, mock the response by setting the sender value as described in Jira, and verify the detail table works as expected (desktop and mobile).
Expected behavior:
- labels and values remain visually separated
- labels do not wrap (try to use a long label)
- long values wrap correctly without overlapping labels