### PR TITLE
feat(PN-19701): handle OneIdentity callback

### DIFF
--- a/packages/pn-personafisica-login/package.json
+++ b/packages/pn-personafisica-login/package.json
@@ -19,7 +19,6 @@
     "react-i18next": "^11.16.1",
     "react-router-dom": "^6.30.3",
     "typescript": "^5.2.2",
-    "uuid": "^13.0.0",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/packages/pn-personafisica-login/public/locales/it/login.json
+++ b/packages/pn-personafisica-login/public/locales/it/login.json
@@ -27,6 +27,12 @@
       "error_25": "Hai annullato l’operazione di login: puoi riprovare quando vuoi.",
       "error_30": "La tipologia di identità SPID che hai usato è diversa da quella richiesta dal Service Provider. Entra di nuovo usando quella corretta.",
       "error_1001": "Accesso negato: non hai l’età minima richiesta per usare la piattaforma."
+    },
+    "oneIdentity": {
+      "invalid_scope": "",
+      "unsupported_response_type": "",
+      "server_error": "",
+      "invalid_request": ""
     }
   },
   "disambiguationPage": {

--- a/packages/pn-personafisica-login/src/api/OneIdentity/OneIdentity.api.ts
+++ b/packages/pn-personafisica-login/src/api/OneIdentity/OneIdentity.api.ts
@@ -1,6 +1,10 @@
 import { IDPS_MOCK } from '../../__mocks__/IDPS.mock';
 import { IDP } from '../../models/IDPS';
-import { OidcAuthorizeParams, OidcAuthorizeResponse } from '../../models/OneIdentity';
+import {
+  OidcAuthorizeParams,
+  OidcAuthorizeResponse,
+  OidcStateDataResponse,
+} from '../../models/OneIdentity';
 import { getConfiguration } from '../../services/configuration.service';
 
 export const OneIdentityApi = {
@@ -36,5 +40,17 @@ export const OneIdentityApi = {
     }
 
     return response.json() as Promise<OidcAuthorizeResponse>;
+  },
+  getOidcStateData: async (state: string): Promise<OidcStateDataResponse> => {
+    const { API_BASE_URL } = getConfiguration();
+    const params = new URLSearchParams({ state });
+
+    const response = await fetch(`${API_BASE_URL}/oidc-state?${params.toString()}`);
+
+    if (!response.ok) {
+      throw new Error('Error during retrieving OIDC state data');
+    }
+
+    return response.json() as Promise<OidcStateDataResponse>;
   },
 };

--- a/packages/pn-personafisica-login/src/models/OneIdentity.ts
+++ b/packages/pn-personafisica-login/src/models/OneIdentity.ts
@@ -7,3 +7,10 @@ export type OidcAuthorizeParams = {
 export type OidcAuthorizeResponse = {
   location: string;
 };
+
+export type OidcStateDataResponse = {
+  nonce: string;
+  idp: string;
+  aar?: string;
+  retrievalId?: string;
+};

--- a/packages/pn-personafisica-login/src/pages/oneIdentityCallback/OneIdentityCallback.tsx
+++ b/packages/pn-personafisica-login/src/pages/oneIdentityCallback/OneIdentityCallback.tsx
@@ -2,78 +2,66 @@ import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Navigate, useSearchParams } from 'react-router-dom';
 
-import { getLangCode, sanitizeString } from '@pagopa-pn/pn-commons';
+import { AppRouteParams, getLangCode, sanitizeString } from '@pagopa-pn/pn-commons';
 
-import {
-  ROUTE_ONE_IDENTITY_LOGIN_ERROR,
-  oneIdentityRedirectUriPath,
-} from '../../navigation/routes.const';
+import { OneIdentityApi } from '../../api/OneIdentity/OneIdentity.api';
+import { PFLoginEventsType } from '../../models/PFLoginEventsType';
+import { ROUTE_ONE_IDENTITY_LOGIN_ERROR } from '../../navigation/routes.const';
 import { getConfiguration } from '../../services/configuration.service';
