### PR TITLE
test(PN-19561): test mixpanel in pages

### DIFF
--- a/packages/pn-personafisica-webapp/src/__test__/mixpanel/App.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/__test__/mixpanel/App.mixpanel.test.tsx
@@ -1,0 +1,94 @@
+import MockAdapter from 'axios-mock-adapter';
+import { Suspense } from 'react';
+import { MockInstance, vi } from 'vitest';
+
+import { ThemeProvider } from '@mui/material';
+import { theme } from '@pagopa/mui-italia';
+
+import App from '../../App';
+import { currentStatusDTO } from '../../__mocks__/AppStatus.mock';
+import { userResponse } from '../../__mocks__/Auth.mock';
+import { tosPrivacyConsentMock } from '../../__mocks__/Consents.mock';
+import { mandatesByDelegate } from '../../__mocks__/Delegations.mock';
+import { apiClient, authClient } from '../../api/apiClients';
+import { LoginProvider } from '../../models/User';
+import { PFEventsType } from '../../models/PFEventsType';
+import PFEventStrategyFactory from '../../utility/MixpanelUtils/PFEventStrategyFactory';
+import { act, fireEvent, render, screen, waitFor, within } from '../test-utils';
+
+vi.mock('../../pages/Notifiche.page', () => ({ default: () => <div>Generic Page</div> }));
+vi.mock('../../pages/Profile.page', () => ({ default: () => <div>Profile Page</div> }));
+
+const Component = () => (
+  <ThemeProvider theme={theme}>
+    <Suspense fallback="loading...">
+      <App />
+    </Suspense>
+  </ThemeProvider>
+);
+
+const reduxInitialState = {
+  userState: {
+    user: userResponse,
+    fetchedTos: false,
+    fetchedPrivacy: false,
+    tosConsent: { accepted: false, isFirstAccept: false, currentVersion: 'mocked-version-1' },
+    privacyConsent: { accepted: false, isFirstAccept: false, currentVersion: 'mocked-version-1' },
+    tosPrivacyApiError: false,
+    loginProvider: LoginProvider.SPIDHUB,
+  },
+};
+
+const unmockedFetch = globalThis.fetch;
+
+describe('App - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+  let mock: MockAdapter;
+  let mockAuth: MockAdapter;
+
+  beforeAll(() => {
+    mock = new MockAdapter(apiClient);
+    mockAuth = new MockAdapter(authClient);
+    globalThis.fetch = () =>
+      Promise.resolve({ json: () => Promise.resolve([]) }) as Promise<Response>;
+  });
+
+  beforeEach(() => {
+    mock.onGet(/\/bff\/v2\/tos-privacy.*/).reply(200, tosPrivacyConsentMock(true, true));
+    mock.onGet('/bff/v1/downtime/status').reply(200, currentStatusDTO);
+    mock.onGet('/bff/v1/mandate/delegate').reply(200, mandatesByDelegate);
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    mock.reset();
+    mockAuth.reset();
+    triggerEventSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    mock.restore();
+    mockAuth.restore();
+    globalThis.fetch = unmockedFetch;
+  });
+
+  it('fires SEND_VIEW_PROFILE when the profile menu item is clicked', async () => {
+    await act(async () => {
+      render(<Component />, { preloadedState: reduxInitialState });
+    });
+
+    const header = document.querySelector('header');
+    const userButton = header?.querySelector(
+      `[aria-label="Area utente ${userResponse.name} ${userResponse.family_name}"]`
+    );
+    fireEvent.click(userButton!);
+
+    const menu = await waitFor(() => screen.getByRole('presentation'));
+    const menuItems = within(menu).getAllByRole('menuitem');
+    fireEvent.click(menuItems[0]);
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_VIEW_PROFILE, {
+      source: 'user_menu',
+    });
+  });
+});

