### PR TITLE
fix(PN-19690): use correct channel type icon on readonly mode of courtesy onboarding wizard

### DIFF
--- a/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/Courtesy/CourtesyContactHandler.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/Courtesy/CourtesyContactHandler.tsx
@@ -142,7 +142,7 @@ const CourtesyContactHandler: React.FC<Props> = ({
         collapse={
           onCollapse ? { onClick: onCollapse, label: labels.insert.collapseLabel } : undefined
         }
-        prefix={<ChannelTypeIcon fontSize="small" sx={{ color: 'text.secondary' }} />}
+        prefix={<ChannelTypeIcon fontSize="small" color="disabled" />}
       />
     );
   }

--- a/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/Courtesy/CourtesyContactHandler.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/Courtesy/CourtesyContactHandler.tsx
@@ -77,6 +77,8 @@ const CourtesyContactHandler: React.FC<Props> = ({
     },
   };
 
+  const ChannelTypeIcon = channelType === ChannelType.EMAIL ? EmailOutlined : PhoneOutlined;
+
   const onEditButtonClick = () => {
     const editEvent =
       channelType === ChannelType.EMAIL
@@ -140,13 +142,7 @@ const CourtesyContactHandler: React.FC<Props> = ({
         collapse={
           onCollapse ? { onClick: onCollapse, label: labels.insert.collapseLabel } : undefined
         }
-        prefix={
-          channelType === ChannelType.SMS ? (
-            <PhoneOutlined fontSize="small" sx={{ color: 'text.secondary' }} />
-          ) : (
-            <EmailOutlined fontSize="small" sx={{ color: 'text.secondary' }} />
-          )
-        }
+        prefix={<ChannelTypeIcon fontSize="small" sx={{ color: 'text.secondary' }} />}
       />
     );
   }
@@ -158,7 +154,7 @@ const CourtesyContactHandler: React.FC<Props> = ({
         introText={labels.readonly.title}
         description={labels.readonly.description}
         value={contactState.value}
-        icon={<EmailOutlined color="disabled" fontSize="small" aria-hidden="true" />}
+        icon={<ChannelTypeIcon color="disabled" fontSize="small" aria-hidden="true" />}
       />
     );
   }
@@ -190,7 +186,7 @@ const CourtesyContactHandler: React.FC<Props> = ({
           onEditConfirmCallback={onEditConfirmClick}
           slots={{
             label: () => <></>,
-            leadingEditIcon: channelType === ChannelType.EMAIL ? EmailOutlined : PhoneOutlined,
+            leadingEditIcon: ChannelTypeIcon,
           }}
           slotsProps={{
             textField: {

--- a/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/EmailSection.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/EmailSection.tsx
@@ -88,6 +88,7 @@ const EmailSection: React.FC<Props> = ({
           label: t('onboarding.digital-domicile.pec.cancel-email-cta'),
           onClick: onCollapse,
         }}
+        prefix={<MailOutlineIcon fontSize="small" color="disabled" />}
       />
     );
   }

--- a/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/EmailStep.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/EmailStep.tsx
@@ -235,7 +235,7 @@ const EmailStep: React.FC<Props> = ({ value, alreadySet, onChange, onVerified })
               width: '100%',
             },
             leadingEditIcon: {
-              sx: { color: 'text.secondary' },
+              sx: { color: 'disabled' },
               fontSize: 'small',
             },
           }}
@@ -255,6 +255,7 @@ const EmailStep: React.FC<Props> = ({ value, alreadySet, onChange, onVerified })
           onChange={handleEmailFieldChange}
           onBlur={formik.handleBlur}
           onSubmit={handleVerifyEmail}
+          prefix={<MailOutlineIcon fontSize="small" color="disabled" />}
         />
       );
     }

--- a/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/PecStep.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/PecStep.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import * as yup from 'yup';
 
+import MailOutlineIcon from '@mui/icons-material/MailOutline';
 import {
   Checkbox,
   Chip,
@@ -452,6 +453,7 @@ const PecStep: React.FC<Props> = ({
         onBlur={formik.handleBlur}
         onSubmit={handleVerifyPec}
         footer={renderPecDisclaimerFooter()}
+        prefix={<MailOutlineIcon fontSize="small" color="disabled" />}
       />
     );
   };


### PR DESCRIPTION
## Short description
Use correct channel type icon on readonly mode of courtesy onboarding wizard

## List of changes proposed in this pull request
- Fix displayed icon

## How to test
- Start PF
- Remove SMS if present from addresses
- Navigate to `/onboarding/avvisi` and insert a new phone number on step 2
- After the contact verification check that the displayed icon is correct