### PR TITLE
test(PN-19561): test contacts components

### DIFF
--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/AddSpecialContact.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/AddSpecialContact.mixpanel.test.tsx
@@ -124,7 +124,7 @@ describe('AddSpecialContact - Mixpanel events', () => {
 
   it('fires SEND_ADD_CUSTOMIZED_CONTACT_UX_CONVERSION when the confirm button is clicked', async () => {
     mock.onGet('/bff/v1/pa-list').reply(200, parties);
-    const result = render(<AddSpecialContactWrapper />, {
+    render(<AddSpecialContactWrapper />, {
       preloadedState: { contactsState: { digitalAddresses: digitalLegalAddresses, parties: [] } },
     });
     fireEvent.click(screen.getByTestId('confirm-btn'));

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/AddSpecialContact.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/AddSpecialContact.mixpanel.test.tsx
@@ -1,0 +1,200 @@
+import MockAdapter from 'axios-mock-adapter';
+import React, { useRef } from 'react';
+import { MockInstance, vi } from 'vitest';
+
+import { testAutocomplete, testSelect } from '@pagopa-pn/pn-commons/src/test-utils';
+
+import { digitalLegalAddresses } from '../../../../__mocks__/Contacts.mock';
+import { parties } from '../../../../__mocks__/ExternalRegistry.mock';
+import { fireEvent, render, screen, waitFor } from '../../../../__test__/test-utils';
+import { apiClient } from '../../../../api/apiClients';
+import { ChannelType } from '../../../../models/contacts';
+import { PFEventsType } from '../../../../models/PFEventsType';
+import PFEventStrategyFactory from '../../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import AddSpecialContact from '../../AddSpecialContact';
+import { fillCodeDialog } from '../test-utils';
+
+interface AddSpecialContactRef {
+  handleConfirm: () => Promise<void>;
+}
+
+const AddSpecialContactWrapper: React.FC<{ handleContactAdded?: () => void }> = ({
+  handleContactAdded = vi.fn(),
+}) => {
+  const ref = useRef<AddSpecialContactRef>(null);
+  return (
+    <>
+      <AddSpecialContact ref={ref} handleContactAdded={handleContactAdded} />
+      <button data-testid="confirm-btn" onClick={() => ref.current?.handleConfirm()}>
+        conferma
+      </button>
+    </>
+  );
+};
+
+const channelTypesItems = [
+  { label: 'special-contacts.pec', value: ChannelType.PEC },
+  { label: 'special-contacts.sercq_send', value: ChannelType.SERCQ_SEND },
+];
+
+describe('AddSpecialContact - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+  let mock: MockAdapter;
+
+  beforeAll(() => {
+    mock = new MockAdapter(apiClient);
+  });
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    mock.reset();
+    triggerEventSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  it('fires SEND_CUSTOMIZE_CONTACT on mount', () => {
+    mock.onGet('/bff/v1/pa-list').reply(200, parties);
+    render(<AddSpecialContactWrapper />, {
+      preloadedState: { contactsState: { digitalAddresses: digitalLegalAddresses, parties: [] } },
+    });
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_CUSTOMIZE_CONTACT,
+      expect.any(Object)
+    );
+  });
+
+  it('fires SEND_ADD_CUSTOMIZED_CONTACT_START when the channel type is changed', async () => {
+    mock.onGet('/bff/v1/pa-list').reply(200, parties);
+    const result = render(<AddSpecialContactWrapper />, {
+      preloadedState: { contactsState: { digitalAddresses: digitalLegalAddresses, parties: [] } },
+    });
+    await testSelect(
+      result.container,
+      'channelType',
+      channelTypesItems,
+      channelTypesItems.findIndex((item) => item.value === ChannelType.PEC)
+    );
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ADD_CUSTOMIZED_CONTACT_START,
+      expect.any(Object)
+    );
+  });
+
+  it('fires SEND_ADD_CUSTOMIZED_CONTACT_TOS_ACCEPTED when the TOS checkbox is checked', async () => {
+    mock.onGet('/bff/v1/pa-list').reply(200, parties);
+    const result = render(<AddSpecialContactWrapper />, {
+      preloadedState: { contactsState: { digitalAddresses: digitalLegalAddresses, parties: [] } },
+    });
+    await testSelect(
+      result.container,
+      'channelType',
+      channelTypesItems,
+      channelTypesItems.findIndex((item) => item.value === ChannelType.PEC)
+    );
+    const checkbox = result.container.querySelector('[name="s_disclaimer"]')!;
+    fireEvent.click(checkbox);
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ADD_CUSTOMIZED_CONTACT_TOS_ACCEPTED);
+  });
+
+  it('fires SEND_ADD_CUSTOMIZED_CONTACT_TOS_DISMISSEDD when the TOS checkbox is unchecked', async () => {
+    mock.onGet('/bff/v1/pa-list').reply(200, parties);
+    const result = render(<AddSpecialContactWrapper />, {
+      preloadedState: { contactsState: { digitalAddresses: digitalLegalAddresses, parties: [] } },
+    });
+    await testSelect(
+      result.container,
+      'channelType',
+      channelTypesItems,
+      channelTypesItems.findIndex((item) => item.value === ChannelType.PEC)
+    );
+    const checkbox = result.container.querySelector('[name="s_disclaimer"]')!;
+    fireEvent.click(checkbox); // check
+    fireEvent.click(checkbox); // uncheck
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ADD_CUSTOMIZED_CONTACT_TOS_DISMISSEDD
+    );
+  });
+
+  it('fires SEND_ADD_CUSTOMIZED_CONTACT_UX_CONVERSION when the confirm button is clicked', async () => {
+    mock.onGet('/bff/v1/pa-list').reply(200, parties);
+    const result = render(<AddSpecialContactWrapper />, {
+      preloadedState: { contactsState: { digitalAddresses: digitalLegalAddresses, parties: [] } },
+    });
+    fireEvent.click(screen.getByTestId('confirm-btn'));
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_ADD_CUSTOMIZED_CONTACT_UX_CONVERSION,
+        expect.any(Object)
+      );
+    });
+  });
+
+  it('fires SEND_ADD_PEC_START, SEND_ADD_PEC_UX_CONVERSION, SEND_ADD_CUSTOMIZED_CONTACT_UX_SUCCESS and SEND_ADD_PEC_UX_SUCCESS for the full PEC add flow', async () => {
+    const pecValue = 'special@pec.it';
+    mock.onGet('/bff/v1/pa-list').reply(200, parties);
+    mock
+      .onPost(`/bff/v1/addresses/LEGAL/${parties[2].id}/PEC`, { value: pecValue })
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+    mock
+      .onPost(`/bff/v1/addresses/LEGAL/${parties[2].id}/PEC`, {
+        value: pecValue,
+        verificationCode: '01234',
+      })
+      .reply(204);
+
+    const result = render(<AddSpecialContactWrapper />, {
+      preloadedState: { contactsState: { digitalAddresses: digitalLegalAddresses, parties: [] } },
+    });
+
+    await testAutocomplete(result.container, 'sender', parties, true, 2, true);
+    await testSelect(
+      result.container,
+      'channelType',
+      channelTypesItems,
+      channelTypesItems.findIndex((item) => item.value === ChannelType.PEC)
+    );
+
+    const pecInput = result.container.querySelector('[name="s_value"]')!;
+    fireEvent.change(pecInput, { target: { value: pecValue } });
+    await waitFor(() => expect(pecInput).toHaveValue(pecValue));
+
+    const checkbox = result.container.querySelector('[name="s_disclaimer"]')!;
+    fireEvent.click(checkbox);
+
+    fireEvent.click(screen.getByTestId('confirm-btn'));
+
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_ADD_PEC_START,
+        expect.any(Object)
+      );
+    });
+
+    await fillCodeDialog(result);
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ADD_PEC_UX_CONVERSION,
+      parties[2].id
+    );
+
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_ADD_CUSTOMIZED_CONTACT_UX_SUCCESS,
+        expect.any(Object)
+      );
+    });
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ADD_PEC_UX_SUCCESS, false);
+    });
+  });
+
+  // SEND_ADD_PEC_CODE_ERROR fires via AppResponsePublisher (ContactCodeDialog subscribes to
+  // createOrUpdateAddress/rejected). Requires AppResponsePublisher setup — not testable at this level.
+});

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/AddSpecialContact.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/AddSpecialContact.mixpanel.test.tsx
@@ -2,6 +2,7 @@ import MockAdapter from 'axios-mock-adapter';
 import React, { useRef } from 'react';
 import { MockInstance, vi } from 'vitest';
 
