### PR TITLE
test(PN-19561): test for mixpanel events

### DIFF
--- a/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/Courtesy/__test__/mixpanel/CourtesyContactHandler.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/Courtesy/__test__/mixpanel/CourtesyContactHandler.mixpanel.test.tsx
@@ -1,0 +1,104 @@
+import { createRef } from 'react';
+import { MockInstance, vi } from 'vitest';
+
+import { act, fireEvent, render } from '../../../../../../__test__/test-utils';
+import { OnboardingAvailableFlows } from '../../../../../../models/Onboarding';
+import { PFEventsType } from '../../../../../../models/PFEventsType';
+import { ChannelType } from '../../../../../../models/contacts';
+import PFEventStrategyFactory from '../../../../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import CourtesyContactHandler from '../../CourtesyContactHandler';
+
+describe('CourtesyContactHandler - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+
+  const mockEmail = 'test@mock.pagopa.it';
+  const mockPhone = '+393331234567';
+  const basePayload = { onboarding_selected_flow: OnboardingAvailableFlows.COURTESY };
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    triggerEventSpy.mockRestore();
+  });
+
+  const createProps = (channelType: ChannelType.EMAIL | ChannelType.SMS = ChannelType.EMAIL) => ({
+    channelType,
+    mode: 'edit' as const,
+    contactValue: '',
+    contactState: {
+      value: channelType === ChannelType.EMAIL ? mockEmail : mockPhone,
+      alreadySet: true,
+    },
+    onContactValueChange: vi.fn(),
+    onInputBlur: vi.fn(),
+    onVerifyContact: vi.fn(),
+    onSubmitEdit: vi.fn(),
+    onExpand: vi.fn(),
+    onCollapse: vi.fn(),
+    contactRef: createRef<{ toggleEdit: () => void; resetForm: () => Promise<void> }>(),
+  });
+
+  it('fires SEND_ONBOARDING_EMAIL_EDITING when the edit button is clicked for email', async () => {
+    const { getByRole } = render(<CourtesyContactHandler {...createProps(ChannelType.EMAIL)} />);
+
+    await act(async () => {
+      fireEvent.click(getByRole('button', { name: 'button.modifica' }));
+    });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_EMAIL_EDITING,
+      basePayload
+    );
+  });
+
+  it('fires SEND_ONBOARDING_SMS_EDITING when the edit button is clicked for SMS', async () => {
+    const { getByRole } = render(<CourtesyContactHandler {...createProps(ChannelType.SMS)} />);
+
+    await act(async () => {
+      fireEvent.click(getByRole('button', { name: 'button.modifica' }));
+    });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_SMS_EDITING,
+      basePayload
+    );
+  });
+
+  it('fires SEND_ONBOARDING_EMAIL_CONFIRMED when edit is confirmed for email', async () => {
+    const { getByRole } = render(<CourtesyContactHandler {...createProps(ChannelType.EMAIL)} />);
+
+    // Enter edit mode first
+    await act(async () => {
+      fireEvent.click(getByRole('button', { name: 'button.modifica' }));
+    });
+
+    // Confirm (same value → no API call)
+    await act(async () => {
+      fireEvent.click(getByRole('button', { name: 'button.conferma' }));
+    });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_EMAIL_CONFIRMED,
+      basePayload
+    );
+  });
+
+  it('fires SEND_ONBOARDING_SMS_CONFIRMED when edit is confirmed for SMS', async () => {
+    const { getByRole } = render(<CourtesyContactHandler {...createProps(ChannelType.SMS)} />);
+
+    await act(async () => {
+      fireEvent.click(getByRole('button', { name: 'button.modifica' }));
+    });
+
+    await act(async () => {
+      fireEvent.click(getByRole('button', { name: 'button.conferma' }));
+    });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_SMS_CONFIRMED,
+      basePayload
+    );
+  });
+});

