### PR TITLE
feat(PN-19839): fetch /oidc-authorize and redirect to IDP login page

### DIFF
--- a/packages/pn-personafisica-login/public/conf/config-dev.json
+++ b/packages/pn-personafisica-login/public/conf/config-dev.json
@@ -19,5 +19,7 @@
   "SERCQ_SERVICE_STATEMENT_LINK": "https://notifichedigitali.it/assets/MO_006_Service_Practice_Statement_Pago_PA_S_p_A_v_1_6_signed_0d50fefc36.pdf",
   "DIGITAL_IDENTITY_LINK": "https://identitadigitale.gov.it/",
   "ONE_IDENTITY_CDN_URL": "https://assets.uat.oneid.pagopa.it",
-  "SPID_REQUEST_LINK": "https://www.spid.gov.it/cos-e-spid/come-attivare-spid/"
+  "SPID_REQUEST_LINK": "https://www.spid.gov.it/cos-e-spid/come-attivare-spid/",
+  "API_BASE_URL": "https://webapi.dev.notifichedigitali.it",
+  "ONE_IDENTITY_CIE_ENTITY_ID": "https://preproduzione.idserver.servizicie.interno.gov.it/idp/profile/SAML2/POST/SSO"
 }

--- a/packages/pn-personafisica-login/src/api/OneIdentity/OneIdentity.api.ts
+++ b/packages/pn-personafisica-login/src/api/OneIdentity/OneIdentity.api.ts
@@ -1,5 +1,6 @@
 import { IDPS_MOCK } from '../../__mocks__/IDPS.mock';
 import { IDP } from '../../models/IDPS';
+import { OidcAuthorizeResponse } from '../../models/OneIdentity';
 import { getConfiguration } from '../../services/configuration.service';
 
 export const OneIdentityApi = {
@@ -13,5 +14,17 @@ export const OneIdentityApi = {
       // TODO - In attesa di risoluzione problema CORS
       return IDPS_MOCK;
     }
+  },
+  authorize: async (entityId: string): Promise<OidcAuthorizeResponse> => {
+    const { API_BASE_URL } = getConfiguration();
+    const params = new URLSearchParams({ idp: entityId });
+
+    const response = await fetch(`${API_BASE_URL}/oidc-authorize?${params.toString()}`);
+
+    if (!response.ok) {
+      throw new Error('Error during OIDC authorize');
+    }
+
+    return response.json() as Promise<OidcAuthorizeResponse>;
   },
 };

--- a/packages/pn-personafisica-login/src/components/OneIdentity/LoginButtons.tsx
+++ b/packages/pn-personafisica-login/src/components/OneIdentity/LoginButtons.tsx
@@ -63,7 +63,7 @@ const LoginButtons: React.FC<Props> = ({
       >
         {t('loginPage.loginBox.cieLogin')}
         {authorizingEntityId === ONE_IDENTITY_CIE_ENTITY_ID && (
-          <CircularProgress size={20} sx={{ position: 'absolute' }} />
+          <CircularProgress size={20} sx={{ position: 'absolute' }} data-testid="cie-loader" />
         )}
       </LoginButton>
     </Grid>

--- a/packages/pn-personafisica-login/src/components/OneIdentity/LoginButtons.tsx
+++ b/packages/pn-personafisica-login/src/components/OneIdentity/LoginButtons.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button, CircularProgress, Grid, styled } from '@mui/material';
+import { CieIcon, SpidIcon } from '@pagopa/mui-italia/icons';
+
+import { getConfiguration } from '../../services/configuration.service';
+
+type Props = {
+  authorizingEntityId: string | null;
+  handleCieClick: () => void;
+  handleSpidClick: () => void;
+};
+
+const LoginButton = styled(Button)({
+  borderRadius: '4px',
+  width: '272px',
+  height: '48px',
+  '& .MuiButton-startIcon': { svg: { fontSize: '25px' } },
+});
+
+const LoginButtons: React.FC<Props> = ({
+  authorizingEntityId,
+  handleCieClick,
+  handleSpidClick,
+}) => {
+  const { t } = useTranslation(['login']);
+
+  const { ONE_IDENTITY_CIE_ENTITY_ID } = getConfiguration();
+
+  return (
+    <Grid
+      item
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        width: {
+          xs: `${(100 / 12) * 10}%`,
+          sm: `${(100 / 12) * 6}%`,
+          md: `${(100 / 12) * 4}%`,
+          lg: `${(100 / 12) * 4}%`,
+          xl: `${(100 / 12) * 3}%`,
+        },
+      }}
+    >
+      <LoginButton
+        id="spidButton"
+        variant="contained"
+        onClick={handleSpidClick}
+        startIcon={<SpidIcon />}
+        sx={{ mb: 3 }}
+      >
+        {t('loginPage.loginBox.spidLogin')}
+      </LoginButton>
+      <LoginButton
+        id="cieButton"
+        variant="contained"
+        onClick={handleCieClick}
+        startIcon={<CieIcon />}
+        disabled={authorizingEntityId !== null}
+        sx={{ position: 'relative' }}
+      >
+        {t('loginPage.loginBox.cieLogin')}
+        {authorizingEntityId === ONE_IDENTITY_CIE_ENTITY_ID && (
+          <CircularProgress size={20} sx={{ position: 'absolute' }} />
+        )}
+      </LoginButton>
+    </Grid>
+  );
+};
+
+export default LoginButtons;