--- a/packages/pn-personafisica-webapp/src/navigation/__test__/mixpanel/RapidAccessGuard.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/__test__/mixpanel/RapidAccessGuard.mixpanel.test.tsx
@@ -1,0 +1,93 @@
+import MockAdapter from 'axios-mock-adapter';
+import { Route, Routes } from 'react-router-dom';
+import { MockInstance, vi } from 'vitest';
+
+import { AppRouteParams } from '@pagopa-pn/pn-commons';
+
+import { act, render, waitFor } from '../../../__test__/test-utils';
+import { apiClient } from '../../../api/apiClients';
+import { BffCheckTPPResponse } from '../../../generated-client/notifications';
+import { PFEventsType } from '../../../models/PFEventsType';
+import PFEventStrategyFactory from '../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import RapidAccessGuard from '../../RapidAccessGuard';
+
+const Guard = () => (
+  <Routes>
+    <Route element={<RapidAccessGuard />}>
+      <Route path="/" element={<div>Generic Page</div>} />
+    </Route>
+  </Routes>
+);
+
+describe('RapidAccessGuard - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+  let mock: MockAdapter;
+
+  beforeAll(() => {
+    mock = new MockAdapter(apiClient);
+  });
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    mock.reset();
+    triggerEventSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  it('fires SEND_RAPID_ACCESS with AAR source after successful QR code exchange', async () => {
+    const mockQrCode = 'qr-code';
+    mock
+      .onPost('/bff/v1/notifications/received/check-aar-qr-code', { aarQrCodeValue: mockQrCode })
+      .reply(200, { iun: 'mock-iun' });
+
+    await act(async () => {
+      render(<Guard />, { route: `/?${AppRouteParams.AAR}=${mockQrCode}` });
+    });
+
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_RAPID_ACCESS, {
+        source: AppRouteParams.AAR,
+      });
+    });
+  });
+
+  it('fires SEND_RAPID_ACCESS with RETRIEVAL_ID source after successful retrieval exchange', async () => {
+    const mockRetrievalId = 'retrieval-id';
+    const url = `/bff/v1/notifications/received/check-tpp?retrievalId=${mockRetrievalId}`;
+    mock.onGet(url).reply(200, {
+      originId: 'mock-iun',
+      retrievalId: mockRetrievalId,
+    } as BffCheckTPPResponse);
+
+    await act(async () => {
+      render(<Guard />, { route: `/?${AppRouteParams.RETRIEVAL_ID}=${mockRetrievalId}` });
+    });
+
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_RAPID_ACCESS, {
+        source: AppRouteParams.RETRIEVAL_ID,
+      });
+    });
+  });
+
+  it('fires SEND_NOTIFICATION_NOT_ALLOWED when QR code exchange fails', async () => {
+    const mockQrCode = 'bad-qr-code';
+    mock
+      .onPost('/bff/v1/notifications/received/check-aar-qr-code', { aarQrCodeValue: mockQrCode })
+      .reply(500);
+
+    await act(async () => {
+      render(<Guard />, { route: `/?${AppRouteParams.AAR}=${mockQrCode}` });
+    });
+
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_NOTIFICATION_NOT_ALLOWED);
+    });
+  });
+});

--- a/packages/pn-personafisica-webapp/src/pages/__test__/mixpanel/AppStatus.page.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/mixpanel/AppStatus.page.mixpanel.test.tsx
@@ -1,0 +1,41 @@
+import MockAdapter from 'axios-mock-adapter';
+import { MockInstance, vi } from 'vitest';
+
+import { currentStatusDTO, downtimesDTO } from '../../../__mocks__/AppStatus.mock';
+import { act, render } from '../../../__test__/test-utils';
+import { apiClient } from '../../../api/apiClients';
+import { PFEventsType } from '../../../models/PFEventsType';
+import PFEventStrategyFactory from '../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import AppStatus from '../../AppStatus.page';
+
+describe('AppStatus.page - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+  let mock: MockAdapter;
+
+  beforeAll(() => {
+    mock = new MockAdapter(apiClient);
+  });
+
+  beforeEach(() => {
+    mock.onGet('/bff/v1/downtime/status').reply(200, currentStatusDTO);
+    mock.onGet(/\/bff\/v1\/downtime\/history.*/).reply(200, downtimesDTO);
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    mock.reset();
+    triggerEventSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  it('fires SEND_SERVICE_STATUS on mount', async () => {
+    await act(async () => {
+      render(<AppStatus />);
+    });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_SERVICE_STATUS, undefined);
+  });
+});

--- a/packages/pn-personafisica-webapp/src/pages/__test__/mixpanel/Contacts.page.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/mixpanel/Contacts.page.mixpanel.test.tsx
@@ -1,7 +1,7 @@
 import MockAdapter from 'axios-mock-adapter';
 import { MockInstance, vi } from 'vitest';
 