--- a/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/Courtesy/__test__/mixpanel/EmailSmsStep.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/Courtesy/__test__/mixpanel/EmailSmsStep.mixpanel.test.tsx
@@ -1,0 +1,268 @@
+import MockAdapter from 'axios-mock-adapter';
+import { MockInstance, vi } from 'vitest';
+
+import { EventAction } from '@pagopa-pn/pn-commons';
+
+import { act, fireEvent, render, waitFor } from '../../../../../../__test__/test-utils';
+import { apiClient } from '../../../../../../api/apiClients';
+import { OnboardingAvailableFlows } from '../../../../../../models/Onboarding';
+import { PFEventsType } from '../../../../../../models/PFEventsType';
+import PFEventStrategyFactory from '../../../../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import EmailSmsStep from '../../EmailSmsStep';
+
+describe('EmailSmsStep - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+  let mock: MockAdapter;
+
+  const mockEmail = 'test@mock.pagopa.it';
+  const mockPhone = '3331234567';
+  const basePayload = { onboarding_selected_flow: OnboardingAvailableFlows.COURTESY };
+
+  beforeAll(() => {
+    mock = new MockAdapter(apiClient);
+  });
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    mock.reset();
+    triggerEventSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  const createProps = (ioEnabled = false) => ({
+    ioEnabled,
+    email: { value: undefined as string | undefined, alreadySet: false },
+    sms: { value: undefined as string | undefined, alreadySet: false },
+    onContactAdded: vi.fn(),
+    registerContinueHandler: vi.fn(),
+  });
+
+  it('fires SEND_ONBOARDING_EMAIL_SMS_ACTIVATION on mount', () => {
+    render(<EmailSmsStep {...createProps()} />);
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_EMAIL_SMS_ACTIVATION,
+      {
+        ...basePayload,
+        event_type: EventAction.SCREEN_VIEW,
+        email_value: undefined,
+        sms_value: undefined,
+      }
+    );
+  });
+
+  it('fires SEND_ONBOARDING_SMS_SELECTED when the SMS section is expanded', () => {
+    const { getByRole } = render(<EmailSmsStep {...createProps(true)} />);
+
+    fireEvent.click(
+      getByRole('button', { name: 'onboarding.courtesy.sms.collapsed.button-label' })
+    );
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_SMS_SELECTED,
+      basePayload
+    );
+  });
+
+  it('fires SEND_ONBOARDING_SMS_ACTIVATION_CANCELED when the SMS section is collapsed', async () => {
+    const { getByRole } = render(<EmailSmsStep {...createProps(true)} />);
+
+    // First expand SMS
+    fireEvent.click(
+      getByRole('button', { name: 'onboarding.courtesy.sms.collapsed.button-label' })
+    );
+
+    // Then collapse it
+    await act(async () => {
+      fireEvent.click(
+        getByRole('button', { name: 'onboarding.courtesy.sms.insert.collapse-label' })
+      );
+    });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_SMS_ACTIVATION_CANCELED,
+      basePayload
+    );
+  });
+
+  it('fires SEND_ONBOARDING_EMAIL_VERIFICATION when verify is clicked with a valid email', async () => {
+    mock.onPost('/bff/v1/addresses/COURTESY/default/EMAIL').reply(200, { result: 'OK' });
+
+    const { getByLabelText, getByRole } = render(<EmailSmsStep {...createProps()} />);
+
+    await act(async () => {
+      fireEvent.change(
+        getByLabelText('onboarding.courtesy.email.insert.input-label'),
+        { target: { value: mockEmail } }
+      );
+    });
+
+    await act(async () => {
+      fireEvent.click(
+        getByRole('button', { name: 'onboarding.courtesy.email.insert.button-label' })
+      );
+    });
+
+    await waitFor(() => {
+      expect(mock.history.post).toHaveLength(1);
+    });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_EMAIL_VERIFICATION,
+      basePayload
+    );
+  });
+
+  it('fires SEND_ONBOARDING_EMAIL_ACTIVATED when the email is verified successfully', async () => {
+    mock.onPost('/bff/v1/addresses/COURTESY/default/EMAIL').reply(200, { result: 'OK' });
+
+    const props = createProps();
+    const { getByLabelText, getByRole } = render(<EmailSmsStep {...props} />);
+
+    await act(async () => {
+      fireEvent.change(
+        getByLabelText('onboarding.courtesy.email.insert.input-label'),
+        { target: { value: mockEmail } }
+      );
+    });
+
+    await act(async () => {
+      fireEvent.click(
+        getByRole('button', { name: 'onboarding.courtesy.email.insert.button-label' })
+      );
+    });
+
+    await waitFor(() => {
+      expect(props.onContactAdded).toHaveBeenCalledWith('email', mockEmail);
+    });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ONBOARDING_EMAIL_ACTIVATED, {
+      ...basePayload,
+      event_type: EventAction.CONFIRM,
+    });
+  });
+
+  it('fires SEND_ONBOARDING_EMAIL_OTP when the API requires code verification for email', async () => {
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/EMAIL')
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+
+    const { getByLabelText, getByRole } = render(<EmailSmsStep {...createProps()} />);
+
+    await act(async () => {
+      fireEvent.change(
+        getByLabelText('onboarding.courtesy.email.insert.input-label'),
+        { target: { value: mockEmail } }
+      );
+    });
+
+    await act(async () => {
+      fireEvent.click(
+        getByRole('button', { name: 'onboarding.courtesy.email.insert.button-label' })
+      );
+    });
+
+    await waitFor(() => {
+      expect(mock.history.post).toHaveLength(1);
+    });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ONBOARDING_EMAIL_OTP, {
+      ...basePayload,
+      event_type: EventAction.SCREEN_VIEW,
+    });
+  });
+
+  it('fires SEND_ONBOARDING_SMS_VERIFICATION when verify is clicked with a valid phone number', async () => {
+    mock.onPost('/bff/v1/addresses/COURTESY/default/SMS').reply(200, { result: 'OK' });
+
+    // SMS starts in insert mode when ioEnabled=false
+    const { getByLabelText, getByRole } = render(<EmailSmsStep {...createProps(false)} />);
+
+    await act(async () => {
+      fireEvent.change(
+        getByLabelText('onboarding.courtesy.sms.insert.input-label'),
+        { target: { value: mockPhone } }
+      );
+    });
+
+    await act(async () => {
+      fireEvent.click(
+        getByRole('button', { name: 'onboarding.courtesy.sms.insert.button-label' })
+      );
+    });
+
+    await waitFor(() => {
+      expect(mock.history.post).toHaveLength(1);
+    });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_SMS_VERIFICATION,
+      basePayload
+    );
+  });
+
+  it('fires SEND_ONBOARDING_SMS_OTP when the API requires code verification for SMS', async () => {
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/SMS')
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+
+    const { getByLabelText, getByRole } = render(<EmailSmsStep {...createProps(false)} />);
+
+    await act(async () => {
+      fireEvent.change(
+        getByLabelText('onboarding.courtesy.sms.insert.input-label'),
+        { target: { value: mockPhone } }
+      );
+    });
+
+    await act(async () => {
+      fireEvent.click(
+        getByRole('button', { name: 'onboarding.courtesy.sms.insert.button-label' })
+      );
+    });
+
+    await waitFor(() => {
+      expect(mock.history.post).toHaveLength(1);
+    });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ONBOARDING_SMS_OTP, {
+      ...basePayload,
+      event_type: EventAction.SCREEN_VIEW,
+    });
+  });
+
+  it('fires SEND_ONBOARDING_SMS_ACTIVATED when the phone number is verified successfully', async () => {
+    mock.onPost('/bff/v1/addresses/COURTESY/default/SMS').reply(200, { result: 'OK' });
+
+    const props = createProps(false);
+    const { getByLabelText, getByRole } = render(<EmailSmsStep {...props} />);
+
+    await act(async () => {
+      fireEvent.change(
+        getByLabelText('onboarding.courtesy.sms.insert.input-label'),
+        { target: { value: mockPhone } }
+      );
+    });
+
+    await act(async () => {
+      fireEvent.click(
+        getByRole('button', { name: 'onboarding.courtesy.sms.insert.button-label' })
+      );
+    });
+
+    await waitFor(() => {
+      expect(props.onContactAdded).toHaveBeenCalled();
+    });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ONBOARDING_SMS_ACTIVATED, {
+      ...basePayload,
+      event_type: EventAction.CONFIRM,
+    });
+  });
+});

--- a/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/Courtesy/__test__/mixpanel/EmailSmsStep.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/Courtesy/__test__/mixpanel/EmailSmsStep.mixpanel.test.tsx
@@ -1,9 +1,10 @@
+import userEvent from '@testing-library/user-event';
 import MockAdapter from 'axios-mock-adapter';
 import { MockInstance, vi } from 'vitest';
 
 import { EventAction } from '@pagopa-pn/pn-commons';
 
-import { act, fireEvent, render, waitFor } from '../../../../../../__test__/test-utils';
+import { act, fireEvent, render, waitFor, within } from '../../../../../../__test__/test-utils';
 import { apiClient } from '../../../../../../api/apiClients';
 import { OnboardingAvailableFlows } from '../../../../../../models/Onboarding';
 import { PFEventsType } from '../../../../../../models/PFEventsType';
@@ -235,6 +236,42 @@ describe('EmailSmsStep - Mixpanel events', () => {
       ...basePayload,
       event_type: EventAction.SCREEN_VIEW,
     });
