### PR TITLE
test(PN-19561): add test events mixpanel for Onboarding flow

### DIFF
--- a/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/__test__/DigitalDomicileWizard.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/__test__/DigitalDomicileWizard.test.tsx
@@ -1,6 +1,7 @@
 import MockAdapter from 'axios-mock-adapter';
+import { vi } from 'vitest';
 
-import { SERCQ_SEND_VALUE } from '@pagopa-pn/pn-commons';
+import { EventAction, SERCQ_SEND_VALUE } from '@pagopa-pn/pn-commons';
 
 import {
   acceptTosSercqSendBodyMock,
@@ -8,9 +9,16 @@ import {
 } from '../../../../__mocks__/Consents.mock';
 import { act, fireEvent, render, waitFor } from '../../../../__test__/test-utils';
 import { apiClient } from '../../../../api/apiClients';
+import { OnboardingAvailableFlows, OnboardingScreen } from '../../../../models/Onboarding';
+import { PFEventsType } from '../../../../models/PFEventsType';
 import { AddressType, ChannelType, IOAllowedValues } from '../../../../models/contacts';
 import { PRIVACY_POLICY, TERMS_OF_SERVICE_SERCQ_SEND } from '../../../../navigation/routes.const';
+import PFEventStrategyFactory from '../../../../utility/MixpanelUtils/PFEventStrategyFactory';
 import DigitalDomicileWizard from '../DigitalDomicileWizard';
+
+vi.mock('../../../../utility/MixpanelUtils/PFEventStrategyFactory', () => ({
+  default: { triggerEvent: vi.fn() },
+}));
 
 describe('DigitalDomicileWizard', () => {
   const labelPrefix = 'onboarding.digital-domicile';
@@ -23,6 +31,7 @@ describe('DigitalDomicileWizard', () => {
 
   beforeEach(() => {
     mock.reset();
+    vi.clearAllMocks();
   });
 
   afterAll(() => {
@@ -44,6 +53,11 @@ describe('DigitalDomicileWizard', () => {
 
     expect(queryByText(`${labelPrefix}.choice.pec-activating.title`)).not.toBeInTheDocument();
     expect(queryByText(`${labelPrefix}.choice.pec-activating.badge`)).not.toBeInTheDocument();
+
+    expect(PFEventStrategyFactory.triggerEvent).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_SERCQ_ACTIVATION,
+      { onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE, event_type: EventAction.SCREEN_VIEW }
+    );
   });
 
   it('starts from the PEC step and shows the pending PEC content when a default PEC is in activation', () => {
@@ -134,6 +148,11 @@ describe('DigitalDomicileWizard', () => {
       queryByRole('button', { name: `${labelPrefix}.choice.pec.cta` })
     ).not.toBeInTheDocument();
     expect(getByRole('button', { name: 'button.continue' })).toBeInTheDocument();
+
+    expect(PFEventStrategyFactory.triggerEvent).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_BACK_SELECTED,
+      { onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE, screen: OnboardingScreen.PEC }
+    );
   });
 
   it('does not show the next button in the SEND contact step when no email is available', () => {
@@ -147,6 +166,15 @@ describe('DigitalDomicileWizard', () => {
 
     fireEvent.click(getByRole('button', { name: `${labelPrefix}.choice.cta` }));
     expect(queryByRole('button', { name: 'button.continue' })).not.toBeInTheDocument();
+
+    expect(PFEventStrategyFactory.triggerEvent).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_SERCQ_SEND_SELECTED,
+      { onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE }
+    );
+    expect(PFEventStrategyFactory.triggerEvent).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_EMAIL_ACTIVATION,
+      { onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE, event_type: EventAction.SCREEN_VIEW, email_value: undefined }
+    );
   });
 
   it('shows the PEC verification modal when the user tries to continue with a formally valid PEC and accepted disclaimer', async () => {
@@ -288,6 +316,19 @@ describe('DigitalDomicileWizard', () => {
 
     expect(await findByText(`${labelPrefix}.feedback.send.title`)).toBeInTheDocument();
     expect(await findByText(`${labelPrefix}.feedback.send.content`)).toBeInTheDocument();
+
+    expect(PFEventStrategyFactory.triggerEvent).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_IO_DOWNLOAD_DECLINED,
+      { onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE }
+    );
+    expect(PFEventStrategyFactory.triggerEvent).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_UX_CONVERSION,
+      { onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE }
+    );
+    expect(PFEventStrategyFactory.triggerEvent).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_UX_SUCCESS,
+      { onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE, event_type: EventAction.SCREEN_VIEW }
+    );
   });
 
   it('completes the PEC flow and shows the final feedback', async () => {
@@ -369,5 +410,14 @@ describe('DigitalDomicileWizard', () => {
 
     expect(await findByText(`${labelPrefix}.feedback.pec.title`)).toBeInTheDocument();
     expect(await findByText(`${labelPrefix}.feedback.pec.content`)).toBeInTheDocument();
+
+    expect(PFEventStrategyFactory.triggerEvent).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_IO_DOWNLOAD_DECLINED,
+      { onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE }
+    );
+    expect(PFEventStrategyFactory.triggerEvent).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_UX_SUCCESS,
+      { onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE, event_type: EventAction.SCREEN_VIEW }
+    );
   });
 });

--- a/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/__test__/EmailStep.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/__test__/EmailStep.test.tsx
@@ -1,9 +1,18 @@
 import MockAdapter from 'axios-mock-adapter';
 import { vi } from 'vitest';
 
+import { EventAction } from '@pagopa-pn/pn-commons';
+
 import { act, fireEvent, render, waitFor } from '../../../../__test__/test-utils';
 import { apiClient } from '../../../../api/apiClients';
+import { OnboardingAvailableFlows } from '../../../../models/Onboarding';
+import { PFEventsType } from '../../../../models/PFEventsType';
+import PFEventStrategyFactory from '../../../../utility/MixpanelUtils/PFEventStrategyFactory';
 import EmailStep from '../EmailStep';
+
+vi.mock('../../../../utility/MixpanelUtils/PFEventStrategyFactory', () => ({
+  default: { triggerEvent: vi.fn() },
+}));
 
 describe('EmailStep', () => {
   const labelPrefix = 'onboarding.digital-domicile.email';
@@ -18,6 +27,7 @@ describe('EmailStep', () => {
 
   beforeEach(() => {
     mock.reset();
+    vi.clearAllMocks();
   });
 
   afterAll(() => {
@@ -61,6 +71,7 @@ describe('EmailStep', () => {
     expect(await findByText('courtesy-contacts.valid-email')).toBeInTheDocument();
     expect(props.onChange).not.toHaveBeenCalled();
     expect(props.onVerified).not.toHaveBeenCalled();
+    expect(PFEventStrategyFactory.triggerEvent).not.toHaveBeenCalled();
   });
 
   it('verifies a new email and calls onChange and onVerified on success', async () => {
@@ -93,6 +104,46 @@ describe('EmailStep', () => {
       expect(props.onChange).toHaveBeenCalledWith(mockEmail);
       expect(props.onVerified).toHaveBeenCalledTimes(1);
     });
+
+    expect(PFEventStrategyFactory.triggerEvent).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_EMAIL_VERIFICATION,
+      { onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE }
+    );
+    expect(PFEventStrategyFactory.triggerEvent).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_EMAIL_ACTIVATED,
+      { onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE, event_type: EventAction.CONFIRM }
+    );
+  });
+
+  it('fires SEND_ONBOARDING_EMAIL_OTP when the API requires code verification', async () => {
+    const props = createProps();
+
+    mock.onPost('/bff/v1/addresses/COURTESY/default/EMAIL').reply(200, {
+      result: 'CODE_VERIFICATION_REQUIRED',
+    });
+
+    const { getByLabelText, getByRole, findByRole } = render(<EmailStep {...props} />);
+
+    await act(async () => {
+      fireEvent.change(getByLabelText(`${labelPrefix}.input-label`), {
+        target: { value: mockEmail },
+      });
+    });
+
+    await act(async () => {
+      fireEvent.click(getByRole('button', { name: `${labelPrefix}.verify-cta` }));
+    });
+
+    await findByRole('dialog');
+
+    expect(PFEventStrategyFactory.triggerEvent).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_EMAIL_VERIFICATION,
+      { onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE }
+    );
+    expect(PFEventStrategyFactory.triggerEvent).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_EMAIL_OTP,
+      { onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE, event_type: EventAction.SCREEN_VIEW }
+    );
   });
 
   it('renders the readonly summary when a new email has already been added during the wizard', () => {
@@ -127,6 +178,10 @@ describe('EmailStep', () => {
     expect(getByLabelText(`${labelPrefix}.input-label`)).toBeInTheDocument();
     expect(getByRole('button', { name: 'button.conferma' })).toBeInTheDocument();
     expect(getByRole('button', { name: 'button.annulla' })).toBeInTheDocument();
+    expect(PFEventStrategyFactory.triggerEvent).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_EMAIL_EDITING,
+      { onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE }
+    );
   });
 
   it('closes edit mode without API calls when confirming the same existing email', async () => {
@@ -157,6 +212,18 @@ describe('EmailStep', () => {
     expect(props.onChange).not.toHaveBeenCalled();
     expect(props.onVerified).not.toHaveBeenCalled();
     expect(mock.history.post).toHaveLength(0);
+    expect(PFEventStrategyFactory.triggerEvent).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_EMAIL_EDITING,
+      { onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE }
+    );
+    expect(PFEventStrategyFactory.triggerEvent).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_EMAIL_CONFIRMED,
+      { onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE }
+    );
+    expect(PFEventStrategyFactory.triggerEvent).not.toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_EMAIL_ACTIVATED,
+      expect.anything()
+    );
   });
 
   it('verifies an edited existing email and calls onChange on success', async () => {
@@ -195,5 +262,18 @@ describe('EmailStep', () => {
       expect(props.onChange).toHaveBeenCalledWith(updatedEmail);
       expect(props.onVerified).not.toHaveBeenCalled();
     });
+
+    expect(PFEventStrategyFactory.triggerEvent).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_EMAIL_EDITING,
+      { onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE }
+    );
+    expect(PFEventStrategyFactory.triggerEvent).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_EMAIL_CONFIRMED,
+      { onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE }
+    );
+    expect(PFEventStrategyFactory.triggerEvent).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_EMAIL_ACTIVATED,
+      { onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE, event_type: EventAction.CONFIRM }
+    );
   });
 });