-import { act, render, waitFor } from '../../../__test__/test-utils';
+import { act, render } from '../../../__test__/test-utils';
 import { apiClient } from '../../../api/apiClients';
 import { PFEventsType } from '../../../models/PFEventsType';
 import PFEventStrategyFactory from '../../../utility/MixpanelUtils/PFEventStrategyFactory';
@@ -29,29 +29,8 @@ describe('Contacts.page - Mixpanel events', () => {
   });
 
   it('fires SEND_YOUR_CONTACT_DETAILS on mount', async () => {
-    mock.onGet('/bff/v1/addresses').reply(200, []);
-
     await act(async () => {
       render(<Contacts />, { preloadedState: { contactsState: { digitalAddresses: [] } } });
-    });
-
-    expect(triggerEventSpy).toHaveBeenCalledWith(
-      PFEventsType.SEND_YOUR_CONTACT_DETAILS,
-      expect.objectContaining({
-        digitalAddresses: expect.any(Array),
-      })
-    );
-  });
-
-  it('fires SEND_YOUR_CONTACT_DETAILS again after addresses API resolves', async () => {
-    mock.onGet('/bff/v1/addresses').reply(200, []);
-
-    await act(async () => {
-      render(<Contacts />, { preloadedState: { contactsState: { digitalAddresses: [] } } });
-    });
-
-    await waitFor(() => {
-      expect(mock.history.get.length).toBeGreaterThanOrEqual(1);
     });
 
     expect(triggerEventSpy).toHaveBeenCalledWith(

--- a/packages/pn-personafisica-webapp/src/pages/__test__/mixpanel/Contacts.page.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/mixpanel/Contacts.page.mixpanel.test.tsx
@@ -1,0 +1,64 @@
+import MockAdapter from 'axios-mock-adapter';
+import { MockInstance, vi } from 'vitest';
+
+import { act, render, waitFor } from '../../../__test__/test-utils';
+import { apiClient } from '../../../api/apiClients';
+import { PFEventsType } from '../../../models/PFEventsType';
+import PFEventStrategyFactory from '../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import Contacts from '../../Contacts.page';
+
+describe('Contacts.page - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+  let mock: MockAdapter;
+
+  beforeAll(() => {
+    mock = new MockAdapter(apiClient);
+  });
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    mock.reset();
+    triggerEventSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  it('fires SEND_YOUR_CONTACT_DETAILS on mount', async () => {
+    mock.onGet('/bff/v1/addresses').reply(200, []);
+
+    await act(async () => {
+      render(<Contacts />, { preloadedState: { contactsState: { digitalAddresses: [] } } });
+    });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_YOUR_CONTACT_DETAILS,
+      expect.objectContaining({
+        digitalAddresses: expect.any(Array),
+      })
+    );
+  });
+
+  it('fires SEND_YOUR_CONTACT_DETAILS again after addresses API resolves', async () => {
+    mock.onGet('/bff/v1/addresses').reply(200, []);
+
+    await act(async () => {
+      render(<Contacts />, { preloadedState: { contactsState: { digitalAddresses: [] } } });
+    });
+
+    await waitFor(() => {
+      expect(mock.history.get.length).toBeGreaterThanOrEqual(1);
+    });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_YOUR_CONTACT_DETAILS,
+      expect.objectContaining({
+        digitalAddresses: expect.any(Array),
+      })
+    );
+  });
+});

--- a/packages/pn-personafisica-webapp/src/pages/__test__/mixpanel/Deleghe.page.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/mixpanel/Deleghe.page.mixpanel.test.tsx
@@ -1,0 +1,50 @@
+import MockAdapter from 'axios-mock-adapter';
+import { MockInstance, vi } from 'vitest';
+
+import { mandatesByDelegate, mandatesByDelegator } from '../../../__mocks__/Delegations.mock';
+import { act, render, waitFor } from '../../../__test__/test-utils';
+import { apiClient } from '../../../api/apiClients';
+import { PFEventsType } from '../../../models/PFEventsType';
+import PFEventStrategyFactory from '../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import Deleghe from '../../Deleghe.page';
+
+describe('Deleghe.page - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+  let mock: MockAdapter;
+
+  beforeAll(() => {
+    mock = new MockAdapter(apiClient);
+  });
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    mock.reset();
+    triggerEventSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  it('fires SEND_YOUR_MANDATES when the page data is loaded', async () => {
+    mock.onGet('/bff/v1/mandate/delegate').reply(200, mandatesByDelegate);
+    mock.onGet('/bff/v1/mandate/delegator').reply(200, mandatesByDelegator);
+
+    await act(async () => {
+      render(<Deleghe />);
+    });
+
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_YOUR_MANDATES,
+        expect.objectContaining({
+          delegates: expect.any(Array),
+          delegators: expect.any(Array),
+        })
+      );
+    });
+  });
+});