--- a/packages/pn-personafisica-login/src/components/OneIdentity/SpidList.tsx
+++ b/packages/pn-personafisica-login/src/components/OneIdentity/SpidList.tsx
@@ -1,6 +1,7 @@
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { Button, Grid, Icon, Skeleton, Typography } from '@mui/material';
+import { Box, Button, CircularProgress, Grid, Icon, Skeleton, Typography } from '@mui/material';
 
 import { IDP } from '../../models/IDPS';
 import { getConfiguration } from '../../services/configuration.service';
@@ -9,14 +10,30 @@ import { shuffleList } from '../../utility/utils';
 type Props = {
   idps: Array<IDP>;
   loading: boolean;
+  authorizingEntityId: string | null;
   onSelect: (idp: IDP) => void;
 };
 
-const SpidList: React.FC<Props> = ({ idps, loading, onSelect }) => {
+const SpidLoader: React.FC = () => (
+  <Box
+    sx={{
+      position: 'absolute',
+      inset: 0,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      bgcolor: 'rgba(255,255,255,0.7)',
+    }}
+  >
+    <CircularProgress size={24} />
+  </Box>
+);
+
+const SpidList: React.FC<Props> = ({ idps, loading, authorizingEntityId, onSelect }) => {
   const { t } = useTranslation(['login']);
   const { ONE_IDENTITY_CDN_URL } = getConfiguration();
 
-  const shuffledIDPS = shuffleList<IDP>(idps);
+  const shuffledIDPS = useMemo(() => shuffleList<IDP>(idps), [idps]);
 
   const getImageUrl = (entityID: string) =>
     `${ONE_IDENTITY_CDN_URL}/assets/idps/${btoa(entityID)}.png`;
@@ -61,12 +78,14 @@ const SpidList: React.FC<Props> = ({ idps, loading, onSelect }) => {
             <Button
               id={`spid-select-${idp.entityID}`}
               onClick={() => onSelect(idp)}
-              sx={{ width: '100px', padding: '0' }}
+              sx={{ width: '100px', padding: '0', position: 'relative' }}
               aria-label={idp.friendlyName}
+              disabled={authorizingEntityId !== null}
             >
               <Icon sx={{ width: '100px', height: '48px' }}>
                 <img width="100px" src={getImageUrl(idp.entityID)} alt={idp.friendlyName} />
               </Icon>
+              {authorizingEntityId === idp.entityID && <SpidLoader />}
             </Button>
           </Grid>
         ))}

--- a/packages/pn-personafisica-login/src/components/OneIdentity/SpidSelectDialog.tsx
+++ b/packages/pn-personafisica-login/src/components/OneIdentity/SpidSelectDialog.tsx
@@ -13,6 +13,7 @@ type Props = {
   show: boolean;
   IDPS: Array<IDP>;
   loading: boolean;
+  authorizingEntityId: string | null;
   onClose: () => void;
   handleSelectIDP: (idp: IDP) => void;
 };