-import {
-  storageOneIdentityNonce,
-  storageOneIdentityState,
-  storageRapidAccessOps,
-} from '../../utility/storage';
+import PFLoginEventStrategyFactory from '../../utility/MixpanelUtils/PFLoginEventStrategyFactory';
 
 const OneIdentityCallback: React.FC = () => {
+  const { i18n } = useTranslation();
   const { PF_URL } = getConfiguration();
 
-  const stateFromStorage = storageOneIdentityState.read();
-  const nonceFromStorage = storageOneIdentityNonce.read();
-
   const [searchParams] = useSearchParams();
-  const oneIdentityState = searchParams.get('state');
-  const oneIdentityCode = searchParams.get('code');
+  const code = searchParams.get('code');
+  const state = searchParams.get('state');
 
-  const rapidAccess = storageRapidAccessOps.read();
-  const { i18n } = useTranslation();
+  const isValidCallback = code && state;
 
-  const isValid =
-    oneIdentityCode &&
-    oneIdentityState &&
-    nonceFromStorage &&
-    oneIdentityState === stateFromStorage;
-
-  const calcRedirectUrl = () => {
-    if (!isValid) {
+  async function handleOidcCallback() {
+    if (!isValidCallback) {
       return;
     }
 
-    const redirectUrl = PF_URL;
+    const { nonce, aar, retrievalId, idp } = await OneIdentityApi.getOidcStateData(state);
+
+    PFLoginEventStrategyFactory.triggerEvent(PFLoginEventsType.SEND_LOGIN_METHOD, {
+      entityID: idp,
+    });
 
     // the findIndex check is needed to prevent xss attacks
-    if (redirectUrl && [PF_URL].some((url) => url && redirectUrl.startsWith(url))) {
+    if (PF_URL && [PF_URL].some((url) => url && PF_URL.startsWith(url))) {
       const queryParams = new URLSearchParams();
-      if (rapidAccess) {
-        storageRapidAccessOps.delete();
-        queryParams.set(rapidAccess[0], sanitizeString(rapidAccess[1]));
+
+      if (aar) {
+        queryParams.set(AppRouteParams.AAR, sanitizeString(aar));
+      } else if (retrievalId) {
+        queryParams.set(AppRouteParams.RETRIEVAL_ID, sanitizeString(retrievalId));
       }
 
       const hashParams = new URLSearchParams({
-        code: oneIdentityCode,
-        state: oneIdentityState,
-        nonce: nonceFromStorage,
-        redirect_uri: encodeURIComponent(`${PF_URL}${oneIdentityRedirectUriPath}`),
+        code,
+        state,
+        nonce,
         lang: sanitizeString(getLangCode(i18n.language)),
       });
 
       const queryString = queryParams.size > 0 ? `?${queryParams.toString()}` : '';
       const hashString = hashParams.toString();
 
-      const url = `${redirectUrl}${queryString}#${hashString}`;
-
-      storageOneIdentityState.delete();
-      storageOneIdentityNonce.delete();
+      const url = `${PF_URL}${queryString}#${hashString}`;
 
       window.location.replace(url);
     }
-  };
+  }
 
   useEffect(() => {
-    calcRedirectUrl();
+    void handleOidcCallback();
   }, []);
 
-  if (!isValid) {
+  if (!isValidCallback) {
     return <Navigate to={ROUTE_ONE_IDENTITY_LOGIN_ERROR} replace />;
   }
 

--- a/packages/pn-personafisica-login/src/pages/oneIdentityCallback/OneIdentityCallback.tsx
+++ b/packages/pn-personafisica-login/src/pages/oneIdentityCallback/OneIdentityCallback.tsx
@@ -22,7 +22,7 @@ const OneIdentityCallback: React.FC = () => {
 
   const isValidCallback = !error && !!code && !!state;
 
-  const redirectToLogoutPage = () => {
+  const redirectToErrorPage = () => {
     const params = new URLSearchParams();
     if (state) {
       params.set('state', state);
@@ -40,7 +40,7 @@ const OneIdentityCallback: React.FC = () => {
 
   async function handleOidcCallback() {
     if (!isValidCallback) {
-      redirectToLogoutPage();
+      redirectToErrorPage();
       return;
     }
 
@@ -52,32 +52,28 @@ const OneIdentityCallback: React.FC = () => {
 
     // the findIndex check is needed to prevent xss attacks
     if (PF_URL && [PF_URL].some((url) => url && PF_URL.startsWith(url))) {
-      const queryParams = new URLSearchParams();
+      const url = new URL(PF_URL);
 
       if (aar) {
-        queryParams.set(AppRouteParams.AAR, sanitizeString(aar));
+        url.searchParams.set(AppRouteParams.AAR, sanitizeString(aar));
       } else if (retrievalId) {
-        queryParams.set(AppRouteParams.RETRIEVAL_ID, sanitizeString(retrievalId));
+        url.searchParams.set(AppRouteParams.RETRIEVAL_ID, sanitizeString(retrievalId));
       }
 
-      const hashParams = new URLSearchParams({
+      // eslint-disable-next-line functional/immutable-data
+      url.hash = new URLSearchParams({
         code,
         state,
         nonce,
         lang: sanitizeString(getLangCode(i18n.language)),
-      });
+      }).toString();
 
-      const queryString = queryParams.size > 0 ? `?${queryParams.toString()}` : '';
-      const hashString = hashParams.toString();
-
-      const url = `${PF_URL}${queryString}#${hashString}`;
-
-      window.location.replace(url);
+      window.location.replace(url.toString());
     }
   }
 
   useEffect(() => {
-    handleOidcCallback().catch(redirectToLogoutPage);
+    handleOidcCallback().catch(redirectToErrorPage);
   }, []);
 
   return null;

--- a/packages/pn-personafisica-login/src/pages/oneIdentityCallback/OneIdentityCallback.tsx
+++ b/packages/pn-personafisica-login/src/pages/oneIdentityCallback/OneIdentityCallback.tsx
@@ -30,12 +30,10 @@ const OneIdentityCallback: React.FC = () => {
     if (error) {
       params.set('error', error);
     }
-    const query = params.toString();
-    const to = query
-      ? `${ROUTE_ONE_IDENTITY_LOGIN_ERROR}?${query}`
-      : ROUTE_ONE_IDENTITY_LOGIN_ERROR;
-
-    navigate(to, { replace: true });
+    navigate(
+      { pathname: ROUTE_ONE_IDENTITY_LOGIN_ERROR, search: params.toString() },
+      { replace: true }
+    );
   };
 
   async function handleOidcCallback() {

--- a/packages/pn-personafisica-login/src/pages/oneIdentityCallback/OneIdentityCallback.tsx
+++ b/packages/pn-personafisica-login/src/pages/oneIdentityCallback/OneIdentityCallback.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Navigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { AppRouteParams, getLangCode, sanitizeString } from '@pagopa-pn/pn-commons';
 
@@ -13,15 +13,34 @@ import PFLoginEventStrategyFactory from '../../utility/MixpanelUtils/PFLoginEven
 const OneIdentityCallback: React.FC = () => {
   const { i18n } = useTranslation();
   const { PF_URL } = getConfiguration();
+  const navigate = useNavigate();
 
   const [searchParams] = useSearchParams();
   const code = searchParams.get('code');
   const state = searchParams.get('state');
+  const error = searchParams.get('error');
 
-  const isValidCallback = code && state;
+  const isValidCallback = !error && !!code && !!state;
+
+  const redirectToLogoutPage = () => {
+    const params = new URLSearchParams();
+    if (state) {
+      params.set('state', state);
+    }
+    if (error) {
+      params.set('error', error);
+    }
+    const query = params.toString();
+    const to = query
+      ? `${ROUTE_ONE_IDENTITY_LOGIN_ERROR}?${query}`
+      : ROUTE_ONE_IDENTITY_LOGIN_ERROR;
+
+    navigate(to, { replace: true });
+  };
 
   async function handleOidcCallback() {
     if (!isValidCallback) {
+      redirectToLogoutPage();
       return;
     }
 
@@ -58,12 +77,8 @@ const OneIdentityCallback: React.FC = () => {
   }
 
   useEffect(() => {
-    void handleOidcCallback();
+    handleOidcCallback().catch(redirectToLogoutPage);
   }, []);
-
-  if (!isValidCallback) {
-    return <Navigate to={ROUTE_ONE_IDENTITY_LOGIN_ERROR} replace />;
-  }
 
   return null;
 };

--- a/packages/pn-personafisica-login/src/pages/oneIdentityCallback/__test__/OneIdentityCallback.test.tsx
+++ b/packages/pn-personafisica-login/src/pages/oneIdentityCallback/__test__/OneIdentityCallback.test.tsx
@@ -1,37 +1,33 @@
 import { vi } from 'vitest';
 
-import { AppRouteParams } from '@pagopa-pn/pn-commons';
+import { waitFor } from '@testing-library/react';
 
 import { render } from '../../../__test__/test-utils';
-import {
-  ROUTE_ONE_IDENTITY_LOGIN_ERROR,
-  oneIdentityRedirectUriPath,
-} from '../../../navigation/routes.const';
+import { OneIdentityApi } from '../../../api/OneIdentity/OneIdentity.api';
+import { ROUTE_ONE_IDENTITY_LOGIN_ERROR } from '../../../navigation/routes.const';
 import { getConfiguration } from '../../../services/configuration.service';
-import {
-  storageOneIdentityNonce,
-  storageOneIdentityState,
-  storageRapidAccessOps,
-} from '../../../utility/storage';
 import OneIdentityCallback from '../OneIdentityCallback';
 
 const mockLocationReplace = vi.fn();
+
+vi.mock('../../../api/OneIdentity/OneIdentity.api', () => ({
+  OneIdentityApi: {
+    getOidcStateData: vi.fn(),
+  },
+}));
 
 describe('OneIdentityCallback component', () => {
   const original = globalThis.location;
   const mockState = 'mock-state-123';
   const mockCode = 'mock-code-456';
   const mockNonce = 'mock-nonce-789';
+  const mockIdp = 'mock-idp';
 
   const checkHashParams = (hashParams: URLSearchParams) => {
-    const { PF_URL } = getConfiguration();
     expect(hashParams.get('code')).toBe(mockCode);
     expect(hashParams.get('state')).toBe(mockState);
     expect(hashParams.get('nonce')).toBe(mockNonce);
     expect(hashParams.get('lang')).toBe('it');
-    expect(hashParams.get('redirect_uri')).toBe(
-      encodeURIComponent(`${PF_URL}${oneIdentityRedirectUriPath}`)
-    );
   };
 
   beforeAll(() => {
@@ -45,27 +41,22 @@ describe('OneIdentityCallback component', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    storageOneIdentityState.write(mockState);
-    storageOneIdentityNonce.write(mockNonce);
-    storageRapidAccessOps.delete();
-  });
-
-  afterEach(() => {
-    storageOneIdentityState.delete();
-    storageOneIdentityNonce.delete();
-    storageRapidAccessOps.delete();
+    vi.mocked(OneIdentityApi.getOidcStateData).mockResolvedValue({
+      nonce: mockNonce,
+      idp: mockIdp,
+    });
   });
 
   afterAll(() => {
     Object.defineProperty(globalThis, 'location', { configurable: true, value: original });
   });
 
-  it('should redirect with correct hash params', () => {
+  it('should redirect with correct hash params', async () => {
     render(<OneIdentityCallback />, { route: `/?state=${mockState}&code=${mockCode}` });
 
-    expect(mockLocationReplace).toHaveBeenCalled();
-    const calledUrl = mockLocationReplace.mock.calls[0][0];
+    await waitFor(() => expect(mockLocationReplace).toHaveBeenCalled());
 
+    const calledUrl = mockLocationReplace.mock.calls[0][0];
     expect(calledUrl).toContain(getConfiguration().PF_URL);
 
     const url = new URL(calledUrl);
@@ -74,46 +65,63 @@ describe('OneIdentityCallback component', () => {
     checkHashParams(hashParams);
   });
 
-  it('should redirect with rapid access (aar)', () => {
-    storageRapidAccessOps.write([AppRouteParams.AAR, 'aar-token']);
+  it('should call getOidcStateData with the state param', async () => {
+    render(<OneIdentityCallback />, { route: `/?state=${mockState}&code=${mockCode}` });
+
+    await waitFor(() => expect(OneIdentityApi.getOidcStateData).toHaveBeenCalledWith(mockState));
+  });
+
+  it('should redirect with rapid access (aar)', async () => {
+    vi.mocked(OneIdentityApi.getOidcStateData).mockResolvedValue({
+      nonce: mockNonce,
+      idp: mockIdp,
+      aar: 'aar-token',
+    });
 
     render(<OneIdentityCallback />, { route: `/?state=${mockState}&code=${mockCode}` });
 
-    expect(mockLocationReplace).toHaveBeenCalled();
-    const calledUrl = mockLocationReplace.mock.calls[0][0];
+    await waitFor(() => expect(mockLocationReplace).toHaveBeenCalled());
 
+    const calledUrl = mockLocationReplace.mock.calls[0][0];
     const url = new URL(calledUrl);
     const queryParams = new URLSearchParams(url.search);
     const hashParams = new URLSearchParams(url.hash.substring(1));
 
     expect(queryParams.get('aar')).toBe('aar-token');
-
     checkHashParams(hashParams);
   });
 
-  it('should redirect with rapid access (retrievalId)', () => {
-    storageRapidAccessOps.write([AppRouteParams.RETRIEVAL_ID, 'retrieval-id']);
+  it('should redirect with rapid access (retrievalId)', async () => {
+    vi.mocked(OneIdentityApi.getOidcStateData).mockResolvedValue({
+      nonce: mockNonce,
+      idp: mockIdp,
+      retrievalId: 'retrieval-id',
+    });
 
     render(<OneIdentityCallback />, { route: `/?state=${mockState}&code=${mockCode}` });
 
-    expect(mockLocationReplace).toHaveBeenCalled();
-    const calledUrl = mockLocationReplace.mock.calls[0][0];
+    await waitFor(() => expect(mockLocationReplace).toHaveBeenCalled());
 
+    const calledUrl = mockLocationReplace.mock.calls[0][0];
     const url = new URL(calledUrl);
     const queryParams = new URLSearchParams(url.search);
     const hashParams = new URLSearchParams(url.hash.substring(1));
 
     expect(queryParams.get('retrievalId')).toBe('retrieval-id');
-
     checkHashParams(hashParams);
   });
 
-  it('should sanitize rapid access parameter (XSS protection)', () => {
-    storageRapidAccessOps.write([AppRouteParams.AAR, '<script>some-code</script>aar-token']);
+  it('should sanitize rapid access parameter (XSS protection)', async () => {
+    vi.mocked(OneIdentityApi.getOidcStateData).mockResolvedValue({
+      nonce: mockNonce,
+      idp: mockIdp,
+      aar: '<script>some-code</script>aar-token',
+    });
 
     render(<OneIdentityCallback />, { route: `/?state=${mockState}&code=${mockCode}` });
 
-    expect(mockLocationReplace).toHaveBeenCalled();
+    await waitFor(() => expect(mockLocationReplace).toHaveBeenCalled());
+
     const calledUrl = mockLocationReplace.mock.calls[0][0];
 
     expect(calledUrl).not.toContain('<script>');
@@ -125,18 +133,6 @@ describe('OneIdentityCallback component', () => {
 
     expect(aarValue).not.toContain('<script>');
     expect(aarValue).not.toContain('</script>');
-  });
-
-  it('should navigate to error route when state does not match', () => {
-    storageOneIdentityState.write('different-state');
-
-    const { router } = render(<OneIdentityCallback />, {
-      route: `/?state=${mockState}&code=${mockCode}`,
-    });
-
-    expect(router.state.location.pathname).toBe(ROUTE_ONE_IDENTITY_LOGIN_ERROR);
-    expect(router.state.historyAction).toBe('REPLACE');
-    expect(mockLocationReplace).not.toHaveBeenCalled();
   });
 
   it('should navigate to error route when code is missing', () => {
@@ -155,45 +151,17 @@ describe('OneIdentityCallback component', () => {
     expect(mockLocationReplace).not.toHaveBeenCalled();
   });
 
-  it('should navigate to error route when nonce is missing from storage', () => {
-    storageOneIdentityNonce.delete();
-
-    const { router } = render(<OneIdentityCallback />, {
-      route: `/?state=${mockState}&code=${mockCode}`,
-    });
-
-    expect(router.state.location.pathname).toBe(ROUTE_ONE_IDENTITY_LOGIN_ERROR);
-    expect(router.state.historyAction).toBe('REPLACE');
-    expect(mockLocationReplace).not.toHaveBeenCalled();
-  });
-
-  it('should clean up storage after successful redirect', () => {
-    const deleteStateSpy = vi.spyOn(storageOneIdentityState, 'delete');
-    const deleteNonceSpy = vi.spyOn(storageOneIdentityNonce, 'delete');
-    const deleteRapidAccessSpy = vi.spyOn(storageRapidAccessOps, 'delete');
-
-    storageRapidAccessOps.write([AppRouteParams.AAR, 'aar-token']);
-
+  it('should not include query params when rapid access is not present', async () => {
     render(<OneIdentityCallback />, { route: `/?state=${mockState}&code=${mockCode}` });
 
-    expect(deleteStateSpy).toHaveBeenCalledTimes(1);
-    expect(deleteNonceSpy).toHaveBeenCalledTimes(1);
-    expect(deleteRapidAccessSpy).toHaveBeenCalledTimes(1);
-  });
+    await waitFor(() => expect(mockLocationReplace).toHaveBeenCalled());
 
-  it('should not include query params when rapid access is not present', () => {
-    render(<OneIdentityCallback />, { route: `/?state=${mockState}&code=${mockCode}` });
-
-    expect(mockLocationReplace).toHaveBeenCalled();
     const calledUrl = mockLocationReplace.mock.calls[0][0];
-
     const url = new URL(calledUrl);
 
     expect(url.search).toBe('');
-    expect(url).not.toContain('?');
 
     const hashParams = new URLSearchParams(url.hash.substring(1));
-
     checkHashParams(hashParams);
   });
 });

--- a/packages/pn-personafisica-login/src/pages/oneIdentityCallback/__test__/OneIdentityCallback.test.tsx
+++ b/packages/pn-personafisica-login/src/pages/oneIdentityCallback/__test__/OneIdentityCallback.test.tsx
@@ -135,18 +135,55 @@ describe('OneIdentityCallback component', () => {
     expect(aarValue).not.toContain('</script>');
   });
 
-  it('should navigate to error route when code is missing', () => {
+  it('should navigate to error route when code is missing', async () => {
     const { router } = render(<OneIdentityCallback />, { route: `/?state=${mockState}` });
 
-    expect(router.state.location.pathname).toBe(ROUTE_ONE_IDENTITY_LOGIN_ERROR);
+    await waitFor(() => expect(router.state.location.pathname).toBe(ROUTE_ONE_IDENTITY_LOGIN_ERROR));
+    expect(router.state.location.search).toBe(`?state=${mockState}`);
     expect(router.state.historyAction).toBe('REPLACE');
     expect(mockLocationReplace).not.toHaveBeenCalled();
   });
 
-  it('should navigate to error route when state is missing', () => {
+  it('should navigate to error route when state is missing', async () => {
     const { router } = render(<OneIdentityCallback />, { route: `/?code=${mockCode}` });
 
-    expect(router.state.location.pathname).toBe(ROUTE_ONE_IDENTITY_LOGIN_ERROR);
+    await waitFor(() => expect(router.state.location.pathname).toBe(ROUTE_ONE_IDENTITY_LOGIN_ERROR));
+    expect(router.state.location.search).toBe('');
+    expect(router.state.historyAction).toBe('REPLACE');
+    expect(mockLocationReplace).not.toHaveBeenCalled();
+  });
+
+  it('should navigate to error route with error param forwarded', async () => {
+    const { router } = render(<OneIdentityCallback />, {
+      route: '/auth/callback?error=invalid_scope',
+    });
+
+    await waitFor(() => expect(router.state.location.pathname).toBe(ROUTE_ONE_IDENTITY_LOGIN_ERROR));
+    expect(router.state.location.search).toBe('?error=invalid_scope');
+    expect(router.state.historyAction).toBe('REPLACE');
+    expect(mockLocationReplace).not.toHaveBeenCalled();
+  });
+
+  it('should navigate to error route when error param is present alongside code and state', async () => {
+    const { router } = render(<OneIdentityCallback />, {
+      route: `/auth/callback?error=invalid_scope&code=${mockCode}&state=${mockState}`,
+    });
+
+    await waitFor(() => expect(router.state.location.pathname).toBe(ROUTE_ONE_IDENTITY_LOGIN_ERROR));
+    expect(router.state.location.search).toBe(`?state=${mockState}&error=invalid_scope`);
+    expect(router.state.historyAction).toBe('REPLACE');
+    expect(mockLocationReplace).not.toHaveBeenCalled();
+  });
+
+  it('should navigate to error route when API call fails', async () => {
+    vi.mocked(OneIdentityApi.getOidcStateData).mockRejectedValue(new Error('API error'));
+
+    const { router } = render(<OneIdentityCallback />, {
+      route: `/auth/callback?state=${mockState}&code=${mockCode}`,
+    });
+
+    await waitFor(() => expect(router.state.location.pathname).toBe(ROUTE_ONE_IDENTITY_LOGIN_ERROR));
+    expect(router.state.location.search).toBe(`?state=${mockState}`);
     expect(router.state.historyAction).toBe('REPLACE');
     expect(mockLocationReplace).not.toHaveBeenCalled();
   });

--- a/packages/pn-personafisica-login/src/pages/oneIdentityLogin/OneIdentityLogin.tsx
+++ b/packages/pn-personafisica-login/src/pages/oneIdentityLogin/OneIdentityLogin.tsx
@@ -80,8 +80,7 @@ const OneIdentityLogin: React.FC = () => {
 
     OneIdentityApi.authorize({ entityId, aar, retrievalId })
       .then(({ location }) => {
-        // eslint-disable-next-line functional/immutable-data
-        window.location.href = location;
+        window.location.assign(location);
       })
       .catch(() => {
         navigate(ROUTE_ONE_IDENTITY_LOGIN_ERROR);

--- a/packages/pn-personafisica-login/src/pages/oneIdentityLogin/__test__/OneIdentityLogin.test.tsx
+++ b/packages/pn-personafisica-login/src/pages/oneIdentityLogin/__test__/OneIdentityLogin.test.tsx
@@ -98,16 +98,11 @@ describe('test login page', () => {
       });
     });
 
-    afterEach(() => {
-      // eslint-disable-next-line functional/immutable-data
-      delete (globalThis.location as any).href;
-    });
-
     it('redirects to location on successful authorize', async () => {
       const { container } = render(<OneIdentityLogin />);
       fireEvent.click(getById(container, 'cieButton'));
       await waitFor(() =>
-        expect(globalThis.location.href).toBe('https://idp.example.com/login')
+        expect(mockAssign).toHaveBeenCalledWith('https://idp.example.com/login')
       );
     });
 

--- a/packages/pn-personafisica-login/src/pages/oneIdentityLoginError/OneIdentityLoginError.tsx
+++ b/packages/pn-personafisica-login/src/pages/oneIdentityLoginError/OneIdentityLoginError.tsx
@@ -12,20 +12,21 @@ import { PFLoginEventsType } from '../../models/PFLoginEventsType';
 import { ROUTE_ONE_IDENTITY_LOGIN } from '../../navigation/routes.const';
 import PFLoginEventStrategyFactory from '../../utility/MixpanelUtils/PFLoginEventStrategyFactory';
 
-const getErrorMessage = (error: string | null) => {
-  switch (error) {
-    case 'invalid_scope':
-      return 'loginError.oneIdentity.invalid_scope';
-    case 'unsupported_response_type':
-      return 'loginError.oneIdentity.unsupported_response_type';
-    case 'server_error':
-      return 'loginError.oneIdentity.server_error';
-    case 'invalid_request':
-      return 'loginError.oneIdentity.invalid_request';
-    default:
-      return 'loginError.message';
-  }
-};
+// TODO - Use this once the copy is available
+// const getErrorMessage = (error: string | null) => {
+//   switch (error) {
+//     case 'invalid_scope':
+//       return 'loginError.oneIdentity.invalid_scope';
+//     case 'unsupported_response_type':
+//       return 'loginError.oneIdentity.unsupported_response_type';
+//     case 'server_error':
+//       return 'loginError.oneIdentity.server_error';
+//     case 'invalid_request':
+//       return 'loginError.oneIdentity.invalid_request';
+//     default:
+//       return 'loginError.message';
+//   }
+// };
 
 const OneIdentityLoginError: React.FC = () => {
   const { t } = useTranslation(['login', 'common']);
@@ -86,7 +87,7 @@ const OneIdentityLoginError: React.FC = () => {
           {t('loginError.title')}
         </Typography>
         <Typography variant="body2" id="message" mb={8}>
-          {t(getErrorMessage(error))}
+          {t('loginError.message')}
         </Typography>
         <Button
           id="login-button"

--- a/packages/pn-personafisica-login/src/pages/oneIdentityLoginError/OneIdentityLoginError.tsx
+++ b/packages/pn-personafisica-login/src/pages/oneIdentityLoginError/OneIdentityLoginError.tsx
@@ -1,16 +1,82 @@
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
-import { Box, Button, Dialog, Typography } from '@mui/material';
+import { Box, Button, CircularProgress, Dialog, Typography } from '@mui/material';
+import { sanitizeString } from '@pagopa-pn/pn-commons';
 import { IllusError } from '@pagopa/mui-italia';
 
+import { OneIdentityApi } from '../../api/OneIdentity/OneIdentity.api';
+import { OidcStateDataResponse } from '../../models/OneIdentity';
+import { PFLoginEventsType } from '../../models/PFLoginEventsType';
 import { ROUTE_ONE_IDENTITY_LOGIN } from '../../navigation/routes.const';
+import PFLoginEventStrategyFactory from '../../utility/MixpanelUtils/PFLoginEventStrategyFactory';
+
+const getErrorMessage = (error: string | null) => {
+  switch (error) {
+    case 'invalid_scope':
+      return 'loginError.oneIdentity.invalid_scope';
+    case 'unsupported_response_type':
+      return 'loginError.oneIdentity.unsupported_response_type';
+    case 'server_error':
+      return 'loginError.oneIdentity.server_error';
+    case 'invalid_request':
+      return 'loginError.oneIdentity.invalid_request';
+    default:
+      return 'loginError.message';
+  }
+};
 
 const OneIdentityLoginError: React.FC = () => {
   const { t } = useTranslation(['login', 'common']);
   const navigate = useNavigate();
 
-  const goToLogin = () => navigate(ROUTE_ONE_IDENTITY_LOGIN);
+  const [searchParams] = useSearchParams();
+  const state = searchParams.get('state');
+  const error = searchParams.get('error');
+
+  const [stateData, setStateData] = useState<{
+    data: OidcStateDataResponse | null;
+    loading: boolean;
+  }>({
+    data: null,
+    loading: !!state,
+  });
+
+  const goToLogin = () => {
+    const { aar, retrievalId } = stateData.data ?? {};
+    const params = new URLSearchParams();
+
+    if (aar) {
+      params.set('aar', sanitizeString(aar));
+    } else if (retrievalId) {
+      params.set('retrievalId', sanitizeString(retrievalId));
+    }
+
+    const query = params.size > 0 ? `?${params}` : '';
+
+    navigate(`${ROUTE_ONE_IDENTITY_LOGIN}${query}`);
+  };
+
+  const trackMixpanelErrorEvent = (idp: string) => {
+    if (process.env.NODE_ENV !== 'test') {
+      PFLoginEventStrategyFactory.triggerEvent(PFLoginEventsType.SEND_LOGIN_FAILURE, {
+        reason: error,
+        IDP: idp,
+      });
+    }
+  };
+
+  useEffect(() => {
+    if (state) {
+      void OneIdentityApi.getOidcStateData(state)
+        .then((response) => {
+          setStateData({ loading: false, data: response });
+          trackMixpanelErrorEvent(response.idp);
+        })
+        .catch(() => setStateData({ loading: false, data: null }));
+    }
+  }, [state]);
 
   return (
     <Dialog fullScreen={true} open={true} aria-labelledby="dialog-per-messaggi-di-errore">
@@ -20,9 +86,15 @@ const OneIdentityLoginError: React.FC = () => {
           {t('loginError.title')}
         </Typography>
         <Typography variant="body2" id="message" mb={8}>
-          {t('loginError.message')}
+          {t(getErrorMessage(error))}
         </Typography>
-        <Button id="login-button" variant="contained" onClick={goToLogin}>
+        <Button
+          id="login-button"
+          variant="contained"
+          onClick={goToLogin}
+          disabled={stateData.loading}
+          startIcon={stateData.loading ? <CircularProgress size={20} color="inherit" /> : undefined}
+        >
           {t('button.go-to-login', { ns: 'common' })}
         </Button>
       </Box>

--- a/packages/pn-personafisica-login/src/pages/oneIdentityLoginError/OneIdentityLoginError.tsx
+++ b/packages/pn-personafisica-login/src/pages/oneIdentityLoginError/OneIdentityLoginError.tsx
@@ -5,16 +5,12 @@ import { Box, Button, Dialog, Typography } from '@mui/material';
 import { IllusError } from '@pagopa/mui-italia';
 
 import { ROUTE_ONE_IDENTITY_LOGIN } from '../../navigation/routes.const';
-import { storageOneIdentityNonce, storageOneIdentityState } from '../../utility/storage';
 
 const OneIdentityLoginError: React.FC = () => {
   const { t } = useTranslation(['login', 'common']);
   const navigate = useNavigate();
 
   const goToLogin = () => navigate(ROUTE_ONE_IDENTITY_LOGIN);
-
-  storageOneIdentityState.delete();
-  storageOneIdentityNonce.delete();
 
   return (
     <Dialog fullScreen={true} open={true} aria-labelledby="dialog-per-messaggi-di-errore">

--- a/packages/pn-personafisica-login/src/pages/oneIdentityLoginError/OneIdentityLoginError.tsx
+++ b/packages/pn-personafisica-login/src/pages/oneIdentityLoginError/OneIdentityLoginError.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { Box, Button, CircularProgress, Dialog, Typography } from '@mui/material';
-import { sanitizeString } from '@pagopa-pn/pn-commons';
+import { AppRouteParams, sanitizeString } from '@pagopa-pn/pn-commons';
 import { IllusError } from '@pagopa/mui-italia';
 
 import { OneIdentityApi } from '../../api/OneIdentity/OneIdentity.api';
@@ -49,14 +49,15 @@ const OneIdentityLoginError: React.FC = () => {
     const params = new URLSearchParams();
 
     if (aar) {
-      params.set('aar', sanitizeString(aar));
+      params.set(AppRouteParams.AAR, sanitizeString(aar));
     } else if (retrievalId) {
-      params.set('retrievalId', sanitizeString(retrievalId));
+      params.set(AppRouteParams.RETRIEVAL_ID, sanitizeString(retrievalId));
     }
 
-    const query = params.size > 0 ? `?${params}` : '';
-
-    navigate(`${ROUTE_ONE_IDENTITY_LOGIN}${query}`);
+    navigate({
+      pathname: ROUTE_ONE_IDENTITY_LOGIN,
+      search: params.toString(),
+    });
   };
 
   const trackMixpanelErrorEvent = (idp: string) => {

--- a/packages/pn-personafisica-login/src/pages/oneIdentityLoginError/__test__/OneIdentityLoginError.test.tsx
+++ b/packages/pn-personafisica-login/src/pages/oneIdentityLoginError/__test__/OneIdentityLoginError.test.tsx
@@ -1,24 +1,142 @@
-import { getById, waitFor } from '@pagopa-pn/pn-commons/src/test-utils';
+import { vi } from 'vitest';
 
-import { fireEvent, render } from '../../../__test__/test-utils';
+import { getById } from '@pagopa-pn/pn-commons/src/test-utils';
+import { waitFor } from '@testing-library/react';
+
+import { fireEvent, render, screen } from '../../../__test__/test-utils';
+import { OneIdentityApi } from '../../../api/OneIdentity/OneIdentity.api';
 import { ROUTE_ONE_IDENTITY_LOGIN } from '../../../navigation/routes.const';
 import OneIdentityLoginError from '../OneIdentityLoginError';
 
+vi.mock('../../../api/OneIdentity/OneIdentity.api', () => ({
+  OneIdentityApi: {
+    getOidcStateData: vi.fn(),
+  },
+}));
+
 describe('OneIdentityLoginError component', () => {
-  it('should render component and navigate to login page on button click', async () => {
-    const { router } = render(<OneIdentityLoginError />);
+  const mockState = 'mock-state-123';
+  const mockIdp = 'mock-idp';
 
-    const errorDialog = getById(document.body, 'oneIdentityErrorDialog');
-    expect(errorDialog).toHaveTextContent('loginError.title');
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(OneIdentityApi.getOidcStateData).mockResolvedValue({
+      nonce: 'mock-nonce',
+      idp: mockIdp,
+    });
+  });
 
-    const message = getById(errorDialog, 'message');
-    expect(message).toHaveTextContent('loginError.message');
+  describe('rendering', () => {
+    it('renders the error dialog with title and default message', () => {
+      render(<OneIdentityLoginError />);
+      const errorDialog = getById(document.body, 'oneIdentityErrorDialog');
+      expect(errorDialog).toHaveTextContent('loginError.title');
+      expect(getById(errorDialog, 'message')).toHaveTextContent('loginError.message');
+    });
 
-    const buttonRedirect = getById(document.body, 'login-button');
-    fireEvent.click(buttonRedirect);
+    it.each([
+      ['invalid_scope', 'loginError.oneIdentity.invalid_scope'],
+      ['unsupported_response_type', 'loginError.oneIdentity.unsupported_response_type'],
+      ['server_error', 'loginError.oneIdentity.server_error'],
+      ['invalid_request', 'loginError.oneIdentity.invalid_request'],
+      ['unknown_error', 'loginError.message'],
+    ])('shows correct message for error=%s', (error, expectedKey) => {
+      render(<OneIdentityLoginError />, { route: `/?error=${error}` });
+      expect(
+        getById(getById(document.body, 'oneIdentityErrorDialog'), 'message')
+      ).toHaveTextContent(expectedKey);
+    });
+  });
 
-    await waitFor(() => {
-      expect(router.state.location.pathname).toBe(ROUTE_ONE_IDENTITY_LOGIN);
+  describe('loading state', () => {
+    it('button is enabled immediately when no state param', () => {
+      render(<OneIdentityLoginError />);
+      expect(getById(document.body, 'login-button')).not.toBeDisabled();
+      expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    });
+
+    it('button is disabled with spinner while API is pending', () => {
+      vi.mocked(OneIdentityApi.getOidcStateData).mockReturnValue(new Promise(() => {}));
+      render(<OneIdentityLoginError />, { route: `/?state=${mockState}` });
+      expect(getById(document.body, 'login-button')).toBeDisabled();
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    });
+
+    it('button is enabled without spinner after API resolves', async () => {
+      render(<OneIdentityLoginError />, { route: `/?state=${mockState}` });
+      await waitFor(() => expect(getById(document.body, 'login-button')).not.toBeDisabled());
+      expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    });
+
+    it('button is enabled without spinner after API rejects', async () => {
+      vi.mocked(OneIdentityApi.getOidcStateData).mockRejectedValue(new Error('API error'));
+      render(<OneIdentityLoginError />, { route: `/?state=${mockState}` });
+      await waitFor(() => expect(getById(document.body, 'login-button')).not.toBeDisabled());
+      expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('API integration', () => {
+    it('calls getOidcStateData with state param', async () => {
+      render(<OneIdentityLoginError />, { route: `/?state=${mockState}` });
+      await waitFor(() => expect(OneIdentityApi.getOidcStateData).toHaveBeenCalledWith(mockState));
+    });
+
+    it('does not call getOidcStateData when no state param', () => {
+      render(<OneIdentityLoginError />);
+      expect(OneIdentityApi.getOidcStateData).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('navigation on button click', () => {
+    it('navigates to login without params when no state param', async () => {
+      const { router } = render(<OneIdentityLoginError />);
+      fireEvent.click(getById(document.body, 'login-button'));
+      await waitFor(() => expect(router.state.location.pathname).toBe(ROUTE_ONE_IDENTITY_LOGIN));
+      expect(router.state.location.search).toBe('');
+    });
+
+    it('navigates to login without params when API call fails', async () => {
+      vi.mocked(OneIdentityApi.getOidcStateData).mockRejectedValue(new Error('API error'));
+      const { router } = render(<OneIdentityLoginError />, { route: `/?state=${mockState}` });
+      await waitFor(() => expect(getById(document.body, 'login-button')).not.toBeDisabled());
+      fireEvent.click(getById(document.body, 'login-button'));
+      await waitFor(() => expect(router.state.location.pathname).toBe(ROUTE_ONE_IDENTITY_LOGIN));
+      expect(router.state.location.search).toBe('');
+    });
+
+    it('navigates to login without params when API returns no rapid access', async () => {
+      const { router } = render(<OneIdentityLoginError />, { route: `/?state=${mockState}` });
+      await waitFor(() => expect(getById(document.body, 'login-button')).not.toBeDisabled());
+      fireEvent.click(getById(document.body, 'login-button'));
+      await waitFor(() => expect(router.state.location.pathname).toBe(ROUTE_ONE_IDENTITY_LOGIN));
+      expect(router.state.location.search).toBe('');
+    });
+
+    it('navigates to login with aar param', async () => {
+      vi.mocked(OneIdentityApi.getOidcStateData).mockResolvedValue({
+        nonce: 'mock-nonce',
+        idp: mockIdp,
+        aar: 'aar-token',
+      });
+      const { router } = render(<OneIdentityLoginError />, { route: `/?state=${mockState}` });
+      await waitFor(() => expect(getById(document.body, 'login-button')).not.toBeDisabled());
+      fireEvent.click(getById(document.body, 'login-button'));
+      await waitFor(() => expect(router.state.location.pathname).toBe(ROUTE_ONE_IDENTITY_LOGIN));
+      expect(router.state.location.search).toBe('?aar=aar-token');
+    });
+
+    it('navigates to login with retrievalId param', async () => {
+      vi.mocked(OneIdentityApi.getOidcStateData).mockResolvedValue({
+        nonce: 'mock-nonce',
+        idp: mockIdp,
+        retrievalId: 'retrieval-id',
+      });
+      const { router } = render(<OneIdentityLoginError />, { route: `/?state=${mockState}` });
+      await waitFor(() => expect(getById(document.body, 'login-button')).not.toBeDisabled());
+      fireEvent.click(getById(document.body, 'login-button'));
+      await waitFor(() => expect(router.state.location.pathname).toBe(ROUTE_ONE_IDENTITY_LOGIN));
+      expect(router.state.location.search).toBe('?retrievalId=retrieval-id');
     });
   });
 });

--- a/packages/pn-personafisica-login/src/pages/oneIdentityLoginError/__test__/OneIdentityLoginError.test.tsx
+++ b/packages/pn-personafisica-login/src/pages/oneIdentityLoginError/__test__/OneIdentityLoginError.test.tsx
@@ -34,18 +34,19 @@ describe('OneIdentityLoginError component', () => {
       expect(getById(errorDialog, 'message')).toHaveTextContent('loginError.message');
     });
 
-    it.each([
-      ['invalid_scope', 'loginError.oneIdentity.invalid_scope'],
-      ['unsupported_response_type', 'loginError.oneIdentity.unsupported_response_type'],
-      ['server_error', 'loginError.oneIdentity.server_error'],
-      ['invalid_request', 'loginError.oneIdentity.invalid_request'],
-      ['unknown_error', 'loginError.message'],
-    ])('shows correct message for error=%s', (error, expectedKey) => {
-      render(<OneIdentityLoginError />, { route: `/?error=${error}` });
-      expect(
-        getById(getById(document.body, 'oneIdentityErrorDialog'), 'message')
-      ).toHaveTextContent(expectedKey);
-    });
+    // TODO - Restore this once the copy is available
+    // it.each([
+    //   ['invalid_scope', 'loginError.oneIdentity.invalid_scope'],
+    //   ['unsupported_response_type', 'loginError.oneIdentity.unsupported_response_type'],
+    //   ['server_error', 'loginError.oneIdentity.server_error'],
+    //   ['invalid_request', 'loginError.oneIdentity.invalid_request'],
+    //   ['unknown_error', 'loginError.message'],
+    // ])('shows correct message for error=%s', (error, expectedKey) => {
+    //   render(<OneIdentityLoginError />, { route: `/?error=${error}` });
+    //   expect(
+    //     getById(getById(document.body, 'oneIdentityErrorDialog'), 'message')
+    //   ).toHaveTextContent(expectedKey);
+    // });
   });
 
   describe('loading state', () => {

--- a/packages/pn-personafisica-login/src/pages/oneIdentityLogout/OneIdentityLogout.tsx
+++ b/packages/pn-personafisica-login/src/pages/oneIdentityLogout/OneIdentityLogout.tsx
@@ -2,21 +2,12 @@ import { useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { ROUTE_ONE_IDENTITY_LOGIN } from '../../navigation/routes.const';
-import {
-  storageOneIdentityNonce,
-  storageOneIdentityState,
-  storageRapidAccessOps,
-} from '../../utility/storage';
 
 const OneIdentityLogout: React.FC = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
 
   useEffect(() => {
-    storageRapidAccessOps.delete();
-    storageOneIdentityState.delete();
-    storageOneIdentityNonce.delete();
-
     const queryString = searchParams.toString();
 
     const route = queryString

--- a/packages/pn-personafisica-login/src/pages/oneIdentityLogout/__test__/OneIdentityLogout.test.tsx
+++ b/packages/pn-personafisica-login/src/pages/oneIdentityLogout/__test__/OneIdentityLogout.test.tsx
@@ -1,43 +1,22 @@
-import { AppRouteParams } from '@pagopa-pn/pn-commons';
-
 import { render } from '../../../__test__/test-utils';
 import {
   ROUTE_ONE_IDENTITY_LOGIN,
   ROUTE_ONE_IDENTITY_LOGOUT,
 } from '../../../navigation/routes.const';
-import {
-  storageOneIdentityNonce,
-  storageOneIdentityState,
-  storageRapidAccessOps,
-} from '../../../utility/storage';
 import OneIdentityLogout from '../OneIdentityLogout';
 
 describe('One Identity Logout Page', () => {
   it('should handle one identity logout successfully', () => {
-    storageRapidAccessOps.write([AppRouteParams.AAR, 'aar-test']);
-    storageOneIdentityNonce.write('123');
-    storageOneIdentityState.write('123');
-
     const { router } = render(<OneIdentityLogout />);
-    expect(storageRapidAccessOps.read()).toBeUndefined();
-    expect(storageOneIdentityNonce.read()).toBeUndefined();
-    expect(storageOneIdentityState.read()).toBeUndefined();
 
     expect(router.state.location.pathname).toBe(ROUTE_ONE_IDENTITY_LOGIN);
     expect(router.state.historyAction).toBe('REPLACE');
   });
 
   it('should handle one identity logout with query params', () => {
-    storageRapidAccessOps.write([AppRouteParams.AAR, 'aar-test']);
-    storageOneIdentityNonce.write('123');
-    storageOneIdentityState.write('123');
-
     const { router } = render(<OneIdentityLogout />, {
       route: ROUTE_ONE_IDENTITY_LOGOUT + '?aar=123456',
     });
-    expect(storageRapidAccessOps.read()).toBeUndefined();
-    expect(storageOneIdentityNonce.read()).toBeUndefined();
-    expect(storageOneIdentityState.read()).toBeUndefined();
 
     expect(router.state.location.pathname).toBe(ROUTE_ONE_IDENTITY_LOGIN);
     expect(router.state.location.search).toBe('?aar=123456');

--- a/packages/pn-personafisica-login/src/utility/__test__/storage.test.tsx
+++ b/packages/pn-personafisica-login/src/utility/__test__/storage.test.tsx
@@ -1,10 +1,6 @@
 import { AppRouteParams } from '@pagopa-pn/pn-commons';
 
-import {
-  storageOneIdentityNonce,
-  storageOneIdentityState,
-  storageRapidAccessOps,
-} from '../storage';
+import { storageRapidAccessOps } from '../storage';
 
 describe('storage utility test', () => {
   it('storage Aar', () => {
@@ -52,23 +48,5 @@ describe('storage utility test', () => {
     expect(sessionStorage.getItem(AppRouteParams.RETRIEVAL_ID)).toBeNull();
     expect(storageRapidAccessOps.read()).toEqual([AppRouteParams.RETRIEVAL_ID, 'local-retrieval']);
     storageRapidAccessOps.delete();
-  });
-
-  it('storageOneIdentityState test', () => {
-    const state = '123456789';
-    storageOneIdentityState.write(state);
-    expect(sessionStorage.getItem('state')).toBe(state);
-    expect(storageOneIdentityState.read()).toEqual(state);
-    storageOneIdentityState.delete();
-    expect(sessionStorage.getItem('state')).toBeNull();
-  });
-
-  it('storageOneIdentityNonce tests', () => {
-    const nonce = '123456789';
-    storageOneIdentityNonce.write(nonce);
-    expect(sessionStorage.getItem('nonce')).toBe(nonce);
-    expect(storageOneIdentityNonce.read()).toEqual(nonce);
-    storageOneIdentityNonce.delete();
-    expect(sessionStorage.getItem('nonce')).toBeNull();
   });
 });

--- a/packages/pn-personafisica-login/src/utility/storage.ts
+++ b/packages/pn-personafisica-login/src/utility/storage.ts
@@ -36,7 +36,3 @@ export const storageRapidAccessOps = {
     storageRetrievalIdOps(true).delete();
   },
 };
-
-export const storageOneIdentityState = storageOpsBuilder<string>('state', 'string', false);
-
-export const storageOneIdentityNonce = storageOpsBuilder<string>('nonce', 'string', false);

--- a/packages/pn-personafisica-login/src/utility/utils.tsx
+++ b/packages/pn-personafisica-login/src/utility/utils.tsx
@@ -1,5 +1,3 @@
-import { v4 as uuidv4 } from 'uuid';
-
 export const shuffleList = <T,>(list: Array<T>) => {
   // eslint-disable-next-line functional/no-let
   for (let i = list.length - 1; i > 0; i--) {
@@ -9,8 +7,6 @@ export const shuffleList = <T,>(list: Array<T>) => {
   }
   return list;
 };
-
-export const generateRandomUniqueString = () => uuidv4().replace(/-/g, '').slice(0, 20);
 
 export const isIOSMobile = (): boolean =>
   /iPhone|iPod|iPad/.test(navigator.userAgent) ||

--- a/yarn.lock
+++ b/yarn.lock
@@ -8562,11 +8562,6 @@ uuid@^11.1.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.0.tgz#9549028be1753bb934fc96e2bca09bb4105ae912"
   integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
 
-uuid@^13.0.0:
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-13.0.0.tgz#263dc341b19b4d755eb8fe36b78d95a6b65707e8"
-  integrity sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==
-
 v8-compile-cache@^2.0.3:
   version "2.3.0"
   resolved "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz"


### PR DESCRIPTION
## How to test

URL to test:

- https://cittadini.dev.notifichedigitali.it/auth/callback?error=invalid_request&error_description=Authorization+error&state=0b0e1672-ac42-49a2-8ad7-c570f76f08cb
- https://cittadini.dev.notifichedigitali.it/auth/callback?error=invalid_scope&error_description=Scope+not+supported&state=0b0e1672-ac42-49a2-8ad7-c570f76f08cb
- https://cittadini.dev.notifichedigitali.it/auth/callback?error=unsupported_response_type&error_description=Unsopported+response+type&state=0b0e1672-ac42-49a2-8ad7-c570f76f08cb
- https://cittadini.dev.notifichedigitali.it/auth/callback?error=server_error&error_description=Server+error&state=0b0e1672-ac42-49a2-8ad7-c570f76f08cb
- https://cittadini.dev.notifichedigitali.it/auth/callback?error=server_error&error_description=Server+error