### PR TITLE
fix(PN-19721): back button alignment on digital domicile wizard

### DIFF
--- a/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/DigitalDomicileWizard.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/DigitalDomicileWizard.tsx
@@ -135,7 +135,7 @@ const getWizardActionsSlotProps = ({
 }) =>
   isChoiceStep && !isPecActivating
     ? { sx: { display: 'none' } }
-    : { justifyContent: showNextButton ? 'space-between' : 'center' };
+    : { justifyContent: showNextButton ? 'space-between' : 'flex-start' };
 
 const DigitalDomicileWizard: React.FC = () => {
   const { t } = useTranslation(['recapiti', 'common']);


### PR DESCRIPTION
## Short description

Back button alignment on digital domicile wizard**

## List of changes proposed in this pull request
- Button alignment on desktop wizard

## How to test
- Start PF
- Go to `/onboardin/domicilio-digitale`
- Select SERCQ SEND flow
- On email step check that back button is aligned to the left