### PR TITLE
fix PN-15746 reset email field on OTP cancel for PF and PG

### DIFF
--- a/packages/pn-personafisica-webapp/src/components/Contacts/EmailSmsContactWizard.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/EmailSmsContactWizard.tsx
@@ -180,8 +180,8 @@ const EmailSmsContactWizard: React.FC = () => {
     if (isEmail) {
       if (emailValue) {
         emailContactRef.current.toggleEdit();
-        await emailContactRef.current.resetForm();
       }
+      await emailContactRef.current.resetForm();
     } else if (isSms && smsValue) {
       smsContactRef.current.toggleEdit();
       await smsContactRef.current.resetForm();

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/EmailSmsContactWizard.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/EmailSmsContactWizard.tsx
@@ -115,8 +115,10 @@ const EmailSmsContactWizard: React.FC = () => {
 
   const handleCancelCode = async () => {
     setModalOpen(null);
-    if (currentAddress.current.channelType === ChannelType.EMAIL && emailValue) {
-      emailContactRef.current.toggleEdit();
+    if (currentAddress.current.channelType === ChannelType.EMAIL) {
+      if (emailValue) {
+        emailContactRef.current.toggleEdit();
+      }
       await emailContactRef.current.resetForm();
     } else if (currentAddress.current.channelType === ChannelType.SMS && smsValue) {
       smsContactRef.current.toggleEdit();


### PR DESCRIPTION
## Short description
Fix for PN-15746: when cancelling the OTP verification flow, the email input field was not reset and remained populated.

## List of changes proposed in this pull request
- Ensure the email form is reset even when no existing email is present in the store
- Applied the same fix consistently to both:
- pn-personafisica-webapp
- pn-personagiuridica-webapp

## How to test
- Open PA or PG portal
- Navigate to the digital domicile activation flow (SERCQ)
- Insert a new email address
- Proceed until the OTP verification modal is shown
- Click on "Annulla" (Cancel)
Verify that:
- The email input field is cleared