### PR TITLE
fix/PN-19535: remove cta and sentence for public registry PEC

### DIFF
--- a/packages/pn-personafisica-webapp/src/components/Notifications/NotificationCostBanner.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Notifications/NotificationCostBanner.tsx
@@ -119,7 +119,7 @@ const getBannerContent = (
 
   const getEnableSercqMessage = () => {
     if (isRegistryPec) {
-      return undefined;
+      return '';
     }
     if (key === 'analog') {
       return t('notification-cost-banner.enable-sercq.message.analog');
@@ -129,7 +129,7 @@ const getBannerContent = (
         : t('notification-cost-banner.enable-sercq.message.default');
     }
   };
-  const ctaLabel = isRegistryPec ? undefined : t('notification-cost-banner.enable-sercq.cta');
+  const ctaLabel = isRegistryPec ? '' : t('notification-cost-banner.enable-sercq.cta');
 
   return {
     title,

--- a/packages/pn-personafisica-webapp/src/components/Notifications/NotificationCostBanner.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Notifications/NotificationCostBanner.tsx
@@ -113,10 +113,14 @@ const getBannerContent = (
     return { title, message };
   }
 
-  const isExternalPec =
-    key === 'digital_special' || key === 'digital_registry' || key === 'digital_failure';
+  const isExternalPec = key === 'digital_special' || key === 'digital_failure';
+
+  const isRegistryPec = key === 'digital_registry';
 
   const getEnableSercqMessage = () => {
+    if (isRegistryPec) {
+      return undefined;
+    }
     if (key === 'analog') {
       return t('notification-cost-banner.enable-sercq.message.analog');
     } else {
@@ -125,7 +129,7 @@ const getBannerContent = (
         : t('notification-cost-banner.enable-sercq.message.default');
     }
   };
-  const ctaLabel = t('notification-cost-banner.enable-sercq.cta');
+  const ctaLabel = isRegistryPec ? undefined : t('notification-cost-banner.enable-sercq.cta');
 
   return {
     title,

--- a/packages/pn-personafisica-webapp/src/components/Notifications/__test__/NotificationCostBanner.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Notifications/__test__/NotificationCostBanner.test.tsx
@@ -185,7 +185,7 @@ describe('NotificationCostBanner component', () => {
       details: { source: DigitalSource.REGISTRY, domicileType: 'SERCQ' },
     } as any;
 
-    const { container, getByTestId, getByText, testStore, router } = render(
+    const { container, getByTestId } = render(
       <NotificationCostBanner deliveryOutcome={deliveryOutcome} />,
       {
         preloadedState: {

--- a/packages/pn-personafisica-webapp/src/components/Notifications/__test__/NotificationCostBanner.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Notifications/__test__/NotificationCostBanner.test.tsx
@@ -199,19 +199,6 @@ describe('NotificationCostBanner component', () => {
 
     expect(container).toHaveTextContent('notification-cost-banner.digital_registry.title');
     expect(container).toHaveTextContent('notification-cost-banner.digital_registry.message');
-    expect(container).toHaveTextContent(
-      'notification-cost-banner.enable-sercq.message.external-pec'
-    );
-
-    const cta = getByText('notification-cost-banner.enable-sercq.cta');
-    fireEvent.click(cta);
-
-    expect(router.state.location.pathname).toBe(routes.DIGITAL_DOMICILE_ACTIVATION);
-    expect(testStore.getState().contactsState.event).toStrictEqual({
-      destination: ChannelType.SERCQ_SEND,
-      source: ContactSource.DETTAGLIO_NOTIFICA,
-      operation: ContactOperation.ADD,
-    });
   });
 
   it('renders the component - digital platform', () => {

--- a/packages/pn-personagiuridica-webapp/src/components/Notifications/NotificationCostBanner.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Notifications/NotificationCostBanner.tsx
@@ -109,7 +109,12 @@ const getBannerContent = (
   const isExternalPec =
     key === 'digital_special' || key === 'digital_registry' || key === 'digital_failure';
 
+  const isRegistryPec = key === 'digital_registry';
+
   const getEnableSercqMessage = () => {
+    if (isRegistryPec) {
+      return undefined;
+    }
     if (key === 'analog') {
       return t('notification-cost-banner.enable-sercq.message.analog');
     } else {
@@ -118,7 +123,7 @@ const getBannerContent = (
         : t('notification-cost-banner.enable-sercq.message.default');
     }
   };
-  const ctaLabel = t('notification-cost-banner.enable-sercq.cta');
+  const ctaLabel = isRegistryPec ? undefined : t('notification-cost-banner.enable-sercq.cta');
 
   return {
     title,

--- a/packages/pn-personagiuridica-webapp/src/components/Notifications/NotificationCostBanner.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Notifications/NotificationCostBanner.tsx
@@ -113,7 +113,7 @@ const getBannerContent = (
 
   const getEnableSercqMessage = () => {
     if (isRegistryPec) {
-      return undefined;
+      return '';
     }
     if (key === 'analog') {
       return t('notification-cost-banner.enable-sercq.message.analog');
@@ -123,7 +123,7 @@ const getBannerContent = (
         : t('notification-cost-banner.enable-sercq.message.default');
     }
   };
-  const ctaLabel = isRegistryPec ? undefined : t('notification-cost-banner.enable-sercq.cta');
+  const ctaLabel = isRegistryPec ? '' : t('notification-cost-banner.enable-sercq.cta');
 
   return {
     title,

--- a/packages/pn-personagiuridica-webapp/src/components/Notifications/__test__/NotificationCostBanner.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Notifications/__test__/NotificationCostBanner.test.tsx
@@ -252,7 +252,7 @@ describe('NotificationCostBanner component', () => {
       details: { source: DigitalSource.REGISTRY, domicileType: 'SERCQ' },
     } as any;
 
-    const { container, getByTestId, getByText, testStore, router } = render(
+    const { container, getByTestId } = render(
       <NotificationCostBanner deliveryOutcome={deliveryOutcome} canManageContacts={true} />,
       {
         preloadedState: {
@@ -266,19 +266,6 @@ describe('NotificationCostBanner component', () => {
 
     expect(container).toHaveTextContent('notification-cost-banner.digital_registry.title');
     expect(container).toHaveTextContent('notification-cost-banner.digital_registry.message');
-    expect(container).toHaveTextContent(
-      'notification-cost-banner.enable-sercq.message.external-pec'
-    );
-
-    const cta = getByText('notification-cost-banner.enable-sercq.cta');
-    fireEvent.click(cta);
-
-    expect(router.state.location.pathname).toBe(routes.DIGITAL_DOMICILE_ACTIVATION);
-    expect(testStore.getState().contactsState.event).toStrictEqual({
-      destination: ChannelType.SERCQ_SEND,
-      source: ContactSource.DETTAGLIO_NOTIFICA,
-      operation: ContactOperation.ADD,
-    });
   });
 
   it('digital platform', () => {


### PR DESCRIPTION
## Short description
remove cta and sentence for public registry PEC

## How to test
Login as PF and check in notification with payment and public registry pec active (es. TEST → marcopolo MQUJ-KNUL-RUPN-202603-H-1) that no cta is provided. Check in other notification cta is preserved.
Do the same for PG.

lapulzella
Flusso digitale --> ERYQ-AJQN-GDZL-202603-G-1
Flusso analogico - 1 invio --> GUYG-GWLZ-XVNU-202603-G-1
Pec nota --> JTXV-WDNT-XGQG-202603-M-1
PEC satura --> WYVJ-MTPJ-KEZE-202603-H-1
Notifica annullata --> KWPM-LDKZ-KXUQ-202603-K-1