### PR TITLE
fix(PN-19702): update oidc token exchange path and remove redirect_uri parameter

### DIFF
--- a/packages/pn-personafisica-webapp/src/api/auth/Auth.api.ts
+++ b/packages/pn-personafisica-webapp/src/api/auth/Auth.api.ts
@@ -29,14 +29,12 @@ export const AuthApi = {
     code,
     state,
     nonce,
-    redirectUri,
     rapidAccess,
   }: OneIdentityCodeExchangeRequest): Promise<User> => {
     const body: OneIdentityExchangeCodeBody = {
       code,
       state,
       nonce,
-      redirect_uri: redirectUri,
     };
     if (rapidAccess) {
       const [param, value] = rapidAccess;

--- a/packages/pn-personafisica-webapp/src/api/auth/__test__/Auth.api.test.ts
+++ b/packages/pn-personafisica-webapp/src/api/auth/__test__/Auth.api.test.ts
@@ -49,13 +49,10 @@ describe('Auth api tests', () => {
     const code = 'mock-code';
     const state = 'mock-state';
     const nonce = 'mock-nonce';
-    const redirectUri = 'mock-redirect-uri';
 
     it('exchange one identity code successfully', async () => {
-      mock
-        .onPost(ONE_IDENTITY_TOKEN_EXCHANGE(), { code, state, nonce, redirect_uri: redirectUri })
-        .reply(200, userResponse);
-      const res = await AuthApi.exchangeOneIdentityCode({ code, state, nonce, redirectUri });
+      mock.onPost(ONE_IDENTITY_TOKEN_EXCHANGE(), { code, state, nonce }).reply(200, userResponse);
+      const res = await AuthApi.exchangeOneIdentityCode({ code, state, nonce });
       expect(res).toStrictEqual(userResponse);
     });
 
@@ -66,7 +63,6 @@ describe('Auth api tests', () => {
           code,
           state,
           nonce,
-          redirect_uri: redirectUri,
           source: {
             type: 'QR',
             id: 'mocked-qr-code',
@@ -77,7 +73,6 @@ describe('Auth api tests', () => {
         code,
         state,
         nonce,
-        redirectUri,
         rapidAccess,
       });
       expect(res).toStrictEqual(userResponseWithRetrievalId);

--- a/packages/pn-personafisica-webapp/src/api/auth/__test__/auth.routes.test.ts
+++ b/packages/pn-personafisica-webapp/src/api/auth/__test__/auth.routes.test.ts
@@ -8,7 +8,7 @@ describe('Authentication routes', () => {
 
   it('should compile ONE_IDENTITY_TOKEN_EXCHANGE', () => {
     const route = ONE_IDENTITY_TOKEN_EXCHANGE();
-    expect(route).toEqual('/token-exchange-oidc');
+    expect(route).toEqual('/oidc-token');
   });
 
   it('should compile AUTH_LOGOUT', () => {

--- a/packages/pn-personafisica-webapp/src/api/auth/auth.routes.ts
+++ b/packages/pn-personafisica-webapp/src/api/auth/auth.routes.ts
@@ -2,7 +2,7 @@ import { compileRoute } from '@pagopa-pn/pn-commons';
 
 // Segments
 const API_AUTH_TOKEN_EXCHANGE = 'token-exchange';
-const API_AUTH_ONE_IDENTITY_TOKEN_EXCHANGE = 'token-exchange-oidc';
+const API_AUTH_ONE_IDENTITY_TOKEN_EXCHANGE = 'oidc-token';
 const API_AUTH_LOGOUT = 'logout';
 
 // APIs

--- a/packages/pn-personafisica-webapp/src/models/User.ts
+++ b/packages/pn-personafisica-webapp/src/models/User.ts
@@ -38,7 +38,6 @@ export interface OneIdentityExchangeCodeBody extends BodySourceRequest {
   code: string;
   state: string;
   nonce: string;
-  redirect_uri: string;
 }
 
 export interface TokenExchangeRequest {
@@ -50,7 +49,6 @@ export interface OneIdentityCodeExchangeRequest {
   code: string;
   state: string;
   nonce: string;
-  redirectUri: string;
   rapidAccess?: [AppRouteParams, string];
 }
 

--- a/packages/pn-personafisica-webapp/src/navigation/SessionGuard.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/SessionGuard.tsx
@@ -59,7 +59,6 @@ const SessionGuard = () => {
   const code = hashParams.get('code');
   const state = hashParams.get('state');
   const nonce = hashParams.get('nonce');
-  const redirectUri = hashParams.get('redirect_uri');
 
   const handleTokenExchangeError = (error: any) => {
     const adaptedError = adaptedTokenExchangeError(error);
@@ -136,12 +135,11 @@ const SessionGuard = () => {
   useEffect(() => {
     if (spidToken) {
       void performExchangeToken({ spidToken, rapidAccess });
-    } else if (code && state && nonce && redirectUri) {
+    } else if (code && state && nonce) {
       void performOneIdentityTokenExchange({
         code,
         state,
         nonce,
-        redirectUri: decodeURIComponent(redirectUri),
         rapidAccess,
       });
     } else if (sessionToken) {

--- a/packages/pn-personafisica-webapp/src/navigation/__test__/SessionGuard.test.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/__test__/SessionGuard.test.tsx
@@ -202,7 +202,7 @@ describe('SessionGuard Component', async () => {
     mock.onPost(ONE_IDENTITY_TOKEN_EXCHANGE()).reply(200, userResponse);
     await act(async () => {
       render(<Guard />, {
-        route: '/#code=valid_code&state=some_state&nonce=some_nonce&redirect_uri=some_uri',
+        route: '/#code=valid_code&state=some_state&nonce=some_nonce',
       });
     });
     expect(mock.history.post).toHaveLength(1);
@@ -211,7 +211,6 @@ describe('SessionGuard Component', async () => {
       code: 'valid_code',
       state: 'some_state',
       nonce: 'some_nonce',
-      redirect_uri: 'some_uri',
     });
   });
 
@@ -220,11 +219,10 @@ describe('SessionGuard Component', async () => {
       code: '403_code',
       state: 'some_state',
       nonce: 'some_nonce',
-      redirect_uri: 'some_uri',
     });
     await act(async () => {
       render(<Guard />, {
-        route: '/#code=403_code&state=some_state&nonce=some_nonce&redirect_uri=some_uri',
+        route: '/#code=403_code&state=some_state&nonce=some_nonce',
       });
     });
     expect(mock.history.post).toHaveLength(1);
@@ -233,7 +231,6 @@ describe('SessionGuard Component', async () => {
       code: '403_code',
       state: 'some_state',
       nonce: 'some_nonce',
-      redirect_uri: 'some_uri',
     });
     const logoutComponent = screen.queryByTestId('session-modal');
     expect(logoutComponent).toBeTruthy();
@@ -246,11 +243,10 @@ describe('SessionGuard Component', async () => {
       code: '451_code',
       state: 'some_state',
       nonce: 'some_nonce',
-      redirect_uri: 'some_uri',
     });
     await act(async () => {
       result = render(<Guard />, {
-        route: '/#code=451_code&state=some_state&nonce=some_nonce&redirect_uri=some_uri',
+        route: '/#code=451_code&state=some_state&nonce=some_nonce',
       });
     });
     expect(mock.history.post).toHaveLength(1);
@@ -259,7 +255,6 @@ describe('SessionGuard Component', async () => {
       code: '451_code',
       state: 'some_state',
       nonce: 'some_nonce',
-      redirect_uri: 'some_uri',
     });
     await waitFor(() => {
       expect(result.router.state.location.pathname).toBe(routes.NOT_ACCESSIBLE);
@@ -277,7 +272,7 @@ describe('SessionGuard Component', async () => {
 
     await act(async () => {
       result = render(<Guard />, {
-        route: '/#code=some_code&state=some_state&nonce=some_nonce&redirect_uri=some_uri',
+        route: '/#code=some_code&state=some_state&nonce=some_nonce',
       });
     });
 
@@ -287,7 +282,6 @@ describe('SessionGuard Component', async () => {
       code: 'some_code',
       state: 'some_state',
       nonce: 'some_nonce',
-      redirect_uri: 'some_uri',
     });
 
     await waitFor(() => {
@@ -310,8 +304,7 @@ describe('SessionGuard Component', async () => {
 
     await act(async () => {
       render(<Guard />, {
-        route:
-          '/?aar=mocked-qr-code#code=valid_code&state=some_state&nonce=some_nonce&redirect_uri=some_uri',
+        route: '/?aar=mocked-qr-code#code=valid_code&state=some_state&nonce=some_nonce',
       });
     });
 
@@ -321,7 +314,6 @@ describe('SessionGuard Component', async () => {
       code: 'valid_code',
       state: 'some_state',
       nonce: 'some_nonce',
-      redirect_uri: 'some_uri',
       source: {
         type: 'QR',
         id: 'mocked-qr-code',
@@ -337,7 +329,7 @@ describe('SessionGuard Component', async () => {
 
     await act(async () => {
       render(<Guard />, {
-        route: '/#code=valid_code&state=some_state&nonce=some_nonce&redirect_uri=some_uri',
+        route: '/#code=valid_code&state=some_state&nonce=some_nonce',
       });
     });
 

--- a/packages/pn-personafisica-webapp/src/redux/auth/__test__/reducers.test.ts
+++ b/packages/pn-personafisica-webapp/src/redux/auth/__test__/reducers.test.ts
@@ -81,7 +81,6 @@ describe('Auth redux state tests', () => {
         code: 'mocked-code',
         state: 'mocked-state',
         nonce: 'mocked-nonce',
-        redirectUri: 'www.test.it',
       })
     );
 


### PR DESCRIPTION
## Short description

Rename OIDC token exchange path and remove redirect_uri parameter

## List of changes proposed in this pull request
- Update OIDC token exchange path 
- Remove redirect_uri from params
- Fix tests