### PR TITLE
fix(PN-19617, PN-19659): move notification and address dispatching inside OnboardingGuard

### DIFF
--- a/packages/pn-personafisica-webapp/src/App.tsx
+++ b/packages/pn-personafisica-webapp/src/App.tsx
@@ -41,9 +41,6 @@ import * as routes from './navigation/routes.const';
 import { getCurrentAppStatus } from './redux/appStatus/actions';
 import { apiLogout } from './redux/auth/actions';
 import { resetState as resetUserState } from './redux/auth/reducers';
-import { getDigitalAddresses } from './redux/contact/actions';
-import { getReceivedNotifications } from './redux/dashboard/actions';
-import { setFirstSearch } from './redux/dashboard/reducers';
 import { useAppDispatch, useAppSelector } from './redux/hooks';
 import { getSidemenuInformation } from './redux/sidemenu/actions';
 import { resetState as resetGeneralState } from './redux/sidemenu/reducers';
@@ -281,11 +278,8 @@ const App = () => {
 
   useEffect(() => {
     if (sessionToken !== '') {
-      void dispatch(getDigitalAddresses());
       void dispatch(getSidemenuInformation());
       void dispatch(getCurrentAppStatus());
-      void dispatch(getReceivedNotifications({ size: 10 }));
-      dispatch(setFirstSearch(true));
     }
   }, [sessionToken]);
 

--- a/packages/pn-personafisica-webapp/src/__test__/App.test.tsx
+++ b/packages/pn-personafisica-webapp/src/__test__/App.test.tsx
@@ -3,16 +3,13 @@ import { Suspense } from 'react';
 import { vi } from 'vitest';
 
 import { ThemeProvider } from '@mui/material';
-import { formatToTimezoneString, tenYearsAgo, today } from '@pagopa-pn/pn-commons';
 import { theme } from '@pagopa/mui-italia';
 
 import App from '../App';
 import { currentStatusDTO } from '../__mocks__/AppStatus.mock';
 import { userResponse } from '../__mocks__/Auth.mock';
 import { tosPrivacyConsentMock } from '../__mocks__/Consents.mock';
-import { digitalAddresses } from '../__mocks__/Contacts.mock';
 import { mandatesByDelegate } from '../__mocks__/Delegations.mock';
-import { notificationsDTO } from '../__mocks__/Notifications.mock';
 import { apiClient, authClient } from '../api/apiClients';
 import { LoginProvider } from '../models/User';
 import { LOGOUT, LOGOUT_OI } from '../navigation/routes.const';
@@ -103,15 +100,7 @@ describe('App', async () => {
   it('render component - user logged in', async () => {
     mock.onGet(/\/bff\/v2\/tos-privacy.*/).reply(200, tosPrivacyConsentMock(true, true));
     mock.onGet('/bff/v1/downtime/status').reply(200, currentStatusDTO);
-    mock.onGet('/bff/v1/addresses').reply(200, digitalAddresses);
     mock.onGet('/bff/v1/mandate/delegate').reply(200, mandatesByDelegate);
-    mock
-      .onGet(
-        `/bff/v1/notifications/received?startDate=${encodeURIComponent(
-          formatToTimezoneString(tenYearsAgo)
-        )}&endDate=${encodeURIComponent(formatToTimezoneString(today))}&size=10`
-      )
-      .reply(200, notificationsDTO);
     await act(async () => {
       result = render(<Component />, { preloadedState: reduxInitialState });
     });
@@ -122,21 +111,13 @@ describe('App', async () => {
     const sideMenu = result.queryByTestId('side-menu');
     expect(sideMenu).toBeInTheDocument();
     expect(result.container).toHaveTextContent('Generic Page');
-    expect(mock.history.get).toHaveLength(5);
+    expect(mock.history.get).toHaveLength(4);
   });
 
   it('check header actions - user logged in', async () => {
     mock.onGet(/\/bff\/v2\/tos-privacy.*/).reply(200, tosPrivacyConsentMock(true, true));
     mock.onGet('/bff/v1/downtime/status').reply(200, currentStatusDTO);
-    mock.onGet('/bff/v1/addresses').reply(200, digitalAddresses);
     mock.onGet('/bff/v1/mandate/delegate').reply(200, mandatesByDelegate);
-    mock
-      .onGet(
-        `/bff/v1/notifications/received?startDate=${encodeURIComponent(
-          formatToTimezoneString(tenYearsAgo)
-        )}&endDate=${encodeURIComponent(formatToTimezoneString(today))}&size=10`
-      )
-      .reply(200, notificationsDTO);
     mockAuth.onPost('/logout').reply(200);
 
     await act(async () => {
@@ -178,15 +159,7 @@ describe('App', async () => {
   it('redirect to One Identity login portal on logout', async () => {
     mock.onGet(/\/bff\/v2\/tos-privacy.*/).reply(200, tosPrivacyConsentMock(true, true));
     mock.onGet('/bff/v1/downtime/status').reply(200, currentStatusDTO);
-    mock.onGet('/bff/v1/addresses').reply(200, digitalAddresses);
     mock.onGet('/bff/v1/mandate/delegate').reply(200, mandatesByDelegate);
-    mock
-      .onGet(
-        `/bff/v1/notifications/received?startDate=${encodeURIComponent(
-          formatToTimezoneString(tenYearsAgo)
-        )}&endDate=${encodeURIComponent(formatToTimezoneString(today))}&size=10`
-      )
-      .reply(200, notificationsDTO);
     mockAuth.onPost('/logout').reply(200);
 
     await act(async () => {
@@ -236,36 +209,22 @@ describe('App', async () => {
   it('sidemenu not included if error in API call to fetch TOS and Privacy', async () => {
     mock.onGet(/\/bff\/v2\/tos-privacy.*/).reply(500);
     mock.onGet('/bff/v1/downtime/status').reply(200, currentStatusDTO);
-    mock.onGet('/bff/v1/addresses').reply(200, digitalAddresses);
     mock.onGet('/bff/v1/mandate/delegate').reply(200, mandatesByDelegate);
-    mock
-      .onGet(
-        `/bff/v1/notifications/received?startDate=${encodeURIComponent(
-          formatToTimezoneString(tenYearsAgo)
-        )}&endDate=${encodeURIComponent(formatToTimezoneString(today))}&size=10`
-      )
-      .reply(200, notificationsDTO);
+
     await act(async () => {
       result = render(<Component />, { preloadedState: reduxInitialState });
     });
     const sideMenu = result.queryByTestId('side-menu');
     expect(sideMenu).not.toBeInTheDocument();
     expect(result.container).not.toHaveTextContent('Generic Page');
-    expect(mock.history.get).toHaveLength(5);
+    expect(mock.history.get).toHaveLength(3);
   });
 
   it('sidemenu not included if user has not accepted the TOS and PRIVACY', async () => {
     mock.onGet(/\/bff\/v2\/tos-privacy.*/).reply(200, tosPrivacyConsentMock(false, false));
     mock.onGet('/bff/v1/downtime/status').reply(200, currentStatusDTO);
-    mock.onGet('/bff/v1/addresses').reply(200, digitalAddresses);
     mock.onGet('/bff/v1/mandate/delegate').reply(200, mandatesByDelegate);
-    mock
-      .onGet(
-        `/bff/v1/notifications/received?startDate=${encodeURIComponent(
-          formatToTimezoneString(tenYearsAgo)
-        )}&endDate=${encodeURIComponent(formatToTimezoneString(today))}&size=10`
-      )
-      .reply(200, notificationsDTO);
+
     await act(async () => {
       result = render(<Component />, { preloadedState: reduxInitialState });
     });
@@ -274,21 +233,14 @@ describe('App', async () => {
     const tosPage = result.queryByTestId('tos-acceptance-page');
     expect(tosPage).toBeInTheDocument();
     expect(result.container).not.toHaveTextContent('Generic Page');
-    expect(mock.history.get).toHaveLength(5);
+    expect(mock.history.get).toHaveLength(3);
   });
 
   it('check header actions - user has not accepted the TOS and PRIVACY', async () => {
     mock.onGet(/\/bff\/v2\/tos-privacy.*/).reply(200, tosPrivacyConsentMock(false, false));
     mock.onGet('/bff/v1/downtime/status').reply(200, currentStatusDTO);
-    mock.onGet('/bff/v1/addresses').reply(200, digitalAddresses);
     mock.onGet('/bff/v1/mandate/delegate').reply(200, mandatesByDelegate);
-    mock
-      .onGet(
-        `/bff/v1/notifications/received?startDate=${encodeURIComponent(
-          formatToTimezoneString(tenYearsAgo)
-        )}&endDate=${encodeURIComponent(formatToTimezoneString(today))}&size=10`
-      )
-      .reply(200, notificationsDTO);
+
     await act(async () => {
       render(<Component />, { preloadedState: reduxInitialState });
     });
@@ -306,15 +258,8 @@ describe('App', async () => {
   it('sidemenu items if there are delegators', async () => {
     mock.onGet(/\/bff\/v2\/tos-privacy.*/).reply(200, tosPrivacyConsentMock(true, true));
     mock.onGet('/bff/v1/downtime/status').reply(200, currentStatusDTO);
-    mock.onGet('/bff/v1/addresses').reply(200, digitalAddresses);
     mock.onGet('/bff/v1/mandate/delegate').reply(200, mandatesByDelegate);
-    mock
-      .onGet(
-        `/bff/v1/notifications/received?startDate=${encodeURIComponent(
-          formatToTimezoneString(tenYearsAgo)
-        )}&endDate=${encodeURIComponent(formatToTimezoneString(today))}&size=10`
-      )
-      .reply(200, notificationsDTO);
+
     await act(async () => {
       result = render(<Component />, { preloadedState: reduxInitialState });
     });
@@ -328,15 +273,8 @@ describe('App', async () => {
   it('sidemenu items if there are no delegators', async () => {
     mock.onGet(/\/bff\/v2\/tos-privacy.*/).reply(200, tosPrivacyConsentMock(true, true));
     mock.onGet('/bff/v1/downtime/status').reply(200, currentStatusDTO);
-    mock.onGet('/bff/v1/addresses').reply(200, digitalAddresses);
     mock.onGet('/bff/v1/mandate/delegate').reply(200, []);
-    mock
-      .onGet(
-        `/bff/v1/notifications/received?startDate=${encodeURIComponent(
-          formatToTimezoneString(tenYearsAgo)
-        )}&endDate=${encodeURIComponent(formatToTimezoneString(today))}&size=10`
-      )
-      .reply(200, notificationsDTO);
+
     await act(async () => {
       result = render(<Component />, { preloadedState: reduxInitialState });
     });

--- a/packages/pn-personafisica-webapp/src/navigation/OnboardingGuard.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/OnboardingGuard.tsx
@@ -47,8 +47,6 @@ const OnboardingGuard: React.FC = () => {
   useEffect(() => {
     fetchOnboardingData()
       .then((notifications) => {
-        console.log('NOTIFICATIONS TO READ? ', hasNotificationsToRead(notifications));
-
         const shouldRedirectToOnboarding =
           location.pathname === '/' &&
           isFreshLogin &&

--- a/packages/pn-personafisica-webapp/src/navigation/OnboardingGuard.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/OnboardingGuard.tsx
@@ -1,55 +1,73 @@
-import { useEffect, useMemo } from 'react';
-import { useDispatch } from 'react-redux';
+import React, { useEffect, useState } from 'react';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 
+import type { Notification } from '@pagopa-pn/pn-commons';
 import { LoadingPage, NotificationStatus } from '@pagopa-pn/pn-commons';
 
 import { OnboardingSource } from '../models/Onboarding';
 import { setIsFreshLogin } from '../redux/auth/reducers';
+import { getDigitalAddresses } from '../redux/contact/actions';
 import { contactsSelectors } from '../redux/contact/reducers';
-import { useAppSelector } from '../redux/hooks';
+import { getReceivedNotifications } from '../redux/dashboard/actions';
+import { setFirstSearch } from '../redux/dashboard/reducers';
+import { useAppDispatch, useAppSelector } from '../redux/hooks';
 import { setOnboardingSource } from '../redux/sidemenu/reducers';
 import { getConfiguration } from '../services/configuration.service';
 import { hasRequiredContacts } from '../utility/contacts.utility';
 import * as routes from './routes.const';
 
-const OnboardingGuard = () => {
-  const navigate = useNavigate();
-  const dispatch = useDispatch();
-  const location = useLocation();
-  const { IS_ONBOARDING_ENABLED } = getConfiguration();
+const hasNotificationsToRead = (notifications: Array<Notification>): boolean => {
+  const managedStatuses = new Set([
+    NotificationStatus.VIEWED,
+    NotificationStatus.CANCELLED,
+    NotificationStatus.RETURNED_TO_SENDER,
+    NotificationStatus.EFFECTIVE_DATE,
+  ]);
+  return notifications.some((n) => !managedStatuses.has(n.notificationStatus));
+};
 
+const OnboardingGuard: React.FC = () => {
+  const navigate = useNavigate();
+  const dispatch = useAppDispatch();
+  const location = useLocation();
+
+  const { IS_ONBOARDING_ENABLED } = getConfiguration();
   const addresses = useAppSelector(contactsSelectors.selectAddresses);
-  const isContactLoading = useAppSelector(contactsSelectors.selectLoading);
-  const { loading: isNotificationsLoading, notifications } = useAppSelector(
-    (state) => state.dashboardState
-  );
   const isFreshLogin = useAppSelector((state) => state.userState.isFreshLogin);
 
-  const isLoading = isContactLoading || isNotificationsLoading;
+  const [isLoading, setIsLoading] = useState(true);
 
-  const hasNotificationsToRead = useMemo(() => {
-    const managedStatusesSet = new Set([
-      NotificationStatus.VIEWED,
-      NotificationStatus.CANCELLED,
-      NotificationStatus.RETURNED_TO_SENDER,
-      NotificationStatus.EFFECTIVE_DATE,
-    ]);
-    return notifications.some((n) => !managedStatusesSet.has(n.notificationStatus));
-  }, [notifications]);
+  const fetchOnboardingData = async () => {
+    await dispatch(getDigitalAddresses()).unwrap();
+    const notifications = await dispatch(getReceivedNotifications({ size: 10 })).unwrap();
+    dispatch(setFirstSearch(true));
+    return notifications.resultsPage;
+  };
 
   useEffect(() => {
-    if (
-      location.pathname === '/' &&
-      isFreshLogin &&
-      !hasRequiredContacts(addresses) &&
-      !hasNotificationsToRead &&
-      IS_ONBOARDING_ENABLED
-    ) {
-      dispatch(setOnboardingSource(OnboardingSource.LOGIN));
-      navigate(routes.ONBOARDING, { replace: true });
-    }
-    dispatch(setIsFreshLogin(false));
+    fetchOnboardingData()
+      .then((notifications) => {
+        console.log('NOTIFICATIONS TO READ? ', hasNotificationsToRead(notifications));
+
+        const shouldRedirectToOnboarding =
+          location.pathname === '/' &&
+          isFreshLogin &&
+          !hasRequiredContacts(addresses) &&
+          !hasNotificationsToRead(notifications) &&
+          IS_ONBOARDING_ENABLED;
+
+        if (shouldRedirectToOnboarding) {
+          dispatch(setOnboardingSource(OnboardingSource.LOGIN));
+          navigate(routes.ONBOARDING, { replace: true });
+        }
+      })
+      .catch((error) => {
+        console.error('OnboardingGuard - Failed to fetch onboarding data', error);
+      })
+      .finally(() => {
+        dispatch(setIsFreshLogin(false));
+        setIsLoading(false);
+      });
   }, []);
 
   if (isLoading) {

--- a/packages/pn-personafisica-webapp/src/navigation/OnboardingGuard.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/OnboardingGuard.tsx
@@ -7,13 +7,12 @@ import { LoadingPage, NotificationStatus } from '@pagopa-pn/pn-commons';
 import { OnboardingSource } from '../models/Onboarding';
 import { setIsFreshLogin } from '../redux/auth/reducers';
 import { getDigitalAddresses } from '../redux/contact/actions';
-import { contactsSelectors } from '../redux/contact/reducers';
 import { getReceivedNotifications } from '../redux/dashboard/actions';
 import { setFirstSearch } from '../redux/dashboard/reducers';
 import { useAppDispatch, useAppSelector } from '../redux/hooks';
 import { setOnboardingSource } from '../redux/sidemenu/reducers';
 import { getConfiguration } from '../services/configuration.service';
-import { hasRequiredContacts } from '../utility/contacts.utility';
+import { groupDigitalAddresses, hasRequiredContacts } from '../utility/contacts.utility';
 import * as routes from './routes.const';
 
 const hasNotificationsToRead = (notifications: Array<Notification>): boolean => {
@@ -32,21 +31,24 @@ const OnboardingGuard: React.FC = () => {
   const location = useLocation();
 
   const { IS_ONBOARDING_ENABLED } = getConfiguration();
-  const addresses = useAppSelector(contactsSelectors.selectAddresses);
   const isFreshLogin = useAppSelector((state) => state.userState.isFreshLogin);
 
   const [isLoading, setIsLoading] = useState(true);
 
   const fetchOnboardingData = async () => {
-    await dispatch(getDigitalAddresses()).unwrap();
+    const addresses = await dispatch(getDigitalAddresses()).unwrap();
     const notifications = await dispatch(getReceivedNotifications({ size: 10 })).unwrap();
     dispatch(setFirstSearch(true));
-    return notifications.resultsPage;
+
+    return {
+      notifications: notifications.resultsPage,
+      addresses: groupDigitalAddresses(addresses),
+    };
   };
 
   useEffect(() => {
     fetchOnboardingData()
-      .then((notifications) => {
+      .then(({ notifications, addresses }) => {
         const shouldRedirectToOnboarding =
           location.pathname === '/' &&
           isFreshLogin &&

--- a/packages/pn-personafisica-webapp/src/navigation/__test__/OnboardingGuard.test.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/__test__/OnboardingGuard.test.tsx
@@ -1,6 +1,5 @@
 import MockAdapter from 'axios-mock-adapter';
 import { Route, Routes } from 'react-router-dom';
-import { vi } from 'vitest';
 
 import {
   Configuration,
@@ -44,7 +43,6 @@ describe('OnboardingGuard', async () => {
 
   afterEach(() => {
     mock.reset();
-    vi.clearAllMocks();
   });
 
   afterAll(() => {

--- a/packages/pn-personafisica-webapp/src/navigation/__test__/OnboardingGuard.test.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/__test__/OnboardingGuard.test.tsx
@@ -1,0 +1,189 @@
+import MockAdapter from 'axios-mock-adapter';
+import { Route, Routes } from 'react-router-dom';
+import { vi } from 'vitest';
+
+import {
+  Configuration,
+  GetNotificationsResponse,
+  NotificationStatus,
+  formatToTimezoneString,
+  tenYearsAgo,
+  today,
+} from '@pagopa-pn/pn-commons';
+
+import { digitalAddresses } from '../../__mocks__/Contacts.mock';
+import { emptyNotificationsFromBe, notificationsDTO } from '../../__mocks__/Notifications.mock';
+import { RenderResult, act, render, screen, waitFor } from '../../__test__/test-utils';
+import { apiClient } from '../../api/apiClients';
+import type { PfConfiguration } from '../../services/configuration.service';
+import OnboardingGuard from '../OnboardingGuard';
+import * as routes from '../routes.const';
+
+const Guard = () => (
+  <Routes>
+    <Route element={<OnboardingGuard />}>
+      <Route path="/" element={<div>Onboarding Page</div>} />
+      <Route path="/notifiche" element={<div>Notifications Page</div>} />
+    </Route>
+  </Routes>
+);
+
+describe('OnboardingGuard', async () => {
+  let mock: MockAdapter;
+  let result: RenderResult;
+
+  beforeAll(() => {
+    mock = new MockAdapter(apiClient);
+  });
+
+  beforeEach(() => {
+    Configuration.setForTest<PfConfiguration>({
+      IS_ONBOARDING_ENABLED: true,
+    } as PfConfiguration);
+  });
+
+  afterEach(() => {
+    mock.reset();
+    vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  const fetchReceivedNotifications = (response: GetNotificationsResponse) => {
+    mock
+      .onGet(
+        `/bff/v1/notifications/received?startDate=${encodeURIComponent(
+          formatToTimezoneString(tenYearsAgo)
+        )}&endDate=${encodeURIComponent(formatToTimezoneString(today))}&size=10`
+      )
+      .reply(200, response);
+  };
+
+  it('redirects to onboarding when all conditions are met', async () => {
+    mock.onGet('/bff/v1/addresses').reply(200, []);
+    fetchReceivedNotifications(emptyNotificationsFromBe);
+
+    await act(async () => {
+      result = render(<Guard />, {
+        preloadedState: { userState: { isFreshLogin: true } },
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.router.state.location.pathname).toBe(routes.ONBOARDING);
+    });
+  });
+
+  it('does not redirect when not on root path', async () => {
+    mock.onGet('/bff/v1/addresses').reply(200, []);
+    fetchReceivedNotifications(emptyNotificationsFromBe);
+
+    await act(async () => {
+      result = render(<Guard />, {
+        preloadedState: { userState: { isFreshLogin: true } },
+        route: '/notifiche',
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Notifications Page')).toBeInTheDocument();
+    });
+    expect(result.router.state.location.pathname).toBe('/notifiche');
+  });
+
+  it('does not redirect when isFreshLogin is false', async () => {
+    mock.onGet('/bff/v1/addresses').reply(200, []);
+    fetchReceivedNotifications(emptyNotificationsFromBe);
+
+    await act(async () => {
+      result = render(<Guard />, {
+        preloadedState: { userState: { isFreshLogin: false } },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Onboarding Page')).toBeInTheDocument();
+    });
+    expect(result.router.state.location.pathname).toBe('/');
+  });
+
+  it('does not redirect when user has required contacts', async () => {
+    mock.onGet('/bff/v1/addresses').reply(200, digitalAddresses);
+    fetchReceivedNotifications(emptyNotificationsFromBe);
+
+    await act(async () => {
+      result = render(<Guard />, {
+        preloadedState: {
+          userState: { isFreshLogin: true },
+          contactsState: { digitalAddresses },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Onboarding Page')).toBeInTheDocument();
+    });
+    expect(result.router.state.location.pathname).toBe('/');
+  });
+
+  it('does not redirect when user has unread notifications', async () => {
+    const unreadNotificationsResponse = {
+      ...emptyNotificationsFromBe,
+      resultsPage: [
+        {
+          ...notificationsDTO.resultsPage[0],
+          notificationStatus: NotificationStatus.DELIVERED,
+        },
+      ],
+    };
+    mock.onGet('/bff/v1/addresses').reply(200, []);
+    fetchReceivedNotifications(unreadNotificationsResponse);
+
+    await act(async () => {
+      result = render(<Guard />, {
+        preloadedState: { userState: { isFreshLogin: true } },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Onboarding Page')).toBeInTheDocument();
+    });
+    expect(result.router.state.location.pathname).toBe('/');
+  });
+
+  it('does not redirect when IS_ONBOARDING_ENABLED is false', async () => {
+    Configuration.setForTest<PfConfiguration>({
+      IS_ONBOARDING_ENABLED: false,
+    } as PfConfiguration);
+    mock.onGet('/bff/v1/addresses').reply(200, []);
+    fetchReceivedNotifications(emptyNotificationsFromBe);
+
+    await act(async () => {
+      result = render(<Guard />, {
+        preloadedState: { userState: { isFreshLogin: true } },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Onboarding Page')).toBeInTheDocument();
+    });
+    expect(result.router.state.location.pathname).toBe('/');
+  });
+
+  it('sets isFreshLogin to false after loading completes', async () => {
+    mock.onGet('/bff/v1/addresses').reply(200, []);
+    fetchReceivedNotifications(emptyNotificationsFromBe);
+
+    await act(async () => {
+      result = render(<Guard />, {
+        preloadedState: { userState: { isFreshLogin: true } },
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.testStore.getState().userState.isFreshLogin).toBe(false);
+    });
+  });
+});

--- a/packages/pn-personafisica-webapp/src/redux/contact/reducers.ts
+++ b/packages/pn-personafisica-webapp/src/redux/contact/reducers.ts
@@ -8,7 +8,11 @@ import {
   IOAllowedValues,
 } from '../../models/contacts';
 import { Party } from '../../models/party';
-import { removeAddress, updateAddressesList } from '../../utility/contacts.utility';
+import {
+  groupDigitalAddresses,
+  removeAddress,
+  updateAddressesList,
+} from '../../utility/contacts.utility';
 import { RootState } from '../store';
 import {
   createOrUpdateAddress,
@@ -129,34 +133,9 @@ export type SelectedAddresses = {
   [key in `special${ChannelType}Addresses`]: Array<DigitalAddress>;
 };
 
-const memoizedSelectAddresses = createSelector([digitalAddresses], (digitalAddresses) => {
-  const initialValue = {
-    addresses: digitalAddresses,
-    legalAddresses: [] as Array<DigitalAddress>,
-    courtesyAddresses: [] as Array<DigitalAddress>,
-    specialAddresses: [] as Array<DigitalAddress>,
-  } as SelectedAddresses;
-  for (const channelType of Object.values(ChannelType)) {
-    initialValue[`default${channelType}Address`] = undefined;
-    initialValue[`special${channelType}Addresses`] = [];
-  }
-  return digitalAddresses.reduce((obj, addr) => {
-    if (addr.addressType === AddressType.LEGAL) {
-      obj.legalAddresses.push(addr);
-    }
-    if (addr.addressType === AddressType.COURTESY) {
-      obj.courtesyAddresses.push(addr);
-    }
-    if (addr.senderId === 'default') {
-      obj[`default${addr.channelType}Address`] = addr;
-    }
-    if (addr.senderId !== 'default') {
-      obj[`special${addr.channelType}Addresses`].push(addr);
-      obj.specialAddresses.push(addr);
-    }
-    return obj;
-  }, initialValue);
-});
+const memoizedSelectAddresses = createSelector([digitalAddresses], (digitalAddresses) =>
+  groupDigitalAddresses(digitalAddresses)
+);
 
 export const contactsSelectors = {
   selectAddresses: memoizedSelectAddresses,

--- a/packages/pn-personafisica-webapp/src/utility/contacts.utility.ts
+++ b/packages/pn-personafisica-webapp/src/utility/contacts.utility.ts
@@ -202,3 +202,40 @@ export const hasCourtesyContacts = (addresses: Array<DigitalAddress>): boolean =
 
   return hasEmail || hasIo || hasSMS;
 };
+
+/**
+ * Groups a flat list of digital addresses into categorized collections,
+ * separating them by type (legal/courtesy) and sender (default/special).
+ * @param digitalAddresses - The user addresses
+ */
+export const groupDigitalAddresses = (digitalAddresses: Array<DigitalAddress>) => {
+  const initialValue = {
+    addresses: digitalAddresses,
+    legalAddresses: [] as Array<DigitalAddress>,
+    courtesyAddresses: [] as Array<DigitalAddress>,
+    specialAddresses: [] as Array<DigitalAddress>,
+  } as SelectedAddresses;
+
+  /* eslint-disable functional/immutable-data */
+  for (const channelType of Object.values(ChannelType)) {
+    initialValue[`default${channelType}Address`] = undefined;
+    initialValue[`special${channelType}Addresses`] = [];
+  }
+
+  return digitalAddresses.reduce((obj, addr) => {
+    if (addr.addressType === AddressType.LEGAL) {
+      obj.legalAddresses.push(addr);
+    }
+    if (addr.addressType === AddressType.COURTESY) {
+      obj.courtesyAddresses.push(addr);
+    }
+    if (addr.senderId === 'default') {
+      obj[`default${addr.channelType}Address`] = addr;
+    }
+    if (addr.senderId !== 'default') {
+      obj[`special${addr.channelType}Addresses`].push(addr);
+      obj.specialAddresses.push(addr);
+    }
+    return obj;
+  }, initialValue);
+};


### PR DESCRIPTION
## Short description

Move notification and address dispatching inside `OnboardingGuard`, removing it from `App.tsx`.

## List of changes proposed in this pull request
- Move API dispatch logic into `OnboardingGuard`

## How to test
### PN-19617
- Start PF
- Verify that the user is redirected to Onboarding if they do not have notifications to read


### PN-19659
  - Navigate to `/onboarding/domicilio-digitale`
  - Go to the IO step
  - Click on "Ho già scaricato e installato l'App IO"
  - Verify that:
    - You are not redirected to the initial step
    - An address fetch is triggered