+  });
+
+  it('fires SEND_ONBOARDING_SMS_OTP_VERIFICATION when the SMS OTP code is confirmed', async () => {
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/SMS')
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+
+    const { getByLabelText, getByRole, getByTestId } = render(<EmailSmsStep {...createProps(false)} />);
+
+    await act(async () => {
+      fireEvent.change(
+        getByLabelText('onboarding.courtesy.sms.insert.input-label'),
+        { target: { value: mockPhone } }
+      );
+    });
+
+    await act(async () => {
+      fireEvent.click(
+        getByRole('button', { name: 'onboarding.courtesy.sms.insert.button-label' })
+      );
+    });
+
+    const dialog = await waitFor(() => getByTestId('codeDialog'));
+    const codeInput = within(dialog).getByRole('textbox');
+    codeInput.focus();
+    await userEvent.keyboard('01234');
+
+    mock.onPost('/bff/v1/addresses/COURTESY/default/SMS').reply(200, { result: 'OK' });
+
+    const dialogButtons = dialog.querySelectorAll('button');
+    await userEvent.click(dialogButtons[1]);
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_SMS_OTP_VERIFICATION,
+      basePayload
+    );
   });
 
   it('fires SEND_ONBOARDING_SMS_ACTIVATED when the phone number is verified successfully', async () => {

--- a/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/Courtesy/__test__/mixpanel/OnboardingCourtesyWizard.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/Courtesy/__test__/mixpanel/OnboardingCourtesyWizard.mixpanel.test.tsx
@@ -1,0 +1,170 @@
+import { MockInstance, vi } from 'vitest';
+
+import { EventAction } from '@pagopa-pn/pn-commons';
+
+import { fireEvent, render, waitFor } from '../../../../../../__test__/test-utils';
+import { OnboardingAvailableFlows, OnboardingScreen } from '../../../../../../models/Onboarding';
+import { PFEventsType } from '../../../../../../models/PFEventsType';
+import { AddressType, ChannelType, IOAllowedValues } from '../../../../../../models/contacts';
+import PFEventStrategyFactory from '../../../../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import OnboardingCourtesyWizard from '../../OnboardingCourtesyWizard';
+
+describe('OnboardingCourtesyWizard - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+
+  const basePayload = { onboarding_selected_flow: OnboardingAvailableFlows.COURTESY };
+
+  const disabledIoState = {
+    contactsState: {
+      digitalAddresses: [
+        {
+          addressType: AddressType.COURTESY,
+          senderId: 'default',
+          channelType: ChannelType.IOMSG,
+          value: IOAllowedValues.DISABLED,
+        },
+      ],
+    },
+  };
+
+  const enabledIoWithEmailState = {
+    contactsState: {
+      digitalAddresses: [
+        {
+          addressType: AddressType.COURTESY,
+          senderId: 'default',
+          channelType: ChannelType.IOMSG,
+          value: IOAllowedValues.ENABLED,
+        },
+        {
+          addressType: AddressType.COURTESY,
+          senderId: 'default',
+          channelType: ChannelType.EMAIL,
+          value: 'test@mock.pagopa.it',
+        },
+      ],
+    },
+  };
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    triggerEventSpy.mockRestore();
+  });
+
+  it('fires SEND_ONBOARDING_EXIT_SELECTED with IO screen when exit is clicked on the IO step', () => {
+    const { getByTestId } = render(<OnboardingCourtesyWizard />, {
+      preloadedState: { contactsState: { digitalAddresses: [] } },
+    });
+
+    fireEvent.click(getByTestId('exit-button'));
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ONBOARDING_EXIT_SELECTED, {
+      ...basePayload,
+      screen: OnboardingScreen.IO,
+    });
+  });
+
+  it('fires SEND_ONBOARDING_CONTINUE_SELECTED and SEND_ONBOARDING_IO_DOWNLOAD_DECLINED when "proceed without IO" is clicked', () => {
+    const { getByRole } = render(<OnboardingCourtesyWizard />, {
+      preloadedState: disabledIoState,
+    });
+
+    fireEvent.click(getByRole('button', { name: 'onboarding.courtesy.proceed-without-io' }));
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ONBOARDING_CONTINUE_SELECTED, {
+      ...basePayload,
+      screen: OnboardingScreen.IO,
+    });
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_IO_DOWNLOAD_DECLINED,
+      basePayload
+    );
+  });
+
+  it('fires SEND_ONBOARDING_CONTINUE_SELECTED and SEND_ONBOARDING_IO_CONFIRMED when IO is enabled and continue is clicked', () => {
+    const { getByRole } = render(<OnboardingCourtesyWizard />, {
+      preloadedState: {
+        contactsState: {
+          digitalAddresses: [
+            {
+              addressType: AddressType.COURTESY,
+              senderId: 'default',
+              channelType: ChannelType.IOMSG,
+              value: IOAllowedValues.ENABLED,
+            },
+          ],
+        },
+      },
+    });
+
+    fireEvent.click(getByRole('button', { name: 'button.continue' }));
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ONBOARDING_CONTINUE_SELECTED, {
+      ...basePayload,
+      screen: OnboardingScreen.IO,
+    });
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_IO_CONFIRMED,
+      basePayload
+    );
+  });
+
+  it('fires SEND_ONBOARDING_BACK_SELECTED when back is clicked on the email/sms step', () => {
+    const { getByRole, getByTestId } = render(<OnboardingCourtesyWizard />, {
+      preloadedState: disabledIoState,
+    });
+
+    fireEvent.click(getByRole('button', { name: 'onboarding.courtesy.proceed-without-io' }));
+
+    triggerEventSpy.mockClear();
+
+    fireEvent.click(getByTestId('prev-button'));
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ONBOARDING_BACK_SELECTED, {
+      ...basePayload,
+      screen: OnboardingScreen.EMAIL_SMS,
+    });
+  });
+
+  it('fires SEND_ONBOARDING_EXIT_SELECTED with EMAIL_SMS screen when exit is clicked on the email/sms step', () => {
+    const { getByRole, getByTestId } = render(<OnboardingCourtesyWizard />, {
+      preloadedState: disabledIoState,
+    });
+
+    fireEvent.click(getByRole('button', { name: 'onboarding.courtesy.proceed-without-io' }));
+
+    triggerEventSpy.mockClear();
+
+    fireEvent.click(getByTestId('exit-button'));
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ONBOARDING_EXIT_SELECTED, {
+      ...basePayload,
+      screen: OnboardingScreen.EMAIL_SMS,
+    });
+  });
+
+  it('fires SEND_ONBOARDING_UX_SUCCESS when the feedback step is reached', async () => {
+    const { getByRole, getByTestId } = render(<OnboardingCourtesyWizard />, {
+      preloadedState: enabledIoWithEmailState,
+    });
+
+    // IO step → continue (IO is enabled)
+    fireEvent.click(getByRole('button', { name: 'button.continue' }));
+
+    // Email/SMS step → confirm (email already set)
+    await waitFor(() => {
+      fireEvent.click(getByTestId('next-button'));
+    });
+
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ONBOARDING_UX_SUCCESS, {
+        ...basePayload,
+        event_type: EventAction.SCREEN_VIEW,
+      });
+    });
+  });
+});