--- a/packages/pn-personafisica-webapp/src/pages/__test__/mixpanel/NotificationDetail.page.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/mixpanel/NotificationDetail.page.mixpanel.test.tsx
@@ -57,6 +57,7 @@ describe('NotificationDetail.page - Mixpanel events', () => {
     mock.reset();
     mockAssignFn.mockClear();
     triggerEventSpy.mockRestore();
+    vi.useRealTimers();
   });
 
   afterAll(() => {

--- a/packages/pn-personafisica-webapp/src/pages/__test__/mixpanel/NotificationDetail.page.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/mixpanel/NotificationDetail.page.mixpanel.test.tsx
@@ -176,7 +176,6 @@ describe('NotificationDetail.page - Mixpanel events', () => {
   // deep payment UI interaction to trigger.
 
   it('fires SEND_START_PAYMENT when the pay button is clicked', async () => {
-    vi.useFakeTimers();
     setupMocks();
     mock.onPost('/bff/v1/payments/cart').reply(500);
 
@@ -188,6 +187,8 @@ describe('NotificationDetail.page - Mixpanel events', () => {
     );
 
     await waitFor(() => getByTestId('pay-button'));
+
+    vi.useFakeTimers();
 
     const item = queryAllByTestId('pagopa-item')[requiredPaymentIndex];
     const radioButton = item?.querySelector('[data-testid="radio-button"] input');

--- a/packages/pn-personafisica-webapp/src/pages/__test__/mixpanel/NotificationDetail.page.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/mixpanel/NotificationDetail.page.mixpanel.test.tsx
@@ -1,0 +1,205 @@
+import MockAdapter from 'axios-mock-adapter';
+import { Route, Routes } from 'react-router-dom';
+import { MockInstance, vi } from 'vitest';
+
+import { PaymentStatus, populatePaymentsPagoPaF24 } from '@pagopa-pn/pn-commons';
+
+import { downtimesDTO } from '../../../__mocks__/AppStatus.mock';
+import { paymentInfo } from '../../../__mocks__/ExternalRegistry.mock';
+import {
+  notificationDTO,
+  notificationToFe,
+  paymentsData,
+} from '../../../__mocks__/NotificationDetail.mock';
+import { act, fireEvent, render, waitFor, within } from '../../../__test__/test-utils';
+import { apiClient } from '../../../api/apiClients';
+import { PFEventsType } from '../../../models/PFEventsType';
+import * as routes from '../../../navigation/routes.const';
+import PFEventStrategyFactory from '../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import NotificationDetail from '../../NotificationDetail.page';
+
+const mockAssignFn = vi.fn();
+
+const Component = () => (
+  <Routes>
+    <Route path={routes.DETTAGLIO_NOTIFICA} element={<NotificationDetail />} />
+    <Route path={routes.DETTAGLIO_NOTIFICA_DELEGATO} element={<NotificationDetail />} />
+  </Routes>
+);
+
+const paymentHistory = populatePaymentsPagoPaF24(
+  notificationToFe.timeline,
+  paymentsData.pagoPaF24,
+  paymentInfo
+);
+const requiredPaymentIndex = paymentHistory.findIndex(
+  (payment) => payment.pagoPa?.status === PaymentStatus.REQUIRED
+);
+
+describe('NotificationDetail.page - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+  let mock: MockAdapter;
+  const original = globalThis.location;
+
+  beforeAll(() => {
+    mock = new MockAdapter(apiClient);
+    Object.defineProperty(globalThis, 'location', {
+      configurable: true,
+      value: { href: '', assign: mockAssignFn },
+    });
+  });
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    mock.reset();
+    mockAssignFn.mockClear();
+    triggerEventSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    mock.restore();
+    Object.defineProperty(globalThis, 'location', { configurable: true, value: original });
+  });
+
+  const setupMocks = () => {
+    mock.onGet(`/bff/v1/notifications/received/${notificationDTO.iun}`).reply(200, notificationDTO);
+    mock.onPost('/bff/v1/payments/info').reply(200, paymentInfo);
+    mock.onGet(/\/bff\/v1\/downtime\/history.*/).reply(200, downtimesDTO);
+  };
+
+  const baseState = {
+    userState: { user: { fiscal_number: notificationDTO.recipients[2].taxId } },
+  };
+
+  it('fires SEND_NOTIFICATION_DETAIL and SEND_NOTIFICATIONS_COUNT on page load', async () => {
+    setupMocks();
+
+    await act(async () => {
+      render(<Component />, {
+        preloadedState: baseState,
+        route: routes.GET_DETTAGLIO_NOTIFICA_PATH(notificationDTO.iun),
+      });
+    });
+
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_NOTIFICATION_DETAIL,
+        expect.objectContaining({
+          notificationStatus: expect.any(String),
+          timeline: expect.any(Array),
+        })
+      );
+    });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_NOTIFICATIONS_COUNT,
+      expect.objectContaining({ timeline: expect.any(Array) })
+    );
+  });
+
+  it('fires SEND_DOWNLOAD_ATTACHMENT when an attachment button is clicked', async () => {
+    setupMocks();
+
+    const { getAllByTestId } = await act(async () =>
+      render(<Component />, {
+        preloadedState: baseState,
+        route: routes.GET_DETTAGLIO_NOTIFICA_PATH(notificationDTO.iun),
+      })
+    );
+
+    await waitFor(() => getAllByTestId('documentButton'));
+    fireEvent.click(getAllByTestId('documentButton')[0]);
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_DOWNLOAD_ATTACHMENT);
+  });
+
+  it('fires SEND_DOWNLOAD_RECEIPT_NOTICE when the AAR document is clicked', async () => {
+    setupMocks();
+
+    const { getByTestId } = await act(async () =>
+      render(<Component />, {
+        preloadedState: baseState,
+        route: routes.GET_DETTAGLIO_NOTIFICA_PATH(notificationDTO.iun),
+      })
+    );
+
+    await waitFor(() => getByTestId('aarBox'));
+    const aarButton = within(getByTestId('aarBox')).getByTestId('documentButton');
+    fireEvent.click(aarButton);
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_DOWNLOAD_RECEIPT_NOTICE);
+  });
+
+  it('fires SEND_DOWNLOAD_CERTIFICATE_OPPOSABLE_TO_THIRD_PARTIES when a legal fact is clicked', async () => {
+    setupMocks();
+
+    const { getAllByTestId } = await act(async () =>
+      render(<Component />, {
+        preloadedState: baseState,
+        route: routes.GET_DETTAGLIO_NOTIFICA_PATH(notificationDTO.iun),
+      })
+    );
+
+    await waitFor(() => getAllByTestId('download-legalfact'));
+    fireEvent.click(getAllByTestId('download-legalfact')[0]);
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_DOWNLOAD_CERTIFICATE_OPPOSABLE_TO_THIRD_PARTIES,
+      { source: 'dettaglio_notifica' }
+    );
+  });
+
+  it('fires SEND_NOTIFICATION_STATUS_DETAIL when the timeline accordion is toggled', async () => {
+    setupMocks();
+
+    const { getAllByTestId } = await act(async () =>
+      render(<Component />, {
+        preloadedState: baseState,
+        route: routes.GET_DETTAGLIO_NOTIFICA_PATH(notificationDTO.iun),
+      })
+    );
+
+    await waitFor(() => getAllByTestId('more-less-timeline-step'));
+    fireEvent.click(getAllByTestId('more-less-timeline-step')[0]);
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_NOTIFICATION_STATUS_DETAIL, {
+      accordion: 'expanded',
+    });
+  });
+
+  it('fires SEND_START_PAYMENT when the pay button is clicked', async () => {
+    vi.useFakeTimers();
+    setupMocks();
+    mock.onPost('/bff/v1/payments/cart').reply(500);
+
+    const { getByTestId, queryAllByTestId } = await act(async () =>
+      render(<Component />, {
+        preloadedState: baseState,
+        route: routes.GET_DETTAGLIO_NOTIFICA_PATH(notificationDTO.iun),
+      })
+    );
+
+    await waitFor(() => getByTestId('pay-button'));
+
+    const item = queryAllByTestId('pagopa-item')[requiredPaymentIndex];
+    const radioButton = item?.querySelector('[data-testid="radio-button"] input');
+    fireEvent.click(radioButton!);
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    await act(async () => {
+      fireEvent.click(getByTestId('pay-button'));
+    });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_START_PAYMENT, {
+      psp: 'pagopa',
+    });
+
+    vi.useRealTimers();
+  });
+});

