### PR TITLE
test(PN:19561): test event for contacts wizard components

### DIFF
--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/EmailSmsContactWizard.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/EmailSmsContactWizard.mixpanel.test.tsx
@@ -1,0 +1,208 @@
+import MockAdapter from 'axios-mock-adapter';
+import { MockInstance, vi } from 'vitest';
+
+import { getById } from '@pagopa-pn/pn-commons/src/test-utils';
+
+import { fireEvent, render, waitFor } from '../../../../__test__/test-utils';
+import { apiClient } from '../../../../api/apiClients';
+import { AddressType, ChannelType } from '../../../../models/contacts';
+import { PFEventsType } from '../../../../models/PFEventsType';
+import PFEventStrategyFactory from '../../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import { internationalPhonePrefix } from '../../../../utility/contacts.utility';
+import EmailSmsContactWizard from '../../EmailSmsContactWizard';
+import { fillCodeDialog } from '../test-utils';
+
+const existingEmail = [
+  { addressType: AddressType.COURTESY, senderId: 'default', channelType: ChannelType.EMAIL, value: 'nome.utente@mail.it' },
+];
+
+const existingSms = [
+  { addressType: AddressType.COURTESY, senderId: 'default', channelType: ChannelType.SMS, value: '+393333333333' },
+];
+
+describe('EmailSmsContactWizard - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+  let mock: MockAdapter;
+
+  beforeAll(() => {
+    mock = new MockAdapter(apiClient);
+  });
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    mock.reset();
+    triggerEventSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_EMAIL_SMS on mount', () => {
+    render(<EmailSmsContactWizard />);
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ADD_SERCQ_SEND_EMAIL_SMS,
+      expect.any(Object)
+    );
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_ADD_EMAIL_START and SEND_ADD_SERCQ_SEND_EMAIL_OTP when email is submitted', async () => {
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/EMAIL', { value: 'test@mail.it' })
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+
+    const { container, getByRole } = render(<EmailSmsContactWizard />);
+    fireEvent.change(getById(container, 'default_email'), { target: { value: 'test@mail.it' } });
+    fireEvent.click(getByRole('button', { name: 'courtesy-contacts.email-add' }));
+
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_ADD_SERCQ_SEND_ADD_EMAIL_START,
+        expect.any(Object)
+      );
+      expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ADD_SERCQ_SEND_EMAIL_OTP);
+    });
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_ADD_EMAIL_UX_CONVERSION and SEND_ADD_SERCQ_SEND_ADD_EMAIL_UX_SUCCESS on email OTP flow', async () => {
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/EMAIL', { value: 'test@mail.it' })
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/EMAIL', { value: 'test@mail.it', verificationCode: '01234' })
+      .reply(204);
+
+    const result = render(<EmailSmsContactWizard />);
+    const { container, getByRole } = result;
+    fireEvent.change(getById(container, 'default_email'), { target: { value: 'test@mail.it' } });
+    fireEvent.click(getByRole('button', { name: 'courtesy-contacts.email-add' }));
+
+    await waitFor(() => expect(getByRole('dialog')).toBeInTheDocument());
+    await fillCodeDialog(result);
+
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_ADD_SERCQ_SEND_ADD_EMAIL_UX_CONVERSION,
+        'default'
+      );
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_ADD_SERCQ_SEND_ADD_EMAIL_UX_SUCCESS
+      );
+    });
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_ADD_EMAIL_BACK when email code dialog is closed', async () => {
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/EMAIL', { value: 'test@mail.it' })
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+
+    const { container, getByRole } = render(<EmailSmsContactWizard />);
+    fireEvent.change(getById(container, 'default_email'), { target: { value: 'test@mail.it' } });
+    fireEvent.click(getByRole('button', { name: 'courtesy-contacts.email-add' }));
+
+    await waitFor(() => expect(getByRole('dialog')).toBeInTheDocument());
+    fireEvent.click(getByRole('button', { name: 'button.annulla' }));
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ADD_SERCQ_SEND_ADD_EMAIL_BACK);
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_CHANGE_EMAIL when edit is clicked on existing email', () => {
+    const { container } = render(<EmailSmsContactWizard />, {
+      preloadedState: { contactsState: { digitalAddresses: existingEmail } },
+    });
+    fireEvent.click(getById(container, 'modifyContact-default_email'));
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ADD_SERCQ_SEND_CHANGE_EMAIL);
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_ADD_SMS_START and SEND_ADD_SERCQ_SEND_SMS_OTP when SMS is submitted', async () => {
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/SMS', {
+        value: `${internationalPhonePrefix}3331234567`,
+      })
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+
+    const { container, getByRole } = render(<EmailSmsContactWizard />, {
+      route: '/recapiti/domicilio-digitale/attivazione',
+    });
+    fireEvent.click(getByRole('button', { name: 'courtesy-contacts.email-sms-add' }));
+    await waitFor(() => expect(getById(container, 'default_sms')).toBeInTheDocument());
+    fireEvent.change(getById(container, 'default_sms'), { target: { value: '3331234567' } });
+    fireEvent.click(getByRole('button', { name: 'courtesy-contacts.sms-add' }));
+
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_ADD_SERCQ_SEND_ADD_SMS_START,
+        expect.any(Object)
+      );
+      expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ADD_SERCQ_SEND_SMS_OTP);
+    });
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_ADD_SMS_UX_CONVERSION and SEND_ADD_SERCQ_SEND_ADD_SMS_UX_SUCCESS on SMS OTP flow', async () => {
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/SMS', {
+        value: `${internationalPhonePrefix}3331234567`,
+      })
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/SMS', {
+        value: `${internationalPhonePrefix}3331234567`,
+        verificationCode: '01234',
+      })
+      .reply(204);
+
+    const result = render(<EmailSmsContactWizard />, {
+      route: '/recapiti/domicilio-digitale/attivazione',
+    });
+    const { container, getByRole } = result;
+    fireEvent.click(getByRole('button', { name: 'courtesy-contacts.email-sms-add' }));
+    await waitFor(() => expect(getById(container, 'default_sms')).toBeInTheDocument());
+    fireEvent.change(getById(container, 'default_sms'), { target: { value: '3331234567' } });
+    fireEvent.click(getByRole('button', { name: 'courtesy-contacts.sms-add' }));
+
+    await waitFor(() => expect(getByRole('dialog')).toBeInTheDocument());
+    await fillCodeDialog(result);
+
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_ADD_SERCQ_SEND_ADD_SMS_UX_CONVERSION
+      );
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_ADD_SERCQ_SEND_ADD_SMS_UX_SUCCESS
+      );
+    });
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_ADD_SMS_BACK when SMS code dialog is closed', async () => {
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/SMS', {
+        value: `${internationalPhonePrefix}3331234567`,
+      })
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+
+    const { container, getByRole } = render(<EmailSmsContactWizard />, {
+      route: '/recapiti/domicilio-digitale/attivazione',
+    });
+    fireEvent.click(getByRole('button', { name: 'courtesy-contacts.email-sms-add' }));
+    await waitFor(() => expect(getById(container, 'default_sms')).toBeInTheDocument());
+    fireEvent.change(getById(container, 'default_sms'), { target: { value: '3331234567' } });
+    fireEvent.click(getByRole('button', { name: 'courtesy-contacts.sms-add' }));
+
+    await waitFor(() => expect(getByRole('dialog')).toBeInTheDocument());
+    fireEvent.click(getByRole('button', { name: 'button.annulla' }));
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ADD_SERCQ_SEND_ADD_SMS_BACK);
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_CHANGE_SMS when edit is clicked on existing SMS', () => {
+    const { container } = render(<EmailSmsContactWizard />, {
+      preloadedState: { contactsState: { digitalAddresses: existingSms } },
+    });
+    fireEvent.click(getById(container, 'modifyContact-default_sms'));
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ADD_SERCQ_SEND_CHANGE_SMS);
+  });
+});

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/HowItWorksContactWizard.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/HowItWorksContactWizard.mixpanel.test.tsx
@@ -1,0 +1,63 @@
+import { vi } from 'vitest';
+import { MockInstance } from 'vitest';
+
+import { fireEvent, render } from '../../../../__test__/test-utils';
+import { PFEventsType } from '../../../../models/PFEventsType';
+import PFEventStrategyFactory from '../../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import HowItWorksContactWizard from '../../HowItWorksContactWizard';
+
+describe('HowItWorksContactWizard - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+
+  const goToNextStep = vi.fn();
+  const setShowPecWizard = vi.fn();
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    triggerEventSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_INTRO on mount', () => {
+    render(
+      <HowItWorksContactWizard goToNextStep={goToNextStep} setShowPecWizard={setShowPecWizard} />
+    );
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ADD_SERCQ_SEND_INTRO,
+      expect.any(Object)
+    );
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_POP_UP when the delivered info link is clicked', () => {
+    const { getByTestId } = render(
+      <HowItWorksContactWizard goToNextStep={goToNextStep} setShowPecWizard={setShowPecWizard} />
+    );
+    fireEvent.click(getByTestId('deliveredLink'));
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ADD_SERCQ_SEND_POP_UP);
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_START when the continue button is clicked', () => {
+    const { getByTestId } = render(
+      <HowItWorksContactWizard goToNextStep={goToNextStep} setShowPecWizard={setShowPecWizard} />
+    );
+    fireEvent.click(getByTestId('continueButton'));
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ADD_SERCQ_SEND_START,
+      expect.any(Object)
+    );
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_PEC_START when the insert PEC button is clicked', () => {
+    const { getByTestId } = render(
+      <HowItWorksContactWizard goToNextStep={goToNextStep} setShowPecWizard={setShowPecWizard} />
+    );
+    fireEvent.click(getByTestId('pec-section').querySelector('button')!);
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ADD_SERCQ_SEND_PEC_START,
+      expect.any(Object)
+    );
+  });
+});

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/IOContactWizard.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/IOContactWizard.mixpanel.test.tsx
@@ -1,0 +1,183 @@
+import MockAdapter from 'axios-mock-adapter';
+import { MockInstance, vi } from 'vitest';
+
+import { fireEvent, render, waitFor, within } from '../../../../__test__/test-utils';
+import { apiClient } from '../../../../api/apiClients';
+import { AddressType, ChannelType, IOAllowedValues } from '../../../../models/contacts';
+import { PFEventsType } from '../../../../models/PFEventsType';
+import PFEventStrategyFactory from '../../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import IOContactWizard from '../../IOContactWizard';
+
+const ioEnabled = [
+  {
+    addressType: AddressType.COURTESY,
+    senderId: 'default',
+    channelType: ChannelType.IOMSG,
+    value: IOAllowedValues.ENABLED,
+  },
+];
+
+const ioDisabled = [
+  {
+    addressType: AddressType.COURTESY,
+    senderId: 'default',
+    channelType: ChannelType.IOMSG,
+    value: IOAllowedValues.DISABLED,
+  },
+];
+
+describe('IOContactWizard - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+  let mock: MockAdapter;
+  const goToNextStep = vi.fn();
+
+  beforeAll(() => {
+    mock = new MockAdapter(apiClient);
+  });
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    mock.reset();
+    triggerEventSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_APP_IO on mount', () => {
+    render(<IOContactWizard goToNextStep={goToNextStep} />);
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ADD_SERCQ_SEND_APP_IO,
+      expect.any(Object)
+    );
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_CONNECT_IO_UX_CONVERSION and SEND_ADD_SERCQ_SEND_CONNECT_IO_UX_SUCCESS when IO is activated', async () => {
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/APPIO', {
+        value: 'APPIO',
+        verificationCode: '00000',
+      })
+      .reply(204);
+
+    const { getByTestId } = render(<IOContactWizard goToNextStep={goToNextStep} />);
+    fireEvent.click(getByTestId('confirmButton'));
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ADD_SERCQ_SEND_CONNECT_IO_UX_CONVERSION
+    );
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_ADD_SERCQ_SEND_CONNECT_IO_UX_SUCCESS
+      );
+    });
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_APP_IO_NEXT_STEP when the continue button is clicked (IO enabled)', () => {
+    const { getByTestId } = render(<IOContactWizard goToNextStep={goToNextStep} />, {
+      preloadedState: { contactsState: { digitalAddresses: ioEnabled } },
+    });
+    fireEvent.click(getByTestId('skipButton'));
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ADD_SERCQ_SEND_APP_IO_NEXT_STEP
+    );
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_REMOVE_IO and SEND_ADD_SERCQ_SEND_POP_UP_REMOVE_APP_IO when deactivate is clicked', () => {
+    const { getByTestId } = render(<IOContactWizard goToNextStep={goToNextStep} />, {
+      preloadedState: { contactsState: { digitalAddresses: ioEnabled } },
+    });
+    fireEvent.click(getByTestId('disableIOButton'));
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ADD_SERCQ_SEND_REMOVE_IO);
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ADD_SERCQ_SEND_POP_UP_REMOVE_APP_IO
+    );
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_POP_UP_REMOVE_APP_IO_DISCONNECT and SEND_ADD_SERCQ_SEND_REMOVE_IO_SUCCESS when deactivation is confirmed', async () => {
+    mock.onDelete('/bff/v1/addresses/COURTESY/default/APPIO').reply(200);
+
+    const { getByTestId, getByRole } = render(<IOContactWizard goToNextStep={goToNextStep} />, {
+      preloadedState: { contactsState: { digitalAddresses: ioEnabled } },
+    });
+    fireEvent.click(getByTestId('disableIOButton'));
+    await waitFor(() => getByRole('dialog'));
+    // confirmButton slot → handleIODeactivation (DELETE)
+    fireEvent.click(getByTestId('confirmButton'));
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ADD_SERCQ_SEND_POP_UP_REMOVE_APP_IO_DISCONNECT
+    );
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_ADD_SERCQ_SEND_REMOVE_IO_SUCCESS
+      );
+    });
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_POP_UP_REMOVE_APP_IO_CANCEL when deactivation modal is cancelled', async () => {
+    const { getByTestId, getByRole } = render(<IOContactWizard goToNextStep={goToNextStep} />, {
+      preloadedState: { contactsState: { digitalAddresses: ioEnabled } },
+    });
+    fireEvent.click(getByTestId('disableIOButton'));
+    const dialog = await waitFor(() => getByRole('dialog'));
+    // closeButton slot → handleConfirmationModalDecline (cancel)
+    fireEvent.click(within(dialog).getByTestId('closeButton'));
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ADD_SERCQ_SEND_POP_UP_REMOVE_APP_IO_CANCEL
+    );
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_CONTINUE_WITHOUT_IO and SEND_ADD_SERCQ_SEND_POP_UP_APP_IO when skip is clicked', () => {
+    const { getByTestId } = render(<IOContactWizard goToNextStep={goToNextStep} />, {
+      preloadedState: { contactsState: { digitalAddresses: ioDisabled } },
+    });
+    fireEvent.click(getByTestId('skipButton'));
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ADD_SERCQ_SEND_CONTINUE_WITHOUT_IO
+    );
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ADD_SERCQ_SEND_POP_UP_APP_IO);
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_POP_UP_APP_IO_DECLINED when skip modal is dismissed', async () => {
+    const { getByTestId, getByRole } = render(<IOContactWizard goToNextStep={goToNextStep} />, {
+      preloadedState: { contactsState: { digitalAddresses: ioDisabled } },
+    });
+    fireEvent.click(getByTestId('skipButton'));
+    const dialog = await waitFor(() => getByRole('dialog'));
+    fireEvent.click(dialog.querySelector('[data-testid="closeButton"]')!);
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ADD_SERCQ_SEND_POP_UP_APP_IO_DECLINED
+    );
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_POP_UP_APP_IO_CONNECT when IO is activated from skip modal', async () => {
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/APPIO', {
+        value: 'APPIO',
+        verificationCode: '00000',
+      })
+      .reply(204);
+
+    const { getByTestId, getByRole } = render(<IOContactWizard goToNextStep={goToNextStep} />, {
+      preloadedState: { contactsState: { digitalAddresses: ioDisabled } },
+    });
+    fireEvent.click(getByTestId('skipButton'));
+    const dialog = await waitFor(() => getByRole('dialog'));
+    fireEvent.click(dialog.querySelector('[data-testid="confirmButton"]')!);
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ADD_SERCQ_SEND_POP_UP_APP_IO_CONNECT
+    );
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ADD_SERCQ_SEND_CONNECT_IO_UX_CONVERSION
+    );
+  });
+});

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/PecContactWizard.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/PecContactWizard.mixpanel.test.tsx
@@ -1,0 +1,189 @@
+import MockAdapter from 'axios-mock-adapter';
+import { MockInstance, vi } from 'vitest';
+
+import { fireEvent, render, waitFor } from '../../../../__test__/test-utils';
+import { apiClient } from '../../../../api/apiClients';
+import { PFEventsType } from '../../../../models/PFEventsType';
+import PFEventStrategyFactory from '../../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import PecContactWizard from '../../PecContactWizard';
+import { fillCodeDialog } from '../test-utils';
+
+const VALID_PEC = 'test@pec.it';
+
+describe('PecContactWizard - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+  let mock: MockAdapter;
+  const setShowPecWizard = vi.fn();
+
+  beforeAll(() => {
+    mock = new MockAdapter(apiClient);
+  });
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    mock.reset();
+    triggerEventSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_PEC_ENTER_PEC on mount', () => {
+    render(<PecContactWizard setShowPecWizard={setShowPecWizard} />);
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ADD_SERCQ_SEND_PEC_ENTER_PEC,
+      expect.any(Object)
+    );
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_PEC_BACK when the back button is clicked', () => {
+    const { getByTestId } = render(<PecContactWizard setShowPecWizard={setShowPecWizard} />);
+    fireEvent.click(getByTestId('prev-button'));
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ADD_SERCQ_SEND_PEC_BACK);
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_PEC_TOS_ACCEPTED when the disclaimer is checked', () => {
+    const { container } = render(<PecContactWizard setShowPecWizard={setShowPecWizard} />);
+    fireEvent.click(container.querySelector('[name="disclaimer"]')!);
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ADD_SERCQ_SEND_PEC_TOS_ACCEPTED
+    );
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_PEC_TOS_DISMISSED when the disclaimer is unchecked', () => {
+    const { container } = render(<PecContactWizard setShowPecWizard={setShowPecWizard} />);
+    const checkbox = container.querySelector('[name="disclaimer"]')!;
+    fireEvent.click(checkbox);
+    fireEvent.click(checkbox);
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ADD_SERCQ_SEND_PEC_TOS_DISMISSED
+    );
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_PEC_ERROR when submit is clicked with invalid PEC', async () => {
+    const { container, getByTestId } = render(
+      <PecContactWizard setShowPecWizard={setShowPecWizard} />
+    );
+    fireEvent.change(container.querySelector('[name="pec"]')!, {
+      target: { value: 'invalid-pec' },
+    });
+    await waitFor(() =>
+      expect(container.querySelector('[name="pec"]')).toHaveValue('invalid-pec')
+    );
+    fireEvent.click(getByTestId('next-button'));
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_ADD_SERCQ_SEND_PEC_ERROR,
+        expect.any(Object)
+      );
+    });
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_PEC_TOS_MANDATORY and SEND_ADD_SERCQ_SEND_PEC_START_ACTIVATION when submit is clicked without disclaimer', async () => {
+    const { container, getByTestId } = render(
+      <PecContactWizard setShowPecWizard={setShowPecWizard} />
+    );
+    fireEvent.change(container.querySelector('[name="pec"]')!, {
+      target: { value: VALID_PEC },
+    });
+    await waitFor(() =>
+      expect(container.querySelector('[name="pec"]')).toHaveValue(VALID_PEC)
+    );
+    fireEvent.click(getByTestId('next-button'));
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_ADD_SERCQ_SEND_PEC_TOS_MANDATORY
+      );
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_ADD_SERCQ_SEND_PEC_START_ACTIVATION,
+        expect.any(Object)
+      );
+    });
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_PEC_OTP and SEND_ADD_SERCQ_SEND_PEC_UX_CONVERSION on full OTP flow', async () => {
+    mock
+      .onPost('/bff/v1/addresses/LEGAL/default/PEC', { value: VALID_PEC })
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+    mock
+      .onPost('/bff/v1/addresses/LEGAL/default/PEC', { value: VALID_PEC, verificationCode: '01234' })
+      .reply(200, { result: 'PEC_VALIDATION_REQUIRED' });
+
+    const result = render(<PecContactWizard setShowPecWizard={setShowPecWizard} />);
+    const { container, getByTestId } = result;
+
+    fireEvent.change(container.querySelector('[name="pec"]')!, { target: { value: VALID_PEC } });
+    await waitFor(() => expect(container.querySelector('[name="pec"]')).toHaveValue(VALID_PEC));
+    fireEvent.click(container.querySelector('[name="disclaimer"]')!);
+    fireEvent.click(getByTestId('next-button'));
+
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ADD_SERCQ_SEND_PEC_OTP);
+    });
+
+    await fillCodeDialog(result);
+
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_ADD_SERCQ_SEND_PEC_UX_CONVERSION
+      );
+    });
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_PEC_OTP_BACK when the code dialog is closed', async () => {
+    mock
+      .onPost('/bff/v1/addresses/LEGAL/default/PEC', { value: VALID_PEC })
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+
+    const { container, getByTestId, getByRole } = render(
+      <PecContactWizard setShowPecWizard={setShowPecWizard} />
+    );
+
+    fireEvent.change(container.querySelector('[name="pec"]')!, { target: { value: VALID_PEC } });
+    await waitFor(() => expect(container.querySelector('[name="pec"]')).toHaveValue(VALID_PEC));
+    fireEvent.click(container.querySelector('[name="disclaimer"]')!);
+    fireEvent.click(getByTestId('next-button'));
+
+    await waitFor(() => expect(getByRole('dialog')).toBeInTheDocument());
+    fireEvent.click(getByRole('button', { name: 'button.annulla' }));
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ADD_SERCQ_SEND_PEC_OTP_BACK
+    );
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_PEC_UX_SUCCESS and SEND_ADD_SERCQ_SEND_PEC_THANK_YOU_PAGE after successful activation', async () => {
+    mock
+      .onPost('/bff/v1/addresses/LEGAL/default/PEC', { value: VALID_PEC })
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+    mock
+      .onPost('/bff/v1/addresses/LEGAL/default/PEC', { value: VALID_PEC, verificationCode: '01234' })
+      .reply(200, { result: 'PEC_VALIDATION_REQUIRED' });
+
+    const result = render(<PecContactWizard setShowPecWizard={setShowPecWizard} />);
+    const { container, getByTestId } = result;
+
+    fireEvent.change(container.querySelector('[name="pec"]')!, { target: { value: VALID_PEC } });
+    await waitFor(() => expect(container.querySelector('[name="pec"]')).toHaveValue(VALID_PEC));
+    fireEvent.click(container.querySelector('[name="disclaimer"]')!);
+    fireEvent.click(getByTestId('next-button'));
+
+    await fillCodeDialog(result);
+
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_ADD_SERCQ_SEND_PEC_UX_SUCCESS,
+        expect.any(Object)
+      );
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_ADD_SERCQ_SEND_PEC_THANK_YOU_PAGE,
+        expect.any(Object)
+      );
+    });
+  });
+});

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/SercqAddSpecialEmail.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/SercqAddSpecialEmail.mixpanel.test.tsx
@@ -1,0 +1,225 @@
+import MockAdapter from 'axios-mock-adapter';
+import { MockInstance, vi } from 'vitest';
+
+import { getById } from '@pagopa-pn/pn-commons/src/test-utils';
+
+import { fireEvent, render, waitFor } from '../../../../__test__/test-utils';
+import { apiClient } from '../../../../api/apiClients';
+import { AddressType, ChannelType } from '../../../../models/contacts';
+import { PFEventsType } from '../../../../models/PFEventsType';
+import PFEventStrategyFactory from '../../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import SercqAddSpecialEmail from '../../SercqAddSpecialEmail';
+import { fillCodeDialog } from '../test-utils';
+
+const existingEmail = [
+  {
+    addressType: AddressType.COURTESY,
+    senderId: 'default',
+    channelType: ChannelType.EMAIL,
+    value: 'nome.utente@mail.it',
+  },
+];
+
+describe('SercqAddSpecialEmail - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+  let mock: MockAdapter;
+
+  beforeAll(() => {
+    mock = new MockAdapter(apiClient);
+  });
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    mock.reset();
+    triggerEventSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  it('fires SEND_ADD_CUSTOMIZED_CONTACT_SERCQ_SEND_ADD_EMAIL_START when a new email is submitted', async () => {
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/EMAIL', { value: 'new@mail.it' })
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+
+    const { container, getByRole } = render(<SercqAddSpecialEmail />);
+    fireEvent.change(getById(container, 'default_email'), { target: { value: 'new@mail.it' } });
+    fireEvent.click(getByRole('button', { name: 'courtesy-contacts.email-add' }));
+
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_ADD_CUSTOMIZED_CONTACT_SERCQ_SEND_ADD_EMAIL_START
+      );
+    });
+  });
+
+  it('fires SEND_ADD_CUSTOMIZED_CONTACT_SERCQ_SEND_ADD_EMAIL_OTP when API requires OTP for new email', async () => {
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/EMAIL', { value: 'new@mail.it' })
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+
+    const { container, getByRole } = render(<SercqAddSpecialEmail />);
+    fireEvent.change(getById(container, 'default_email'), { target: { value: 'new@mail.it' } });
+    fireEvent.click(getByRole('button', { name: 'courtesy-contacts.email-add' }));
+
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_ADD_CUSTOMIZED_CONTACT_SERCQ_SEND_ADD_EMAIL_OTP
+      );
+    });
+  });
+
+  it('fires SEND_ADD_CUSTOMIZED_CONTACT_SERCQ_SEND_ADD_EMAIL_UX_CONVERSION and ADD_EMAIL_UX_SUCCESS on full add flow', async () => {
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/EMAIL', { value: 'new@mail.it' })
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/EMAIL', {
+        value: 'new@mail.it',
+        verificationCode: '01234',
+      })
+      .reply(204);
+
+    const result = render(<SercqAddSpecialEmail />);
+    const { container, getByRole } = result;
+    fireEvent.change(getById(container, 'default_email'), { target: { value: 'new@mail.it' } });
+    fireEvent.click(getByRole('button', { name: 'courtesy-contacts.email-add' }));
+
+    await waitFor(() => expect(getByRole('dialog')).toBeInTheDocument());
+    await fillCodeDialog(result);
+
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_ADD_CUSTOMIZED_CONTACT_SERCQ_SEND_ADD_EMAIL_UX_CONVERSION
+      );
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_ADD_CUSTOMIZED_CONTACT_SERCQ_SEND_ADD_EMAIL_UX_SUCCESS
+      );
+    });
+  });
+
+  it('fires SEND_ADD_CUSTOMIZED_CONTACT_SERCQ_SEND_ADD_EMAIL_BACK when the code dialog is closed (add flow)', async () => {
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/EMAIL', { value: 'new@mail.it' })
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+
+    const { container, getByRole } = render(<SercqAddSpecialEmail />);
+    fireEvent.change(getById(container, 'default_email'), { target: { value: 'new@mail.it' } });
+    fireEvent.click(getByRole('button', { name: 'courtesy-contacts.email-add' }));
+
+    await waitFor(() => expect(getByRole('dialog')).toBeInTheDocument());
+    fireEvent.click(getByRole('button', { name: 'button.annulla' }));
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ADD_CUSTOMIZED_CONTACT_SERCQ_SEND_ADD_EMAIL_BACK
+    );
+  });
+
+  it('fires SEND_ADD_CUSTOMIZED_CONTACT_SERCQ_SEND_CHANGE_EMAIL_START when edit is clicked on existing email', () => {
+    const { container } = render(<SercqAddSpecialEmail />, {
+      preloadedState: { contactsState: { digitalAddresses: existingEmail } },
+    });
+    fireEvent.click(getById(container, 'modifyContact-default_email'));
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ADD_CUSTOMIZED_CONTACT_SERCQ_SEND_CHANGE_EMAIL_START
+    );
+  });
+
+  it('fires SEND_ADD_CUSTOMIZED_CONTACT_SERCQ_SEND_CHANGE_EMAIL_CANCEL when edit is cancelled', () => {
+    const { container, getByRole } = render(<SercqAddSpecialEmail />, {
+      preloadedState: { contactsState: { digitalAddresses: existingEmail } },
+    });
+    fireEvent.click(getById(container, 'modifyContact-default_email'));
+    fireEvent.click(getByRole('button', { name: 'button.annulla' }));
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ADD_CUSTOMIZED_CONTACT_SERCQ_SEND_CHANGE_EMAIL_CANCEL
+    );
+  });
+
+  it('fires SEND_ADD_CUSTOMIZED_CONTACT_SERCQ_SEND_CHANGE_EMAIL_CONTINUE when edit confirm is clicked', async () => {
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/EMAIL', { value: 'changed@mail.it' })
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+
+    const { container } = render(<SercqAddSpecialEmail />, {
+      preloadedState: { contactsState: { digitalAddresses: existingEmail } },
+    });
+    fireEvent.click(getById(container, 'modifyContact-default_email'));
+    fireEvent.change(getById(container, 'default_email'), { target: { value: 'changed@mail.it' } });
+    await waitFor(() =>
+      expect(getById(container, 'default_email')).toHaveValue('changed@mail.it')
+    );
+    fireEvent.click(getById(container, 'saveContact-default_email'));
+
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_ADD_CUSTOMIZED_CONTACT_SERCQ_SEND_CHANGE_EMAIL_CONTINUE
+      );
+    });
+  });
+
+  it('fires SEND_ADD_CUSTOMIZED_CONTACT_SERCQ_SEND_CHANGE_EMAIL_OTP and CHANGE_EMAIL_UX_CONVERSION on change flow', async () => {
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/EMAIL', { value: 'changed@mail.it' })
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/EMAIL', {
+        value: 'changed@mail.it',
+        verificationCode: '01234',
+      })
+      .reply(204);
+
+    const result = render(<SercqAddSpecialEmail />, {
+      preloadedState: { contactsState: { digitalAddresses: existingEmail } },
+    });
+    const { container } = result;
+    fireEvent.click(getById(container, 'modifyContact-default_email'));
+    fireEvent.change(getById(container, 'default_email'), { target: { value: 'changed@mail.it' } });
+    await waitFor(() =>
+      expect(getById(container, 'default_email')).toHaveValue('changed@mail.it')
+    );
+    fireEvent.click(getById(container, 'saveContact-default_email'));
+
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_ADD_CUSTOMIZED_CONTACT_SERCQ_SEND_CHANGE_EMAIL_OTP
+      );
+    });
+
+    await fillCodeDialog(result);
+
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_ADD_CUSTOMIZED_CONTACT_SERCQ_SEND_CHANGE_EMAIL_UX_CONVERSION
+      );
+    });
+  });
+
+  it('fires SEND_ADD_CUSTOMIZED_CONTACT_SERCQ_SEND_CHANGE_EMAIL_BACK when code dialog is closed (change flow)', async () => {
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/EMAIL', { value: 'changed@mail.it' })
+      .reply(200, { result: 'CODE_VERIFICATION_REQUIRED' });
+
+    const { container, getByRole } = render(<SercqAddSpecialEmail />, {
+      preloadedState: { contactsState: { digitalAddresses: existingEmail } },
+    });
+    fireEvent.click(getById(container, 'modifyContact-default_email'));
+    fireEvent.change(getById(container, 'default_email'), { target: { value: 'changed@mail.it' } });
+    await waitFor(() =>
+      expect(getById(container, 'default_email')).toHaveValue('changed@mail.it')
+    );
+    fireEvent.click(getById(container, 'saveContact-default_email'));
+
+    await waitFor(() => expect(getByRole('dialog')).toBeInTheDocument());
+    fireEvent.click(getByRole('button', { name: 'button.annulla' }));
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ADD_CUSTOMIZED_CONTACT_SERCQ_SEND_CHANGE_EMAIL_BACK
+    );
+  });
+});

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/SercqSendContactWizard.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/SercqSendContactWizard.mixpanel.test.tsx
@@ -1,0 +1,166 @@
+import MockAdapter from 'axios-mock-adapter';
+import { MockInstance, vi } from 'vitest';
+
+import { SERCQ_SEND_VALUE } from '@pagopa-pn/pn-commons';
+import { getById } from '@pagopa-pn/pn-commons/src/test-utils';
+
+import {
+  acceptTosSercqSendBodyMock,
+  sercqSendTosConsentMock,
+} from '../../../../__mocks__/Consents.mock';
+import { fireEvent, render, waitFor } from '../../../../__test__/test-utils';
+import { apiClient } from '../../../../api/apiClients';
+import { AddressType, ChannelType, IOAllowedValues } from '../../../../models/contacts';
+import { PFEventsType } from '../../../../models/PFEventsType';
+import PFEventStrategyFactory from '../../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import SercqSendContactWizard from '../../SercqSendContactWizard';
+
+const courtesyEmailOnly = [
+  {
+    addressType: AddressType.COURTESY,
+    senderId: 'default',
+    channelType: ChannelType.EMAIL,
+    value: 'nome.utente@mail.it',
+  },
+];
+
+const courtesySmsOnly = [
+  {
+    addressType: AddressType.COURTESY,
+    senderId: 'default',
+    channelType: ChannelType.SMS,
+    value: '+393333333333',
+  },
+];
+
+const courtesyEmailAndSms = [
+  ...courtesyEmailOnly,
+  ...courtesySmsOnly,
+  {
+    addressType: AddressType.COURTESY,
+    senderId: 'default',
+    channelType: ChannelType.IOMSG,
+    value: IOAllowedValues.DISABLED,
+  },
+];
+
+describe('SercqSendContactWizard - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+  let mock: MockAdapter;
+  const goToStep = vi.fn();
+
+  beforeAll(() => {
+    mock = new MockAdapter(apiClient);
+  });
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    mock.reset();
+    triggerEventSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_SUMMARY on mount', () => {
+    render(<SercqSendContactWizard goToStep={goToStep} />, {
+      preloadedState: { contactsState: { digitalAddresses: courtesyEmailOnly } },
+    });
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ADD_SERCQ_SEND_SUMMARY,
+      expect.any(Object)
+    );
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_SUMMARY_TOS_ACCEPTED when disclaimer is checked', () => {
+    const { container } = render(<SercqSendContactWizard goToStep={goToStep} />, {
+      preloadedState: { contactsState: { digitalAddresses: courtesyEmailOnly } },
+    });
+    fireEvent.click(getById(container, 'disclaimer'));
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ADD_SERCQ_SEND_SUMMARY_TOS_ACCEPTED
+    );
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_SUMMARY_TOS_DISMISSED when disclaimer is unchecked', () => {
+    const { container } = render(<SercqSendContactWizard goToStep={goToStep} />, {
+      preloadedState: { contactsState: { digitalAddresses: courtesyEmailOnly } },
+    });
+    const checkbox = getById(container, 'disclaimer');
+    fireEvent.click(checkbox);
+    fireEvent.click(checkbox);
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ADD_SERCQ_SEND_SUMMARY_TOS_DISMISSED
+    );
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_TOS_MANDATORY and SEND_ADD_SERCQ_SEND_UX_CONVERSION when activate is clicked without disclaimer', async () => {
+    const { getByTestId, findByTestId } = render(
+      <SercqSendContactWizard goToStep={goToStep} />,
+      { preloadedState: { contactsState: { digitalAddresses: courtesyEmailOnly } } }
+    );
+    // wait for validateOnMount async Yup validation to settle before clicking
+    await findByTestId('activateButton');
+    fireEvent.click(getByTestId('activateButton'));
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ADD_SERCQ_SEND_TOS_MANDATORY);
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ADD_SERCQ_SEND_UX_CONVERSION,
+      expect.any(Object)
+    );
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_UX_SUCCESS after successful activation', async () => {
+    mock
+      .onPost('/bff/v1/addresses/LEGAL/default/SERCQ_SEND', { value: SERCQ_SEND_VALUE })
+      .reply(204);
+    mock.onGet(/\/bff\/v2\/tos-privacy.*/).reply(200, sercqSendTosConsentMock(false));
+    mock.onPut('/bff/v2/tos-privacy', acceptTosSercqSendBodyMock).reply(200);
+
+    const { container, getByTestId } = render(
+      <SercqSendContactWizard goToStep={goToStep} />,
+      { preloadedState: { contactsState: { digitalAddresses: courtesyEmailOnly } } }
+    );
+
+    fireEvent.click(getById(container, 'disclaimer'));
+    fireEvent.click(getByTestId('activateButton'));
+
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_ADD_SERCQ_SEND_UX_SUCCESS,
+        expect.any(Object)
+      );
+    });
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_GO_TO_SMS when the SMS link is clicked', () => {
+    const { getByTestId } = render(<SercqSendContactWizard goToStep={goToStep} />, {
+      preloadedState: { contactsState: { digitalAddresses: courtesyEmailOnly } },
+    });
+    fireEvent.click(getByTestId('backToContactStep'));
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ADD_SERCQ_SEND_GO_TO_SMS);
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_GO_TO_EMAIL when the email link is clicked', () => {
+    const { getByTestId } = render(<SercqSendContactWizard goToStep={goToStep} />, {
+      preloadedState: { contactsState: { digitalAddresses: courtesySmsOnly } },
+    });
+    fireEvent.click(getByTestId('backToContactStep'));
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ADD_SERCQ_SEND_GO_TO_EMAIL);
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_GO_TO_APP_IO when the IO link is clicked', () => {
+    const { getByTestId } = render(
+      <SercqSendContactWizard goToStep={goToStep} showIOStep />,
+      { preloadedState: { contactsState: { digitalAddresses: courtesyEmailAndSms } } }
+    );
+    fireEvent.click(getByTestId('backToContactStep'));
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ADD_SERCQ_SEND_GO_TO_APP_IO
+    );
+  });
+});

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/SercqSendIODialog.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/mixpanel/SercqSendIODialog.mixpanel.test.tsx
@@ -1,0 +1,62 @@
+import MockAdapter from 'axios-mock-adapter';
+import { MockInstance, vi } from 'vitest';
+
+import { fireEvent, render, screen, waitFor } from '../../../../__test__/test-utils';
+import { apiClient } from '../../../../api/apiClients';
+import { PFEventsType } from '../../../../models/PFEventsType';
+import PFEventStrategyFactory from '../../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import SercqSendIODialog from '../../SercqSendIODialog';
+
+describe('SercqSendIODialog - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+  let mock: MockAdapter;
+
+  beforeAll(() => {
+    mock = new MockAdapter(apiClient);
+  });
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    mock.reset();
+    triggerEventSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  it('fires SEND_ACTIVE_IO_START and SEND_ACTIVE_IO_UX_CONVERSION when the activate button is clicked', () => {
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/APPIO', {
+        value: 'APPIO',
+        verificationCode: '00000',
+      })
+      .reply(204);
+
+    render(<SercqSendIODialog open onDiscard={vi.fn()} />);
+    fireEvent.click(screen.getByText('button.attiva'));
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ACTIVE_IO_START);
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ACTIVE_IO_UX_CONVERSION);
+  });
+
+  it('fires SEND_ACTIVE_IO_UX_SUCCESS after successful API activation', async () => {
+    mock
+      .onPost('/bff/v1/addresses/COURTESY/default/APPIO', {
+        value: 'APPIO',
+        verificationCode: '00000',
+      })
+      .reply(204);
+
+    render(<SercqSendIODialog open onDiscard={vi.fn()} />);
+    fireEvent.click(screen.getByText('button.attiva'));
+
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ACTIVE_IO_UX_SUCCESS, true);
+    });
+  });
+});