@@ -21,6 +22,7 @@ const OneIdentitySpidSelectDialog: React.FC<Props> = ({
   show,
   IDPS,
   loading,
+  authorizingEntityId,
   onClose,
   handleSelectIDP,
 }) => {
@@ -70,7 +72,12 @@ const OneIdentitySpidSelectDialog: React.FC<Props> = ({
             </Typography>
           </Grid>
 
-          <SpidList idps={IDPS} loading={loading} onSelect={handleSelectIDP} />
+          <SpidList
+            idps={IDPS}
+            loading={loading}
+            authorizingEntityId={authorizingEntityId}
+            onSelect={handleSelectIDP}
+          />
 
           <Grid item>
             <Typography

--- a/packages/pn-personafisica-login/src/components/OneIdentity/__test__/LoginButtons.test.tsx
+++ b/packages/pn-personafisica-login/src/components/OneIdentity/__test__/LoginButtons.test.tsx
@@ -1,0 +1,76 @@
+import { vi } from 'vitest';
+
+import { Configuration } from '@pagopa-pn/pn-commons';
+
+import { fireEvent, render } from '../../../__test__/test-utils';
+import { LoginConfiguration } from '../../../services/configuration.service';
+import LoginButtons from '../LoginButtons';
+
+describe('LoginButtons', () => {
+  let ONE_IDENTITY_CIE_ENTITY_ID: string;
+  const handleCieClick = vi.fn();
+  const handleSpidClick = vi.fn();
+
+  beforeAll(() => {
+    ONE_IDENTITY_CIE_ENTITY_ID = Configuration.get<LoginConfiguration>().ONE_IDENTITY_CIE_ENTITY_ID;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const defaultProps = {
+    authorizingEntityId: null,
+    handleCieClick,
+    handleSpidClick,
+  };
+
+  it('renders SPID and CIE buttons', () => {
+    const { container } = render(<LoginButtons {...defaultProps} />);
+    expect(container.querySelector('#spidButton')).toBeInTheDocument();
+    expect(container.querySelector('#cieButton')).toBeInTheDocument();
+  });
+
+  it('calls handleSpidClick when SPID button is clicked', () => {
+    const { container } = render(<LoginButtons {...defaultProps} />);
+    fireEvent.click(container.querySelector('#spidButton')!);
+    expect(handleSpidClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls handleCieClick when CIE button is clicked', () => {
+    const { container } = render(<LoginButtons {...defaultProps} />);
+    fireEvent.click(container.querySelector('#cieButton')!);
+    expect(handleCieClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('disable CIE button when authorizingEntityId is set', () => {
+    const { container } = render(
+      <LoginButtons {...defaultProps} authorizingEntityId={ONE_IDENTITY_CIE_ENTITY_ID} />
+    );
+    expect(container.querySelector('#cieButton')).toBeDisabled();
+  });
+
+  it('does not disable CIE button when authorizingEntityId is null', () => {
+    const { container } = render(<LoginButtons {...defaultProps} />);
+    expect(container.querySelector('#cieButton')).not.toBeDisabled();
+  });
+
+  it('shows spinner on CIE button when authorizingEntityId matches CIE entity id', () => {
+    const { container } = render(
+      <LoginButtons {...defaultProps} authorizingEntityId={ONE_IDENTITY_CIE_ENTITY_ID} />
+    );
+    expect(container.querySelector('[data-testid="cie-loader"]')).toBeInTheDocument();
+  });
+
+  it('does not show spinner on CIE button when authorizingEntityId is null', () => {
+    const { container } = render(<LoginButtons {...defaultProps} />);
+    expect(container.querySelector('[data-testid="cie-loader"]')).not.toBeInTheDocument();
+  });
+
+  it('does not show spinner on CIE button when authorizingEntityId is a SPID entity id', () => {
+    const { container } = render(
+      <LoginButtons {...defaultProps} authorizingEntityId="https://some-spid-idp.it" />
+    );
+    expect(container.querySelector('[data-testid="cie-loader"]')).not.toBeInTheDocument();
+  });
+});

--- a/packages/pn-personafisica-login/src/components/OneIdentity/__test__/SpidList.test.tsx
+++ b/packages/pn-personafisica-login/src/components/OneIdentity/__test__/SpidList.test.tsx
@@ -16,7 +16,7 @@ describe('SpidList', () => {
 
   it('shows loading spinner when loading is true', () => {
     const { getByTestId, queryAllByRole } = render(
-      <SpidList idps={IDPS_MOCK} loading={true} onSelect={handleSelect} />
+      <SpidList idps={IDPS_MOCK} loading={true} authorizingEntityId={null} onSelect={handleSelect} />
     );
     expect(getByTestId('spid-loader')).toBeInTheDocument();
     expect(queryAllByRole('button')).toHaveLength(0);
@@ -24,14 +24,14 @@ describe('SpidList', () => {
 
   it('renders idp buttons when not loading', () => {
     const { queryByTestId, getAllByRole } = render(
-      <SpidList idps={IDPS_MOCK} loading={false} onSelect={handleSelect} />
+      <SpidList idps={IDPS_MOCK} loading={false} authorizingEntityId={null} onSelect={handleSelect} />
     );
     expect(queryByTestId('spid-loader')).not.toBeInTheDocument();
     expect(getAllByRole('button')).toHaveLength(IDPS_MOCK.length);
   });
 
   it('renders a button for each idp with correct id and aria-label', () => {
-    render(<SpidList idps={IDPS_MOCK} loading={false} onSelect={handleSelect} />);
+    render(<SpidList idps={IDPS_MOCK} loading={false} authorizingEntityId={null} onSelect={handleSelect} />);
     IDPS_MOCK.forEach((idp) => {
       const btn = document.getElementById(`spid-select-${idp.entityID}`);
       expect(btn).toBeInTheDocument();
@@ -41,7 +41,7 @@ describe('SpidList', () => {
 
   it('calls onSelect with the correct idp when a button is clicked', () => {
     const onSelect = vi.fn();
-    render(<SpidList idps={IDPS_MOCK} loading={false} onSelect={onSelect} />);
+    render(<SpidList idps={IDPS_MOCK} loading={false} authorizingEntityId={null} onSelect={onSelect} />);
     const btn = document.getElementById(`spid-select-${IDPS_MOCK[0].entityID}`)!;
     fireEvent.click(btn);
     expect(onSelect).toHaveBeenCalledTimes(1);
@@ -49,7 +49,7 @@ describe('SpidList', () => {
   });
 
   it('renders images with correct src built from CDN and btoa(entityID)', () => {
-    render(<SpidList idps={IDPS_MOCK} loading={false} onSelect={handleSelect} />);
+    render(<SpidList idps={IDPS_MOCK} loading={false} authorizingEntityId={null} onSelect={handleSelect} />);
     const cdnUrl = Configuration.get<LoginConfiguration>().ONE_IDENTITY_CDN_URL;
 
     IDPS_MOCK.forEach((idp) => {
@@ -61,8 +61,19 @@ describe('SpidList', () => {
   });
 
   it('renders no empty state when idps list is empty', () => {
-    const { getByTestId } = render(<SpidList idps={[]} loading={false} onSelect={handleSelect} />);
-
+    const { getByTestId } = render(
+      <SpidList idps={[]} loading={false} authorizingEntityId={null} onSelect={handleSelect} />
+    );
     expect(getByTestId('idp-empty-state')).toBeInTheDocument();
+  });
+
+  it('disables all buttons and shows overlay spinner on the authorizing idp', () => {
+    const authorizingId = IDPS_MOCK[0].entityID;
+    render(
+      <SpidList idps={IDPS_MOCK} loading={false} authorizingEntityId={authorizingId} onSelect={handleSelect} />
+    );
+    const authorizingBtn = document.getElementById(`spid-select-${authorizingId}`)!;
+    expect(authorizingBtn).toBeDisabled();
+    expect(authorizingBtn.querySelector('[role="progressbar"]')).toBeInTheDocument();
   });
 });

--- a/packages/pn-personafisica-login/src/components/OneIdentity/__test__/SpidSelectDialog.test.tsx
+++ b/packages/pn-personafisica-login/src/components/OneIdentity/__test__/SpidSelectDialog.test.tsx
@@ -28,29 +28,22 @@ describe('OneIdentitySpidSelectDialog', () => {
     vi.clearAllMocks();
   });
 
+  const defaultProps = {
+    show: true,
+    IDPS: IDPS_MOCK,
+    loading: false,
+    authorizingEntityId: null,
+    onClose,
+    handleSelectIDP,
+  };
+
   it('does not render dialog content when show is false', () => {
-    render(
-      <OneIdentitySpidSelectDialog
-        show={false}
-        IDPS={IDPS_MOCK}
-        loading={false}
-        onClose={onClose}
-        handleSelectIDP={handleSelectIDP}
-      />
-    );
+    render(<OneIdentitySpidSelectDialog {...defaultProps} show={false} />);
     expect(queryById(document.body, 'spidSelect')).not.toBeInTheDocument();
   });
 
   it('renders the modal', () => {
-    render(
-      <OneIdentitySpidSelectDialog
-        show={true}
-        IDPS={IDPS_MOCK}
-        loading={false}
-        onClose={onClose}
-        handleSelectIDP={handleSelectIDP}
-      />
-    );
+    render(<OneIdentitySpidSelectDialog {...defaultProps} />);
     expect(document.body).toHaveTextContent('spidSelect.title');
 
     fireEvent.click(getById(document.body, 'backIcon'));
@@ -58,60 +51,36 @@ describe('OneIdentitySpidSelectDialog', () => {
   });
 
   it('calls onClose when the cancel button is clicked', () => {
-    render(
-      <OneIdentitySpidSelectDialog
-        show={true}
-        IDPS={IDPS_MOCK}
-        loading={false}
-        onClose={onClose}
-        handleSelectIDP={handleSelectIDP}
-      />
-    );
+    render(<OneIdentitySpidSelectDialog {...defaultProps} />);
     fireEvent.click(getById(document.body, 'backButton'));
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   it('renders the request spid link with the correct href', () => {
-    render(
-      <OneIdentitySpidSelectDialog
-        show={true}
-        IDPS={IDPS_MOCK}
-        loading={false}
-        onClose={onClose}
-        handleSelectIDP={handleSelectIDP}
-      />
-    );
+    render(<OneIdentitySpidSelectDialog {...defaultProps} />);
     const link = getById(document.body, 'requestForSpid');
     expect(link).toBeInTheDocument();
     expect(link).toHaveAttribute('href', SPID_REQUEST_LINK);
   });
 
   it('shows loading spinner when loading is true', () => {
-    render(
-      <OneIdentitySpidSelectDialog
-        show={true}
-        IDPS={IDPS_MOCK}
-        loading={true}
-        onClose={onClose}
-        handleSelectIDP={handleSelectIDP}
-      />
-    );
+    render(<OneIdentitySpidSelectDialog {...defaultProps} loading={true} />);
     expect(document.body.querySelector('[data-testid="spid-loader"]')).toBeInTheDocument();
   });
 
   it('calls handleSelectIDP with the correct idp when an idp button is clicked', () => {
-    render(
-      <OneIdentitySpidSelectDialog
-        show={true}
-        IDPS={IDPS_MOCK}
-        loading={false}
-        onClose={onClose}
-        handleSelectIDP={handleSelectIDP}
-      />
-    );
+    render(<OneIdentitySpidSelectDialog {...defaultProps} />);
     const btn = document.getElementById(`spid-select-${IDPS_MOCK[0].entityID}`)!;
     fireEvent.click(btn);
     expect(handleSelectIDP).toHaveBeenCalledTimes(1);
     expect(handleSelectIDP).toHaveBeenCalledWith(IDPS_MOCK[0]);
+  });
+
+  it('disables idp buttons and shows overlay spinner when authorizingEntityId is set', () => {
+    const authorizingId = IDPS_MOCK[0].entityID;
+    render(<OneIdentitySpidSelectDialog {...defaultProps} authorizingEntityId={authorizingId} />);
+    const btn = document.getElementById(`spid-select-${authorizingId}`)!;
+    expect(btn).toBeDisabled();
+    expect(btn.querySelector('[role="progressbar"]')).toBeInTheDocument();
   });
 });

--- a/packages/pn-personafisica-login/src/models/OneIdentity.ts
+++ b/packages/pn-personafisica-login/src/models/OneIdentity.ts
@@ -1,0 +1,3 @@
+export type OidcAuthorizeResponse = {
+  location: string;
+};

--- a/packages/pn-personafisica-login/src/pages/oneIdentityLogin/OneIdentityLogin.tsx
+++ b/packages/pn-personafisica-login/src/pages/oneIdentityLogin/OneIdentityLogin.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
 
 import { Box, Button, Divider, Grid, Link, Typography, styled } from '@mui/material';
 import {
@@ -15,6 +16,7 @@ import IOSmartAppBanner from '../../components/IoSmartAppBanner';
 import OneIdentitySpidSelectDialog from '../../components/OneIdentity/SpidSelectDialog';
 import { IDP } from '../../models/IDPS';
 import { PFLoginEventsType } from '../../models/PFLoginEventsType';
+import { ROUTE_ONE_IDENTITY_LOGIN_ERROR } from '../../navigation/routes.const';
 import { getConfiguration } from '../../services/configuration.service';
 import PFLoginEventStrategyFactory from '../../utility/MixpanelUtils/PFLoginEventStrategyFactory';
 
@@ -34,14 +36,15 @@ const LoginButton = styled(Button)({
 const OneIdentityLogin: React.FC = () => {
   const { t, i18n } = useTranslation(['login']);
   const isMobile = useIsMobile();
+  const navigate = useNavigate();
   const {
-    SPID_CIE_ENTITY_ID,
     PAGOPA_HELP_EMAIL,
     PF_URL,
     IS_SMART_APP_BANNER_ENABLED,
     ACCESSIBILITY_LINK,
     SERCQ_SERVICE_STATEMENT_LINK,
     DIGITAL_IDENTITY_LINK,
+    ONE_IDENTITY_CIE_ENTITY_ID,
   } = getConfiguration();
 
   const [showIdpSelect, setShowIdpSelect] = useState(false);
@@ -59,11 +62,24 @@ const OneIdentityLogin: React.FC = () => {
   // eslint-disable-next-line functional/immutable-data
   const handleAssistanceClick = () => (window.location.href = `mailto:${PAGOPA_HELP_EMAIL}`);
 
-  const handleCieClick = () => {
+  const handleCieClick = () => handleIdpLogin('CIE', ONE_IDENTITY_CIE_ENTITY_ID);
+
+  const handleSelectSpid = (idp: IDP) => handleIdpLogin(idp.friendlyName, idp.entityID);
+
+  const handleIdpLogin = (spidName: string, entityId: string) => {
     PFLoginEventStrategyFactory.triggerEvent(PFLoginEventsType.SEND_IDP_SELECTED, {
-      SPID_IDP_NAME: 'CIE',
-      SPID_IDP_ID: SPID_CIE_ENTITY_ID,
+      SPID_IDP_NAME: spidName,
+      SPID_IDP_ID: entityId,
     });
+
+    OneIdentityApi.authorize(entityId)
+      .then(({ location }) => {
+        // eslint-disable-next-line functional/immutable-data
+        window.location.href = location;
+      })
+      .catch(() => {
+        navigate(ROUTE_ONE_IDENTITY_LOGIN_ERROR);
+      });
   };
 
   const fetchIDPS = () => {
@@ -80,6 +96,8 @@ const OneIdentityLogin: React.FC = () => {
   };
 
   useEffect(() => {
+    PFLoginEventStrategyFactory.triggerEvent(PFLoginEventsType.SEND_LOGIN);
+
     fetchIDPS();
   }, []);
 
@@ -203,7 +221,7 @@ const OneIdentityLogin: React.FC = () => {
         show={showIdpSelect}
         IDPS={idpsState.idps}
         loading={idpsState.loading}
-        handleSelectIDP={(idp) => console.log(idp)}
+        handleSelectIDP={handleSelectSpid}
         onClose={() => setShowIdpSelect(false)}
       />
     </>

--- a/packages/pn-personafisica-login/src/pages/oneIdentityLogin/OneIdentityLogin.tsx
+++ b/packages/pn-personafisica-login/src/pages/oneIdentityLogin/OneIdentityLogin.tsx
@@ -2,17 +2,17 @@ import React, { useEffect, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 
-import { Box, Button, Divider, Grid, Link, Typography, styled } from '@mui/material';
+import { Box, Divider, Grid, Link, Typography } from '@mui/material';
 import {
   Layout,
   PRIVACY_LINK_RELATIVE_PATH as PRIVACY_POLICY,
   useIsMobile,
 } from '@pagopa-pn/pn-commons';
-import { CieIcon, SpidIcon } from '@pagopa/mui-italia/icons';
 
 import { OneIdentityApi } from '../../api/OneIdentity/OneIdentity.api';
 import sendLogo from '../../assets/send.svg';
 import IOSmartAppBanner from '../../components/IoSmartAppBanner';
+import LoginButtons from '../../components/OneIdentity/LoginButtons';
 import OneIdentitySpidSelectDialog from '../../components/OneIdentity/SpidSelectDialog';
 import { IDP } from '../../models/IDPS';
 import { PFLoginEventsType } from '../../models/PFLoginEventsType';
@@ -25,13 +25,6 @@ const SMART_BANNER_HEIGHT_PX = 66;
 const LOGO_HEADER_HEIGHT_PX = 81;
 
 const unloggedUser = { id: '', name: undefined, surname: undefined, email: undefined };
-
-const LoginButton = styled(Button)({
-  borderRadius: '4px',
-  width: '272px',
-  height: '48px',
-  '& .MuiButton-startIcon': { svg: { fontSize: '25px' } },
-});
 
 const OneIdentityLogin: React.FC = () => {
   const { t, i18n } = useTranslation(['login']);
@@ -48,6 +41,7 @@ const OneIdentityLogin: React.FC = () => {
   } = getConfiguration();
 
   const [showIdpSelect, setShowIdpSelect] = useState(false);
+  const [authorizingEntityId, setAuthorizingEntityId] = useState<string | null>(null);
   const [idpsState, setIdpsState] = useState<{ idps: Array<IDP>; loading: boolean }>({
     idps: [],
     loading: true,
@@ -64,6 +58,8 @@ const OneIdentityLogin: React.FC = () => {
 
   const handleCieClick = () => handleIdpLogin('CIE', ONE_IDENTITY_CIE_ENTITY_ID);
 
+  const handleSpidClick = () => setShowIdpSelect(true);
+
   const handleSelectSpid = (idp: IDP) => handleIdpLogin(idp.friendlyName, idp.entityID);
 
   const handleIdpLogin = (spidName: string, entityId: string) => {
@@ -72,6 +68,7 @@ const OneIdentityLogin: React.FC = () => {
       SPID_IDP_ID: entityId,
     });
 
+    setAuthorizingEntityId(entityId);
     OneIdentityApi.authorize(entityId)
       .then(({ location }) => {
         // eslint-disable-next-line functional/immutable-data
@@ -79,7 +76,8 @@ const OneIdentityLogin: React.FC = () => {
       })
       .catch(() => {
         navigate(ROUTE_ONE_IDENTITY_LOGIN_ERROR);
-      });
+      })
+      .finally(() => setAuthorizingEntityId(null));
   };
 
   const fetchIDPS = () => {
@@ -163,39 +161,11 @@ const OneIdentityLogin: React.FC = () => {
               </Typography>
             </Grid>
 
-            <Grid
-              item
-              sx={{
-                display: 'flex',
-                flexDirection: 'column',
-                alignItems: 'center',
-                width: {
-                  xs: `${(100 / 12) * 10}%`,
-                  sm: `${(100 / 12) * 6}%`,
-                  md: `${(100 / 12) * 4}%`,
-                  lg: `${(100 / 12) * 4}%`,
-                  xl: `${(100 / 12) * 3}%`,
-                },
-              }}
-            >
-              <LoginButton
-                id="spidButton"
-                variant="contained"
-                onClick={() => setShowIdpSelect(true)}
-                startIcon={<SpidIcon />}
-                sx={{ mb: 3 }}
-              >
-                {t('loginPage.loginBox.spidLogin')}
-              </LoginButton>
-              <LoginButton
-                id="cieButton"
-                variant="contained"
-                onClick={handleCieClick}
-                startIcon={<CieIcon />}
-              >
-                {t('loginPage.loginBox.cieLogin')}
-              </LoginButton>
-            </Grid>
+            <LoginButtons
+              authorizingEntityId={authorizingEntityId}
+              handleCieClick={handleCieClick}
+              handleSpidClick={handleSpidClick}
+            />
 
             <Typography fontSize="16px" sx={{ mt: 3 }}>
               <Trans
@@ -221,6 +191,7 @@ const OneIdentityLogin: React.FC = () => {
         show={showIdpSelect}
         IDPS={idpsState.idps}
         loading={idpsState.loading}
+        authorizingEntityId={authorizingEntityId}
         handleSelectIDP={handleSelectSpid}
         onClose={() => setShowIdpSelect(false)}
       />

--- a/packages/pn-personafisica-login/src/pages/oneIdentityLogin/__test__/OneIdentityLogin.test.tsx
+++ b/packages/pn-personafisica-login/src/pages/oneIdentityLogin/__test__/OneIdentityLogin.test.tsx
@@ -9,8 +9,8 @@ import {
   waitFor,
 } from '@pagopa-pn/pn-commons/src/test-utils';
 
-import { render } from '../../../__test__/test-utils';
 import { IDPS_MOCK } from '../../../__mocks__/IDPS.mock';
+import { render } from '../../../__test__/test-utils';
 import { OneIdentityApi } from '../../../api/OneIdentity/OneIdentity.api';
 import { storageRapidAccessOps } from '../../../utility/storage';
 import OneIdentityLogin from '../OneIdentityLogin';
@@ -27,11 +27,6 @@ vi.mock('../../../services/configuration.service', async () => {
     }),
   };
 });
-
-vi.mock('../../../utility/utils', async () => ({
-  ...(await vi.importActual<any>('../../../utility/utils')),
-  isIOSMobile: vi.fn().mockReturnValue(false),
-}));
 
 vi.mock('../../../api/OneIdentity/OneIdentity.api', () => ({
   OneIdentityApi: {
@@ -104,7 +99,7 @@ describe('test login page', () => {
       await waitFor(() => expect(OneIdentityApi.getIdps).toHaveBeenCalledTimes(1));
     });
 
-    it('shows loading spinner in dialog while fetch is pending', async () => {
+    it('shows loading spinner in dialog while IDPS fetch is pending', async () => {
       vi.mocked(OneIdentityApi.getIdps).mockImplementation(() => new Promise(() => {}));
       const { container } = render(<OneIdentityLogin />);
       fireEvent.click(getById(container, 'spidButton'));

--- a/packages/pn-personafisica-login/src/services/configuration.service.ts
+++ b/packages/pn-personafisica-login/src/services/configuration.service.ts
@@ -23,6 +23,8 @@ export interface LoginConfiguration {
   DIGITAL_IDENTITY_LINK: string;
   ONE_IDENTITY_CDN_URL: string;
   SPID_REQUEST_LINK: string;
+  API_BASE_URL: string;
+  ONE_IDENTITY_CIE_ENTITY_ID: string;
 }
 
 class LoginConfigurationValidator extends Validator<LoginConfiguration> {
@@ -54,11 +56,19 @@ class LoginConfigurationValidator extends Validator<LoginConfiguration> {
         }
         return null;
       });
-    this.ruleFor('ONE_IDENTITY_BASE_URL').isString().isRequired();
-    this.ruleFor('SERCQ_SERVICE_STATEMENT_LINK').isString().isRequired();
-    this.ruleFor('DIGITAL_IDENTITY_LINK').isString().isRequired();
-    this.ruleFor('ONE_IDENTITY_CDN_URL').isString().isRequired();
-    this.ruleFor('SPID_REQUEST_LINK').isString().isRequired();
+    this.ruleFor('ONE_IDENTITY_BASE_URL').isString().isRequired().matches(dataRegex.htmlPageUrl);
+    this.ruleFor('SERCQ_SERVICE_STATEMENT_LINK')
+      .isString()
+      .isRequired()
+      .matches(dataRegex.htmlPageUrl);
+    this.ruleFor('DIGITAL_IDENTITY_LINK').isString().isRequired().matches(dataRegex.htmlPageUrl);
+    this.ruleFor('ONE_IDENTITY_CDN_URL').isString().isRequired().matches(dataRegex.htmlPageUrl);
+    this.ruleFor('SPID_REQUEST_LINK').isString().isRequired().matches(dataRegex.htmlPageUrl);
+    this.ruleFor('API_BASE_URL').isString().isRequired().matches(dataRegex.htmlPageUrl);
+    this.ruleFor('ONE_IDENTITY_CIE_ENTITY_ID')
+      .isString()
+      .isRequired()
+      .matches(dataRegex.htmlPageUrl);
   }
 }
 

--- a/packages/pn-personafisica-login/src/setupTests.tsx
+++ b/packages/pn-personafisica-login/src/setupTests.tsx
@@ -33,6 +33,8 @@ beforeAll(async () => {
     DIGITAL_IDENTITY_LINK: 'https://identitadigitale.gov.it/',
     ONE_IDENTITY_CDN_URL: 'https://assets.uat.oneid.pagopa.it',
     SPID_REQUEST_LINK: 'https://www.spid.gov.it/cos-e-spid/come-attivare-spid/',
+    API_BASE_URL: 'https://mock-api-base-url',
+    ONE_IDENTITY_CIE_ENTITY_ID: 'https://mock-cie-entityID.it',
   });
   // mock translations
   vi.mock('react-i18next', () => ({


### PR DESCRIPTION
## Short description

Fetch `/oidc-authorize` and redirect to IDP login page

## List of changes proposed in this pull request
- Fetch API that return the URL of IDP login page

## How to test
- Start PF Login
- Navigate to /auth/login-oi
- Select SPID login and verify that on Internal IDP selection you are redirected to IDP login page
- Also try to make the `/oidc-authorize` API fails and verify that you are redirected to login error page