+import { ResponseEventDispatcher } from '@pagopa-pn/pn-commons';
 import { testAutocomplete, testSelect } from '@pagopa-pn/pn-commons/src/test-utils';
 
 import { digitalLegalAddresses } from '../../../../__mocks__/Contacts.mock';
@@ -195,6 +196,48 @@ describe('AddSpecialContact - Mixpanel events', () => {
     });
   });
 
-  // SEND_ADD_PEC_CODE_ERROR fires via AppResponsePublisher (ContactCodeDialog subscribes to
-  // createOrUpdateAddress/rejected). Requires AppResponsePublisher setup — not testable at this level.
+  it('fires SEND_ADD_PEC_CODE_ERROR when the verification code call fails', async () => {
+    const pecValue = 'special@pec.it';
+    mock.onGet('/bff/v1/pa-list').reply(200, parties);
+    mock
+      .onPost(`/bff/v1/addresses/LEGAL/${parties[2].id}/PEC`, { value: pecValue })
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+    mock
+      .onPost(`/bff/v1/addresses/LEGAL/${parties[2].id}/PEC`, {
+        value: pecValue,
+        verificationCode: '01234',
+      })
+      .reply(500);
+
+    const result = render(
+      <>
+        <ResponseEventDispatcher />
+        <AddSpecialContactWrapper />
+      </>,
+      { preloadedState: { contactsState: { digitalAddresses: digitalLegalAddresses, parties: [] } } }
+    );
+
+    await testAutocomplete(result.container, 'sender', parties, true, 2, true);
+    await testSelect(
+      result.container,
+      'channelType',
+      channelTypesItems,
+      channelTypesItems.findIndex((item) => item.value === ChannelType.PEC)
+    );
+
+    const pecInput = result.container.querySelector('[name="s_value"]')!;
+    fireEvent.change(pecInput, { target: { value: pecValue } });
+    await waitFor(() => expect(pecInput).toHaveValue(pecValue));
+
+    const checkbox = result.container.querySelector('[name="s_disclaimer"]')!;
+    fireEvent.click(checkbox);
+
+    fireEvent.click(screen.getByTestId('confirm-btn'));
+
+    await fillCodeDialog(result);
+
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ADD_PEC_CODE_ERROR);
+    });
+  });
 });

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/CancelVerificationModal.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/CancelVerificationModal.mixpanel.test.tsx
@@ -1,0 +1,45 @@
+import { MockInstance, vi } from 'vitest';
+
+import { fireEvent, render, screen, within } from '../../../../__test__/test-utils';
+import { PFEventsType } from '../../../../models/PFEventsType';
+import PFEventStrategyFactory from '../../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import CancelVerificationModal from '../../CancelVerificationModal';
+
+describe('CancelVerificationModal - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    triggerEventSpy.mockRestore();
+  });
+
+  it('fires SEND_PEC_CANCEL_VALIDATION_POP_UP when opened', () => {
+    render(<CancelVerificationModal open handleClose={vi.fn()} />);
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_PEC_CANCEL_VALIDATION_POP_UP
+    );
+  });
+
+  it('fires SEND_PEC_CANCEL_VALIDATION_CANCEL when the cancel button is clicked', () => {
+    render(<CancelVerificationModal open handleClose={vi.fn()} />);
+    const dialog = screen.getByTestId('cancelVerificationModal');
+    const buttons = within(dialog).getAllByRole('button');
+    fireEvent.click(buttons[0]);
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_PEC_CANCEL_VALIDATION_CANCEL
+    );
+  });
+
+  it('fires SEND_PEC_CANCEL_VALIDATION_CONFIRM when the confirm button is clicked', () => {
+    render(<CancelVerificationModal open handleClose={vi.fn()} />);
+    const dialog = screen.getByTestId('cancelVerificationModal');
+    const buttons = within(dialog).getAllByRole('button');
+    fireEvent.click(buttons[1]);
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_PEC_CANCEL_VALIDATION_CONFIRM
+    );
+  });
+});

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/DigitalContactManagement.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/DigitalContactManagement.mixpanel.test.tsx
@@ -1,0 +1,33 @@
+import { MockInstance, vi } from 'vitest';
+
+import { digitalAddressesSercq } from '../../../../__mocks__/Contacts.mock';
+import { render } from '../../../../__test__/test-utils';
+import { PFEventsType } from '../../../../models/PFEventsType';
+import PFEventStrategyFactory from '../../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import DigitalContactManagement from '../../DigitalContactManagement';
+
+describe('DigitalContactManagement - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    triggerEventSpy.mockRestore();
+  });
+
+  it('fires SEND_DIGITAL_DOMICILE_MANAGEMENT on mount', () => {
+    render(<DigitalContactManagement />, {
+      preloadedState: { contactsState: { digitalAddresses: digitalAddressesSercq } },
+    });
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_DIGITAL_DOMICILE_MANAGEMENT,
+      expect.any(Object)
+    );
+  });
+
+  // SEND_ADD_CUSTOMIZED_CONTACT_THANK_YOU_PAGE and SEND_ADD_CUSTOMIZED_CONTACT_THANK_YOU_PAGE_CLOSE
+  // require completing the full AddSpecialContact flow and reaching the wizard feedback step.
+  // Covered by integration tests.
+});

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/EmailContactItem.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/EmailContactItem.mixpanel.test.tsx
@@ -1,6 +1,8 @@
 import MockAdapter from 'axios-mock-adapter';
 import { MockInstance, vi } from 'vitest';
 
+import { ResponseEventDispatcher } from '@pagopa-pn/pn-commons';
+
 import { digitalCourtesyAddresses } from '../../../../__mocks__/Contacts.mock';
 import { fireEvent, render, screen, waitFor } from '../../../../__test__/test-utils';
 import { apiClient } from '../../../../api/apiClients';
@@ -175,6 +177,33 @@ describe('EmailContactItem - Mixpanel events', () => {
     });
   });
 
