### PR TITLE
fix(PN-19354): extend name regex to support extended Unicode characters

### DIFF
--- a/packages/pn-commons/src/utility/__test__/string.utility.test.ts
+++ b/packages/pn-commons/src/utility/__test__/string.utility.test.ts
@@ -1,4 +1,4 @@
-import { formatFiscalCode, fromStringToBase64, sanitizeString } from '../string.utility';
+import { dataRegex, formatFiscalCode, fromStringToBase64, sanitizeString } from '../string.utility';
 
 describe('String utility', () => {
   it('formatFiscalCode', () => {
@@ -38,5 +38,58 @@ describe('String utility', () => {
     const srt = 'Hello';
     const result = fromStringToBase64(srt);
     expect(result).toStrictEqual('SGVsbG8=');
+  });
+});
+
+describe('dataRegex.name', () => {
+  const valid = [
+    'Mario Rossi',
+    "Giovanni D'Angelo",
+    'Müller',         // tedesco: umlaut
+    'François',       // francese: cedilla
+    'Škoda',          // ceco: háček
+    'Maša',           // rumeno/slavo: Š
+    'José',           // spagnolo: accento acuto
+    'O\'Brien',       // irlandese: apostrofo
+    'Smith-Jones',    // trattino
+    'Name123',        // cifre
+    'St. John',       // punto
+    'Łukasz',         // polacco: Ł
+    'Ångström',       // svedese: Å
+    'Ñoño',           // spagnolo: tilde
+    'Žan',            // sloveno: Ž
+    'Αλέξης',         // greco
+    'Иван',           // cirillico
+  ];
+
+  const invalid = [
+    'Mario@Rossi',    // @
+    'Name<script>',   // <
+    'Test/Name',      // /
+    'Hello\\World',   // \
+    'Name=Value',     // =
+    'Name!',          // !
+    'Name?',          // ?
+    'Name#tag',       // #
+    'Name$',          // $
+    'Name%20',        // %
+    '(Mario)',        // parentesi
+    '[test]',         // parentesi quadre
+    '{name}',         // parentesi graffe
+    'name_test',      // underscore
+    'name,cognome',   // virgola
+    'name;cognome',   // punto e virgola
+    'name:cognome',   // due punti
+    'name|cognome',   // pipe
+    'name~cognome',   // tilde
+    'name`cognome',   // backtick
+  ];
+
+  it.each(valid)('accetta "%s"', (name) => {
+    expect(dataRegex.name.test(name)).toBe(true);
+  });
+
+  it.each(invalid)('rifiuta "%s"', (name) => {
+    expect(dataRegex.name.test(name)).toBe(false);
   });
 });

--- a/packages/pn-commons/src/utility/string.utility.ts
+++ b/packages/pn-commons/src/utility/string.utility.ts
@@ -21,7 +21,7 @@ export const dataRegex = {
   // ------------------------------------
   // Carlos Lombardi, 2023.01.23
 
-  name: /^[A-Za-zÀ-ÿ\-'" 0-9\.]+$/,
+  name: /^[\p{L}\-'" 0-9.]+$/u,
   publicKeyName: /^[a-zA-Z0-9-\\s]+$/i,
   lettersAndNumbers: /^[A-Za-z0-9]+$/,
   // this for string that have numbers, characters, - and _


### PR DESCRIPTION
## Short description
The `name` regex in dataRegex only covered the range `À-ÿ` (U+00C0–U+00FF), rejecting valid characters from Eastern European names such as Š, Ž, Ł, Ř, Ą.

## List of changes proposed in this pull request
- Replaced `[A-Za-zÀ-ÿ]` with `\p{L} `(Unicode letter category) and added the u flag, covering all Unicode letters
- Added tests for valid names with Greek, Cyrillic, Polish, Swedish, Slovenian characters
- Added tests for invalid symbols (!, ?, #, _, ,, |, etc.)

## How to test
?