### PR TITLE
fix(PN-17961): fixed group overflow in the notifications page on mobile devices

### DIFF
--- a/packages/pn-pa-webapp/src/components/Notifications/NotificationsDataSwitch.tsx
+++ b/packages/pn-pa-webapp/src/components/Notifications/NotificationsDataSwitch.tsx
@@ -73,7 +73,7 @@ const NotificationsDataSwitch: React.FC<{
     return data.group ? (
       <CustomTagGroup visibleItems={1}>
         {[
-          <Box sx={{ mb: 1, mr: 1, display: 'inline-block' }} key={data.id}>
+          <Box sx={{ mb: 1, mr: 1, display: 'inline-block', maxWidth: '100%' }} key={data.id}>
             <Tag value={data.group} mode="truncate" />
           </Box>,
         ]}


### PR DESCRIPTION
## Short description
On mobile devices, groups' names with long value aren't truncated

## List of changes proposed in this pull request
- Set maxwidth to container with inline-block property

## How to test
Login with PA -> set mobile view -> find a PA with long group -> check that the value is truncated