--- a/packages/pn-personafisica-webapp/src/setupTests.tsx
+++ b/packages/pn-personafisica-webapp/src/setupTests.tsx
@@ -8,6 +8,15 @@ import { initAxiosClients } from './api/apiClients';
 import { initStore } from './redux/store';
 import { PfConfiguration } from './services/configuration.service';
 
+const originalWarn = console.warn;
+// eslint-disable-next-line functional/immutable-data
+console.warn = (...args) => {
+  if (typeof args[0] === 'string' && args[0].includes('React Router Future Flag Warning')) {
+    return;
+  }
+  originalWarn(...args);
+};
+
 // This is a workaround related to this issue https://github.com/nickcolley/jest-axe/issues/147
 const { getComputedStyle } = window;
 // eslint-disable-next-line functional/immutable-data


### PR DESCRIPTION
## tested events

File | Evento | Trigger
--- | --- | ---
HowItWorksContactWizard | SEND_ADD_SERCQ_SEND_INTRO | mount
HowItWorksContactWizard | SEND_ADD_SERCQ_SEND_POP_UP | click deliveredLink
HowItWorksContactWizard | SEND_ADD_SERCQ_SEND_START | click continueButton
HowItWorksContactWizard | SEND_ADD_SERCQ_SEND_PEC_START | click bottone sezione PEC
SercqSendIODialog | SEND_ACTIVE_IO_START | click "Attiva"
SercqSendIODialog | SEND_ACTIVE_IO_UX_CONVERSION | click "Attiva"
SercqSendIODialog | SEND_ACTIVE_IO_UX_SUCCESS | risposta API 204
SercqSendContactWizard | SEND_ADD_SERCQ_SEND_SUMMARY | mount
SercqSendContactWizard | SEND_ADD_SERCQ_SEND_SUMMARY_TOS_ACCEPTED | check disclaimer
SercqSendContactWizard | SEND_ADD_SERCQ_SEND_SUMMARY_TOS_DISMISSED | uncheck disclaimer
SercqSendContactWizard | SEND_ADD_SERCQ_SEND_TOS_MANDATORY | click activateButton senza disclaimer
SercqSendContactWizard | SEND_ADD_SERCQ_SEND_UX_CONVERSION | click activateButton senza disclaimer
SercqSendContactWizard | SEND_ADD_SERCQ_SEND_UX_SUCCESS | attivazione completata (API 204)
SercqSendContactWizard | SEND_ADD_SERCQ_SEND_GO_TO_SMS | click backToContactStep (solo email)
SercqSendContactWizard | SEND_ADD_SERCQ_SEND_GO_TO_EMAIL | click backToContactStep (solo SMS)
SercqSendContactWizard | SEND_ADD_SERCQ_SEND_GO_TO_APP_IO | click backToContactStep (email + SMS + IO disabilitato)
IOContactWizard | SEND_ADD_SERCQ_SEND_APP_IO | mount
IOContactWizard | SEND_ADD_SERCQ_SEND_CONNECT_IO_UX_CONVERSION | click confirmButton (attivazione IO)
IOContactWizard | SEND_ADD_SERCQ_SEND_CONNECT_IO_UX_SUCCESS | risposta API 204
IOContactWizard | SEND_ADD_SERCQ_SEND_APP_IO_NEXT_STEP | click skipButton (IO già attivo)
IOContactWizard | SEND_ADD_SERCQ_SEND_REMOVE_IO | click disableIOButton
IOContactWizard | SEND_ADD_SERCQ_SEND_POP_UP_REMOVE_APP_IO | click disableIOButton
IOContactWizard | SEND_ADD_SERCQ_SEND_POP_UP_REMOVE_APP_IO_DISCONNECT | click confirmButton nel modale di disattivazione
IOContactWizard | SEND_ADD_SERCQ_SEND_REMOVE_IO_SUCCESS | DELETE completato (API 200)
IOContactWizard | SEND_ADD_SERCQ_SEND_POP_UP_REMOVE_APP_IO_CANCEL | click closeButton nel modale di disattivazione
IOContactWizard | SEND_ADD_SERCQ_SEND_CONTINUE_WITHOUT_IO | click skipButton (IO disabilitato)
IOContactWizard | SEND_ADD_SERCQ_SEND_POP_UP_APP_IO | click skipButton (IO disabilitato)
IOContactWizard | SEND_ADD_SERCQ_SEND_POP_UP_APP_IO_DECLINED | click closeButton nel modale skip
IOContactWizard | SEND_ADD_SERCQ_SEND_POP_UP_APP_IO_CONNECT | click confirmButton nel modale skip
IOContactWizard | SEND_ADD_SERCQ_SEND_CONNECT_IO_UX_CONVERSION | click confirmButton nel modale skip
SercqAddSpecialEmail | SEND_ADD_CUSTOMIZED_CONTACT_SERCQ_SEND_ADD_EMAIL_START | submit nuova email
SercqAddSpecialEmail | SEND_ADD_CUSTOMIZED_CONTACT_SERCQ_SEND_ADD_EMAIL_OTP | API richiede OTP
SercqAddSpecialEmail | SEND_ADD_CUSTOMIZED_CONTACT_SERCQ_SEND_ADD_EMAIL_UX_CONVERSION | conferma OTP (add flow)
SercqAddSpecialEmail | SEND_ADD_CUSTOMIZED_CONTACT_SERCQ_SEND_ADD_EMAIL_UX_SUCCESS | OTP confermato con successo
SercqAddSpecialEmail | SEND_ADD_CUSTOMIZED_CONTACT_SERCQ_SEND_ADD_EMAIL_BACK | chiusura dialog OTP (add flow)
SercqAddSpecialEmail | SEND_ADD_CUSTOMIZED_CONTACT_SERCQ_SEND_CHANGE_EMAIL_START | click modifica su email esistente
SercqAddSpecialEmail | SEND_ADD_CUSTOMIZED_CONTACT_SERCQ_SEND_CHANGE_EMAIL_CANCEL | annulla modifica
SercqAddSpecialEmail | SEND_ADD_CUSTOMIZED_CONTACT_SERCQ_SEND_CHANGE_EMAIL_CONTINUE | conferma modifica
SercqAddSpecialEmail | SEND_ADD_CUSTOMIZED_CONTACT_SERCQ_SEND_CHANGE_EMAIL_OTP | API richiede OTP (change flow)
SercqAddSpecialEmail | SEND_ADD_CUSTOMIZED_CONTACT_SERCQ_SEND_CHANGE_EMAIL_UX_CONVERSION | conferma OTP (change flow)
SercqAddSpecialEmail | SEND_ADD_CUSTOMIZED_CONTACT_SERCQ_SEND_CHANGE_EMAIL_BACK | chiusura dialog OTP (change flow)
PecContactWizard | SEND_ADD_SERCQ_SEND_PEC_ENTER_PEC | mount
PecContactWizard | SEND_ADD_SERCQ_SEND_PEC_BACK | click prev-button
PecContactWizard | SEND_ADD_SERCQ_SEND_PEC_TOS_ACCEPTED | check disclaimer
PecContactWizard | SEND_ADD_SERCQ_SEND_PEC_TOS_DISMISSED | uncheck disclaimer
PecContactWizard | SEND_ADD_SERCQ_SEND_PEC_ERROR | submit con PEC non valida
PecContactWizard | SEND_ADD_SERCQ_SEND_PEC_TOS_MANDATORY | submit senza disclaimer
PecContactWizard | SEND_ADD_SERCQ_SEND_PEC_START_ACTIVATION | submit senza disclaimer
PecContactWizard | SEND_ADD_SERCQ_SEND_PEC_OTP | risposta API richiede OTP
PecContactWizard | SEND_ADD_SERCQ_SEND_PEC_UX_CONVERSION | conferma OTP
PecContactWizard | SEND_ADD_SERCQ_SEND_PEC_OTP_BACK | chiusura dialog OTP
PecContactWizard | SEND_ADD_SERCQ_SEND_PEC_UX_SUCCESS | attivazione completata
PecContactWizard | SEND_ADD_SERCQ_SEND_PEC_THANK_YOU_PAGE | attivazione completata
EmailSmsContactWizard | SEND_ADD_SERCQ_SEND_EMAIL_SMS | mount
EmailSmsContactWizard | SEND_ADD_SERCQ_SEND_ADD_EMAIL_START | submit email
EmailSmsContactWizard | SEND_ADD_SERCQ_SEND_EMAIL_OTP | API richiede OTP (email)
EmailSmsContactWizard | SEND_ADD_SERCQ_SEND_ADD_EMAIL_UX_CONVERSION | conferma OTP (email)
EmailSmsContactWizard | SEND_ADD_SERCQ_SEND_ADD_EMAIL_UX_SUCCESS | OTP email confermato
EmailSmsContactWizard | SEND_ADD_SERCQ_SEND_ADD_EMAIL_BACK | chiusura dialog OTP (email)
EmailSmsContactWizard | SEND_ADD_SERCQ_SEND_CHANGE_EMAIL | click modifica su email esistente
EmailSmsContactWizard | SEND_ADD_SERCQ_SEND_ADD_SMS_START | submit SMS (route SERCQ)
EmailSmsContactWizard | SEND_ADD_SERCQ_SEND_SMS_OTP | API richiede OTP (SMS)
EmailSmsContactWizard | SEND_ADD_SERCQ_SEND_ADD_SMS_UX_CONVERSION | conferma OTP (SMS)
EmailSmsContactWizard | SEND_ADD_SERCQ_SEND_ADD_SMS_UX_SUCCESS | OTP SMS confermato
EmailSmsContactWizard | SEND_ADD_SERCQ_SEND_ADD_SMS_BACK | chiusura dialog OTP (SMS)
EmailSmsContactWizard | SEND_ADD_SERCQ_SEND_CHANGE_SMS | click modifica su SMS esistente