--- a/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/__test__/IoStep.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/__test__/IoStep.test.tsx
@@ -1,16 +1,24 @@
 import MockAdapter from 'axios-mock-adapter';
 import { vi } from 'vitest';
 
+import { EventAction } from '@pagopa-pn/pn-commons';
+
 import { act, fireEvent, render, waitFor } from '../../../../__test__/test-utils';
 import { apiClient } from '../../../../api/apiClients';
 import { OnboardingAvailableFlows } from '../../../../models/Onboarding';
+import { PFEventsType } from '../../../../models/PFEventsType';
 import { AddressType, ChannelType, IOAllowedValues } from '../../../../models/contacts';
 import { getConfiguration } from '../../../../services/configuration.service';
 import { openAppIoDownloadPage } from '../../../../utility/appio.utility';
+import PFEventStrategyFactory from '../../../../utility/MixpanelUtils/PFEventStrategyFactory';
 import IoStep from '../IoStep';
 
 vi.mock('../../../../utility/appio.utility', () => ({
   openAppIoDownloadPage: vi.fn(),
+}));
+
+vi.mock('../../../../utility/MixpanelUtils/PFEventStrategyFactory', () => ({
+  default: { triggerEvent: vi.fn() },
 }));
 
 describe('IoStep', () => {
@@ -50,6 +58,10 @@ describe('IoStep', () => {
     expect(
       getByRole('button', { name: `${labelPrefix}.not-installed.refresh-cta` })
     ).toBeInTheDocument();
+    expect(PFEventStrategyFactory.triggerEvent).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_IO_DOWNLOAD,
+      { event_type: EventAction.SCREEN_VIEW, onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE }
+    );
   });
 
   it('opens the App IO download page when the primary CTA is clicked in unavailable state', async () => {
@@ -75,6 +87,10 @@ describe('IoStep', () => {
     });
     expect(props.onChange).not.toHaveBeenCalled();
     expect(props.onContinue).not.toHaveBeenCalled();
+    expect(PFEventStrategyFactory.triggerEvent).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_IO_DOWNLOAD_SELECTED,
+      { onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE }
+    );
   });
 
   it('refreshes the IO state and calls onChange with the value from addresses', async () => {
@@ -99,6 +115,11 @@ describe('IoStep', () => {
       expect(mock.history.get).toHaveLength(1);
       expect(props.onChange).toHaveBeenCalledWith(IOAllowedValues.DISABLED);
     });
+
+    expect(PFEventStrategyFactory.triggerEvent).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_IO_DOWNLOAD_VERIFICATION,
+      { onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE }
+    );
   });
 
   it('renders the disabled state and enables IO on primary CTA click', async () => {
@@ -120,6 +141,10 @@ describe('IoStep', () => {
     expect(
       queryByRole('button', { name: `${labelPrefix}.not-installed.refresh-cta` })
     ).not.toBeInTheDocument();
+    expect(PFEventStrategyFactory.triggerEvent).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_IO_ACTIVATION,
+      { event_type: EventAction.SCREEN_VIEW, onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE }
+    );
 
     await act(async () => {
       fireEvent.click(getByRole('button', { name: `${labelPrefix}.disabled.primary-cta` }));
@@ -137,6 +162,15 @@ describe('IoStep', () => {
       expect(props.onChange).toHaveBeenCalledWith(IOAllowedValues.ENABLED);
       expect(props.onContinue).not.toHaveBeenCalled();
     });
+
+    expect(PFEventStrategyFactory.triggerEvent).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_IO_ACTIVATION_SELECTED,
+      { onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE }
+    );
+    expect(PFEventStrategyFactory.triggerEvent).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_IO_ACTIVATED,
+      { onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE }
+    );
   });
 
   it('renders the enabled state and calls onContinue on primary CTA click', async () => {
@@ -147,6 +181,10 @@ describe('IoStep', () => {
     expect(getByText(`${labelPrefix}.enabled.title`)).toBeInTheDocument();
     expect(getByText(`${labelPrefix}.description`)).toBeInTheDocument();
     expect(getByRole('button', { name: `${labelPrefix}.enabled.primary-cta` })).toBeInTheDocument();
+    expect(PFEventStrategyFactory.triggerEvent).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_IO_VERIFICATION,
+      { event_type: EventAction.SCREEN_VIEW, onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE }
+    );
 
     await act(async () => {
       fireEvent.click(getByRole('button', { name: `${labelPrefix}.enabled.primary-cta` }));
@@ -154,5 +192,9 @@ describe('IoStep', () => {
 
     expect(props.onContinue).toHaveBeenCalledTimes(1);
     expect(props.onChange).not.toHaveBeenCalled();
+    expect(PFEventStrategyFactory.triggerEvent).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_IO_CONFIRMED,
+      { onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE }
+    );
   });
 });

--- a/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/__test__/OnboardingHome.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/__test__/OnboardingHome.test.tsx
@@ -1,0 +1,100 @@
+import { vi } from 'vitest';
+
+import { EventAction } from '@pagopa-pn/pn-commons';
+
+import { fireEvent, render } from '../../../../__test__/test-utils';
+import { OnboardingAvailableFlows } from '../../../../models/Onboarding';
+import { PFEventsType } from '../../../../models/PFEventsType';
+import { AddressType, ChannelType, IOContactStatus } from '../../../../models/contacts';
+import PFEventStrategyFactory from '../../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import OnboardingHome from '../OnboardingHome';
+
+vi.mock('../../../../utility/MixpanelUtils/PFEventStrategyFactory', () => ({
+  default: { triggerEvent: vi.fn() },
+}));
+
+describe('OnboardingHome - Mixpanel events', () => {
+  const preloadedState = {
+    contactsState: { digitalAddresses: [] },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fires SEND_ONBOARDING_START_FLOW on mount', () => {
+    render(<OnboardingHome />, { preloadedState });
+
+    expect(PFEventStrategyFactory.triggerEvent).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_START_FLOW,
+      { event_type: EventAction.SCREEN_VIEW }
+    );
+  });
+
+  it('fires SEND_ONBOARDING_FLOW_SELECTED with DIGITAL_DOMICILE when clicking the SEND card', () => {
+    const { getByRole } = render(<OnboardingHome />, { preloadedState });
+    vi.clearAllMocks();
+
+    fireEvent.click(getByRole('button', { name: 'onboarding.cards.send.cta' }));
+
+    expect(PFEventStrategyFactory.triggerEvent).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_FLOW_SELECTED,
+      { onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE }
+    );
+  });
+
+  it('fires SEND_ONBOARDING_FLOW_SELECTED with COURTESY when clicking the contacts card', () => {
+    const { getByRole } = render(<OnboardingHome />, { preloadedState });
+    vi.clearAllMocks();
+
+    fireEvent.click(getByRole('button', { name: 'onboarding.cards.contacts.cta' }));
+
+    expect(PFEventStrategyFactory.triggerEvent).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_FLOW_SELECTED,
+      { onboarding_selected_flow: OnboardingAvailableFlows.COURTESY }
+    );
+  });
+
+  it('fires SEND_ONBOARDING_FLOW_SELECTED with IO when clicking the IO card', () => {
+    const { getByRole } = render(<OnboardingHome />, { preloadedState });
+    vi.clearAllMocks();
+
+    fireEvent.click(getByRole('button', { name: 'onboarding.cards.io.cta' }));
+
+    expect(PFEventStrategyFactory.triggerEvent).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_FLOW_SELECTED,
+      { onboarding_selected_flow: OnboardingAvailableFlows.IO }
+    );
+  });
+
+  it('fires SEND_ONBOARDING_DECLINED when clicking the exit flow button', () => {
+    const { getByRole } = render(<OnboardingHome />, { preloadedState });
+    vi.clearAllMocks();
+
+    fireEvent.click(getByRole('button', { name: 'onboarding.exit-flow' }));
+
+    expect(PFEventStrategyFactory.triggerEvent).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_DECLINED,
+      { event_type: EventAction.EXIT }
+    );
+  });
+
+  it('does not show the IO card when IO is already enabled', () => {
+    const { queryByRole } = render(<OnboardingHome />, {
+      preloadedState: {
+        contactsState: {
+          digitalAddresses: [
+            {
+              addressType: AddressType.COURTESY,
+              senderId: 'default',
+              channelType: ChannelType.IOMSG,
+              value: IOContactStatus.ENABLED,
+            },
+          ],
+        },
+      },
+    });
+
+    expect(queryByRole('button', { name: 'onboarding.cards.io.cta' })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Adds Mixpanel triggerEvent assertions to the onboarding test suite in pn-personafisica-webapp. Previously, component tests verified UI behaviour and API calls but never asserted that analytics events were actually fired.

### Changes
- OnboardingHome.test.tsx (new file) — covers the home screen view event on mount, the flow-selection event for each card (SEND, Courtesy, IO), and the exit-flow event.
- EmailStep.test.tsx — asserts EMAIL_VERIFICATION, EMAIL_ACTIVATED, EMAIL_EDITING, EMAIL_CONFIRMED, and EMAIL_OTP (OTP dialog opened) across the relevant existing tests. Also adds a new test for the pending-verification scenario.
- IoStep.test.tsx — asserts the screen-view event on each IO status (unavailable / disabled / enabled) and the action events: IO_DOWNLOAD_SELECTED, IO_DOWNLOAD_VERIFICATION, IO_ACTIVATION_SELECTED, IO_ACTIVATED, IO_CONFIRMED.
- DigitalDomicileWizard.test.tsx — asserts SERCQ_ACTIVATION on mount, SERCQ_SEND_SELECTED and EMAIL_ACTIVATION when the SEND path is chosen, BACK_SELECTED with the correct screen, and the end-of-flow events (IO_DOWNLOAD_DECLINED, UX_CONVERSION, UX_SUCCESS) in both the SEND and PEC full-flow tests.

### Approach
PFEventStrategyFactory is mocked at module level in each test file via vi.mock. The mock is reset with vi.clearAllMocks() in beforeEach so each test gets a clean call history. No production code was changed.