-  // SEND_ADD_EMAIL_CODE_ERROR fires via AppResponsePublisher (ContactCodeDialog subscribes to
-  // createOrUpdateAddress/rejected). Requires AppResponsePublisher setup — not testable at this level.
+  it('fires SEND_ADD_EMAIL_CODE_ERROR when the verification code call fails', async () => {
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/EMAIL', { value: VALID_EMAIL })
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/EMAIL', {
+        value: VALID_EMAIL,
+        verificationCode: '01234',
+      })
+      .reply(500);
+
+    const result = render(
+      <>
+        <ResponseEventDispatcher />
+        <EmailContactItem />
+      </>
+    );
+
+    const input = result.container.querySelector('[name="default_email"]')!;
+    fireEvent.change(input, { target: { value: VALID_EMAIL } });
+    await waitFor(() => expect(input).toHaveValue(VALID_EMAIL));
+    fireEvent.click(result.getByTestId('default_email-button'));
+
+    await fillCodeDialog(result);
+
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ADD_EMAIL_CODE_ERROR);
+    });
+  });
 });

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/EmailContactItem.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/EmailContactItem.mixpanel.test.tsx
@@ -1,0 +1,180 @@
+import MockAdapter from 'axios-mock-adapter';
+import { MockInstance, vi } from 'vitest';
+
+import { digitalCourtesyAddresses } from '../../../../__mocks__/Contacts.mock';
+import { fireEvent, render, screen, waitFor } from '../../../../__test__/test-utils';
+import { apiClient } from '../../../../api/apiClients';
+import { ChannelType } from '../../../../models/contacts';
+import { PFEventsType } from '../../../../models/PFEventsType';
+import PFEventStrategyFactory from '../../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import EmailContactItem from '../../EmailContactItem';
+import { fillCodeDialog } from '../test-utils';
+
+const VALID_EMAIL = 'test@example.com';
+const defaultAddress = digitalCourtesyAddresses.find(
+  (addr) => addr.channelType === ChannelType.EMAIL && addr.senderId === 'default'
+)!;
+
+describe('EmailContactItem - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+  let mock: MockAdapter;
+
+  beforeAll(() => {
+    mock = new MockAdapter(apiClient);
+  });
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    mock.reset();
+    triggerEventSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  const submitEmail = async (email = VALID_EMAIL) => {
+    const result = render(<EmailContactItem />);
+    const input = result.container.querySelector('[name="default_email"]')!;
+    fireEvent.change(input, { target: { value: email } });
+    await waitFor(() => expect(input).toHaveValue(email));
+    fireEvent.click(result.getByTestId('default_email-button'));
+    return result;
+  };
+
+  it('fires SEND_ADD_EMAIL_START when the form is submitted', async () => {
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/EMAIL', { value: VALID_EMAIL })
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+    await submitEmail();
+    await waitFor(() => expect(mock.history.post).toHaveLength(1));
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ADD_EMAIL_START,
+      expect.any(Object)
+    );
+  });
+
+  it('fires SEND_ADD_EMAIL_OTP when the code dialog opens', async () => {
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/EMAIL', { value: VALID_EMAIL })
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+    await submitEmail();
+    await waitFor(() =>
+      expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ADD_EMAIL_OTP)
+    );
+  });
+
+  it('fires SEND_ADD_EMAIL_UX_CONVERSION when the verification code is submitted', async () => {
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/EMAIL', { value: VALID_EMAIL })
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/EMAIL', {
+        value: VALID_EMAIL,
+        verificationCode: '01234',
+      })
+      .reply(204);
+    const result = await submitEmail();
+    await fillCodeDialog(result);
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ADD_EMAIL_UX_CONVERSION, 'default');
+  });
+
+  it('fires SEND_ADD_EMAIL_UX_SUCCESS after the email is verified', async () => {
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/EMAIL', { value: VALID_EMAIL })
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/EMAIL', {
+        value: VALID_EMAIL,
+        verificationCode: '01234',
+      })
+      .reply(204);
+    const result = await submitEmail();
+    await fillCodeDialog(result);
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_ADD_EMAIL_UX_SUCCESS,
+        expect.any(Object)
+      );
+    });
+  });
+
+  it('fires SEND_ADD_EMAIL_BACK when the code dialog is cancelled', async () => {
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/EMAIL', { value: VALID_EMAIL })
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+    await submitEmail();
+    await waitFor(() => screen.getByRole('dialog'));
+    fireEvent.click(screen.getByRole('button', { name: 'button.annulla' }));
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ADD_EMAIL_BACK);
+  });
+
+  it('fires SEND_CHANGE_EMAIL_START when the edit button is clicked', () => {
+    const { container } = render(<EmailContactItem />, {
+      preloadedState: { contactsState: { digitalAddresses: [defaultAddress] } },
+    });
+    const editButton = container.querySelector('#modifyContact-default_email')!;
+    fireEvent.click(editButton);
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_CHANGE_EMAIL_START);
+  });
+
+  it('fires SEND_CHANGE_EMAIL_CANCEL when the edit is cancelled', () => {
+    const { container } = render(<EmailContactItem />, {
+      preloadedState: { contactsState: { digitalAddresses: [defaultAddress] } },
+    });
+    const editButton = container.querySelector('#modifyContact-default_email')!;
+    fireEvent.click(editButton);
+    fireEvent.click(screen.getByRole('button', { name: 'button.annulla' }));
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_CHANGE_EMAIL_CANCEL);
+  });
+
+  it('fires SEND_REMOVE_EMAIL_START and SEND_REMOVE_EMAIL_POP_UP when the disable button is clicked', () => {
+    render(<EmailContactItem />, {
+      preloadedState: { contactsState: { digitalAddresses: [defaultAddress] } },
+    });
+    fireEvent.click(screen.getByTestId('disable-email'));
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_REMOVE_EMAIL_START,
+      expect.any(Object)
+    );
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_REMOVE_EMAIL_POP_UP,
+      expect.any(Object)
+    );
+  });
+
+  it('fires SEND_REMOVE_EMAIL_POP_UP_CANCEL when the delete dialog is cancelled', async () => {
+    render(<EmailContactItem />, {
+      preloadedState: { contactsState: { digitalAddresses: [defaultAddress] } },
+    });
+    fireEvent.click(screen.getByTestId('disable-email'));
+    const dialog = await waitFor(() => screen.getByRole('dialog'));
+    fireEvent.click(dialog.querySelectorAll('button')[0]);
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_REMOVE_EMAIL_POP_UP_CANCEL,
+      expect.any(Object)
+    );
+  });
+
+  it('fires SEND_REMOVE_EMAIL_UX_SUCCESS after the email is deleted', async () => {
+    mock.onDelete('/bff/v1/addresses/COURTESY/default/EMAIL').reply(204);
+    render(<EmailContactItem />, {
+      preloadedState: { contactsState: { digitalAddresses: [defaultAddress] } },
+    });
+    fireEvent.click(screen.getByTestId('disable-email'));
+    const dialog = await waitFor(() => screen.getByRole('dialog'));
+    fireEvent.click(dialog.querySelectorAll('button')[1]);
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_REMOVE_EMAIL_UX_SUCCESS,
+        expect.any(Object)
+      );
+    });
+  });
+
+  // SEND_ADD_EMAIL_CODE_ERROR fires via AppResponsePublisher (ContactCodeDialog subscribes to
+  // createOrUpdateAddress/rejected). Requires AppResponsePublisher setup — not testable at this level.
+});

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/IOContact.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/IOContact.mixpanel.test.tsx
@@ -1,0 +1,122 @@
+import MockAdapter from 'axios-mock-adapter';
+import { MockInstance, vi } from 'vitest';
+
+import { digitalCourtesyAddresses } from '../../../../__mocks__/Contacts.mock';
+import { fireEvent, render, screen, waitFor } from '../../../../__test__/test-utils';
+import { apiClient } from '../../../../api/apiClients';
+import { ChannelType, IOAllowedValues } from '../../../../models/contacts';
+import { PFEventsType } from '../../../../models/PFEventsType';
+import PFEventStrategyFactory from '../../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import IOContact from '../../IOContact';
+
+const IOAddress = digitalCourtesyAddresses.find((addr) => addr.channelType === ChannelType.IOMSG)!;
+const IOAddressEnabled = { ...IOAddress, value: IOAllowedValues.ENABLED };
+
+describe('IOContact - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+  let mock: MockAdapter;
+
+  beforeAll(() => {
+    mock = new MockAdapter(apiClient);
+  });
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    mock.reset();
+    triggerEventSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  const renderDisabled = () =>
+    render(<IOContact />, {
+      preloadedState: { contactsState: { digitalAddresses: [IOAddress] } },
+    });
+
+  const renderEnabled = () =>
+    render(<IOContact />, {
+      preloadedState: { contactsState: { digitalAddresses: [IOAddressEnabled] } },
+    });
+
+  it('fires SEND_ACTIVE_IO_START and SEND_ACTIVE_IO_UX_CONVERSION when IO is enabled via informative dialog', async () => {
+    mock.onPost('/bff/v1/addresses/COURTESY/default/APPIO').reply(204);
+    renderDisabled();
+    fireEvent.click(screen.getByRole('button', { name: 'io-contact.enable' }));
+    const understandButton = await waitFor(() => screen.getByTestId('understandButton'));
+    fireEvent.click(understandButton);
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ACTIVE_IO_START);
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ACTIVE_IO_UX_CONVERSION);
+  });
+
+  it('fires SEND_ACTIVE_IO_UX_SUCCESS after IO enable API succeeds', async () => {
+    mock.onPost('/bff/v1/addresses/COURTESY/default/APPIO').reply(204);
+    renderDisabled();
+    fireEvent.click(screen.getByRole('button', { name: 'io-contact.enable' }));
+    const understandButton = await waitFor(() => screen.getByTestId('understandButton'));
+    fireEvent.click(understandButton);
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ACTIVE_IO_UX_SUCCESS, false);
+    });
+  });
+
+  it('fires SEND_ACTIVE_IO_CANCEL when informative dialog is cancelled', async () => {
+    renderDisabled();
+    fireEvent.click(screen.getByRole('button', { name: 'io-contact.enable' }));
+    await waitFor(() => screen.getByTestId('informativeDialog'));
+    fireEvent.click(screen.getByTestId('discardButton'));
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ACTIVE_IO_CANCEL);
+  });
+
+  it('fires SEND_DEACTIVE_IO_POP_UP when the disable button is clicked', () => {
+    renderEnabled();
+    fireEvent.click(screen.getByRole('button', { name: 'button.disable' }));
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_DEACTIVE_IO_POP_UP,
+      expect.any(Object)
+    );
+  });
+
+  it('fires SEND_DEACTIVE_IO_CANCEL when the disable dialog is cancelled', async () => {
+    renderEnabled();
+    fireEvent.click(screen.getByRole('button', { name: 'button.disable' }));
+    const dialog = await waitFor(() => screen.getByRole('dialog'));
+    fireEvent.click(dialog.querySelectorAll('button')[0]);
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_DEACTIVE_IO_CANCEL,
+      expect.any(Object)
+    );
+  });
+
+  // SEND_DEACTIVE_IO_START fires inside handleConfirm (InformativeDialog) only when isAppIOEnabled=true,
+  // but InformativeDialog only opens via the enable button (IO disabled) — unreachable in practice.
+  it('fires SEND_DEACTIVE_IO_UX_CONVERSION when disable is confirmed', async () => {
+    mock.onDelete('/bff/v1/addresses/COURTESY/default/APPIO').reply(200);
+    renderEnabled();
+    fireEvent.click(screen.getByRole('button', { name: 'button.disable' }));
+    const dialog = await waitFor(() => screen.getByRole('dialog'));
+    fireEvent.click(dialog.querySelectorAll('button')[1]);
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_DEACTIVE_IO_UX_CONVERSION,
+      expect.any(Object)
+    );
+  });
+
+  it('fires SEND_DEACTIVE_IO_UX_SUCCESS after IO disable API succeeds', async () => {
+    mock.onDelete('/bff/v1/addresses/COURTESY/default/APPIO').reply(200);
+    renderEnabled();
+    fireEvent.click(screen.getByRole('button', { name: 'button.disable' }));
+    const dialog = await waitFor(() => screen.getByRole('dialog'));
+    fireEvent.click(dialog.querySelectorAll('button')[1]);
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_DEACTIVE_IO_UX_SUCCESS,
+        expect.any(Object)
+      );
+    });
+  });
+});

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/LegalContactManager.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/LegalContactManager.mixpanel.test.tsx
@@ -1,0 +1,34 @@
+import { MockInstance, vi } from 'vitest';
+
+import { digitalAddressesSercq } from '../../../../__mocks__/Contacts.mock';
+import { fireEvent, render, screen } from '../../../../__test__/test-utils';
+import { PFEventsType } from '../../../../models/PFEventsType';
+import PFEventStrategyFactory from '../../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import LegalContactManager from '../../LegalContactManager';
+
+describe('LegalContactManager - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    triggerEventSpy.mockRestore();
+  });
+
+  it('fires SEND_ADD_CUSTOMIZED_CONTACT when the special contacts button is clicked', () => {
+    render(<LegalContactManager setAction={vi.fn()} />, {
+      preloadedState: { contactsState: { digitalAddresses: digitalAddressesSercq } },
+    });
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'legal-contacts.digital-domicile-management.special_contacts.action',
+      })
+    );
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ADD_CUSTOMIZED_CONTACT,
+      expect.any(Object)
+    );
+  });
+});

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/LegalContacts.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/LegalContacts.mixpanel.test.tsx
@@ -1,0 +1,171 @@
+import MockAdapter from 'axios-mock-adapter';
+import { MockInstance, vi } from 'vitest';
+
+import {
+  digitalLegalAddresses,
+  digitalLegalAddressesSercq,
+} from '../../../../__mocks__/Contacts.mock';
+import { fireEvent, render, screen, waitFor } from '../../../../__test__/test-utils';
+import { apiClient } from '../../../../api/apiClients';
+import { AddressType } from '../../../../models/contacts';
+import { PFEventsType } from '../../../../models/PFEventsType';
+import PFEventStrategyFactory from '../../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import LegalContacts from '../../LegalContacts';
+
+// Default PEC only, no special legal contacts → delete dialog not blocked
+const pecNoSpecials = digitalLegalAddresses.filter((addr) => addr.senderId === 'default');
+// SERCQ only, no special legal contacts → delete dialog not blocked
+const sercqNoSpecials = digitalLegalAddressesSercq.filter(
+  (addr) => !(addr.addressType === AddressType.LEGAL && addr.senderId !== 'default')
+);
+
+describe('LegalContacts - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+  let mock: MockAdapter;
+
+  beforeAll(() => {
+    mock = new MockAdapter(apiClient);
+  });
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    mock.reset();
+    triggerEventSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_ENTER_FLOW when the start button is clicked', () => {
+    render(<LegalContacts />, {
+      preloadedState: { contactsState: { digitalAddresses: [] } },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'button.start' }));
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ADD_SERCQ_SEND_ENTER_FLOW,
+      expect.any(Object)
+    );
+  });
+
+  it('fires SEND_MANAGE_DIGITAL_DOMICILE when the manage button is clicked', () => {
+    render(<LegalContacts />, {
+      preloadedState: { contactsState: { digitalAddresses: sercqNoSpecials } },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'button.manage' }));
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_MANAGE_DIGITAL_DOMICILE,
+      expect.any(Object)
+    );
+  });
+
+  it('fires SEND_REMOVE_SERCQ_SEND_START and SEND_REMOVE_SERCQ_SEND_POP_UP when the disable button is clicked', () => {
+    render(<LegalContacts />, {
+      preloadedState: { contactsState: { digitalAddresses: sercqNoSpecials } },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'button.disable' }));
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_REMOVE_SERCQ_SEND_START,
+      expect.any(Object)
+    );
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_REMOVE_SERCQ_SEND_POP_UP,
+      expect.any(Object)
+    );
+  });
+
+  it('fires SEND_REMOVE_SERCQ_SEND_POP_UP_CANCEL when the SERCQ delete dialog is cancelled', async () => {
+    render(<LegalContacts />, {
+      preloadedState: { contactsState: { digitalAddresses: sercqNoSpecials } },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'button.disable' }));
+    await waitFor(() => screen.getByRole('dialog'));
+    fireEvent.click(screen.getByRole('button', { name: 'button.annulla' }));
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_REMOVE_SERCQ_SEND_POP_UP_CANCEL,
+      expect.any(Object)
+    );
+  });
+
+  it('fires SEND_REMOVE_SERCQ_SEND_POP_UP_CONTINUE and SEND_REMOVE_SERCQ_SEND_SUCCESS and SEND_REMOVE_SERCQ_SEND_UX_SUCCESS after SERCQ is deleted', async () => {
+    mock.onDelete('/bff/v1/addresses/LEGAL/default/SERCQ_SEND').reply(204);
+    render(<LegalContacts />, {
+      preloadedState: { contactsState: { digitalAddresses: sercqNoSpecials } },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'button.disable' }));
+    await waitFor(() => screen.getByRole('dialog'));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'legal-contacts.remove-sercq_send-confirm' })
+    );
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_REMOVE_SERCQ_SEND_POP_UP_CONTINUE,
+      expect.any(Object)
+    );
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_REMOVE_SERCQ_SEND_SUCCESS,
+        'default'
+      );
+    });
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_REMOVE_SERCQ_SEND_UX_SUCCESS,
+        expect.any(Object)
+      );
+    });
+  });
+
+  it('fires SEND_REMOVE_DIGITAL_DOMICILE_PEC_START and SEND_REMOVE_DIGITAL_DOMICILE_PEC_POP_UP when the PEC disable button is clicked', () => {
+    render(<LegalContacts />, {
+      preloadedState: { contactsState: { digitalAddresses: pecNoSpecials } },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'button.disable' }));
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_REMOVE_DIGITAL_DOMICILE_PEC_START,
+      expect.any(Object)
+    );
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_REMOVE_DIGITAL_DOMICILE_PEC_POP_UP,
+      expect.any(Object)
+    );
+  });
+
+  it('fires SEND_REMOVE_DIGITAL_DOMICILE_PEC_POP_UP_CANCEL when the PEC delete dialog is cancelled', async () => {
+    render(<LegalContacts />, {
+      preloadedState: { contactsState: { digitalAddresses: pecNoSpecials } },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'button.disable' }));
+    await waitFor(() => screen.getByRole('dialog'));
+    fireEvent.click(screen.getByRole('button', { name: 'button.annulla' }));
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_REMOVE_DIGITAL_DOMICILE_PEC_POP_UP_CANCEL,
+      expect.any(Object)
+    );
+  });
+
+  it('fires SEND_REMOVE_DIGITAL_DOMICILE_PEC_POP_UP_CONTINUE and SEND_REMOVE_PEC_SUCCESS and SEND_REMOVE_DIGITAL_DOMICILE_PEC_UX_SUCCESS after PEC is deleted', async () => {
+    mock.onDelete('bff/v1/addresses/LEGAL/default/PEC').reply(200);
+    render(<LegalContacts />, {
+      preloadedState: { contactsState: { digitalAddresses: pecNoSpecials } },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'button.disable' }));
+    await waitFor(() => screen.getByRole('dialog'));
+    fireEvent.click(screen.getByRole('button', { name: 'legal-contacts.remove-pec-confirm' }));
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_REMOVE_DIGITAL_DOMICILE_PEC_POP_UP_CONTINUE,
+      expect.any(Object)
+    );
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_REMOVE_PEC_SUCCESS, 'default');
+    });
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_REMOVE_DIGITAL_DOMICILE_PEC_UX_SUCCESS,
+        expect.any(Object)
+      );
+    });
+  });
+});

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/PecContactItem.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/PecContactItem.mixpanel.test.tsx
@@ -1,0 +1,81 @@
+import MockAdapter from 'axios-mock-adapter';
+import { MockInstance, vi } from 'vitest';
+
+import { fireEvent, render, waitFor } from '../../../../__test__/test-utils';
+import { apiClient } from '../../../../api/apiClients';
+import { PFEventsType } from '../../../../models/PFEventsType';
+import PFEventStrategyFactory from '../../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import PecContactItem from '../../PecContactItem';
+import { fillCodeDialog } from '../test-utils';
+
+const VALID_PEC = 'pec@valida.com';
+
+describe('PecContactItem - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+  let mock: MockAdapter;
+
+  beforeAll(() => {
+    mock = new MockAdapter(apiClient);
+  });
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    mock.reset();
+    triggerEventSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  const submitPec = async () => {
+    const result = render(<PecContactItem />);
+    const input = result.container.querySelector('input[name="default_pec"]')!;
+    fireEvent.change(input, { target: { value: VALID_PEC } });
+    await waitFor(() => expect(input).toHaveValue(VALID_PEC));
+    fireEvent.click(result.getByTestId('default_pec-button'));
+    return result;
+  };
+
+  it('fires SEND_ADD_PEC_START when the form is submitted', async () => {
+    mock.onPost('/bff/v1/addresses/LEGAL/default/PEC').reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+    await submitPec();
+    await waitFor(() => expect(mock.history.post).toHaveLength(1));
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ADD_PEC_START, expect.any(Object));
+  });
+
+  it('fires SEND_ADD_PEC_UX_CONVERSION when the verification code is submitted', async () => {
+    mock
+      .onPost('/bff/v1/addresses/LEGAL/default/PEC', { value: VALID_PEC })
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+    mock
+      .onPost('/bff/v1/addresses/LEGAL/default/PEC', { value: VALID_PEC, verificationCode: '01234' })
+      .reply(200, { result: 'PEC_VALIDATION_REQUIRED' });
+    const result = await submitPec();
+    await fillCodeDialog(result);
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ADD_PEC_UX_CONVERSION, 'default');
+  });
+
+  it('fires SEND_ADD_PEC_UX_SUCCESS after verification code is accepted', async () => {
+    mock
+      .onPost('/bff/v1/addresses/LEGAL/default/PEC', { value: VALID_PEC })
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+    mock
+      .onPost('/bff/v1/addresses/LEGAL/default/PEC', { value: VALID_PEC, verificationCode: '01234' })
+      .reply(200, { result: 'PEC_VALIDATION_REQUIRED' });
+    const result = await submitPec();
+    await fillCodeDialog(result);
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_ADD_PEC_UX_SUCCESS,
+        expect.any(Boolean)
+      );
+    });
+  });
+
+  // SEND_ADD_PEC_CODE_ERROR fires via AppResponsePublisher (ContactCodeDialog subscribes to
+  // createOrUpdateAddress/rejected). Requires AppResponsePublisher setup — not testable at this level.
+});

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/PecContactItem.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/PecContactItem.mixpanel.test.tsx
@@ -1,6 +1,8 @@
 import MockAdapter from 'axios-mock-adapter';
 import { MockInstance, vi } from 'vitest';
 