--- a/packages/pn-personafisica-webapp/src/pages/__test__/mixpanel/NotificationDetail.page.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/mixpanel/NotificationDetail.page.mixpanel.test.tsx
@@ -170,6 +170,11 @@ describe('NotificationDetail.page - Mixpanel events', () => {
     });
   });
 
+  // trackEventPaymentRecipient events (SEND_PAYMENT_OUTCOME, SEND_F24_DOWNLOAD,
+  // SEND_PAYMENT_LIST_CHANGE_PAGE, etc.) are not covered here — they fire through
+  // a callback passed down to NotificationPaymentRecipient (pn-commons), requiring
+  // deep payment UI interaction to trigger.
+
   it('fires SEND_START_PAYMENT when the pay button is clicked', async () => {
     vi.useFakeTimers();
     setupMocks();

--- a/packages/pn-personafisica-webapp/src/pages/__test__/mixpanel/Notifiche.page.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/mixpanel/Notifiche.page.mixpanel.test.tsx
@@ -1,0 +1,84 @@
+import MockAdapter from 'axios-mock-adapter';
+import { MockInstance, vi } from 'vitest';
+
+import { mandatesByDelegate } from '../../../__mocks__/Delegations.mock';
+import { notificationsDTO } from '../../../__mocks__/Notifications.mock';
+import { act, render, waitFor } from '../../../__test__/test-utils';
+import { apiClient } from '../../../api/apiClients';
+import { PFEventsType } from '../../../models/PFEventsType';
+import * as routes from '../../../navigation/routes.const';
+import PFEventStrategyFactory from '../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import Notifiche from '../../Notifiche.page';
+
+describe('Notifiche.page - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+  let mock: MockAdapter;
+  const originalResizeObserver = globalThis.ResizeObserver;
+
+  beforeAll(() => {
+    mock = new MockAdapter(apiClient);
+    globalThis.ResizeObserver = vi.fn().mockImplementation(() => ({
+      observe: vi.fn(),
+      unobserve: vi.fn(),
+      disconnect: vi.fn(),
+    }));
+  });
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    mock.reset();
+    triggerEventSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    mock.restore();
+    globalThis.ResizeObserver = originalResizeObserver;
+  });
+
+  it('fires SEND_YOUR_NOTIFICATIONS after notifications API resolves', async () => {
+    mock.onGet(/\/bff\/v1\/notifications\/received.*/).reply(200, notificationsDTO);
+
+    await act(async () => {
+      render(<Notifiche />);
+    });
+
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_YOUR_NOTIFICATIONS,
+        expect.objectContaining({
+          notifications: expect.any(Array),
+        })
+      );
+    });
+  });
+
+  it('fires SEND_NOTIFICATION_DELEGATED when viewing delegated notifications', async () => {
+    const delegator = mandatesByDelegate[1]; // mandateId: '4', status: 'active'
+    mock.onGet(/\/bff\/v1\/notifications\/received.*/).reply(200, notificationsDTO);
+
+    await act(async () => {
+      render(<Notifiche />, {
+        route: routes.GET_NOTIFICHE_DELEGATO_PATH(delegator.mandateId),
+        path: routes.NOTIFICHE_DELEGATO,
+        preloadedState: {
+          generalInfoState: {
+            delegators: mandatesByDelegate,
+            pendingDelegators: 0,
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_NOTIFICATION_DELEGATED,
+        expect.objectContaining({
+          notifications: expect.any(Array),
+        })
+      );
+    });
+  });
+});

--- a/packages/pn-personafisica-webapp/src/pages/__test__/mixpanel/NuovaDelega.page.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/mixpanel/NuovaDelega.page.mixpanel.test.tsx
@@ -1,0 +1,84 @@
+import MockAdapter from 'axios-mock-adapter';
+import { MockInstance, vi } from 'vitest';
+
+import { RecipientType } from '@pagopa-pn/pn-commons';
+import { testInput } from '@pagopa-pn/pn-commons/src/test-utils';
+
+import { parties } from '../../../__mocks__/ExternalRegistry.mock';
+import { act, fireEvent, render, waitFor } from '../../../__test__/test-utils';
+import { apiClient } from '../../../api/apiClients';
+import { PFEventsType } from '../../../models/PFEventsType';
+import PFEventStrategyFactory from '../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import NuovaDelega from '../../NuovaDelega.page';
+
+vi.mock('../../../utility/delegation.utility', async () => ({
+  ...(await vi.importActual<any>('../../../utility/delegation.utility')),
+  generateVCode: () => '34153',
+}));
+
+describe('NuovaDelega.page - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+  let mock: MockAdapter;
+
+  beforeAll(() => {
+    mock = new MockAdapter(apiClient);
+  });
+
+  beforeEach(() => {
+    mock.onGet('/bff/v1/pa-list').reply(200, parties);
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    mock.reset();
+    triggerEventSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  it('fires SEND_ADD_MANDATE_DATA_INPUT on mount', async () => {
+    await act(async () => {
+      render(<NuovaDelega />);
+    });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ADD_MANDATE_DATA_INPUT);
+  });
+
+  it('fires SEND_ADD_MANDATE_BACK when the back button is clicked', async () => {
+    const { getByTestId } = await act(async () => render(<NuovaDelega />));
+
+    fireEvent.click(getByTestId('breadcrumb-indietro-button'));
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ADD_MANDATE_BACK);
+  });
+
+  it('fires SEND_ADD_MANDATE_UX_CONVERSION on form submit and SEND_ADD_MANDATE_UX_SUCCESS on API success', async () => {
+    mock.onPost('/bff/v1/mandate').reply(200);
+
+    const { container, getByTestId } = await act(async () => render(<NuovaDelega />));
+
+    const form = container.querySelector('form') as HTMLFormElement;
+    await testInput(form, 'nome', 'Mario');
+    await testInput(form, 'cognome', 'Rossi');
+    await testInput(form, 'codiceFiscale', 'RSSMRA01A01A111A');
+    await testInput(form, 'expirationDate', '01/01/2122');
+
+    await act(async () => {
+      fireEvent.click(getByTestId('createButton'));
+    });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ADD_MANDATE_UX_CONVERSION, {
+      selectPersonaFisicaOrPersonaGiuridica: RecipientType.PF,
+      selectTuttiEntiOrSelezionati: 'tuttiGliEnti',
+    });
+
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ADD_MANDATE_UX_SUCCESS, {
+        person_type: RecipientType.PF,
+        mandate_type: 'all',
+      });
+    });
+  });
+});

