### PR TITLE
fix(PN-16004)

### DIFF
--- a/packages/pn-pa-webapp/public/locales/de/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/de/notifiche.json
@@ -487,6 +487,7 @@
         "pec-error": "Ungültige PEC-Adresse",
         "forbidden-characters-denomination-error": "Sie haben ungültige Zeichen eingegeben",
         "legal-entity": "Rechtssubjekt",
+        "legal-entity-subtitle": "Diese Informationen helfen dem Empfänger, den Inhalt und die Bedeutung der Mitteilung zu verstehen.",
         "physical-person": "Natürliche Person",
         "name": "Vorname",
         "surname": "Nachname",

--- a/packages/pn-pa-webapp/public/locales/de/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/de/notifiche.json
@@ -487,7 +487,6 @@
         "pec-error": "Ungültige PEC-Adresse",
         "forbidden-characters-denomination-error": "Sie haben ungültige Zeichen eingegeben",
         "legal-entity": "Rechtssubjekt",
-        "legal-entity-subtitle": "Diese Informationen helfen dem Empfänger, den Inhalt und die Bedeutung der Mitteilung zu verstehen.",
         "physical-person": "Natürliche Person",
         "name": "Vorname",
         "surname": "Nachname",
@@ -504,6 +503,7 @@
         "pec-address": "PEC-Adresse",
         "add-physical-domicile": "Eine physische Adresse hinzufügen",
         "address": "Adresse",
+        "physical-address": "Physische Adresse",
         "house-number": "Hausnummer",
         "municipality-details": "Ort",
         "municipality": "Gemeinde",