--- a/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/__test__/mixpanel/DigitalDomicileWizard.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/__test__/mixpanel/DigitalDomicileWizard.mixpanel.test.tsx
@@ -1,0 +1,277 @@
+import MockAdapter from 'axios-mock-adapter';
+import { MockInstance, vi } from 'vitest';
+
+import { EventAction, SERCQ_SEND_VALUE } from '@pagopa-pn/pn-commons';
+
+import {
+  acceptTosSercqSendBodyMock,
+  sercqSendTosConsentMock,
+} from '../../../../../__mocks__/Consents.mock';
+import { act, fireEvent, render, waitFor } from '../../../../../__test__/test-utils';
+import { apiClient } from '../../../../../api/apiClients';
+import { OnboardingAvailableFlows, OnboardingScreen } from '../../../../../models/Onboarding';
+import { PFEventsType } from '../../../../../models/PFEventsType';
+import { AddressType, ChannelType } from '../../../../../models/contacts';
+import PFEventStrategyFactory from '../../../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import DigitalDomicileWizard from '../../DigitalDomicileWizard';
+
+describe('DigitalDomicileWizard - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+  let mock: MockAdapter;
+
+  const emptyContactsState = { contactsState: { digitalAddresses: [] } };
+
+  const basePayload = { onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE };
+
+  beforeAll(() => {
+    mock = new MockAdapter(apiClient);
+  });
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    mock.reset();
+    triggerEventSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  it('fires SEND_ONBOARDING_SERCQ_ACTIVATION on mount (choice step screen view)', () => {
+    render(<DigitalDomicileWizard />, { preloadedState: emptyContactsState });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ONBOARDING_SERCQ_ACTIVATION, {
+      ...basePayload,
+      event_type: EventAction.SCREEN_VIEW,
+    });
+  });
+
+  it('fires SEND_ONBOARDING_SERCQ_SEND_SELECTED when the SEND CTA is clicked', () => {
+    const { getByRole } = render(<DigitalDomicileWizard />, {
+      preloadedState: emptyContactsState,
+    });
+
+    fireEvent.click(getByRole('button', { name: 'onboarding.digital-domicile.choice.cta' }));
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_SERCQ_SEND_SELECTED,
+      basePayload
+    );
+  });
+
+  it('fires SEND_ONBOARDING_EMAIL_ACTIVATION on entering the email step in SEND mode', () => {
+    const mockEmail = 'test@mock.pagopa.it';
+
+    const { getByRole } = render(<DigitalDomicileWizard />, {
+      preloadedState: {
+        contactsState: {
+          digitalAddresses: [
+            {
+              addressType: AddressType.COURTESY,
+              senderId: 'default',
+              channelType: ChannelType.EMAIL,
+              value: mockEmail,
+            },
+          ],
+        },
+      },
+    });
+
+    fireEvent.click(getByRole('button', { name: 'onboarding.digital-domicile.choice.cta' }));
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ONBOARDING_EMAIL_ACTIVATION, {
+      ...basePayload,
+      event_type: EventAction.SCREEN_VIEW,
+      email_value: mockEmail,
+    });
+  });
+
+  it('fires SEND_ONBOARDING_PEC_EMAIL_ACTIVATION on entering the PEC step', () => {
+    const { getByRole } = render(<DigitalDomicileWizard />, {
+      preloadedState: emptyContactsState,
+    });
+
+    fireEvent.click(getByRole('button', { name: 'onboarding.digital-domicile.choice.pec.cta' }));
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_PEC_EMAIL_ACTIVATION,
+      {
+        ...basePayload,
+        event_type: EventAction.SCREEN_VIEW,
+        email_value: undefined,
+      }
+    );
+  });
+
+  it('fires SEND_ONBOARDING_CONTINUE_SELECTED when the next button is clicked on the PEC step', () => {
+    const { getByRole } = render(<DigitalDomicileWizard />, {
+      preloadedState: {
+        contactsState: {
+          digitalAddresses: [
+            {
+              addressType: AddressType.LEGAL,
+              senderId: 'default',
+              channelType: ChannelType.PEC,
+              pecValid: false,
+            },
+          ],
+        },
+      },
+    });
+
+    // Wizard starts at PEC step (step 1) because a PEC with pecValid:false is already present
+    fireEvent.click(getByRole('button', { name: 'button.continue' }));
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ONBOARDING_CONTINUE_SELECTED, {
+      ...basePayload,
+      screen: OnboardingScreen.PEC,
+    });
+  });
+
+  it('fires SEND_ONBOARDING_BACK_SELECTED when the back button is clicked on the PEC step', () => {
+    const { getByRole } = render(<DigitalDomicileWizard />, {
+      preloadedState: {
+        contactsState: {
+          digitalAddresses: [
+            {
+              addressType: AddressType.LEGAL,
+              senderId: 'default',
+              channelType: ChannelType.PEC,
+              pecValid: false,
+            },
+          ],
+        },
+      },
+    });
+
+    fireEvent.click(getByRole('button', { name: 'button.indietro' }));
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ONBOARDING_BACK_SELECTED, {
+      ...basePayload,
+      screen: OnboardingScreen.PEC,
+    });
+  });
+
+  it('fires SEND_ONBOARDING_EXIT_SELECTED when the exit button is clicked', () => {
+    const { getByTestId } = render(<DigitalDomicileWizard />, {
+      preloadedState: emptyContactsState,
+    });
+
+    fireEvent.click(getByTestId('exit-button'));
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ONBOARDING_EXIT_SELECTED, {
+      ...basePayload,
+      screen: OnboardingScreen.CHOICE,
+    });
+  });
+
+  it('fires SEND_ONBOARDING_IO_DOWNLOAD_DECLINED and SEND_ONBOARDING_FLOW_RECAP when skipping IO and reaching summary in SEND mode', async () => {
+    const mockEmail = 'test@mock.pagopa.it';
+
+    const { getByRole, findByText } = render(<DigitalDomicileWizard />, {
+      preloadedState: {
+        contactsState: {
+          digitalAddresses: [
+            {
+              addressType: AddressType.COURTESY,
+              senderId: 'default',
+              channelType: ChannelType.EMAIL,
+              value: mockEmail,
+            },
+          ],
+        },
+      },
+    });
+
+    // Enter SEND mode
+    await act(async () => {
+      fireEvent.click(getByRole('button', { name: 'onboarding.digital-domicile.choice.cta' }));
+    });
+
+    // Continue from email step
+    await act(async () => {
+      fireEvent.click(getByRole('button', { name: 'button.continue' }));
+    });
+
+    // Skip IO (continue without IO)
+    await act(async () => {
+      fireEvent.click(
+        getByRole('button', {
+          name: 'onboarding.digital-domicile.buttons.continue-without-io',
+        })
+      );
+    });
+
+    await findByText('onboarding.digital-domicile.summary.title');
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_IO_DOWNLOAD_DECLINED,
+      expect.objectContaining(basePayload)
+    );
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ONBOARDING_FLOW_RECAP, {
+      ...basePayload,
+      event_type: EventAction.SCREEN_VIEW,
+    });
+  });
+
+  it('fires SEND_ONBOARDING_UX_CONVERSION and SEND_ONBOARDING_UX_SUCCESS on completing the SEND flow', async () => {
+    const mockEmail = 'test@mock.pagopa.it';
+
+    mock.onGet(/\/bff\/v2\/tos-privacy.*/).reply(200, sercqSendTosConsentMock(false));
+    mock.onPut('/bff/v2/tos-privacy', acceptTosSercqSendBodyMock).reply(200);
+    mock.onPost('/bff/v1/addresses/LEGAL/default/SERCQ_SEND').reply(204, {
+      value: SERCQ_SEND_VALUE,
+    });
+
+    const { getByRole, findByText } = render(<DigitalDomicileWizard />, {
+      preloadedState: {
+        contactsState: {
+          digitalAddresses: [
+            {
+              addressType: AddressType.COURTESY,
+              senderId: 'default',
+              channelType: ChannelType.EMAIL,
+              value: mockEmail,
+            },
+          ],
+        },
+      },
+    });
+
+    await act(async () => {
+      fireEvent.click(getByRole('button', { name: 'onboarding.digital-domicile.choice.cta' }));
+    });
+
+    await act(async () => {
+      fireEvent.click(getByRole('button', { name: 'button.continue' }));
+    });
+
+    await act(async () => {
+      fireEvent.click(
+        getByRole('button', { name: 'onboarding.digital-domicile.buttons.continue-without-io' })
+      );
+    });
+
+    await act(async () => {
+      fireEvent.click(getByRole('button', { name: 'button.conferma' }));
+    });
+
+    await waitFor(() => {
+      expect(mock.history.post).toHaveLength(1);
+    });
+
+    await findByText('onboarding.digital-domicile.feedback.send.title');
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_UX_CONVERSION,
+      expect.objectContaining(basePayload)
+    );
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ONBOARDING_UX_SUCCESS, {
+      ...basePayload,
+      event_type: EventAction.SCREEN_VIEW,
+    });
+  });
+});

