### PR TITLE
fix(PN-19648): align onboarding summary step with design

### DIFF
--- a/packages/pn-personafisica-webapp/public/locales/de/recapiti.json
+++ b/packages/pn-personafisica-webapp/public/locales/de/recapiti.json
@@ -442,8 +442,7 @@
         "summary": "Überprüfe die gewählten Optionen"
       },
       "buttons": {
-        "continue-without-io": "Ohne IO-App fortfahren",
-        "confirm-activation": "Aktivierung bestätigen"
+        "continue-without-io": "Ohne IO-App fortfahren"
       }
     },
     "io-activation": {

--- a/packages/pn-personafisica-webapp/public/locales/en/recapiti.json
+++ b/packages/pn-personafisica-webapp/public/locales/en/recapiti.json
@@ -442,8 +442,7 @@
         "summary": "Check the chosen options"
       },
       "buttons": {
-        "continue-without-io": "Continue without the IO app",
-        "confirm-activation": "Confirm activation"
+        "continue-without-io": "Continue without the IO app"
       }
     },
     "io-activation": {

--- a/packages/pn-personafisica-webapp/public/locales/fr/recapiti.json
+++ b/packages/pn-personafisica-webapp/public/locales/fr/recapiti.json
@@ -442,8 +442,7 @@
         "summary": "Vérifie les options choisies"
       },
       "buttons": {
-        "continue-without-io": "Continuer sans l’app IO",
-        "confirm-activation": "Confirmer l’activation"
+        "continue-without-io": "Continuer sans l’app IO"
       }
     },
     "io-activation": {

--- a/packages/pn-personafisica-webapp/public/locales/it/recapiti.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/recapiti.json
@@ -442,8 +442,7 @@
         "summary": "Controlla le opzioni scelte"
       },
       "buttons": {
-        "continue-without-io": "Continua senza l’app IO",
-        "confirm-activation": "Conferma attivazione"
+        "continue-without-io": "Continua senza l’app IO"
       }
     },
     "io-activation": {

--- a/packages/pn-personafisica-webapp/public/locales/sl/recapiti.json
+++ b/packages/pn-personafisica-webapp/public/locales/sl/recapiti.json
@@ -442,8 +442,7 @@
         "summary": "Preveri izbrane možnosti"
       },
       "buttons": {
-        "continue-without-io": "Nadaljuj brez aplikacije IO",
-        "confirm-activation": "Potrdi aktivacijo"
+        "continue-without-io": "Nadaljuj brez aplikacije IO"
       }
     },
     "io-activation": {

--- a/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/DigitalDomicileWizard.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/DigitalDomicileWizard.tsx
@@ -283,17 +283,14 @@ const DigitalDomicileWizard: React.FC = () => {
   };
 
   const getNextButtonLabel = () => {
-    if (isContactStep) {
-      return t('button.continue', { ns: 'common' });
-    }
     if (isIoStep) {
       return t('onboarding.digital-domicile.buttons.continue-without-io');
     }
-    if (isSummaryStep) {
-      return t('onboarding.digital-domicile.buttons.confirm-activation');
+    if (!isSummaryStep) {
+      return t('button.continue', { ns: 'common' });
     }
 
-    return t('button.continue', { ns: 'common' });
+    return t('button.conferma', { ns: 'common' });
   };
 
   const handlePrevious = () => {

--- a/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/OnboardingContactItem.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/OnboardingContactItem.tsx
@@ -10,8 +10,15 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
+import { SxProps, Theme } from '@mui/material/styles';
 import { useIsMobile } from '@pagopa-pn/pn-commons';
 import { ButtonNaked } from '@pagopa/mui-italia';
+
+type CommonSlotProps = {
+  container?: {
+    sx?: SxProps<Theme>;
+  };
+};
 
 type EntryModeProps = {
   mode: 'entry';
@@ -32,6 +39,7 @@ type EntryModeProps = {
   };
   footer?: ReactNode;
   prefix?: string | ReactNode;
+  slotProps?: CommonSlotProps;
 };
 
 type ViewModeProps = {
@@ -46,6 +54,7 @@ type ViewModeProps = {
     label: string;
     onClick: () => void;
   };
+  slotProps?: CommonSlotProps;
 };
 
 type Props = EntryModeProps | ViewModeProps;
@@ -65,6 +74,7 @@ const EntryMode: React.FC<Omit<EntryModeProps, 'mode'>> = ({
   collapse,
   footer,
   prefix,
+  slotProps,
 }) => {
   const isMobile = useIsMobile();
 
@@ -81,7 +91,7 @@ const EntryMode: React.FC<Omit<EntryModeProps, 'mode'>> = ({
   );
 
   return (
-    <Stack>
+    <Stack sx={slotProps?.container?.sx}>
       {title && (
         <Typography fontSize="16px" fontWeight={700}>
           {title}
@@ -139,8 +149,9 @@ const ViewMode: React.FC<Omit<ViewModeProps, 'mode'>> = ({
   secondaryContent,
   icon,
   action,
+  slotProps,
 }) => (
-  <Stack>
+  <Stack sx={slotProps?.container?.sx}>
     {introText && (
       <Typography fontSize="16px" fontWeight={700} sx={{ mb: 1 }}>
         {introText}

--- a/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/SummaryStep.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/SummaryStep.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Chip, Stack, Typography } from '@mui/material';
+import { useIsMobile } from '@pagopa-pn/pn-commons';
 import { MIAlert } from '@pagopa/mui-italia';
 
 import { WizardMode } from '../../../models/Onboarding';
@@ -24,6 +25,7 @@ type SummaryRow = {
 
 const SummaryStep: React.FC<Props> = ({ mode, email, pec, io }) => {
   const { t } = useTranslation(['recapiti']);
+  const isMobile = useIsMobile();
 
   const sendLabel = t('onboarding.digital-domicile.summary.send-badge');
   const pecLabel = t('onboarding.digital-domicile.summary.pec-badge');
@@ -49,21 +51,21 @@ const SummaryStep: React.FC<Props> = ({ mode, email, pec, io }) => {
         };
 
   const courtesyRows: Array<SummaryRow> = [
-    ...(io === IOAllowedValues.ENABLED
-      ? [
-          {
-            id: 'io',
-            label: t('onboarding.digital-domicile.summary.io-label'),
-            value: t('onboarding.digital-domicile.summary.io-value'),
-          },
-        ]
-      : []),
     ...(email
       ? [
           {
             id: 'email',
             label: t('onboarding.digital-domicile.summary.email-label'),
             value: email,
+          },
+        ]
+      : []),
+    ...(io === IOAllowedValues.ENABLED
+      ? [
+          {
+            id: 'io',
+            label: t('onboarding.digital-domicile.summary.io-label'),
+            value: t('onboarding.digital-domicile.summary.io-value'),
           },
         ]
       : []),
@@ -92,7 +94,7 @@ const SummaryStep: React.FC<Props> = ({ mode, email, pec, io }) => {
             {t('onboarding.digital-domicile.summary.courtesy-title')}
           </Typography>
 
-          <Stack spacing={2}>
+          <Stack spacing={2} direction={isMobile ? 'column' : 'row'}>
             {courtesyRows.map((row) => (
               <OnboardingContactItem
                 mode="view"
@@ -100,6 +102,13 @@ const SummaryStep: React.FC<Props> = ({ mode, email, pec, io }) => {
                 label={row.label}
                 value={row.value}
                 secondaryContent={row.secondaryContent}
+                slotProps={{
+                  container: {
+                    sx: {
+                      flex: isMobile ? '1 1 100%' : '1 1 50%',
+                    },
+                  },
+                }}
               />
             ))}
           </Stack>

--- a/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/SummaryStep.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/SummaryStep.tsx
@@ -77,7 +77,7 @@ const SummaryStep: React.FC<Props> = ({ mode, email, pec, io }) => {
         {t('onboarding.digital-domicile.summary.title')}
       </Typography>
 
-      <Stack spacing={2}>
+      <Stack spacing={2} mb={3}>
         <Typography variant="body2" color="text.secondary">
           {t('onboarding.digital-domicile.summary.legal-title')}
         </Typography>
@@ -89,7 +89,7 @@ const SummaryStep: React.FC<Props> = ({ mode, email, pec, io }) => {
         />
       </Stack>
       {courtesyRows.length > 0 && (
-        <Stack spacing={2} my={3}>
+        <Stack spacing={2} mb={3}>
           <Typography variant="body2" color="text.secondary">
             {t('onboarding.digital-domicile.summary.courtesy-title')}
           </Typography>

--- a/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/__test__/DigitalDomicileWizard.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/__test__/DigitalDomicileWizard.test.tsx
@@ -272,7 +272,7 @@ describe('DigitalDomicileWizard', () => {
     await act(async () => {
       fireEvent.click(
         getByRole('button', {
-          name: `${labelPrefix}.buttons.confirm-activation`,
+          name: 'button.conferma',
         })
       );
     });
@@ -362,7 +362,7 @@ describe('DigitalDomicileWizard', () => {
     await act(async () => {
       fireEvent.click(
         getByRole('button', {
-          name: `${labelPrefix}.buttons.confirm-activation`,
+          name: 'button.conferma',
         })
       );
     });


### PR DESCRIPTION
## List of changes proposed in this pull request
- use the correct confirm button label in the final recap step
- show courtesy email before IO when both are present
- render courtesy email and IO on the same row on desktop

This also addresses PN-19675