@@ -519,7 +519,8 @@
         "address-physical-lookup-radios": {
           "national-registry": "Automatische Übernahme aus dem nationalen Register",
           "manual": "Manuelle Eingabe"
-        }
+        },
+        "recipient-info-subtitle": "Diese Informationen helfen dem Empfänger, den Inhalt und die Bedeutung der Mitteilung zu verstehen."
       },
       "attachments": {
         "title": "Dokumentation",

--- a/packages/pn-pa-webapp/public/locales/en/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/en/notifiche.json
@@ -487,7 +487,6 @@
         "pec-error": "Invalid PEC address",
         "forbidden-characters-denomination-error": "You have entered invalid characters",
         "legal-entity": "Legal entity",
-        "legal-entity-subtitle": "These information will help the recipient understand the content and importance of the communication.",
         "physical-person": "Natural person",
         "name": "First name",
         "surname": "Surname",
@@ -504,6 +503,7 @@
         "pec-address": "PEC Address",
         "add-physical-domicile": "Add a physical address",
         "address": "Address",
+        "physical-address": "Physical address",
         "house-number": "House number",
         "municipality-details": "Location",
         "municipality": "Municipality",
@@ -519,7 +519,8 @@
         "address-physical-lookup-radios": {
           "national-registry": "Automatic entry from national registry",
           "manual": "Manual entry"
-        }
+        },
+        "recipient-info-subtitle": "This information will help the recipient understand the content and importance of the communication."
       },
       "attachments": {
         "title": "Documentation",

--- a/packages/pn-pa-webapp/public/locales/en/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/en/notifiche.json
@@ -487,6 +487,7 @@
         "pec-error": "Invalid PEC address",
         "forbidden-characters-denomination-error": "You have entered invalid characters",
         "legal-entity": "Legal entity",
+        "legal-entity-subtitle": "These information will help the recipient understand the content and importance of the communication.",
         "physical-person": "Natural person",
         "name": "First name",
         "surname": "Surname",

--- a/packages/pn-pa-webapp/public/locales/fr/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/fr/notifiche.json
@@ -487,6 +487,7 @@
         "pec-error": "Adresse PEC non valide",
         "forbidden-characters-denomination-error": "Vous avez saisi des caractères non valides",
         "legal-entity": "Sujet juridique",
+        "legal-entity-subtitle": "Ces informations aideront le destinataire à comprendre le contenu et l'importance de la communication.",
         "physical-person": "Personne physique",
         "name": "Prénom",
         "surname": "Nom",

--- a/packages/pn-pa-webapp/public/locales/fr/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/fr/notifiche.json
@@ -487,7 +487,6 @@
         "pec-error": "Adresse PEC non valide",
         "forbidden-characters-denomination-error": "Vous avez saisi des caractères non valides",
         "legal-entity": "Sujet juridique",
-        "legal-entity-subtitle": "Ces informations aideront le destinataire à comprendre le contenu et l'importance de la communication.",
         "physical-person": "Personne physique",
         "name": "Prénom",
         "surname": "Nom",
@@ -504,6 +503,7 @@
         "pec-address": "Adresse PEC",
         "add-physical-domicile": "Ajouter une adresse physique",
         "address": "Adresse",
+        "physical-address": "Adresse physique",
         "house-number": "Numéro de rue",
         "municipality-details": "Localité",
         "municipality": "Mairie",
@@ -519,7 +519,8 @@
         "address-physical-lookup-radios": {
           "national-registry": "Insertion automatique à partir du registre national",
           "manual": "Insertion manuelle"
-        }
+        },
+        "recipient-info-subtitle": "Ces informations aideront le destinataire à comprendre le contenu et l'importance de la communication."
       },
       "attachments": {
         "title": "Documentation",

--- a/packages/pn-pa-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/it/notifiche.json
@@ -487,7 +487,6 @@
         "pec-error": "Indirizzo PEC non valido",
         "forbidden-characters-denomination-error": "Hai inserito caratteri non validi",
         "legal-entity": "Soggetto giuridico",
-        "legal-entity-subtitle": "Queste informazioni aiuteranno il destinatario a comprendere il contenuto e l'importanza della comunicazione.",
         "physical-person": "Persona fisica",
         "name": "Nome",
         "surname": "Cognome",
@@ -504,6 +503,7 @@
         "pec-address": "Indirizzo PEC",
         "add-physical-domicile": "Aggiungi un indirizzo fisico",
         "address": "Indirizzo",
+        "physical-address": "Indirizzo fisico",
         "house-number": "Numero civico",
         "municipality-details": "Località",
         "municipality": "Comune",
@@ -519,7 +519,8 @@
         "address-physical-lookup-radios": {
           "national-registry": "Inserimento automatico da registro nazionale",
           "manual": "Inserimento manuale"
-        }
+        },
+        "recipient-info-subtitle": "Queste informazioni aiuteranno il destinatario a comprendere il contenuto e l'importanza della comunicazione."
       },
       "attachments": {
         "title": "Documentazione",

--- a/packages/pn-pa-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/it/notifiche.json
@@ -487,6 +487,7 @@
         "pec-error": "Indirizzo PEC non valido",
         "forbidden-characters-denomination-error": "Hai inserito caratteri non validi",
         "legal-entity": "Soggetto giuridico",
+        "legal-entity-subtitle": "Queste informazioni aiuteranno il destinatario a comprendere il contenuto e l'importanza della comunicazione.",
         "physical-person": "Persona fisica",
         "name": "Nome",
         "surname": "Cognome",

--- a/packages/pn-pa-webapp/public/locales/sl/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/sl/notifiche.json
@@ -487,6 +487,7 @@
         "pec-error": "Neveljaven naslov PEC",
         "forbidden-characters-denomination-error": "Vnesli ste neveljavne znake",
         "legal-entity": "Pravna oseba",
+        "legal-entity-subtitle": "Te informacije bodo prejemniku pomagale razumeti vsebino in pomembnost sporočila.",
         "physical-person": "Fizična oseba",
         "name": "Ime",
         "surname": "Priimek",

--- a/packages/pn-pa-webapp/public/locales/sl/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/sl/notifiche.json
@@ -487,7 +487,6 @@
         "pec-error": "Neveljaven naslov PEC",
         "forbidden-characters-denomination-error": "Vnesli ste neveljavne znake",
         "legal-entity": "Pravna oseba",
-        "legal-entity-subtitle": "Te informacije bodo prejemniku pomagale razumeti vsebino in pomembnost sporočila.",
         "physical-person": "Fizična oseba",
         "name": "Ime",
         "surname": "Priimek",
@@ -504,6 +503,7 @@
         "pec-address": "Naslov PEC",
         "add-physical-domicile": "Dodajte fizični naslov",
         "address": "Naslov",
+        "physical-address": "Fizični naslov",
         "house-number": "Hišna številka",
         "municipality-details": "Kraj",
         "municipality": "Občina",
@@ -519,7 +519,8 @@
         "address-physical-lookup-radios": {
           "national-registry": "Samodejni vnos iz nacionalnega registra",
           "manual": "Ročni vnos"
-        }
+        },
+        "recipient-info-subtitle": "Te informacije bodo prejemniku pomagale razumeti vsebino in pomembnost sporočila."
       },
       "attachments": {
         "title": "Dokumentacija",

--- a/packages/pn-pa-webapp/src/components/NewNotification/Recipient.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/Recipient.tsx
@@ -368,6 +368,7 @@ const Recipient: React.FC<Props> = ({
                       </ButtonNaked>
                     )}
                   </Stack>
+                  <FormBoxSubtitle text={t('legal-entity-subtitle')} />
                   <Box mt={3} mb={1}>
                     <FormControl>
                       <RadioGroup

--- a/packages/pn-pa-webapp/src/components/NewNotification/Recipient.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/Recipient.tsx
@@ -349,7 +349,7 @@ const Recipient: React.FC<Props> = ({
                 <FormBox testid="RecipientFormBox">
                   {/* Soggetto giuridico */}
                   <Stack direction="row" justifyContent="space-between">
-                    <FormBoxTitle text={`${t('legal-entity')}*`} />
+                    <FormBoxTitle text={`${t('legal-entity')}`} />
                     {values.recipients.length > 1 && (
                       <ButtonNaked
                         data-testid="DeleteRecipientIcon"
@@ -368,7 +368,7 @@ const Recipient: React.FC<Props> = ({
                       </ButtonNaked>
                     )}
                   </Stack>
-                  <FormBoxSubtitle text={t('legal-entity-subtitle')} />
+                  <FormBoxSubtitle text={t('recipient-info-subtitle')} />
                   <Box mt={3} mb={1}>
                     <FormControl>
                       <RadioGroup
@@ -468,9 +468,16 @@ const Recipient: React.FC<Props> = ({
                       data-testid={`recipients[${index}].physicalAddressLabel`}
                       sx={{ mt: 4 }}
                     >
-                      <FormBoxTitle text={t('address')} />
-                      {PHYSICAL_ADDRESS_LOOKUP !== PhysicalAddressLookupConfig.OFF && (
-                        <FormBoxSubtitle text={t('address-subtitle')} />
+                      {PHYSICAL_ADDRESS_LOOKUP === PhysicalAddressLookupConfig.OFF ? (
+                        <>
+                          <FormBoxTitle text={t('physical-address')} />
+                          <FormBoxSubtitle text={t('recipient-info-subtitle')} />
+                        </>
+                      ) : (
+                        <>
+                          <FormBoxTitle text={t('address')} />
+                          <FormBoxSubtitle text={t('address-subtitle')} />
+                        </>
                       )}
                     </FormLabel>
                     {PHYSICAL_ADDRESS_LOOKUP === PhysicalAddressLookupConfig.DOWN && (


### PR DESCRIPTION
## Short description
UI alignment with Figma specifications for the "Legal Entity" and "Address" sections in the Recipient step of the notification form.

## List of changes proposed in this pull request

- Added subtitle to the "Legal Entity" section
- Added subtitle to the "Address" section
- Implemented dynamic title rendering:
  - "Address" when PHYSICAL_ADDRESS_LOOKUP is enabled
  - "Physical address" when PHYSICAL_ADDRESS_LOOKUP is OFF
- Implemented dynamic subtitle rendering based on configuration

## How to test
1. Open the PA portal
2. Click on "Send a notification"
3. Go to the Recipient step of the form

Verify:
- The "Legal Entity" section displays the subtitle correctly
- The "Address" section displays:
  - "Address" title when PHYSICAL_ADDRESS_LOOKUP is enabled
  - "Physical address" title when PHYSICAL_ADDRESS_LOOKUP is OFF
- The subtitle is correctly shown under the Address section according to the configuration