--- a/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/__test__/mixpanel/EmailStep.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/__test__/mixpanel/EmailStep.mixpanel.test.tsx
@@ -1,0 +1,192 @@
+import userEvent from '@testing-library/user-event';
+import MockAdapter from 'axios-mock-adapter';
+import { MockInstance, vi } from 'vitest';
+
+import { EventAction } from '@pagopa-pn/pn-commons';
+
+import { act, fireEvent, render, waitFor, within } from '../../../../../__test__/test-utils';
+import { apiClient } from '../../../../../api/apiClients';
+import { OnboardingAvailableFlows } from '../../../../../models/Onboarding';
+import { PFEventsType } from '../../../../../models/PFEventsType';
+import PFEventStrategyFactory from '../../../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import EmailStep from '../../EmailStep';
+
+describe('EmailStep - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+  let mock: MockAdapter;
+
+  const mockEmail = 'test@mock.pagopa.it';
+  const basePayload = { onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE };
+
+  beforeAll(() => {
+    mock = new MockAdapter(apiClient);
+  });
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    mock.reset();
+    triggerEventSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  const createProps = () => ({
+    value: undefined as string | undefined,
+    alreadySet: false,
+    onChange: vi.fn(),
+    onVerified: vi.fn(),
+  });
+
+  it('fires SEND_ONBOARDING_EMAIL_VERIFICATION when verify is clicked with a valid email', async () => {
+    mock.onPost('/bff/v1/addresses/COURTESY/default/EMAIL').reply(200, { result: 'OK' });
+
+    const props = createProps();
+    const { getByLabelText, getByRole } = render(<EmailStep {...props} />);
+
+    await act(async () => {
+      fireEvent.change(getByLabelText('onboarding.digital-domicile.email.input-label'), {
+        target: { value: mockEmail },
+      });
+    });
+
+    await act(async () => {
+      fireEvent.click(getByRole('button', { name: 'onboarding.digital-domicile.email.verify-cta' }));
+    });
+
+    await waitFor(() => {
+      expect(mock.history.post).toHaveLength(1);
+    });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_EMAIL_VERIFICATION,
+      basePayload
+    );
+  });
+
+  it('fires SEND_ONBOARDING_EMAIL_ACTIVATED when the email is verified successfully', async () => {
+    mock.onPost('/bff/v1/addresses/COURTESY/default/EMAIL').reply(200, { result: 'OK' });
+
+    const props = createProps();
+    const { getByLabelText, getByRole } = render(<EmailStep {...props} />);
+
+    await act(async () => {
+      fireEvent.change(getByLabelText('onboarding.digital-domicile.email.input-label'), {
+        target: { value: mockEmail },
+      });
+    });
+
+    await act(async () => {
+      fireEvent.click(getByRole('button', { name: 'onboarding.digital-domicile.email.verify-cta' }));
+    });
+
+    await waitFor(() => {
+      expect(props.onChange).toHaveBeenCalledWith(mockEmail);
+    });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ONBOARDING_EMAIL_ACTIVATED, {
+      ...basePayload,
+      event_type: EventAction.CONFIRM,
+    });
+  });
+
+  it('fires SEND_ONBOARDING_EMAIL_OTP when the API requires code verification', async () => {
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/EMAIL')
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+
+    const props = createProps();
+    const { getByLabelText, getByRole } = render(<EmailStep {...props} />);
+
+    await act(async () => {
+      fireEvent.change(getByLabelText('onboarding.digital-domicile.email.input-label'), {
+        target: { value: mockEmail },
+      });
+    });
+
+    await act(async () => {
+      fireEvent.click(getByRole('button', { name: 'onboarding.digital-domicile.email.verify-cta' }));
+    });
+
+    await waitFor(() => {
+      expect(mock.history.post).toHaveLength(1);
+    });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ONBOARDING_EMAIL_OTP, {
+      ...basePayload,
+      event_type: EventAction.SCREEN_VIEW,
+    });
+  });
+
+  it('fires SEND_ONBOARDING_EMAIL_OTP_VERIFICATION when the OTP code is confirmed', async () => {
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/EMAIL')
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+
+    const props = createProps();
+    const { getByLabelText, getByRole, getByTestId } = render(<EmailStep {...props} />);
+
+    await act(async () => {
+      fireEvent.change(getByLabelText('onboarding.digital-domicile.email.input-label'), {
+        target: { value: mockEmail },
+      });
+    });
+
+    await act(async () => {
+      fireEvent.click(getByRole('button', { name: 'onboarding.digital-domicile.email.verify-cta' }));
+    });
+
+    const dialog = await waitFor(() => getByTestId('codeDialog'));
+    const codeInput = within(dialog).getByRole('textbox');
+    codeInput.focus();
+    await userEvent.keyboard('01234');
+
+    mock.onPost('/bff/v1/addresses/COURTESY/default/EMAIL').reply(200, { result: 'OK' });
+
+    const dialogButtons = dialog.querySelectorAll('button');
+    await userEvent.click(dialogButtons[1]);
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_EMAIL_OTP_VERIFICATION,
+      basePayload
+    );
+  });
+
+  it('fires SEND_ONBOARDING_EMAIL_EDITING when edit button is clicked on an existing email', async () => {
+    const props = { ...createProps(), value: mockEmail, alreadySet: true };
+    const { getByRole } = render(<EmailStep {...props} />);
+
+    await act(async () => {
+      fireEvent.click(getByRole('button', { name: 'button.modifica' }));
+    });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_EMAIL_EDITING,
+      basePayload
+    );
+  });
+
+  it('fires SEND_ONBOARDING_EMAIL_CONFIRMED when edit is confirmed on an existing email', async () => {
+    const props = { ...createProps(), value: mockEmail, alreadySet: true };
+    const { getByRole } = render(<EmailStep {...props} />);
+
+    // Enter edit mode
+    await act(async () => {
+      fireEvent.click(getByRole('button', { name: 'button.modifica' }));
+    });
+
+    // Confirm without changing value (no API call needed)
+    await act(async () => {
+      fireEvent.click(getByRole('button', { name: 'button.conferma' }));
+    });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_EMAIL_CONFIRMED,
+      basePayload
+    );
+  });
+});

