### PR TITLE
fix(PN-19290): add noindex and canonical meta tags for auth routes

### DIFF
--- a/packages/pn-personafisica-login/public/js/redirect.js
+++ b/packages/pn-personafisica-login/public/js/redirect.js
@@ -1,4 +1,4 @@
-const regex = new RegExp('https://login\\.(((dev|test|uat|hotfix)\\.)?)notifichedigitali\\.it') 
+const regex = new RegExp('https://login\\.(((dev|test|uat|hotfix)\\.)?)notifichedigitali\\.it');
 const origin = window.origin;
 if (regex.test(origin)) {
   const matches = origin.match(regex);
@@ -7,4 +7,15 @@ if (regex.test(origin)) {
   const newlogin = newloginElements.join('');
   document.write(`<meta http-equiv="refresh" content="0; url=${newlogin}">`);
   document.write(`<meta name="robots" content="noindex">`);
+}
+
+const currentPath = window.location.pathname;
+const currentParams = new URLSearchParams(window.location.search);
+
+const noIndexPaths = ['/auth/login/error', '/auth/login/success', '/auth/logout'];
+
+if (noIndexPaths.includes(currentPath)) {
+  document.write(`<meta name="robots" content="noindex">`);
+} else if (currentParams.has('aar') || currentParams.has('retrievalId')) {
+  document.write(`<link rel="canonical" href="${window.location.origin}/auth/login">`);
 }


### PR DESCRIPTION
## Short description

Add canonical meta tag on `/auth/login` URLs that contains `aar` or `retrievalId` query param in order to index those pages as `/auth/login`

## List of changes proposed in this pull request
- Added canonical meta tag pointing to `<origin>/auth/login` for `/auth/login` URLs containing aar or retrievalId query parameters
- Added `noindex` meta tag for `/auth/login/error`, `/auth/login/success` and `/auth/logout` routes

## How to test

- Start PF login 
- Navigate to `/auth/login/error`, `/auth/login/success` and `/auth/logout` and inspect the `<head>` and verify that `<meta name="robots" content="noindex">` is present
- Navigate to `/auth/login?aar=test` (or `?retrievalId=test`) and inspect the `<head>` and verify that `<link rel="canonical" href="<origin>/auth/login">` is present
- Navigate to `/auth/login` (no query params) and verify neither tag is present