--- a/packages/pn-personafisica-webapp/src/pages/__test__/mixpanel/Profile.page.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/mixpanel/Profile.page.mixpanel.test.tsx
@@ -1,0 +1,25 @@
+import { MockInstance, vi } from 'vitest';
+
+import { userResponse } from '../../../__mocks__/Auth.mock';
+import { render } from '../../../__test__/test-utils';
+import { PFEventsType } from '../../../models/PFEventsType';
+import PFEventStrategyFactory from '../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import Profile from '../../Profile.page';
+
+describe('Profile.page - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    triggerEventSpy.mockRestore();
+  });
+
+  it('fires SEND_PROFILE on mount', () => {
+    render(<Profile />, { preloadedState: { userState: { user: userResponse } } });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_PROFILE);
+  });
+});

--- a/packages/pn-personafisica-webapp/src/pages/__test__/mixpanel/TppLanding.page.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/mixpanel/TppLanding.page.mixpanel.test.tsx
@@ -1,0 +1,52 @@
+import { MockInstance, vi } from 'vitest';
+
+import { AppRouteParams } from '@pagopa-pn/pn-commons';
+
+import { act, fireEvent, render } from '../../../__test__/test-utils';
+import * as routes from '../../../navigation/routes.const';
+import { PFEventsType } from '../../../models/PFEventsType';
+import PFEventStrategyFactory from '../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import TppLanding from '../../TppLanding.page';
+
+describe('TppLanding.page - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+
+  const mockRetrievalId = '123456';
+  const mockRoute = `${routes.TPP_LANDING}?${AppRouteParams.RETRIEVAL_ID}=${mockRetrievalId}`;
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    triggerEventSpy.mockRestore();
+  });
+
+  it('fires SEND_LANDING_PAGE on mount', () => {
+    render(<TppLanding />, { route: mockRoute });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_LANDING_PAGE);
+  });
+
+  it('fires SEND_LANDING_PAGE_FAQ_OPEN when an FAQ accordion is expanded', async () => {
+    const { getByTestId } = render(<TppLanding />, { route: mockRoute });
+
+    await act(async () => {
+      fireEvent.click(getByTestId('notificationsAccordionSummary'));
+    });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_LANDING_PAGE_FAQ_OPEN, {
+      faq_name: 'faq.what-are-notifications.question',
+    });
+  });
+
+  it('fires SEND_LANDING_PAGE_CLICK_ACCESS when the access button is clicked', async () => {
+    const { getByTestId } = render(<TppLanding />, { route: mockRoute });
+
+    await act(async () => {
+      fireEvent.click(getByTestId('accessButton'));
+    });
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_LANDING_PAGE_CLICK_ACCESS);
+  });
+});


