### PR TITLE
fix(PN-19628, PN-19639): replace IOContactStatus with IOAllowedValues in contacts utility and tests

### DIFF
--- a/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/__test__/NotificationDetailOnboardingPrompt.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/__test__/NotificationDetailOnboardingPrompt.test.tsx
@@ -9,7 +9,7 @@ import {
   AddressType,
   ChannelType,
   DigitalAddress,
-  IOContactStatus,
+  IOAllowedValues
 } from '../../../../models/contacts';
 import * as routes from '../../../../navigation/routes.const';
 import type { PfConfiguration } from '../../../../services/configuration.service';
@@ -223,7 +223,7 @@ describe('NotificationDetailOnboardingPrompt', () => {
           addressType: AddressType.COURTESY,
           channelType: ChannelType.IOMSG,
           senderId: 'default',
-          value: IOContactStatus.ENABLED,
+          value: IOAllowedValues.ENABLED,
         },
       ],
     });

--- a/packages/pn-personafisica-webapp/src/utility/__test__/contacts.utility.test.ts
+++ b/packages/pn-personafisica-webapp/src/utility/__test__/contacts.utility.test.ts
@@ -6,7 +6,7 @@ import {
   digitalAddressesSercq,
   digitalCourtesyAddresses,
 } from '../../__mocks__/Contacts.mock';
-import { AddressType, ChannelType, DigitalAddress, IOContactStatus } from '../../models/contacts';
+import { AddressType, ChannelType, DigitalAddress, IOAllowedValues } from '../../models/contacts';
 import { SelectedAddresses } from '../../redux/contact/reducers';
 import {
   contactAlreadyExists,
@@ -254,7 +254,7 @@ describe('Contacts utility test', () => {
         addressType: AddressType.COURTESY,
         channelType: ChannelType.IOMSG,
         senderId: 'default',
-        value: IOContactStatus.ENABLED,
+        value: IOAllowedValues.ENABLED,
       },
     ];
 
@@ -273,7 +273,7 @@ describe('Contacts utility test', () => {
         addressType: AddressType.COURTESY,
         channelType: ChannelType.IOMSG,
         senderId: 'default',
-        value: IOContactStatus.ENABLED,
+        value: IOAllowedValues.ENABLED,
       },
     ];
 

--- a/packages/pn-personafisica-webapp/src/utility/contacts.utility.ts
+++ b/packages/pn-personafisica-webapp/src/utility/contacts.utility.ts
@@ -4,7 +4,7 @@ import * as yup from 'yup';
 import type { TextFieldProps } from '@mui/material';
 import { dataRegex } from '@pagopa-pn/pn-commons';
 
-import { AddressType, ChannelType, DigitalAddress, IOContactStatus } from '../models/contacts';
+import { AddressType, ChannelType, DigitalAddress, IOAllowedValues } from '../models/contacts';
 import { SelectedAddresses } from '../redux/contact/reducers';
 
 export const internationalPhonePrefix = '+39';
@@ -182,7 +182,7 @@ export const hasRequiredContacts = (addresses: SelectedAddresses): boolean => {
   );
   const hasIo = addresses.courtesyAddresses.some(
     (address) =>
-      address.channelType === ChannelType.IOMSG && address.value === IOContactStatus.ENABLED
+      address.channelType === ChannelType.IOMSG && address.value === IOAllowedValues.ENABLED
   );
 
   return hasLegal || (hasEmail && hasIo);
@@ -197,7 +197,7 @@ export const hasCourtesyContacts = (addresses: Array<DigitalAddress>): boolean =
   const hasSMS = addresses.some((address) => address.channelType === ChannelType.SMS);
   const hasIo = addresses.some(
     (address) =>
-      address.channelType === ChannelType.IOMSG && address.value === IOContactStatus.ENABLED
+      address.channelType === ChannelType.IOMSG && address.value === IOAllowedValues.ENABLED
   );
 
   return hasEmail || hasIo || hasSMS;


### PR DESCRIPTION
## Short description

Replace `IOContactStatus` with `IOAllowedValues` in contacts utility and tests.

## List of changes proposed in this pull request
- Use `IOAllowedValues` to check the AppIO status 

## How to test

### PN-19628
- Start PF
- Mock the `/addresses` API and use this response
```json
[
   {
      "addressType":"COURTESY",
      "senderId":"default",
      "channelType":"APPIO",
      "value":"ENABLED"
   },
   {
      "addressType":"COURTESY",
      "channelType":"EMAIL",
      "senderId":"default",
      "value":"prova@gmail.com"
   }
]
```
- Log in and check that you are not redirected to the onboarding page.

### PN-19639
- Start PF
- Mock the `/addresses` API and use this response
```json
[
   {
      "addressType":"COURTESY",
      "senderId":"default",
      "channelType":"APPIO",
      "value":"ENABLED"
   }
]
```
- Log in and check that the AppIO pack is not displayed on the onboarding page