--- a/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/__test__/mixpanel/IoActivationWizard.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/__test__/mixpanel/IoActivationWizard.mixpanel.test.tsx
@@ -1,0 +1,106 @@
+import MockAdapter from 'axios-mock-adapter';
+import { MockInstance, vi } from 'vitest';
+
+import { EventAction } from '@pagopa-pn/pn-commons';
+
+import { act, fireEvent, render, waitFor } from '../../../../../__test__/test-utils';
+import { apiClient } from '../../../../../api/apiClients';
+import { OnboardingAvailableFlows, OnboardingScreen } from '../../../../../models/Onboarding';
+import { PFEventsType } from '../../../../../models/PFEventsType';
+import { AddressType, ChannelType, IOAllowedValues } from '../../../../../models/contacts';
+import PFEventStrategyFactory from '../../../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import IoActivationWizard from '../../IoActivationWizard';
+
+describe('IoActivationWizard - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+  let mock: MockAdapter;
+
+  const basePayload = { onboarding_selected_flow: OnboardingAvailableFlows.IO };
+
+  const disabledIoState = {
+    contactsState: {
+      digitalAddresses: [
+        {
+          addressType: AddressType.COURTESY,
+          senderId: 'default',
+          channelType: ChannelType.IOMSG,
+          value: IOAllowedValues.DISABLED,
+        },
+      ],
+    },
+  };
+
+  beforeAll(() => {
+    mock = new MockAdapter(apiClient);
+  });
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    mock.reset();
+    vi.clearAllMocks();
+    triggerEventSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  it('fires SEND_ONBOARDING_IO_DOWNLOAD on mount when IO is not installed', () => {
+    render(<IoActivationWizard />, {
+      preloadedState: { contactsState: { digitalAddresses: [] } },
+    });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ONBOARDING_IO_DOWNLOAD, {
+      event_type: EventAction.SCREEN_VIEW,
+      onboarding_selected_flow: OnboardingAvailableFlows.IO,
+    });
+  });
+
+  it('fires SEND_ONBOARDING_IO_ACTIVATION on mount when IO is installed but disabled', () => {
+    render(<IoActivationWizard />, { preloadedState: disabledIoState });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ONBOARDING_IO_ACTIVATION, {
+      event_type: EventAction.SCREEN_VIEW,
+      onboarding_selected_flow: OnboardingAvailableFlows.IO,
+    });
+  });
+
+  it('fires SEND_ONBOARDING_UX_SUCCESS when IO is enabled and the feedback step is reached', async () => {
+    mock.onPost('/bff/v1/addresses/COURTESY/default/APPIO').reply(200, { result: 'OK' });
+
+    const { getByTestId, findByText } = render(<IoActivationWizard />, {
+      preloadedState: disabledIoState,
+    });
+
+    await act(async () => {
+      fireEvent.click(getByTestId('io-primary-button'));
+    });
+
+    await waitFor(() => {
+      expect(mock.history.post).toHaveLength(1);
+    });
+
+    await findByText('onboarding.io-activation.feedback.title');
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ONBOARDING_UX_SUCCESS, {
+      ...basePayload,
+      event_type: EventAction.SCREEN_VIEW,
+    });
+  });
+
+  it('fires SEND_ONBOARDING_EXIT_SELECTED with IO screen when the exit button is clicked', () => {
+    const { getByTestId } = render(<IoActivationWizard />, {
+      preloadedState: { contactsState: { digitalAddresses: [] } },
+    });
+
+    fireEvent.click(getByTestId('exit-button'));
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ONBOARDING_EXIT_SELECTED, {
+      ...basePayload,
+      screen: OnboardingScreen.IO,
+    });
+  });
+});

--- a/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/__test__/mixpanel/IoStep.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/__test__/mixpanel/IoStep.mixpanel.test.tsx
@@ -1,0 +1,145 @@
+import MockAdapter from 'axios-mock-adapter';
+import { MockInstance, vi } from 'vitest';
+
+import { EventAction } from '@pagopa-pn/pn-commons';
+
+import { act, fireEvent, render, waitFor } from '../../../../../__test__/test-utils';
+import { apiClient } from '../../../../../api/apiClients';
+import { OnboardingAvailableFlows } from '../../../../../models/Onboarding';
+import { PFEventsType } from '../../../../../models/PFEventsType';
+import { IOAllowedValues } from '../../../../../models/contacts';
+import PFEventStrategyFactory from '../../../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import { openAppIoDownloadPage } from '../../../../../utility/appio.utility';
+import IoStep from '../../IoStep';
+
+vi.mock('../../../../../utility/appio.utility', () => ({
+  openAppIoDownloadPage: vi.fn(),
+}));
+
+describe('IoStep - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+  let mock: MockAdapter;
+
+  beforeAll(() => {
+    mock = new MockAdapter(apiClient);
+  });
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    mock.reset();
+    vi.clearAllMocks();
+    triggerEventSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  const createProps = (value?: IOAllowedValues, flow = OnboardingAvailableFlows.DIGITAL_DOMICILE) => ({
+    value,
+    onChange: vi.fn(),
+    onContinue: vi.fn(),
+    selectedOnboardingFlow: flow,
+  });
+
+  it('fires SEND_ONBOARDING_IO_DOWNLOAD on mount when IO is not installed (value undefined)', () => {
+    const props = createProps(undefined);
+    render(<IoStep {...props} />);
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ONBOARDING_IO_DOWNLOAD, {
+      event_type: EventAction.SCREEN_VIEW,
+      onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE,
+    });
+  });
+
+  it('fires SEND_ONBOARDING_IO_ACTIVATION on mount when IO is installed but disabled', () => {
+    const props = createProps(IOAllowedValues.DISABLED);
+    render(<IoStep {...props} />);
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ONBOARDING_IO_ACTIVATION, {
+      event_type: EventAction.SCREEN_VIEW,
+      onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE,
+    });
+  });
+
+  it('fires SEND_ONBOARDING_IO_VERIFICATION on mount when IO is already enabled', () => {
+    const props = createProps(IOAllowedValues.ENABLED);
+    render(<IoStep {...props} />);
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ONBOARDING_IO_VERIFICATION, {
+      event_type: EventAction.SCREEN_VIEW,
+      onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE,
+    });
+  });
+
+  it('fires SEND_ONBOARDING_IO_DOWNLOAD_SELECTED when the download CTA is clicked', async () => {
+    const props = createProps(undefined);
+    const { getByTestId } = render(<IoStep {...props} />);
+
+    await act(async () => {
+      fireEvent.click(getByTestId('io-primary-button'));
+    });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_IO_DOWNLOAD_SELECTED,
+      { onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE }
+    );
+    expect(openAppIoDownloadPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires SEND_ONBOARDING_IO_ACTIVATION_SELECTED and SEND_ONBOARDING_IO_ACTIVATED when IO is enabled successfully', async () => {
+    mock.onPost('/bff/v1/addresses/COURTESY/default/APPIO').reply(200, { result: 'OK' });
+
+    const props = createProps(IOAllowedValues.DISABLED);
+    const { getByTestId } = render(<IoStep {...props} />);
+
+    await act(async () => {
+      fireEvent.click(getByTestId('io-primary-button'));
+    });
+
+    await waitFor(() => {
+      expect(mock.history.post).toHaveLength(1);
+    });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_IO_ACTIVATION_SELECTED,
+      { onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE }
+    );
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ONBOARDING_IO_ACTIVATED, {
+      onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE,
+    });
+  });
+
+  it('fires SEND_ONBOARDING_IO_DOWNLOAD_VERIFICATION when the refresh link is clicked', async () => {
+    mock.onGet('/bff/v1/addresses').reply(200, []);
+
+    const props = createProps(undefined);
+    const { getByTestId } = render(<IoStep {...props} />);
+
+    await act(async () => {
+      fireEvent.click(getByTestId('io-refresh-link'));
+    });
+
+    await waitFor(() => {
+      expect(mock.history.get).toHaveLength(1);
+    });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_IO_DOWNLOAD_VERIFICATION,
+      { onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE }
+    );
+  });
+
+  it('passes the selectedOnboardingFlow to the events when using COURTESY flow', () => {
+    const props = createProps(undefined, OnboardingAvailableFlows.COURTESY);
+    render(<IoStep {...props} />);
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ONBOARDING_IO_DOWNLOAD, {
+      event_type: EventAction.SCREEN_VIEW,
+      onboarding_selected_flow: OnboardingAvailableFlows.COURTESY,
+    });
+  });
+});