### PR DESCRIPTION
## Short description
Tests for events:

| File | Event | Trigger |
|---|---|---|
| `Profile.page` | `SEND_PROFILE` | mount |
| `Contacts.page` | `SEND_YOUR_CONTACT_DETAILS` | mount 
| `AppStatus.page` | `SEND_SERVICE_STATUS` | mount |
| `TppLanding.page` | `SEND_LANDING_PAGE` | mount |
| `TppLanding.page` | `SEND_LANDING_PAGE_FAQ_OPEN` | FAQ accordion click |
| `TppLanding.page` | `SEND_LANDING_PAGE_CLICK_ACCESS` | access button click |
| `Deleghe.page` | `SEND_YOUR_MANDATES` | after mandates API |
| `NuovaDelega.page` | `SEND_ADD_MANDATE_DATA_INPUT` | mount |
| `NuovaDelega.page` | `SEND_ADD_MANDATE_BACK` | breadcrumb back button click |
| `NuovaDelega.page` | `SEND_ADD_MANDATE_UX_CONVERSION` | form submit |
| `NuovaDelega.page` | `SEND_ADD_MANDATE_UX_SUCCESS` | POST mandate API success |
| `Notifiche.page` | `SEND_YOUR_NOTIFICATIONS` | after notifications API |
| `Notifiche.page` | `SEND_NOTIFICATION_DELEGATED` | after notifications API with `mandateId` |
| `RapidAccessGuard` | `SEND_RAPID_ACCESS` | QR code exchange success (`source: aar`) |
| `RapidAccessGuard` | `SEND_RAPID_ACCESS` | retrieval ID exchange success (`source: retrievalId`) |
| `RapidAccessGuard` | `SEND_NOTIFICATION_NOT_ALLOWED` | QR code exchange failure |
| `App` | `SEND_VIEW_PROFILE` | profile menu item click |
| `NotificationDetail.page` | `SEND_NOTIFICATION_DETAIL` | page ready + downtimes ready |
| `NotificationDetail.page` | `SEND_NOTIFICATIONS_COUNT` | page ready + downtimes ready |
| `NotificationDetail.page` | `SEND_DOWNLOAD_ATTACHMENT` | attachment button click |
| `NotificationDetail.page` | `SEND_DOWNLOAD_RECEIPT_NOTICE` | AAR document button click |
| `NotificationDetail.page` | `SEND_DOWNLOAD_CERTIFICATE_OPPOSABLE_TO_THIRD_PARTIES` | legal fact button click |
| `NotificationDetail.page` | `SEND_NOTIFICATION_STATUS_DETAIL` | timeline accordion toggle |
| `NotificationDetail.page` | `SEND_START_PAYMENT` | pay button click |