+import { ResponseEventDispatcher } from '@pagopa-pn/pn-commons';
+
 import { fireEvent, render, waitFor } from '../../../../__test__/test-utils';
 import { apiClient } from '../../../../api/apiClients';
 import { PFEventsType } from '../../../../models/PFEventsType';
@@ -76,6 +78,33 @@ describe('PecContactItem - Mixpanel events', () => {
     });
   });
 
-  // SEND_ADD_PEC_CODE_ERROR fires via AppResponsePublisher (ContactCodeDialog subscribes to
-  // createOrUpdateAddress/rejected). Requires AppResponsePublisher setup — not testable at this level.
+  it('fires SEND_ADD_PEC_CODE_ERROR when the verification code call fails', async () => {
+    mock
+      .onPost('/bff/v1/addresses/LEGAL/default/PEC', { value: VALID_PEC })
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+    mock
+      .onPost('/bff/v1/addresses/LEGAL/default/PEC', {
+        value: VALID_PEC,
+        verificationCode: '01234',
+      })
+      .reply(500);
+
+    const result = render(
+      <>
+        <ResponseEventDispatcher />
+        <PecContactItem />
+      </>
+    );
+
+    const input = result.container.querySelector('input[name="default_pec"]')!;
+    fireEvent.change(input, { target: { value: VALID_PEC } });
+    await waitFor(() => expect(input).toHaveValue(VALID_PEC));
+    fireEvent.click(result.getByTestId('default_pec-button'));
+
+    await fillCodeDialog(result);
+
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ADD_PEC_CODE_ERROR);
+    });
+  });
 });

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/PecValidationItem.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/PecValidationItem.mixpanel.test.tsx
@@ -1,0 +1,24 @@
+import { MockInstance, vi } from 'vitest';
+
+import { fireEvent, render, screen } from '../../../../__test__/test-utils';
+import { PFEventsType } from '../../../../models/PFEventsType';
+import PFEventStrategyFactory from '../../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import PecValidationItem from '../../PecValidationItem';
+
+describe('PecValidationItem - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    triggerEventSpy.mockRestore();
+  });
+
+  it('fires SEND_PEC_CANCEL_VALIDATION when the cancel validation button is clicked', () => {
+    render(<PecValidationItem senderId="default" onCancelValidation={vi.fn()} />);
+    fireEvent.click(screen.getByTestId('cancelValidation'));
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_PEC_CANCEL_VALIDATION);
+  });
+});

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/SmsContactItem.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/SmsContactItem.mixpanel.test.tsx
@@ -1,0 +1,202 @@
+import MockAdapter from 'axios-mock-adapter';
+import { MockInstance, vi } from 'vitest';
+
+import { digitalCourtesyAddresses } from '../../../../__mocks__/Contacts.mock';
+import { fireEvent, render, screen, waitFor } from '../../../../__test__/test-utils';
+import { apiClient } from '../../../../api/apiClients';
+import { ChannelType } from '../../../../models/contacts';
+import { PFEventsType } from '../../../../models/PFEventsType';
+import PFEventStrategyFactory from '../../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import { internationalPhonePrefix } from '../../../../utility/contacts.utility';
+import SmsContactItem from '../../SmsContactItem';
+import { fillCodeDialog } from '../test-utils';
+
+const VALID_PHONE = '3331234567';
+const defaultAddress = digitalCourtesyAddresses.find(
+  (addr) => addr.channelType === ChannelType.SMS && addr.senderId === 'default'
+)!;
+
+describe('SmsContactItem - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+  let mock: MockAdapter;
+
+  beforeAll(() => {
+    mock = new MockAdapter(apiClient);
+  });
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    mock.reset();
+    triggerEventSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  const enterInsertMode = async () => {
+    const result = render(<SmsContactItem />);
+    const addBtn = result.getByRole('button', { name: 'courtesy-contacts.email-sms-add' });
+    fireEvent.click(addBtn);
+    return result;
+  };
+
+  const submitSms = async (phone = VALID_PHONE) => {
+    const result = await enterInsertMode();
+    const form = result.container.querySelector('form')!;
+    const input = form.querySelector('[name="default_sms"]')!;
+    fireEvent.change(input, { target: { value: phone } });
+    await waitFor(() => expect(input).toHaveValue(phone));
+    fireEvent.click(result.getByTestId('default_sms-button'));
+    return result;
+  };
+
+  it('fires SEND_ADD_SMS_START when the form is submitted', async () => {
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/SMS', {
+        value: internationalPhonePrefix + VALID_PHONE,
+      })
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+    await submitSms();
+    await waitFor(() => expect(mock.history.post).toHaveLength(1));
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ADD_SMS_START,
+      expect.any(Object)
+    );
+  });
+
+  it('fires SEND_ADD_SMS_OTP when the code dialog opens', async () => {
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/SMS', {
+        value: internationalPhonePrefix + VALID_PHONE,
+      })
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+    await submitSms();
+    await waitFor(() =>
+      expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ADD_SMS_OTP)
+    );
+  });
+
+  it('fires SEND_ADD_SMS_UX_CONVERSION when the verification code is submitted', async () => {
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/SMS', {
+        value: internationalPhonePrefix + VALID_PHONE,
+      })
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/SMS', {
+        value: internationalPhonePrefix + VALID_PHONE,
+        verificationCode: '01234',
+      })
+      .reply(204);
+    const result = await submitSms();
+    await fillCodeDialog(result);
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ADD_SMS_UX_CONVERSION, 'default');
+  });
+
+  it('fires SEND_ADD_SMS_UX_SUCCESS after the SMS is verified', async () => {
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/SMS', {
+        value: internationalPhonePrefix + VALID_PHONE,
+      })
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/SMS', {
+        value: internationalPhonePrefix + VALID_PHONE,
+        verificationCode: '01234',
+      })
+      .reply(204);
+    const result = await submitSms();
+    await fillCodeDialog(result);
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_ADD_SMS_UX_SUCCESS,
+        expect.any(Object)
+      );
+    });
+  });
+
+  it('fires SEND_ADD_SMS_BACK when the code dialog is cancelled', async () => {
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/SMS', {
+        value: internationalPhonePrefix + VALID_PHONE,
+      })
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+    await submitSms();
+    await waitFor(() => screen.getByRole('dialog'));
+    fireEvent.click(screen.getByRole('button', { name: 'button.annulla' }));
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ADD_SMS_BACK);
+  });
+
+  it('fires SEND_CHANGE_SMS_START when the edit button is clicked', () => {
+    const { container } = render(<SmsContactItem />, {
+      preloadedState: { contactsState: { digitalAddresses: [defaultAddress] } },
+    });
+    fireEvent.click(container.querySelector('#modifyContact-default_sms')!);
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_CHANGE_SMS_START);
+  });
+
+  it('fires SEND_CHANGE_SMS_CANCEL when the edit is cancelled', () => {
+    const { container } = render(<SmsContactItem />, {
+      preloadedState: { contactsState: { digitalAddresses: [defaultAddress] } },
+    });
+    fireEvent.click(container.querySelector('#modifyContact-default_sms')!);
+    fireEvent.click(screen.getByRole('button', { name: 'button.annulla' }));
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_CHANGE_SMS_CANCEL);
+  });
+
+  it('fires SEND_REMOVE_SMS_START and SEND_REMOVE_SMS_POP_UP when the disable button is clicked', () => {
+    render(<SmsContactItem />, {
+      preloadedState: { contactsState: { digitalAddresses: [defaultAddress] } },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'button.disable' }));
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_REMOVE_SMS_START,
+      expect.any(Object)
+    );
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_REMOVE_SMS_POP_UP,
+      expect.any(Object)
+    );
+  });
+
+  it('fires SEND_REMOVE_SMS_POP_UP_CANCEL when the delete dialog is cancelled', async () => {
+    render(<SmsContactItem />, {
+      preloadedState: { contactsState: { digitalAddresses: [defaultAddress] } },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'button.disable' }));
+    const dialog = await waitFor(() => screen.getByRole('dialog'));
+    // DeleteDialog renders secondary first ([0]=cancel) then primary ([1]=confirm)
+    fireEvent.click(dialog.querySelectorAll('button')[0]);
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_REMOVE_SMS_POP_UP_CANCEL,
+      expect.any(Object)
+    );
+  });
+
+  it('fires SEND_REMOVE_SMS_SUCCESS and SEND_REMOVE_SMS_POP_UP_UX_SUCCESS after SMS is deleted', async () => {
+    mock.onDelete('/bff/v1/addresses/COURTESY/default/SMS').reply(204);
+    render(<SmsContactItem />, {
+      preloadedState: { contactsState: { digitalAddresses: [defaultAddress] } },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'button.disable' }));
+    const dialog = await waitFor(() => screen.getByRole('dialog'));
+    // DeleteDialog renders secondary first ([0]=cancel) then primary ([1]=confirm)
+    fireEvent.click(dialog.querySelectorAll('button')[1]);
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_REMOVE_SMS_SUCCESS, 'default');
+    });
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_REMOVE_SMS_POP_UP_UX_SUCCESS,
+        expect.any(Object)
+      );
+    });
+  });
+
+  // SEND_ADD_SMS_CODE_ERROR fires via AppResponsePublisher (ContactCodeDialog subscribes to
+  // createOrUpdateAddress/rejected). Requires AppResponsePublisher setup — not testable at this level.
+});

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/SmsContactItem.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/SmsContactItem.mixpanel.test.tsx
@@ -1,6 +1,8 @@
 import MockAdapter from 'axios-mock-adapter';
 import { MockInstance, vi } from 'vitest';
 