--- a/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/__test__/mixpanel/OnboardingHome.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/__test__/mixpanel/OnboardingHome.mixpanel.test.tsx
@@ -1,0 +1,93 @@
+import { MockInstance, vi } from 'vitest';
+
+import { EventAction } from '@pagopa-pn/pn-commons';
+
+import { fireEvent, render } from '../../../../../__test__/test-utils';
+import { OnboardingAvailableFlows } from '../../../../../models/Onboarding';
+import { PFEventsType } from '../../../../../models/PFEventsType';
+import { AddressType, ChannelType, IOAllowedValues } from '../../../../../models/contacts';
+import PFEventStrategyFactory from '../../../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import OnboardingHome from '../../OnboardingHome';
+
+describe('OnboardingHome - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+
+  const emptyContactsState = { contactsState: { digitalAddresses: [] } };
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    triggerEventSpy.mockRestore();
+  });
+
+  it('fires SEND_ONBOARDING_START_FLOW on mount', () => {
+    render(<OnboardingHome />, { preloadedState: emptyContactsState });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ONBOARDING_START_FLOW, {
+      event_type: EventAction.SCREEN_VIEW,
+    });
+  });
+
+  it('fires SEND_ONBOARDING_FLOW_SELECTED with DIGITAL_DOMICILE when that card CTA is clicked', () => {
+    const { getByTestId } = render(<OnboardingHome />, { preloadedState: emptyContactsState });
+
+    fireEvent.click(getByTestId(`onboarding-card-cta-${OnboardingAvailableFlows.DIGITAL_DOMICILE}`));
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ONBOARDING_FLOW_SELECTED, {
+      onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE,
+    });
+  });
+
+  it('fires SEND_ONBOARDING_FLOW_SELECTED with COURTESY when that card CTA is clicked', () => {
+    const { getByTestId } = render(<OnboardingHome />, { preloadedState: emptyContactsState });
+
+    fireEvent.click(getByTestId(`onboarding-card-cta-${OnboardingAvailableFlows.COURTESY}`));
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ONBOARDING_FLOW_SELECTED, {
+      onboarding_selected_flow: OnboardingAvailableFlows.COURTESY,
+    });
+  });
+
+  it('fires SEND_ONBOARDING_FLOW_SELECTED with IO when that card CTA is clicked', () => {
+    const { getByTestId } = render(<OnboardingHome />, { preloadedState: emptyContactsState });
+
+    fireEvent.click(getByTestId(`onboarding-card-cta-${OnboardingAvailableFlows.IO}`));
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ONBOARDING_FLOW_SELECTED, {
+      onboarding_selected_flow: OnboardingAvailableFlows.IO,
+    });
+  });
+
+  it('does not fire SEND_ONBOARDING_FLOW_SELECTED with IO when IO is already enabled', () => {
+    const { queryByTestId } = render(<OnboardingHome />, {
+      preloadedState: {
+        contactsState: {
+          digitalAddresses: [
+            {
+              addressType: AddressType.COURTESY,
+              senderId: 'default',
+              channelType: ChannelType.IOMSG,
+              value: IOAllowedValues.ENABLED,
+            },
+          ],
+        },
+      },
+    });
+
+    expect(
+      queryByTestId(`onboarding-card-cta-${OnboardingAvailableFlows.IO}`)
+    ).not.toBeInTheDocument();
+  });
+
+  it('fires SEND_ONBOARDING_DECLINED when the exit button is clicked', () => {
+    const { getByRole } = render(<OnboardingHome />, { preloadedState: emptyContactsState });
+
+    fireEvent.click(getByRole('button', { name: 'onboarding.exit-flow' }));
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ONBOARDING_DECLINED, {
+      event_type: EventAction.EXIT,
+    });
+  });
+});

