### PR TITLE
fix(PN-18983): improve required fields accessibility

### DIFF
--- a/packages/pn-pa-webapp/src/components/NewNotification/Attachments.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/Attachments.tsx
@@ -367,7 +367,7 @@ const Attachments: React.FC<Props> = ({
               }
               canBeDeleted={i > 0}
               onDelete={() => deleteDocumentHandler(i)}
-              fieldLabel={`${t('doc-name')}`}
+              fieldLabel={t('doc-name')}
               required
               fieldValue={d.name}
               fileUploaded={d}

--- a/packages/pn-pa-webapp/src/components/NewNotification/Attachments.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/Attachments.tsx
@@ -47,6 +47,7 @@ type AttachmentBoxProps = {
   onDelete?: () => void;
   fieldLabel: string;
   fieldValue: string;
+  required?: boolean;
   fieldTouched?: boolean;
   fieldErrors?: string;
   onFieldTouched: (e: ChangeEvent) => void;
@@ -70,6 +71,7 @@ const AttachmentBox: React.FC<AttachmentBoxProps> = ({
   onDelete,
   fieldLabel,
   fieldValue,
+  required = false,
   fieldTouched,
   fieldErrors,
   onFieldTouched,
@@ -111,6 +113,7 @@ const AttachmentBox: React.FC<AttachmentBoxProps> = ({
           error={fieldTouched && Boolean(fieldErrors)}
           helperText={(fieldTouched && fieldErrors) || <NameFocusHelperText />}
           size="small"
+          required={required}
           margin="normal"
           data-testid="attachmentNameInput"
         />
@@ -364,7 +367,8 @@ const Attachments: React.FC<Props> = ({
               }
               canBeDeleted={i > 0}
               onDelete={() => deleteDocumentHandler(i)}
-              fieldLabel={`${t('doc-name')}*`}
+              fieldLabel={`${t('doc-name')}`}
+              required
               fieldValue={d.name}
               fileUploaded={d}
               fieldTouched={

--- a/packages/pn-pa-webapp/src/components/NewNotification/FormTextField.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/FormTextField.tsx
@@ -6,6 +6,7 @@ import { Grid, SxProps, TextField } from '@mui/material';
 type Props = {
   keyName: string;
   label: string;
+  required?: boolean;
   values: FormikValues;
   touched: FormikTouched<any>;
   errors: FormikErrors<FormikValues>;
@@ -18,6 +19,7 @@ type Props = {
 const FormTextField: React.FC<Props> = ({
   keyName,
   label,
+  required = false,
   values,
   setFieldValue,
   touched,
@@ -41,6 +43,7 @@ const FormTextField: React.FC<Props> = ({
         }}
         onBlur={handleBlur}
         label={label}
+        required={required}
         name={keyName}
         error={showErrorIfPresent && Boolean(getIn(errors, keyName))}
         helperText={showErrorIfPresent && getIn(errors, keyName)}

--- a/packages/pn-pa-webapp/src/components/NewNotification/PhysicalAddress.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/PhysicalAddress.tsx
@@ -27,13 +27,13 @@ const PhysicalAddress = ({
   });
 
   const physicalAddressFields = [
-    { key: 'foreignState', label: `${t('foreign-state')}*`, width: 4 },
-    { key: 'province', label: `${t('province')}*`, width: 4 },
-    { key: 'zip', label: `${t('zip')}*`, width: 4 },
-    { key: 'municipality', label: `${t('municipality')}*`, width: 6 },
+    { key: 'foreignState', label: t('foreign-state'), width: 4, required: true },
+    { key: 'province', label: t('province'), width: 4, required: true },
+    { key: 'zip', label: t('zip'), width: 4, required: true },
+    { key: 'municipality', label: t('municipality'), width: 6, required: true },
     { key: 'municipalityDetails', label: t('municipality-details'), width: 6 },
-    { key: 'address', label: `${t('address')}*`, width: 9 },
-    { key: 'houseNumber', label: `${t('house-number')}*`, width: 3 },
+    { key: 'address', label: t('address'), width: 9, required: true },
+    { key: 'houseNumber', label: t('house-number'), width: 3, required: true },
     { key: 'addressDetails', label: t('address-details'), width: 12 },
   ];
 
@@ -44,6 +44,7 @@ const PhysicalAddress = ({
           <FormTextField
             keyName={`recipients[${recipient}].${field.key}`}
             label={field.label}
+            required={field.required}
             values={values}
             touched={touched}
             errors={errors}

--- a/packages/pn-pa-webapp/src/components/NewNotification/PreliminaryInformations.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/PreliminaryInformations.tsx
@@ -184,7 +184,8 @@ const PreliminaryInformations = ({ notification, onConfirm }: Props) => {
             <FormBoxTitle text={t('sender-denomination')} />
             <TextField
               id="senderDenomination"
-              label={`${t('sender-name')}*`}
+              label={`${t('sender-name')}`}
+              required
               fullWidth
               name="senderDenomination"
               value={formik.values.senderDenomination}
@@ -214,8 +215,9 @@ const PreliminaryInformations = ({ notification, onConfirm }: Props) => {
             <FormBoxSubtitle text={t('protocol-number-subtitle')} />
             <TextField
               id="paProtocolNumber"
-              label={`${t('protocol-number')}*`}
+              label={`${t('protocol-number')}`}
               fullWidth
+              required
               name="paProtocolNumber"
               value={formik.values.paProtocolNumber}
               onChange={handleChangeTouched}
@@ -245,7 +247,8 @@ const PreliminaryInformations = ({ notification, onConfirm }: Props) => {
             </Typography>
             <TextField
               id="taxonomyCode"
-              label={`${t('taxonomy-id')}*`}
+              label={`${t('taxonomy-id')}`}
+              required
               fullWidth
               name="taxonomyCode"
               value={formik.values.taxonomyCode}

--- a/packages/pn-pa-webapp/src/components/NewNotification/PreliminaryInformations.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/PreliminaryInformations.tsx
@@ -293,7 +293,7 @@ const PreliminaryInformations = ({ notification, onConfirm }: Props) => {
             <FormBoxSubtitle text={t('notification-management-subtitle')} />
             <CustomDropdown
               id="group"
-              label={`${t('group')}${hasGroups ? '*' : ''}`}
+              label={t('group')}
               fullWidth
               name="group"
               size="small"

--- a/packages/pn-pa-webapp/src/components/NewNotification/PreliminaryInformations.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/PreliminaryInformations.tsx
@@ -294,6 +294,7 @@ const PreliminaryInformations = ({ notification, onConfirm }: Props) => {
             <CustomDropdown
               id="group"
               label={t('group')}
+              required={hasGroups}
               fullWidth
               name="group"
               size="small"

--- a/packages/pn-pa-webapp/src/components/NewNotification/PreliminaryInformations.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/PreliminaryInformations.tsx
@@ -184,7 +184,7 @@ const PreliminaryInformations = ({ notification, onConfirm }: Props) => {
             <FormBoxTitle text={t('sender-denomination')} />
             <TextField
               id="senderDenomination"
-              label={`${t('sender-name')}`}
+              label={t('sender-name')}
               required
               fullWidth
               name="senderDenomination"
@@ -215,7 +215,7 @@ const PreliminaryInformations = ({ notification, onConfirm }: Props) => {
             <FormBoxSubtitle text={t('protocol-number-subtitle')} />
             <TextField
               id="paProtocolNumber"
-              label={`${t('protocol-number')}`}
+              label={t('protocol-number')}
               fullWidth
               required
               name="paProtocolNumber"
@@ -247,7 +247,7 @@ const PreliminaryInformations = ({ notification, onConfirm }: Props) => {
             </Typography>
             <TextField
               id="taxonomyCode"
-              label={`${t('taxonomy-id')}`}
+              label={t('taxonomy-id')}
               required
               fullWidth
               name="taxonomyCode"

--- a/packages/pn-pa-webapp/src/components/NewNotification/PreliminaryInformationsContent.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/PreliminaryInformationsContent.tsx
@@ -52,7 +52,7 @@ const PreliminaryInformationsContent = ({ formik, languages, onChangeTouched }: 
       )}
       <TextField
         id="subject"
-        label={`${t('subject')}`}
+        label={t('subject')}
         required
         fullWidth
         name="subject"
@@ -86,7 +86,7 @@ const PreliminaryInformationsContent = ({ formik, languages, onChangeTouched }: 
           </Typography>
           <TextField
             id="additionalSubject"
-            label={`${t('subject')}`}
+            label={t('subject')}
             required
             fullWidth
             name="additionalSubject"

--- a/packages/pn-pa-webapp/src/components/NewNotification/PreliminaryInformationsContent.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/PreliminaryInformationsContent.tsx
@@ -5,20 +5,23 @@ import { useTranslation } from 'react-i18next';
 import { TextField, Typography, useFormControl } from '@mui/material';
 import { LangCode, LangLabels } from '@pagopa/mui-italia';
 
-import { NewNotificationLangOther, PreliminaryInformationsPayload } from '../../models/NewNotification';
+import {
+  NewNotificationLangOther,
+  PreliminaryInformationsPayload,
+} from '../../models/NewNotification';
 import { FormBox, FormBoxSubtitle, FormBoxTitle } from './NewNotificationFormElelements';
 
 type SubjectFocusHelperTextProps = {
   hasOtherLang: boolean | undefined | string;
 };
 
-function SubjectFocusHelperText({hasOtherLang} : SubjectFocusHelperTextProps) {
+function SubjectFocusHelperText({ hasOtherLang }: SubjectFocusHelperTextProps) {
   const { t } = useTranslation(['common']);
   const { focused } = useFormControl() || {};
 
   return useMemo(() => {
     if (focused) {
-      return t('too-long-field-error', { maxLength: hasOtherLang ? 66: 134 });
+      return t('too-long-field-error', { maxLength: hasOtherLang ? 66 : 134 });
     }
     return false;
   }, [focused]);
@@ -49,13 +52,18 @@ const PreliminaryInformationsContent = ({ formik, languages, onChangeTouched }: 
       )}
       <TextField
         id="subject"
-        label={`${t('subject')}*`}
+        label={`${t('subject')}`}
+        required
         fullWidth
         name="subject"
         value={formik.values.subject}
         onChange={onChangeTouched}
         error={formik.touched.subject && Boolean(formik.errors.subject)}
-        helperText={(formik.touched.subject && formik.errors.subject) || <SubjectFocusHelperText hasOtherLang ={hasOtherLang} />}
+        helperText={
+          (formik.touched.subject && formik.errors.subject) || (
+            <SubjectFocusHelperText hasOtherLang={hasOtherLang} />
+          )
+        }
         size="small"
         margin="normal"
       />
@@ -78,7 +86,8 @@ const PreliminaryInformationsContent = ({ formik, languages, onChangeTouched }: 
           </Typography>
           <TextField
             id="additionalSubject"
-            label={`${t('subject')}*`}
+            label={`${t('subject')}`}
+            required
             fullWidth
             name="additionalSubject"
             value={formik.values.additionalSubject}

--- a/packages/pn-pa-webapp/src/components/NewNotification/Recipient.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/Recipient.tsx
@@ -409,7 +409,8 @@ const Recipient: React.FC<Props> = ({
                           values.recipients[index].recipientType === RecipientType.PG
                             ? 'recipient-organization-tax-id'
                             : 'recipient-citizen-tax-id'
-                        )}*`}
+                        )}`}
+                        required
                         values={values}
                         touched={touched}
                         errors={errors}
@@ -424,7 +425,8 @@ const Recipient: React.FC<Props> = ({
                         <Grid item xs={12} lg={4}>
                           <FormTextField
                             keyName={`recipients[${index}].firstName`}
-                            label={`${t('name')}*`}
+                            label={`${t('name')}`}
+                            required
                             values={values}
                             touched={touched}
                             errors={errors}
@@ -435,7 +437,7 @@ const Recipient: React.FC<Props> = ({
                         <Grid item xs={12} lg={4}>
                           <FormTextField
                             keyName={`recipients[${index}].lastName`}
-                            label={`${t('surname')}*`}
+                            label={`${t('surname')}`}
                             values={values}
                             touched={touched}
                             errors={errors}
@@ -449,7 +451,8 @@ const Recipient: React.FC<Props> = ({
                       <Grid item xs={12} lg={8}>
                         <FormTextField
                           keyName={`recipients[${index}].firstName`}
-                          label={`${t('business-name')}*`}
+                          label={`${t('business-name')}`}
+                          required
                           values={values}
                           touched={touched}
                           errors={errors}

--- a/packages/pn-pa-webapp/src/components/NewNotification/Recipient.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/Recipient.tsx
@@ -425,7 +425,7 @@ const Recipient: React.FC<Props> = ({
                         <Grid item xs={12} lg={4}>
                           <FormTextField
                             keyName={`recipients[${index}].firstName`}
-                            label={`${t('name')}`}
+                            label={t('name')}
                             required
                             values={values}
                             touched={touched}
@@ -437,7 +437,7 @@ const Recipient: React.FC<Props> = ({
                         <Grid item xs={12} lg={4}>
                           <FormTextField
                             keyName={`recipients[${index}].lastName`}
-                            label={`${t('surname')}`}
+                            label={t('surname')}
                             values={values}
                             touched={touched}
                             errors={errors}
@@ -451,7 +451,7 @@ const Recipient: React.FC<Props> = ({
                       <Grid item xs={12} lg={8}>
                         <FormTextField
                           keyName={`recipients[${index}].firstName`}
-                          label={`${t('business-name')}`}
+                          label={t('business-name')}
                           required
                           values={values}
                           touched={touched}

--- a/packages/pn-pa-webapp/src/components/NewNotification/__test__/PhysicalAddress.test.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/__test__/PhysicalAddress.test.tsx
@@ -30,11 +30,11 @@ describe('PhysicalAddress Component', () => {
         setFieldValue={mockSetValue}
       />
     );
-    testFormElements(container, 'recipients[1].address', 'address*', formTestValues.address);
+    testFormElements(container, 'recipients[1].address', 'address', formTestValues.address);
     testFormElements(
       container,
       'recipients[1].houseNumber',
-      'house-number*',
+      'house-number',
       formTestValues.houseNumber
     );
     testFormElements(
@@ -46,15 +46,15 @@ describe('PhysicalAddress Component', () => {
     testFormElements(
       container,
       'recipients[1].municipality',
-      'municipality*',
+      'municipality',
       formTestValues.municipality
     );
-    testFormElements(container, 'recipients[1].province', 'province*', formTestValues.province);
-    testFormElements(container, 'recipients[1].zip', 'zip*', formTestValues.zip);
+    testFormElements(container, 'recipients[1].province', 'province', formTestValues.province);
+    testFormElements(container, 'recipients[1].zip', 'zip', formTestValues.zip);
     testFormElements(
       container,
       'recipients[1].foreignState',
-      'foreign-state*',
+      'foreign-state',
       formTestValues.foreignState
     );
     testFormElements(

--- a/packages/pn-pa-webapp/src/components/NewNotification/__test__/PreliminaryInformations.test.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/__test__/PreliminaryInformations.test.tsx
@@ -109,12 +109,12 @@ describe('PreliminaryInformations Component', async () => {
     });
     expect(result.container).toHaveTextContent(/title/i);
     const form = result.getByTestId('preliminaryInformationsForm') as HTMLFormElement;
-    testFormElements(form, 'paProtocolNumber', 'protocol-number*');
-    testFormElements(form, 'subject', 'subject*');
+    testFormElements(form, 'paProtocolNumber', 'protocol-number');
+    testFormElements(form, 'subject', 'subject');
     testFormElements(form, 'abstract', 'abstract');
     testFormElements(form, 'group', 'group');
-    testFormElements(form, 'taxonomyCode', 'taxonomy-id*');
-    testFormElements(form, 'senderDenomination', 'sender-name*');
+    testFormElements(form, 'taxonomyCode', 'taxonomy-id');
+    testFormElements(form, 'senderDenomination', 'sender-name');
     testRadio(form, 'comunicationTypeRadio', ['registered-letter-890', 'simple-registered-letter']);
     const button = within(form).getByTestId('step-submit');
     expect(button).toBeDisabled();
@@ -371,17 +371,12 @@ describe('PreliminaryInformations Component', async () => {
       );
     });
     const form = result.getByTestId('preliminaryInformationsForm') as HTMLFormElement;
-    testFormElements(
-      form,
-      'paProtocolNumber',
-      'protocol-number*',
-      newNotification.paProtocolNumber
-    );
-    testFormElements(form, 'subject', 'subject*', newNotification.subject);
+    testFormElements(form, 'paProtocolNumber', 'protocol-number', newNotification.paProtocolNumber);
+    testFormElements(form, 'subject', 'subject', newNotification.subject);
     testFormElements(form, 'abstract', 'abstract', newNotification.abstract);
     testFormElements(form, 'group', 'group', newNotification.group);
-    testFormElements(form, 'taxonomyCode', 'taxonomy-id*', newNotification.taxonomyCode);
-    testFormElements(form, 'senderDenomination', 'sender-name*', userResponse.organization.name);
+    testFormElements(form, 'taxonomyCode', 'taxonomy-id', newNotification.taxonomyCode);
+    testFormElements(form, 'senderDenomination', 'sender-name', userResponse.organization.name);
     const physicalCommunicationType = form.querySelector(
       `input[name="physicalCommunicationType"][value="${newNotification.physicalCommunicationType}"]`
     );

--- a/packages/pn-pa-webapp/src/components/NewNotification/__test__/PreliminaryInformationsContent.test.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/__test__/PreliminaryInformationsContent.test.tsx
@@ -3,7 +3,11 @@ import { Formik } from 'formik';
 import { PhysicalCommunicationType } from '@pagopa-pn/pn-commons';
 import { fireEvent, getById, render, testFormElements } from '@pagopa-pn/pn-commons/src/test-utils';
 
-import { NewNotificationLangOther, PaymentModel, PreliminaryInformationsPayload } from '../../../models/NewNotification';
+import {
+  NewNotificationLangOther,
+  PaymentModel,
+  PreliminaryInformationsPayload,
+} from '../../../models/NewNotification';
 import PreliminaryInformationsContent from '../PreliminaryInformationsContent';
 
 describe('PreliminaryInformationsContent', () => {
@@ -37,7 +41,7 @@ describe('PreliminaryInformationsContent', () => {
       </Formik>
     );
 
-    testFormElements(container, 'subject', 'subject*');
+    testFormElements(container, 'subject', 'subject');
     testFormElements(container, 'abstract', 'abstract');
   });
 

--- a/packages/pn-pa-webapp/src/components/NewNotification/__test__/Recipient.test.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/__test__/Recipient.test.tsx
@@ -41,14 +41,14 @@ const testRecipientFormRendering = async (
   testFormElements(
     form,
     `recipients[${recipientIndex}].firstName`,
-    'name*',
+    'name',
     recipient ? recipient.firstName : undefined
   );
   if (!recipient || recipient?.recipientType === RecipientType.PF) {
     testFormElements(
       form,
       `recipients[${recipientIndex}].lastName`,
-      'surname*',
+      'surname',
       recipient ? recipient.lastName : undefined
     );
   }
@@ -56,8 +56,8 @@ const testRecipientFormRendering = async (
     form,
     `recipients[${recipientIndex}].taxId`,
     recipient?.recipientType === RecipientType.PG
-      ? 'recipient-organization-tax-id*'
-      : 'recipient-citizen-tax-id*',
+      ? 'recipient-organization-tax-id'
+      : 'recipient-citizen-tax-id',
     recipient ? recipient.taxId : undefined
   );
 

--- a/packages/pn-pa-webapp/src/components/Notifications/NotificationPaymentSender.tsx
+++ b/packages/pn-pa-webapp/src/components/Notifications/NotificationPaymentSender.tsx
@@ -142,7 +142,7 @@ const NotificationPaymentSender: React.FC<Props> = ({ iun, recipients, timeline 
           size="small"
           fullWidth
           onChange={recipientSelectionHandler}
-          label={`${t('detail.recipient')}`}
+          label={t('detail.recipient')}
           required
           sx={{ mb: 1 }}
           select

--- a/packages/pn-pa-webapp/src/components/Notifications/NotificationPaymentSender.tsx
+++ b/packages/pn-pa-webapp/src/components/Notifications/NotificationPaymentSender.tsx
@@ -142,7 +142,8 @@ const NotificationPaymentSender: React.FC<Props> = ({ iun, recipients, timeline 
           size="small"
           fullWidth
           onChange={recipientSelectionHandler}
-          label={`${t('detail.recipient')}*`}
+          label={`${t('detail.recipient')}`}
+          required
           sx={{ mb: 1 }}
           select
           SelectProps={{


### PR DESCRIPTION
## Short description
Improved accessibility handling for required form fields by removing hardcoded * from labels and using semantic required attributes.

## List of changes proposed in this pull request

- Removed hardcoded * from form field labels
- Added required support to custom form components (FormTextField, AttachmentBox)
- Propagated required attribute to underlying MUI TextField
- Updated required fields configuration in recipient and attachment forms
- Improved screen reader support for required fields

## How to test

- Open the new notification flow
- Verify that required fields still show the visual *
- Check that labels no longer render duplicated **
- Enable VoiceOver (Mac) and navigate through required fields
- Verify that screen reader announces a word as “richiesto” for mandatory fields