+import { ResponseEventDispatcher } from '@pagopa-pn/pn-commons';
+
 import { digitalCourtesyAddresses } from '../../../../__mocks__/Contacts.mock';
 import { fireEvent, render, screen, waitFor } from '../../../../__test__/test-utils';
 import { apiClient } from '../../../../api/apiClients';
@@ -197,6 +199,36 @@ describe('SmsContactItem - Mixpanel events', () => {
     });
   });
 
-  // SEND_ADD_SMS_CODE_ERROR fires via AppResponsePublisher (ContactCodeDialog subscribes to
-  // createOrUpdateAddress/rejected). Requires AppResponsePublisher setup — not testable at this level.
+  it('fires SEND_ADD_SMS_CODE_ERROR when the verification code call fails', async () => {
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/SMS', {
+        value: internationalPhonePrefix + VALID_PHONE,
+      })
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/SMS', {
+        value: internationalPhonePrefix + VALID_PHONE,
+        verificationCode: '01234',
+      })
+      .reply(500);
+
+    const result = render(
+      <>
+        <ResponseEventDispatcher />
+        <SmsContactItem />
+      </>
+    );
+
+    fireEvent.click(result.getByRole('button', { name: 'courtesy-contacts.email-sms-add' }));
+    const input = result.container.querySelector('[name="default_sms"]')!;
+    fireEvent.change(input, { target: { value: VALID_PHONE } });
+    await waitFor(() => expect(input).toHaveValue(VALID_PHONE));
+    fireEvent.click(result.getByTestId('default_sms-button'));
+
+    await fillCodeDialog(result);
+
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ADD_SMS_CODE_ERROR);
+    });
+  });
 });

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/SpecialContacts.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/SpecialContacts.mixpanel.test.tsx
@@ -1,0 +1,120 @@
+import MockAdapter from 'axios-mock-adapter';
+import { MockInstance, vi } from 'vitest';
+
+import { digitalLegalAddresses } from '../../../../__mocks__/Contacts.mock';
+import { fireEvent, render, screen, waitFor, within } from '../../../../__test__/test-utils';
+import { apiClient } from '../../../../api/apiClients';
+import { AddressType } from '../../../../models/contacts';
+import { PFEventsType } from '../../../../models/PFEventsType';
+import PFEventStrategyFactory from '../../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import SpecialContacts from '../../SpecialContacts';
+
+const specialLegalAddresses = digitalLegalAddresses.filter((addr) => addr.senderId !== 'default');
+const firstSenderId = specialLegalAddresses[0].senderId;
+
+describe('SpecialContacts - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+  let mock: MockAdapter;
+
+  beforeAll(() => {
+    mock = new MockAdapter(apiClient);
+  });
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    mock.reset();
+    triggerEventSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  const renderSpecialPec = () =>
+    render(<SpecialContacts addressType={AddressType.LEGAL} />, {
+      preloadedState: { contactsState: { digitalAddresses: specialLegalAddresses } },
+    });
+
+  it('fires SEND_ADD_PEC_START when a special PEC form is submitted', async () => {
+    const VALID_PEC = 'new@pec.it';
+    mock
+      .onPost(`/bff/v1/addresses/LEGAL/${firstSenderId}/PEC`, { value: VALID_PEC })
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+
+    const result = renderSpecialPec();
+    const editButton = result.container.querySelector(`#modifyContact-${firstSenderId}_pec`)!;
+    fireEvent.click(editButton);
+
+    const input = result.container.querySelector(`[name="${firstSenderId}_pec"]`)!;
+    fireEvent.change(input, { target: { value: VALID_PEC } });
+    await waitFor(() => expect(input).toHaveValue(VALID_PEC));
+
+    const saveButton = result.container.querySelector(`#saveContact-${firstSenderId}_pec`)!;
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_ADD_PEC_START,
+        expect.any(Object)
+      );
+    });
+  });
+
+  it('fires SEND_REMOVE_DIGITAL_DOMICILE_PEC_START and SEND_REMOVE_DIGITAL_DOMICILE_PEC_POP_UP when PEC delete is clicked', () => {
+    const result = renderSpecialPec();
+    const firstForm = result.getAllByTestId(/^[a-zA-Z0-9-]+_pecSpecialContact$/)[0];
+    fireEvent.click(within(firstForm).getByRole('button', { name: 'button.elimina' }));
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_REMOVE_DIGITAL_DOMICILE_PEC_START,
+      expect.any(Object)
+    );
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_REMOVE_DIGITAL_DOMICILE_PEC_POP_UP,
+      expect.any(Object)
+    );
+  });
+
+  it('fires SEND_REMOVE_DIGITAL_DOMICILE_PEC_POP_UP_CANCEL when the delete dialog is cancelled', async () => {
+    const result = renderSpecialPec();
+    const firstForm = result.getAllByTestId(/^[a-zA-Z0-9-]+_pecSpecialContact$/)[0];
+    fireEvent.click(within(firstForm).getByRole('button', { name: 'button.elimina' }));
+    const dialog = await waitFor(() => screen.getByRole('dialog'));
+    // secondary button [0] = cancel → fires handleCloseModal → SEND_REMOVE_..._POP_UP_CANCEL
+    fireEvent.click(dialog.querySelectorAll('button')[0]);
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_REMOVE_DIGITAL_DOMICILE_PEC_POP_UP_CANCEL,
+      expect.any(Object)
+    );
+  });
+
+  it('fires SEND_REMOVE_DIGITAL_DOMICILE_PEC_POP_UP_CONTINUE, SEND_REMOVE_PEC_SUCCESS and SEND_REMOVE_DIGITAL_DOMICILE_PEC_UX_SUCCESS after deletion', async () => {
+    mock.onDelete(`/bff/v1/addresses/LEGAL/${firstSenderId}/PEC`).reply(200);
+
+    const result = renderSpecialPec();
+    const firstForm = result.getAllByTestId(/^[a-zA-Z0-9-]+_pecSpecialContact$/)[0];
+    fireEvent.click(within(firstForm).getByRole('button', { name: 'button.elimina' }));
+    const dialog = await waitFor(() => screen.getByRole('dialog'));
+    // primary button [1] = confirm → fires deleteConfirmHandler
+    fireEvent.click(dialog.querySelectorAll('button')[1]);
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_REMOVE_DIGITAL_DOMICILE_PEC_POP_UP_CONTINUE,
+      expect.any(Object)
+    );
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_REMOVE_PEC_SUCCESS,
+        firstSenderId
+      );
+    });
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_REMOVE_DIGITAL_DOMICILE_PEC_UX_SUCCESS,
+        expect.any(Object)
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Short description