--- a/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/__test__/mixpanel/PecStep.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/Onboarding/__test__/mixpanel/PecStep.mixpanel.test.tsx
@@ -1,0 +1,288 @@
+import userEvent from '@testing-library/user-event';
+import MockAdapter from 'axios-mock-adapter';
+import { MockInstance, vi } from 'vitest';
+
+import { EventAction } from '@pagopa-pn/pn-commons';
+
+import { act, fireEvent, render, waitFor, within } from '../../../../../__test__/test-utils';
+import { apiClient } from '../../../../../api/apiClients';
+import { OnboardingAvailableFlows } from '../../../../../models/Onboarding';
+import { PFEventsType } from '../../../../../models/PFEventsType';
+import PFEventStrategyFactory from '../../../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import PecStep from '../../PecStep';
+
+describe('PecStep - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+  let mock: MockAdapter;
+
+  const mockPec = 'test@pec.mock.pagopa.it';
+  const mockEmail = 'test@mock.pagopa.it';
+  const basePayload = { onboarding_selected_flow: OnboardingAvailableFlows.DIGITAL_DOMICILE };
+
+  beforeAll(() => {
+    mock = new MockAdapter(apiClient);
+  });
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    mock.reset();
+    triggerEventSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  const createProps = () => ({
+    pec: { value: undefined as string | undefined, alreadySet: false, isValid: undefined },
+    email: { value: undefined as string | undefined, alreadySet: false },
+    showOptionalEmail: false,
+    onPecChange: vi.fn(),
+    onEmailChange: vi.fn(),
+    onShowOptionalEmail: vi.fn(),
+    registerContinueHandler: vi.fn(),
+  });
+
+  it('fires SEND_ONBOARDING_PEC_VERIFICATION when verify is clicked with a valid PEC', async () => {
+    mock.onPost('/bff/v1/addresses/LEGAL/default/PEC').reply(200, { result: 'OK', pecValid: true });
+
+    const props = createProps();
+    const { getByLabelText, getByRole } = render(<PecStep {...props} />);
+
+    await act(async () => {
+      fireEvent.change(getByLabelText('onboarding.digital-domicile.pec.input-label'), {
+        target: { value: mockPec },
+      });
+    });
+
+    await act(async () => {
+      fireEvent.click(getByRole('checkbox'));
+    });
+
+    await act(async () => {
+      fireEvent.click(
+        getByRole('button', { name: 'onboarding.digital-domicile.pec.verify-cta' })
+      );
+    });
+
+    await waitFor(() => {
+      expect(mock.history.post).toHaveLength(1);
+    });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_PEC_VERIFICATION,
+      basePayload
+    );
+  });
+
+  it('fires SEND_ONBOARDING_PEC_ACTIVATED when the PEC is verified successfully', async () => {
+    mock.onPost('/bff/v1/addresses/LEGAL/default/PEC').reply(200, { result: 'OK', pecValid: true });
+
+    const props = createProps();
+    const { getByLabelText, getByRole } = render(<PecStep {...props} />);
+
+    await act(async () => {
+      fireEvent.change(getByLabelText('onboarding.digital-domicile.pec.input-label'), {
+        target: { value: mockPec },
+      });
+    });
+
+    await act(async () => {
+      fireEvent.click(getByRole('checkbox'));
+    });
+
+    await act(async () => {
+      fireEvent.click(
+        getByRole('button', { name: 'onboarding.digital-domicile.pec.verify-cta' })
+      );
+    });
+
+    await waitFor(() => {
+      expect(props.onPecChange).toHaveBeenCalled();
+    });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ONBOARDING_PEC_ACTIVATED, {
+      ...basePayload,
+      event_type: EventAction.CONFIRM,
+    });
+  });
+
+  it('fires SEND_ONBOARDING_PEC_OTP when the API requires code verification for PEC', async () => {
+    mock
+      .onPost('/bff/v1/addresses/LEGAL/default/PEC')
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+
+    const props = createProps();
+    const { getByLabelText, getByRole } = render(<PecStep {...props} />);
+
+    await act(async () => {
+      fireEvent.change(getByLabelText('onboarding.digital-domicile.pec.input-label'), {
+        target: { value: mockPec },
+      });
+    });
+
+    await act(async () => {
+      fireEvent.click(getByRole('checkbox'));
+    });
+
+    await act(async () => {
+      fireEvent.click(
+        getByRole('button', { name: 'onboarding.digital-domicile.pec.verify-cta' })
+      );
+    });
+
+    await waitFor(() => {
+      expect(mock.history.post).toHaveLength(1);
+    });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ONBOARDING_PEC_OTP, {
+      ...basePayload,
+      event_type: EventAction.SCREEN_VIEW,
+    });
+  });
+
+  it('fires SEND_ONBOARDING_PEC_OTP_VERIFICATION when the PEC OTP code is confirmed', async () => {
+    mock
+      .onPost('/bff/v1/addresses/LEGAL/default/PEC')
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+
+    const props = createProps();
+    const { getByLabelText, getByRole, getByTestId } = render(<PecStep {...props} />);
+
+    await act(async () => {
+      fireEvent.change(getByLabelText('onboarding.digital-domicile.pec.input-label'), {
+        target: { value: mockPec },
+      });
+    });
+
+    await act(async () => {
+      fireEvent.click(getByRole('checkbox'));
+    });
+
+    await act(async () => {
+      fireEvent.click(
+        getByRole('button', { name: 'onboarding.digital-domicile.pec.verify-cta' })
+      );
+    });
+
+    const dialog = await waitFor(() => getByTestId('codeDialog'));
+    const codeInput = within(dialog).getByRole('textbox');
+    codeInput.focus();
+    await userEvent.keyboard('01234');
+
+    mock.onPost('/bff/v1/addresses/LEGAL/default/PEC').reply(200, { result: 'OK', pecValid: true });
+
+    const dialogButtons = dialog.querySelectorAll('button');
+    await userEvent.click(dialogButtons[1]);
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_PEC_OTP_VERIFICATION,
+      basePayload
+    );
+  });
+
+  it('fires SEND_ONBOARDING_EMAIL_SELECTED when the optional email section is expanded', async () => {
+    const props = { ...createProps(), showOptionalEmail: false };
+    const { getByRole } = render(<PecStep {...props} />);
+
+    await act(async () => {
+      fireEvent.click(
+        getByRole('button', { name: 'onboarding.digital-domicile.pec.email-cta' })
+      );
+    });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_EMAIL_SELECTED,
+      basePayload
+    );
+  });
+
+  it('fires SEND_ONBOARDING_EMAIL_ACTIVATION_CANCELED when the optional email section is collapsed', async () => {
+    const props = { ...createProps(), showOptionalEmail: true };
+    const { getByRole } = render(<PecStep {...props} />);
+
+    await act(async () => {
+      fireEvent.click(
+        getByRole('button', { name: 'onboarding.digital-domicile.pec.cancel-email-cta' })
+      );
+    });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_EMAIL_ACTIVATION_CANCELED,
+      basePayload
+    );
+  });
+
+  it('fires SEND_ONBOARDING_EMAIL_VERIFICATION when verify is clicked with a valid email in the optional email section', async () => {
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/EMAIL')
+      .reply(200, { result: 'OK' });
+
+    const props = { ...createProps(), showOptionalEmail: true };
+    const { getByLabelText, getByRole } = render(<PecStep {...props} />);
+
+    await act(async () => {
+      fireEvent.change(getByLabelText('onboarding.digital-domicile.email.input-label'), {
+        target: { value: mockEmail },
+      });
+    });
+
+    await act(async () => {
+      fireEvent.click(
+        getByRole('button', { name: 'onboarding.digital-domicile.email.verify-cta' })
+      );
+    });
+
+    await waitFor(() => {
+      expect(mock.history.post).toHaveLength(1);
+    });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_EMAIL_VERIFICATION,
+      basePayload
+    );
+  });
+
+  it('fires SEND_ONBOARDING_EMAIL_EDITING when edit button is clicked on an existing optional email', async () => {
+    const props = {
+      ...createProps(),
+      email: { value: mockEmail, alreadySet: true },
+      showOptionalEmail: true,
+    };
+    const { getByRole } = render(<PecStep {...props} />);
+
+    await act(async () => {
+      fireEvent.click(getByRole('button', { name: 'button.modifica' }));
+    });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_EMAIL_EDITING,
+      basePayload
+    );
+  });
+
+  it('fires SEND_ONBOARDING_EMAIL_CONFIRMED when edit is confirmed on the optional email', async () => {
+    const props = {
+      ...createProps(),
+      email: { value: mockEmail, alreadySet: true },
+      showOptionalEmail: true,
+    };
+    const { getByRole } = render(<PecStep {...props} />);
+
+    await act(async () => {
+      fireEvent.click(getByRole('button', { name: 'button.modifica' }));
+    });
+
+    await act(async () => {
+      fireEvent.click(getByRole('button', { name: 'button.conferma' }));
+    });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ONBOARDING_EMAIL_CONFIRMED,
+      basePayload
+    );
+  });
+});


### PR DESCRIPTION
## Short description
Add dedicated Mixpanel test files for all Onboarding components, verifying that each user interaction triggers the expected analytics event with the correct payload.

OnboardingHome — flow selection, exit
DigitalDomicileWizard — SEND activation, email/PEC step entry, continue/back/exit navigation, IO skip, full flow completion
EmailStep — verify, OTP flow, edit/confirm on existing address
PecStep — verify, OTP flow, optional email section expand/collapse
IoStep — mount variants (no IO / disabled / enabled), download/activation CTAs, refresh
IoActivationWizard — mount variants, success feedback, exit
EmailSmsStep (Courtesy) — SMS expand/collapse, email and SMS verify/OTP/activate flows
CourtesyContactHandler — edit/confirm for email and SMS
OnboardingCourtesyWizard — IO step navigation, email/SMS step navigation, full flow success

## How to test
run tests