File | Evento | Trigger
-- | -- | --
PecContactItem | SEND_ADD_PEC_START | Submit form PEC
PecContactItem | SEND_ADD_PEC_UX_CONVERSION | Inserimento codice verifica
PecContactItem | SEND_ADD_PEC_UX_SUCCESS | API conferma PEC
EmailContactItem | SEND_ADD_EMAIL_START | Submit form email (nuovo inserimento)
EmailContactItem | SEND_ADD_EMAIL_OTP | API richiede codice OTP
EmailContactItem | SEND_ADD_EMAIL_UX_CONVERSION | Inserimento codice verifica
EmailContactItem | SEND_ADD_EMAIL_UX_SUCCESS | API conferma email
EmailContactItem | SEND_ADD_EMAIL_BACK | Chiusura dialog codice
EmailContactItem | SEND_CHANGE_EMAIL_START | Click modifica email esistente
EmailContactItem | SEND_CHANGE_EMAIL_CANCEL | Click annulla in modalità modifica
EmailContactItem | SEND_REMOVE_EMAIL_START | Click elimina email
EmailContactItem | SEND_REMOVE_EMAIL_POP_UP | Apertura dialog conferma eliminazione
EmailContactItem | SEND_REMOVE_EMAIL_POP_UP_CANCEL | Click annulla nel dialog eliminazione
EmailContactItem | SEND_REMOVE_EMAIL_UX_SUCCESS | API conferma eliminazione email
SmsContactItem | SEND_ADD_SMS_START | Submit form SMS (nuovo inserimento)
SmsContactItem | SEND_ADD_SMS_OTP | API richiede codice OTP
SmsContactItem | SEND_ADD_SMS_UX_CONVERSION | Inserimento codice verifica
SmsContactItem | SEND_ADD_SMS_UX_SUCCESS | API conferma SMS
SmsContactItem | SEND_ADD_SMS_BACK | Chiusura dialog codice
SmsContactItem | SEND_CHANGE_SMS_START | Click modifica SMS esistente
SmsContactItem | SEND_CHANGE_SMS_CANCEL | Click annulla in modalità modifica
SmsContactItem | SEND_REMOVE_SMS_START | Click elimina SMS
SmsContactItem | SEND_REMOVE_SMS_POP_UP | Apertura dialog conferma eliminazione
SmsContactItem | SEND_REMOVE_SMS_POP_UP_CANCEL | Click annulla nel dialog eliminazione
SmsContactItem | SEND_REMOVE_SMS_SUCCESS | API conferma eliminazione SMS
SmsContactItem | SEND_REMOVE_SMS_POP_UP_UX_SUCCESS | UX success dopo eliminazione
IOContact | SEND_ACTIVE_IO_START | Click attiva IO
IOContact | SEND_ACTIVE_IO_UX_CONVERSION | Click conferma attivazione IO
IOContact | SEND_ACTIVE_IO_UX_SUCCESS | API conferma attivazione IO
IOContact | SEND_ACTIVE_IO_CANCEL | Click annulla attivazione IO
IOContact | SEND_DEACTIVE_IO_POP_UP | Apertura dialog disattivazione IO
IOContact | SEND_DEACTIVE_IO_UX_CONVERSION | Click conferma disattivazione IO
IOContact | SEND_DEACTIVE_IO_UX_SUCCESS | API conferma disattivazione IO
IOContact | SEND_DEACTIVE_IO_CANCEL | Click annulla nel dialog disattivazione
PecValidationItem | SEND_PEC_CANCEL_VALIDATION | Click cancella validazione PEC
CancelVerificationModal | SEND_PEC_CANCEL_VALIDATION_POP_UP | Apertura modal annulla validazione
CancelVerificationModal | SEND_PEC_CANCEL_VALIDATION_CONFIRM | Click conferma annullamento validazione
CancelVerificationModal | SEND_PEC_CANCEL_VALIDATION_CANCEL | Click annulla nel modal
LegalContacts | SEND_MANAGE_DIGITAL_DOMICILE | Mount componente
LegalContacts | SEND_ADD_SERCQ_SEND_ENTER_FLOW | Click attiva SERCQ SEND
LegalContacts | SEND_REMOVE_SERCQ_SEND_START | Click rimuovi SERCQ SEND
LegalContacts | SEND_REMOVE_SERCQ_SEND_POP_UP | Apertura dialog conferma rimozione SERCQ
LegalContacts | SEND_REMOVE_SERCQ_SEND_POP_UP_CANCEL | Click annulla nel dialog rimozione SERCQ
LegalContacts | SEND_REMOVE_SERCQ_SEND_POP_UP_CONTINUE | Click conferma rimozione SERCQ
LegalContacts | SEND_REMOVE_SERCQ_SEND_SUCCESS | API conferma rimozione SERCQ
LegalContacts | SEND_REMOVE_SERCQ_SEND_UX_SUCCESS | UX success dopo rimozione SERCQ
LegalContacts | SEND_REMOVE_DIGITAL_DOMICILE_PEC_START | Click rimuovi PEC default
LegalContacts | SEND_REMOVE_DIGITAL_DOMICILE_PEC_POP_UP | Apertura dialog conferma rimozione PEC
LegalContacts | SEND_REMOVE_DIGITAL_DOMICILE_PEC_POP_UP_CANCEL | Click annulla nel dialog rimozione PEC
LegalContacts | SEND_REMOVE_DIGITAL_DOMICILE_PEC_POP_UP_CONTINUE | Click conferma rimozione PEC
LegalContacts | SEND_REMOVE_PEC_SUCCESS | API conferma eliminazione PEC
LegalContacts | SEND_REMOVE_DIGITAL_DOMICILE_PEC_UX_SUCCESS | UX success dopo rimozione PEC
LegalContactManager | SEND_ADD_CUSTOMIZED_CONTACT | Click gestione contatti speciali
DigitalContactManagement | SEND_DIGITAL_DOMICILE_MANAGEMENT | Mount componente
SpecialContacts | SEND_ADD_PEC_START | Submit form PEC contatto speciale
SpecialContacts | SEND_REMOVE_DIGITAL_DOMICILE_PEC_START | Click elimina PEC speciale
SpecialContacts | SEND_REMOVE_DIGITAL_DOMICILE_PEC_POP_UP | Apertura dialog conferma eliminazione
SpecialContacts | SEND_REMOVE_DIGITAL_DOMICILE_PEC_POP_UP_CANCEL | Click annulla nel dialog
SpecialContacts | SEND_REMOVE_DIGITAL_DOMICILE_PEC_POP_UP_CONTINUE | Click conferma eliminazione
SpecialContacts | SEND_REMOVE_PEC_SUCCESS | API conferma eliminazione PEC speciale
SpecialContacts | SEND_REMOVE_DIGITAL_DOMICILE_PEC_UX_SUCCESS | UX success dopo eliminazione
AddSpecialContact | SEND_CUSTOMIZE_CONTACT | Mount componente
AddSpecialContact | SEND_ADD_CUSTOMIZED_CONTACT_START | Cambio tipo canale (es. PEC)
AddSpecialContact | SEND_ADD_CUSTOMIZED_CONTACT_TOS_ACCEPTED | Check checkbox disclaimer
AddSpecialContact | SEND_ADD_CUSTOMIZED_CONTACT_TOS_DISMISSEDD | Uncheck checkbox disclaimer
AddSpecialContact | SEND_ADD_CUSTOMIZED_CONTACT_UX_CONVERSION | Click conferma
AddSpecialContact | SEND_ADD_CUSTOMIZED_CONTACT_UX_SUCCESS | API conferma inserimento contatto speciale
AddSpecialContact | SEND_ADD_PEC_START | Submit PEC nel flow contatto speciale
AddSpecialContact | SEND_ADD_PEC_UX_CONVERSION | Inserimento codice verifica PEC speciale
AddSpecialContact | SEND_ADD_PEC_UX_SUCCESS | API conferma PEC speciale
SmsContactItem | SEND_ADD_SMS_CODE_ERROR |
EmailContactItem | SEND_ADD_EMAIL_CODE_ERROR | 
PecContactItem | SEND_ADD_PEC_CODE_ERROR |
AddSpecialContact | SEND_ADD_PEC_CODE_ERROR | 

