### PR TITLE
test: replace Object.defineProperty with vi.stubGlobal

### DIFF
--- a/packages/pn-commons/src/components/ApiError/__test__/ApiErrorWrapper.test.tsx
+++ b/packages/pn-commons/src/components/ApiError/__test__/ApiErrorWrapper.test.tsx
@@ -14,19 +14,15 @@ vi.mock('../../../hooks/useErrors', () => ({
 }));
 
 describe('ApiErrorWrapper', () => {
-  const original = window.location;
   const reloadText = 'Ricarica';
   const user = userEvent.setup();
 
   beforeAll(() => {
-    Object.defineProperty(window, 'location', {
-      configurable: true,
-      value: { reload: vi.fn() },
-    });
+    vi.stubGlobal('location', { reload: vi.fn() });
   });
 
   afterAll(() => {
-    Object.defineProperty(window, 'location', { configurable: true, value: original });
+    vi.unstubAllGlobals();
   });
 
   it('mocks reload function', () => {

--- a/packages/pn-commons/src/components/Footer/__test__/Footer.test.tsx
+++ b/packages/pn-commons/src/components/Footer/__test__/Footer.test.tsx
@@ -22,17 +22,12 @@ const accessibilityLink = 'accessibility-link.it';
 const sercqServiceStatementLink = 'sercq-service-statement-link.it';
 
 describe('Footer Component', () => {
-  const original = window.open;
-
   beforeAll(() => {
-    Object.defineProperty(window, 'open', {
-      configurable: true,
-      value: mockOpenFn,
-    });
+    vi.stubGlobal('open', mockOpenFn);
   });
 
   afterAll((): void => {
-    Object.defineProperty(window, 'open', { configurable: true, value: original });
+    vi.unstubAllGlobals();
   });
 
   it('renders footer', () => {

--- a/packages/pn-commons/src/components/Header/__test__/Header.test.tsx
+++ b/packages/pn-commons/src/components/Header/__test__/Header.test.tsx
@@ -24,16 +24,12 @@ const userActions = [
 ];
 
 describe('Header Component', () => {
-  beforeAll(() => {
-    vi.stubGlobal('location', { href: '', assign: assignFn });
-  });
-
   beforeEach(() => {
-    globalThis.location.href = '';
+    vi.stubGlobal('location', { href: '', assign: assignFn });
     vi.clearAllMocks();
   });
 
-  afterAll((): void => {
+  afterEach((): void => {
     vi.unstubAllGlobals();
   });
 

--- a/packages/pn-commons/src/components/Header/__test__/Header.test.tsx
+++ b/packages/pn-commons/src/components/Header/__test__/Header.test.tsx
@@ -24,13 +24,8 @@ const userActions = [
 ];
 
 describe('Header Component', () => {
-  const original = globalThis.location;
-
   beforeAll(() => {
-    Object.defineProperty(globalThis, 'location', {
-      configurable: true,
-      value: { href: '', assign: assignFn },
-    });
+    vi.stubGlobal('location', { href: '', assign: assignFn });
   });
 
   beforeEach(() => {
@@ -39,7 +34,7 @@ describe('Header Component', () => {
   });
 
   afterAll((): void => {
-    Object.defineProperty(globalThis, 'location', { configurable: true, value: original });
+    vi.unstubAllGlobals();
   });
 
   it('renders header (one product, no parties and no user dropdown)', async () => {

--- a/packages/pn-commons/src/components/NotificationDetail/__test__/NotificationPaymentF24Item.test.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/__test__/NotificationPaymentF24Item.test.tsx
@@ -57,13 +57,8 @@ describe('NotificationPaymentF24Item Component', () => {
   const TIMERF24 = 5000;
   const store = createTestStore();
 
-  const original = window.location;
-
   beforeAll(() => {
-    Object.defineProperty(window, 'location', {
-      configurable: true,
-      value: { href: '' },
-    });
+    vi.stubGlobal('location', { href: '' });
   });
 
   beforeEach(() => {
@@ -71,7 +66,7 @@ describe('NotificationPaymentF24Item Component', () => {
   });
 
   afterAll((): void => {
-    Object.defineProperty(window, 'location', { configurable: true, value: original });
+    vi.unstubAllGlobals();
   });
 
   const getPaymentAttachmentActionMk = (

--- a/packages/pn-commons/src/components/SideMenu/__test__/SideMenuListItem.test.tsx
+++ b/packages/pn-commons/src/components/SideMenu/__test__/SideMenuListItem.test.tsx
@@ -9,13 +9,8 @@ const handleOnSelect = vi.fn();
 const mockOpenFn = vi.fn();
 
 describe('SideMenuListItem', () => {
-  const original = window.open;
-
   beforeAll(() => {
-    Object.defineProperty(window, 'open', {
-      configurable: true,
-      value: mockOpenFn,
-    });
+    vi.stubGlobal('open', mockOpenFn);
   });
 
   afterEach(() => {
@@ -23,7 +18,7 @@ describe('SideMenuListItem', () => {
   });
 
   afterAll((): void => {
-    Object.defineProperty(window, 'open', { configurable: true, value: original });
+    vi.unstubAllGlobals();
   });
 
   it('renders component', () => {

--- a/packages/pn-commons/src/components/__test__/ErrorBoundary.test.tsx
+++ b/packages/pn-commons/src/components/__test__/ErrorBoundary.test.tsx
@@ -18,20 +18,15 @@ const mockEventTrackingCallbackRefreshPage = vi.fn();
 const mockReload = vi.fn();
 
 describe('ErrorBoundary Component', () => {
-  const original = window.location;
-
   disableConsoleLogging('error');
 
   beforeAll(() => {
     initLocalizationForTest();
-    Object.defineProperty(window, 'location', {
-      configurable: true,
-      value: { reload: mockReload },
-    });
+    vi.stubGlobal('location', { reload: mockReload });
   });
 
   afterAll(() => {
-    Object.defineProperty(window, 'location', { configurable: true, value: original });
+    vi.unstubAllGlobals();
   });
 
   it('renders ErrorBoundary (no errors)', () => {

--- a/packages/pn-commons/src/utility/__test__/lazyRetry.utility.test.tsx
+++ b/packages/pn-commons/src/utility/__test__/lazyRetry.utility.test.tsx
@@ -10,15 +10,10 @@ import { lazyRetry } from '../lazyRetry.utility';
 // Carlos Lombardi, 2023-11-10
 // ---------------------------------
 describe('test lazy loading retry', () => {
-  const original = window.location;
-
   const reloadFn = vi.fn();
 
   beforeAll(() => {
-    Object.defineProperty(window, 'location', {
-      configurable: true,
-      value: { reload: reloadFn },
-    });
+    vi.stubGlobal('location', { reload: reloadFn });
   });
 
   afterEach(() => {
@@ -28,7 +23,7 @@ describe('test lazy loading retry', () => {
   });
 
   afterAll(() => {
-    Object.defineProperty(window, 'location', { configurable: true, value: original });
+    vi.unstubAllGlobals();
   });
 
   it('test lazyRetry - component loaded at first try', async () => {

--- a/packages/pn-pa-webapp/src/__test__/App.test.tsx
+++ b/packages/pn-pa-webapp/src/__test__/App.test.tsx
@@ -49,12 +49,11 @@ const reduxInitialState = {
   },
 };
 
-describe('App', async () => {
+describe('App', () => {
   let mock: MockAdapter;
   let mockAuth: MockAdapter;
   let result: RenderResult;
   const mockOpenFn = vi.fn();
-  const originalOpen = globalThis.open;
 
   beforeAll(() => {
     mock = new MockAdapter(apiClient);
@@ -66,10 +65,7 @@ describe('App', async () => {
         json: () => Promise.resolve([]),
       }) as Promise<Response>;
 
-    Object.defineProperty(globalThis, 'open', {
-      configurable: true,
-      value: mockOpenFn,
-    });
+    vi.stubGlobal('open', mockOpenFn);
   });
 
   afterEach(() => {
@@ -82,7 +78,7 @@ describe('App', async () => {
     mock.restore();
     mockAuth.restore();
     globalThis.fetch = unmockedFetch;
-    Object.defineProperty(globalThis, 'open', { configurable: true, value: originalOpen });
+    vi.unstubAllGlobals();
   });
 
   it('render component - user not logged in', async () => {

--- a/packages/pn-pa-webapp/src/components/NewNotification/__test__/Attachments.test.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/__test__/Attachments.test.tsx
@@ -43,7 +43,7 @@ async function uploadDocument(elem: HTMLElement, index: number, document: NewNot
   });
 }
 
-describe('Attachments Component with payment enabled', async () => {
+describe('Attachments Component with payment enabled', () => {
   let result: RenderResult;
   let mock: MockAdapter;
   let extMock: MockAdapter;

--- a/packages/pn-pa-webapp/src/components/NewNotification/__test__/DebtPosition.test.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/__test__/DebtPosition.test.tsx
@@ -23,7 +23,7 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
-describe('DebtPosition Component', async () => {
+describe('DebtPosition Component', () => {
   afterEach(() => {
     vi.clearAllMocks();
   });

--- a/packages/pn-pa-webapp/src/components/NewNotification/__test__/DebtPositionDetail.test.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/__test__/DebtPositionDetail.test.tsx
@@ -15,7 +15,7 @@ import DebtPositionDetail from '../DebtPositionDetail';
 const confirmHandlerMk = vi.fn();
 const previousStepMk = vi.fn();
 
-describe('DebtPositionDetail Component', async () => {
+describe('DebtPositionDetail Component', () => {
   describe('Render Payment Boxes', () => {
     afterEach(() => {
       vi.clearAllMocks();

--- a/packages/pn-pa-webapp/src/components/NewNotification/__test__/PreliminaryInformations.test.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/__test__/PreliminaryInformations.test.tsx
@@ -68,7 +68,7 @@ const populateForm = async (
   );
 };
 
-describe('PreliminaryInformations Component', async () => {
+describe('PreliminaryInformations Component', () => {
   let result: RenderResult;
   const confirmHandlerMk = vi.fn();
   let mock: MockAdapter;

--- a/packages/pn-pa-webapp/src/components/NewNotification/__test__/Recipient.test.tsx
+++ b/packages/pn-pa-webapp/src/components/NewNotification/__test__/Recipient.test.tsx
@@ -208,7 +208,7 @@ const recipientsWithoutPayments = newNotification.recipients.map(
   })
 );
 
-describe('Recipient Component with payment enabled', async () => {
+describe('Recipient Component with payment enabled', () => {
   const confirmHandlerMk = vi.fn();
   let result: RenderResult;
 
@@ -453,7 +453,7 @@ describe('Recipient Component with payment enabled', async () => {
   }, 10000);
 });
 
-describe('Recipient Component without payment enabled', async () => {
+describe('Recipient Component without payment enabled', () => {
   const confirmHandlerMk = vi.fn();
   let result: RenderResult;
 
@@ -491,7 +491,7 @@ describe('Recipient Component without payment enabled', async () => {
   });
 });
 
-describe('Feature flag for physical address lookup', async () => {
+describe('Feature flag for physical address lookup', () => {
   let result: RenderResult;
 
   it('FF is off', async () => {

--- a/packages/pn-pa-webapp/src/components/Notifications/__test__/FilterNotifications.test.tsx
+++ b/packages/pn-pa-webapp/src/components/Notifications/__test__/FilterNotifications.test.tsx
@@ -50,7 +50,7 @@ async function setFormValues(
   iunMatch !== '' && (await testInput(form, 'iunMatch', iunMatch));
 }
 
-describe('Filter Notifications Table Component', async () => {
+describe('Filter Notifications Table Component', () => {
   let result: RenderResult;
   let form: HTMLFormElement | undefined;
 

--- a/packages/pn-pa-webapp/src/components/Notifications/__test__/NotificationPaymentPagoPa.test.tsx
+++ b/packages/pn-pa-webapp/src/components/Notifications/__test__/NotificationPaymentPagoPa.test.tsx
@@ -22,7 +22,7 @@ vi.mock('@pagopa-pn/pn-commons', async () => {
   };
 });
 
-describe('NotificationPaymentPagoPa Component', async () => {
+describe('NotificationPaymentPagoPa Component', () => {
   let mock: MockAdapter;
 
   beforeAll(() => {

--- a/packages/pn-pa-webapp/src/components/Notifications/__test__/NotificationSettingsDrawer.test.tsx
+++ b/packages/pn-pa-webapp/src/components/Notifications/__test__/NotificationSettingsDrawer.test.tsx
@@ -7,7 +7,7 @@ import userEvent from '@testing-library/user-event';
 import { RenderResult, render } from '../../../__test__/test-utils';
 import NotificationSettingsDrawer from '../NotificationSettingsDrawer';
 
-describe('Notification Settings Drawer', async () => {
+describe('Notification Settings Drawer', () => {
   let result: RenderResult;
 
   afterEach(() => {

--- a/packages/pn-pa-webapp/src/navigation/__test__/SessionGuard.test.tsx
+++ b/packages/pn-pa-webapp/src/navigation/__test__/SessionGuard.test.tsx
@@ -21,18 +21,14 @@ const Guard = () => (
   </Routes>
 );
 
-describe('SessionGuard Component', async () => {
+describe('SessionGuard Component', () => {
   let mock: MockAdapter;
   let result: RenderResult;
-  const originalOpen = globalThis.open;
   const mockOpenFn = vi.fn();
 
   beforeAll(() => {
     mock = new MockAdapter(authClient);
-    Object.defineProperty(globalThis, 'open', {
-      configurable: true,
-      value: mockOpenFn,
-    });
+    vi.stubGlobal('open', mockOpenFn);
   });
 
   afterEach(() => {
@@ -42,7 +38,7 @@ describe('SessionGuard Component', async () => {
 
   afterAll(() => {
     mock.restore();
-    Object.defineProperty(globalThis, 'open', { configurable: true, value: originalOpen });
+    vi.unstubAllGlobals();
   });
 
   // expected behavior: enters the app, does a navigate, launches sessionCheck, the user is deleted from redux

--- a/packages/pn-pa-webapp/src/navigation/__test__/ToSGuard.test.tsx
+++ b/packages/pn-pa-webapp/src/navigation/__test__/ToSGuard.test.tsx
@@ -34,7 +34,7 @@ const Guard = () => (
   </Routes>
 );
 
-describe('Tests the ToSGuard component', async () => {
+describe('Tests the ToSGuard component', () => {
   let mock: MockAdapter;
 
   beforeAll(() => {

--- a/packages/pn-pa-webapp/src/navigation/__test__/navigation.utility.test.ts
+++ b/packages/pn-pa-webapp/src/navigation/__test__/navigation.utility.test.ts
@@ -11,13 +11,8 @@ import {
 const mockOpenFn = vi.fn();
 
 describe('Tests notification.utility', () => {
-  const original = window.location;
-
   beforeAll(() => {
-    Object.defineProperty(window, 'open', {
-      configurable: true,
-      value: mockOpenFn,
-    });
+    vi.stubGlobal('open', mockOpenFn);
   });
 
   beforeEach(() => {
@@ -25,7 +20,7 @@ describe('Tests notification.utility', () => {
   });
 
   afterAll((): void => {
-    Object.defineProperty(window, 'open', { configurable: true, value: original });
+    vi.unstubAllGlobals();
   });
 
   it('goToSelfcareLogin', () => {

--- a/packages/pn-pa-webapp/src/pages/__test__/ApiKeys.page.test.tsx
+++ b/packages/pn-pa-webapp/src/pages/__test__/ApiKeys.page.test.tsx
@@ -64,7 +64,7 @@ async function testApiKeyChangeStatus(
   });
 }
 
-describe('ApiKeys Page', async () => {
+describe('ApiKeys Page', () => {
   let result: RenderResult;
   let mock: MockAdapter;
   const original = globalThis.ResizeObserver;

--- a/packages/pn-pa-webapp/src/pages/__test__/AppStatus.page.test.tsx
+++ b/packages/pn-pa-webapp/src/pages/__test__/AppStatus.page.test.tsx
@@ -25,17 +25,19 @@ describe('AppStatus page', () => {
 
   beforeAll(() => {
     mock = new MockAdapter(apiClient);
+  });
+
+  beforeEach(() => {
     vi.stubGlobal('location', { href: '' });
   });
 
   afterEach(() => {
     mock.reset();
-    globalThis.location.href = '';
+    vi.unstubAllGlobals();
   });
 
   afterAll(() => {
     mock.restore();
-    vi.unstubAllGlobals();
   });
   /*
    * The intent of the "OK" test is to verify somehow that the result of the API calls

--- a/packages/pn-pa-webapp/src/pages/__test__/AppStatus.page.test.tsx
+++ b/packages/pn-pa-webapp/src/pages/__test__/AppStatus.page.test.tsx
@@ -1,4 +1,5 @@
 import MockAdapter from 'axios-mock-adapter';
+import { vi } from 'vitest';
 
 import { ThemeProvider } from '@mui/material';
 import { AppResponseMessage, ResponseEventDispatcher, formatDate } from '@pagopa-pn/pn-commons';
@@ -19,26 +20,22 @@ const AppStatusWithErrorHandling = () => (
   </ThemeProvider>
 );
 
-describe('AppStatus page', async () => {
+describe('AppStatus page', () => {
   let mock: MockAdapter;
-  const original = window.location;
 
   beforeAll(() => {
     mock = new MockAdapter(apiClient);
-    Object.defineProperty(window, 'location', {
-      configurable: true,
-      value: { href: '' },
-    });
+    vi.stubGlobal('location', { href: '' });
   });
 
   afterEach(() => {
     mock.reset();
-    window.location.href = '';
+    globalThis.location.href = '';
   });
 
   afterAll(() => {
     mock.restore();
-    Object.defineProperty(window, 'location', { configurable: true, value: original });
+    vi.unstubAllGlobals();
   });
   /*
    * The intent of the "OK" test is to verify somehow that the result of the API calls
@@ -136,7 +133,7 @@ describe('AppStatus page', async () => {
       expect(mock.history.get).toHaveLength(3);
     });
     await waitFor(() => {
-      expect(window.location.href).toBe('https://www.mocked-url.com');
+      expect(globalThis.location.href).toBe('https://www.mocked-url.com');
     });
   });
 

--- a/packages/pn-pa-webapp/src/pages/__test__/Dashboard.page.test.tsx
+++ b/packages/pn-pa-webapp/src/pages/__test__/Dashboard.page.test.tsx
@@ -20,7 +20,7 @@ import { DASHBOARD_ACTIONS } from '../../redux/dashboard/actions';
 import { ServerResponseErrorCode } from '../../utility/AppError/types';
 import Dashboard from '../Dashboard.page';
 
-describe('Dashboard Page', async () => {
+describe('Dashboard Page', () => {
   let result: RenderResult;
   let mock: MockAdapter;
   const originalMatchMedia = globalThis.matchMedia;

--- a/packages/pn-pa-webapp/src/pages/__test__/NewApiKey.page.test.tsx
+++ b/packages/pn-pa-webapp/src/pages/__test__/NewApiKey.page.test.tsx
@@ -14,7 +14,7 @@ import { apiClient } from '../../api/apiClients';
 import * as routes from '../../navigation/routes.const';
 import NewApiKey from '../NewApiKey.page';
 
-describe('NewApiKey component', async () => {
+describe('NewApiKey component', () => {
   let result: RenderResult;
   let mock: MockAdapter;
 

--- a/packages/pn-pa-webapp/src/pages/__test__/NewNotification.page.test.tsx
+++ b/packages/pn-pa-webapp/src/pages/__test__/NewNotification.page.test.tsx
@@ -31,7 +31,7 @@ vi.mock('../../services/configuration.service', async () => {
   };
 });
 
-describe('NewNotification Page without payment enabled in configuration', async () => {
+describe('NewNotification Page without payment enabled in configuration', () => {
   let result: RenderResult;
   let mock: MockAdapter;
 

--- a/packages/pn-pa-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
+++ b/packages/pn-pa-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
@@ -37,19 +37,15 @@ const getLegalFactIds = (notification: NotificationDetailModel, recIndex: number
   return timelineElementDigitalSuccessWorkflow.legalFactsIds![0];
 };
 
-describe('NotificationDetail Page', async () => {
+describe('NotificationDetail Page', () => {
   const mockLegalIds = getLegalFactIds(notificationDTO, 0);
-  const original = globalThis.location;
 
   let result: RenderResult;
   let mock: MockAdapter;
 
   beforeAll(() => {
     mock = new MockAdapter(apiClient);
-    Object.defineProperty(globalThis, 'location', {
-      configurable: true,
-      value: { href: '', assign: vi.fn() },
-    });
+    vi.stubGlobal('location', { href: '', assign: vi.fn() });
   });
 
   afterEach(() => {
@@ -59,7 +55,7 @@ describe('NotificationDetail Page', async () => {
 
   afterAll(() => {
     mock.restore();
-    Object.defineProperty(globalThis, 'location', { configurable: true, value: original });
+    vi.unstubAllGlobals();
   });
 
   it('renders NotificationDetail page - mono recipient', async () => {

--- a/packages/pn-pa-webapp/src/pages/__test__/ToSAcceptance.page.test.tsx
+++ b/packages/pn-pa-webapp/src/pages/__test__/ToSAcceptance.page.test.tsx
@@ -27,17 +27,13 @@ const privacyConsent: ConsentUser = {
   consentVersion: 'mocked-version-1',
 };
 
-describe('test Terms of Service page', async () => {
+describe('test Terms of Service page', () => {
   let mock: MockAdapter;
   let result: RenderResult;
-  const original = globalThis.open;
 
   beforeAll(() => {
     mock = new MockAdapter(apiClient);
-    Object.defineProperty(globalThis, 'open', {
-      configurable: true,
-      value: mockOpenFn,
-    });
+    vi.stubGlobal('open', mockOpenFn);
   });
 
   afterEach(() => {
@@ -47,7 +43,7 @@ describe('test Terms of Service page', async () => {
 
   afterAll(() => {
     mock.restore();
-    Object.defineProperty(globalThis, 'open', { configurable: true, value: original });
+    vi.unstubAllGlobals();
   });
 
   it('checks the texts in the page - First ToS acceptance', async () => {

--- a/packages/pn-pa-webapp/src/setupTests.tsx
+++ b/packages/pn-pa-webapp/src/setupTests.tsx
@@ -14,6 +14,15 @@ import { PhysicalAddressLookupConfig } from './models/NewNotification';
 import { initStore } from './redux/store';
 import { PaConfiguration } from './services/configuration.service';
 
+const originalWarn = console.warn;
+// eslint-disable-next-line functional/immutable-data
+console.warn = (...args) => {
+  if (typeof args[0] === 'string' && args[0].includes('React Router Future Flag Warning')) {
+    return;
+  }
+  originalWarn(...args);
+};
+
 beforeAll(() => {
   Configuration.setForTest<PaConfiguration>({
     API_BASE_URL: 'https://mock-api-base-url',

--- a/packages/pn-personafisica-login/src/components/__test__/IoSmartAppBanner.test.tsx
+++ b/packages/pn-personafisica-login/src/components/__test__/IoSmartAppBanner.test.tsx
@@ -15,7 +15,7 @@ vi.mock('@pagopa-pn/pn-commons', async (importActual) => {
   };
 });
 
-describe('test IO Smart App Banner', async () => {
+describe('test IO Smart App Banner', () => {
   afterEach(() => {
     vi.clearAllMocks();
   });

--- a/packages/pn-personafisica-login/src/components/__test__/SpidSelect.test.tsx
+++ b/packages/pn-personafisica-login/src/components/__test__/SpidSelect.test.tsx
@@ -14,10 +14,8 @@ const mockAssign = vi.fn();
 const backHandler = vi.fn();
 
 describe('test spid select page', () => {
-  const original = window.location;
-
   beforeAll(() => {
-    Object.defineProperty(window, 'location', { value: { assign: mockAssign } });
+    vi.stubGlobal('location', { assign: mockAssign });
   });
 
   afterEach(() => {
@@ -26,7 +24,7 @@ describe('test spid select page', () => {
   });
 
   afterAll(() => {
-    Object.defineProperty(window, 'location', { value: original });
+    vi.unstubAllGlobals();
   });
 
   it('renders page', () => {

--- a/packages/pn-personafisica-login/src/pages/login/__test__/Login.test.tsx
+++ b/packages/pn-personafisica-login/src/pages/login/__test__/Login.test.tsx
@@ -33,10 +33,8 @@ vi.mock('../../../utility/utils', async () => ({
 }));
 
 describe('test login page', () => {
-  const original = globalThis.location;
-
   beforeAll(() => {
-    Object.defineProperty(globalThis, 'location', { value: { assign: mockAssign } });
+    vi.stubGlobal('location', { assign: mockAssign });
   });
 
   afterEach(() => {
@@ -45,7 +43,7 @@ describe('test login page', () => {
   });
 
   afterAll(() => {
-    Object.defineProperty(globalThis, 'location', { value: original });
+    vi.unstubAllGlobals();
   });
 
   it('renders page', () => {

--- a/packages/pn-personafisica-login/src/pages/oneIdentityCallback/__test__/OneIdentityCallback.test.tsx
+++ b/packages/pn-personafisica-login/src/pages/oneIdentityCallback/__test__/OneIdentityCallback.test.tsx
@@ -18,7 +18,6 @@ import OneIdentityCallback from '../OneIdentityCallback';
 const mockLocationReplace = vi.fn();
 
 describe('OneIdentityCallback component', () => {
-  const original = globalThis.location;
   const mockState = 'mock-state-123';
   const mockCode = 'mock-code-456';
   const mockNonce = 'mock-nonce-789';
@@ -35,12 +34,7 @@ describe('OneIdentityCallback component', () => {
   };
 
   beforeAll(() => {
-    Object.defineProperty(globalThis, 'location', {
-      configurable: true,
-      value: {
-        replace: mockLocationReplace,
-      },
-    });
+    vi.stubGlobal('location', { replace: mockLocationReplace });
   });
 
   beforeEach(() => {
@@ -57,7 +51,7 @@ describe('OneIdentityCallback component', () => {
   });
 
   afterAll(() => {
-    Object.defineProperty(globalThis, 'location', { configurable: true, value: original });
+    vi.unstubAllGlobals();
   });
 
   it('should redirect with correct hash params', () => {

--- a/packages/pn-personafisica-login/src/pages/oneIdentityLogin/__test__/OneIdentityLogin.test.tsx
+++ b/packages/pn-personafisica-login/src/pages/oneIdentityLogin/__test__/OneIdentityLogin.test.tsx
@@ -22,10 +22,8 @@ vi.mock('../../../utility/utils', async () => ({
 }));
 
 describe('OneIdentityLogin component', () => {
-  const original = globalThis.location;
-
   beforeAll(() => {
-    Object.defineProperty(globalThis, 'location', { value: { assign: mockAssign } });
+    vi.stubGlobal('location', { assign: mockAssign });
   });
 
   beforeEach(() => {
@@ -44,7 +42,7 @@ describe('OneIdentityLogin component', () => {
   });
 
   afterAll(() => {
-    Object.defineProperty(globalThis, 'location', { value: original });
+    vi.unstubAllGlobals();
   });
 
   it('redirects to OneIdentity login with correct parameters', () => {

--- a/packages/pn-personafisica-login/src/pages/success/__test__/Success.test.tsx
+++ b/packages/pn-personafisica-login/src/pages/success/__test__/Success.test.tsx
@@ -11,17 +11,12 @@ const mockLocationAssign = vi.fn();
 
 // mock imports
 describe('test login page', () => {
-  const original = globalThis.location;
-
   beforeAll(() => {
-    Object.defineProperty(globalThis, 'location', {
-      configurable: true,
-      value: { replace: mockLocationAssign, hash: '#token=fake-token' },
-    });
+    vi.stubGlobal('location', { replace: mockLocationAssign, hash: '#token=fake-token' });
   });
 
   afterAll(() => {
-    Object.defineProperty(globalThis, 'location', { configurable: true, value: original });
+    vi.unstubAllGlobals();
   });
 
   it('test redirect', () => {

--- a/packages/pn-personafisica-login/src/setupTests.tsx
+++ b/packages/pn-personafisica-login/src/setupTests.tsx
@@ -10,6 +10,15 @@ import '@testing-library/jest-dom';
 
 import { LoginConfiguration } from './services/configuration.service';
 
+const originalWarn = console.warn;
+// eslint-disable-next-line functional/immutable-data
+console.warn = (...args) => {
+  if (typeof args[0] === 'string' && args[0].includes('React Router Future Flag Warning')) {
+    return;
+  }
+  originalWarn(...args);
+};
+
 beforeAll(async () => {
   Configuration.setForTest<LoginConfiguration>({
     MIXPANEL_TOKEN: 'ba1f5101fe34a61bb125cbfe587780d8',

--- a/packages/pn-personafisica-webapp/src/__test__/App.test.tsx
+++ b/packages/pn-personafisica-webapp/src/__test__/App.test.tsx
@@ -48,12 +48,11 @@ const reduxInitialState = {
   },
 };
 
-describe('App', async () => {
+describe('App', () => {
   let mock: MockAdapter;
   let mockAuth: MockAdapter;
   let result: RenderResult;
   const mockOpenFn = vi.fn();
-  const originalOpen = globalThis.open;
 
   beforeAll(() => {
     mock = new MockAdapter(apiClient);
@@ -64,10 +63,7 @@ describe('App', async () => {
       Promise.resolve({
         json: () => Promise.resolve([]),
       }) as Promise<Response>;
-    Object.defineProperty(globalThis, 'open', {
-      configurable: true,
-      value: mockOpenFn,
-    });
+    vi.stubGlobal('open', mockOpenFn);
   });
 
   afterEach(() => {
@@ -80,7 +76,7 @@ describe('App', async () => {
     mock.restore();
     mockAuth.restore();
     globalThis.fetch = unmockedFetch;
-    Object.defineProperty(globalThis, 'open', { configurable: true, value: originalOpen });
+    vi.unstubAllGlobals();
   });
 
   it('render component - user not logged in', async () => {

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/CancelVerificationModal.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/CancelVerificationModal.test.tsx
@@ -7,7 +7,7 @@ import CancelVerificationModal from '../CancelVerificationModal';
 
 const mockCloseHandler = vi.fn();
 
-describe('CancelVerificationModal component', async () => {
+describe('CancelVerificationModal component', () => {
   it('renders component and clicks on cancel button', () => {
     render(<CancelVerificationModal open handleClose={mockCloseHandler} />);
     const dialog = screen.getByTestId('cancelVerificationModal');

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/CourtesyContacts.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/CourtesyContacts.test.tsx
@@ -18,7 +18,7 @@ const defaultSmsAddress = digitalCourtesyAddresses.find(
   (addr) => addr.senderId === 'default' && addr.channelType === ChannelType.SMS
 );
 
-describe('CourtesyContacts Component', async () => {
+describe('CourtesyContacts Component', () => {
   it('renders component - no contacts', async () => {
     const { container, getByTestId, getByRole } = render(<CourtesyContacts />);
     const emailContact = getByTestId(`default_emailContact`);

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/IOContact.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/IOContact.test.tsx
@@ -13,16 +13,12 @@ import IOContact from '../IOContact';
 const IOAddress = digitalCourtesyAddresses.find((addr) => addr.channelType === ChannelType.IOMSG);
 const assignFn = vi.fn();
 
-describe('IOContact component', async () => {
+describe('IOContact component', () => {
   let mock: MockAdapter;
-  const originalLocation = globalThis.location;
 
   beforeAll(() => {
     mock = new MockAdapter(apiClient);
-    Object.defineProperty(globalThis, 'location', {
-      configurable: true,
-      value: { assign: assignFn },
-    });
+    vi.stubGlobal('location', { assign: assignFn });
   });
 
   afterEach(() => {
@@ -32,7 +28,7 @@ describe('IOContact component', async () => {
 
   afterAll(() => {
     mock.restore();
-    Object.defineProperty(globalThis, 'location', { configurable: true, value: originalLocation });
+    vi.unstubAllGlobals();
   });
 
   it('renders component - no contacts', () => {
@@ -130,25 +126,25 @@ describe('IOContact component', async () => {
   });
 
   it('Click on download AppIO button - IOS', () => {
-    Object.defineProperty(globalThis, 'navigator', {
-      value: { userAgent: 'iPhone' },
-    });
+    vi.stubGlobal('navigator', { userAgent: 'iPhone' });
     const { getByRole } = render(<IOContact />);
     const button = getByRole('button', { name: 'io-contact.download' });
     fireEvent.click(button);
     expect(assignFn).toHaveBeenCalledTimes(1);
     expect(assignFn).toHaveBeenCalledWith(getConfiguration().APP_IO_IOS);
+    vi.unstubAllGlobals();
+    vi.stubGlobal('location', { assign: assignFn });
   });
 
   it('Click on download AppIO button - Android', () => {
-    Object.defineProperty(globalThis, 'navigator', {
-      value: { userAgent: 'Android' },
-    });
+    vi.stubGlobal('navigator', { userAgent: 'Android' });
     const { getByRole } = render(<IOContact />);
     const button = getByRole('button', { name: 'io-contact.download' });
     fireEvent.click(button);
     expect(assignFn).toHaveBeenCalledTimes(1);
     expect(assignFn).toHaveBeenCalledWith(getConfiguration().APP_IO_ANDROID);
+    vi.unstubAllGlobals();
+    vi.stubGlobal('location', { assign: assignFn });
   });
 
   it('disables IO - Digital Domicile enabled', async () => {

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/IOContact.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/IOContact.test.tsx
@@ -18,17 +18,20 @@ describe('IOContact component', () => {
 
   beforeAll(() => {
     mock = new MockAdapter(apiClient);
+  });
+
+  beforeEach(() => {
     vi.stubGlobal('location', { assign: assignFn });
   });
 
   afterEach(() => {
     mock.reset();
     vi.clearAllMocks();
+    vi.unstubAllGlobals();
   });
 
   afterAll(() => {
     mock.restore();
-    vi.unstubAllGlobals();
   });
 
   it('renders component - no contacts', () => {
@@ -132,8 +135,6 @@ describe('IOContact component', () => {
     fireEvent.click(button);
     expect(assignFn).toHaveBeenCalledTimes(1);
     expect(assignFn).toHaveBeenCalledWith(getConfiguration().APP_IO_IOS);
-    vi.unstubAllGlobals();
-    vi.stubGlobal('location', { assign: assignFn });
   });
 
   it('Click on download AppIO button - Android', () => {
@@ -143,8 +144,6 @@ describe('IOContact component', () => {
     fireEvent.click(button);
     expect(assignFn).toHaveBeenCalledTimes(1);
     expect(assignFn).toHaveBeenCalledWith(getConfiguration().APP_IO_ANDROID);
-    vi.unstubAllGlobals();
-    vi.stubGlobal('location', { assign: assignFn });
   });
 
   it('disables IO - Digital Domicile enabled', async () => {

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/LegalContacts.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/LegalContacts.test.tsx
@@ -17,16 +17,12 @@ const defaultPecAddress = digitalLegalAddresses.find(
 );
 const assignFn = vi.fn();
 
-describe('LegalContacts Component', async () => {
+describe('LegalContacts Component', () => {
   let mock: MockAdapter;
-  const originalLocation = globalThis.location;
 
   beforeAll(() => {
     mock = new MockAdapter(apiClient);
-    Object.defineProperty(globalThis, 'location', {
-      configurable: true,
-      value: { assign: assignFn },
-    });
+    vi.stubGlobal('location', { assign: assignFn });
   });
 
   afterEach(() => {
@@ -36,7 +32,7 @@ describe('LegalContacts Component', async () => {
 
   afterAll(() => {
     mock.restore();
-    Object.defineProperty(globalThis, 'location', { configurable: true, value: originalLocation });
+    vi.unstubAllGlobals();
   });
 
   it('renders component - PEC enabled', async () => {

--- a/packages/pn-personafisica-webapp/src/components/Contacts/__test__/SpecialContacts.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Contacts/__test__/SpecialContacts.test.tsx
@@ -17,7 +17,7 @@ const specialCourtesyAddresses = digitalCourtesyAddresses.filter(
   (addr) => addr.senderId !== 'default'
 );
 
-describe('SpecialContacts Component', async () => {
+describe('SpecialContacts Component', () => {
   let mock: MockAdapter;
 
   beforeAll(() => {

--- a/packages/pn-personafisica-webapp/src/components/Deleghe/__test__/Delegates.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Deleghe/__test__/Delegates.test.tsx
@@ -6,7 +6,7 @@ import * as routes from '../../../navigation/routes.const';
 import { sortDelegations } from '../../../utility/delegation.utility';
 import Delegates from '../Delegates';
 
-describe('Delegates Component', async () => {
+describe('Delegates Component', () => {
   afterEach(() => {
     vi.clearAllMocks();
   });

--- a/packages/pn-personafisica-webapp/src/components/Deleghe/__test__/DelegationsElements.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Deleghe/__test__/DelegationsElements.test.tsx
@@ -5,7 +5,7 @@ import { AcceptButton, Menu, OrganizationsList } from '../DelegationsElements';
 
 const mockOpenCodeModalHandler = vi.fn();
 
-describe('DelegationElements', async () => {
+describe('DelegationElements', () => {
   it('renders the Menu closed', () => {
     const { queryByTestId } = render(<Menu />);
     const menuIcon = queryByTestId('delegationMenuIcon');

--- a/packages/pn-personafisica-webapp/src/components/Deleghe/__test__/Delegators.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Deleghe/__test__/Delegators.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, waitFor, within } from '../../../__test__/test-utils
 import { sortDelegations } from '../../../utility/delegation.utility';
 import Delegators from '../Delegators';
 
-describe('Delegators Component', async () => {
+describe('Delegators Component', () => {
   it('renders the empty state', () => {
     const { container, queryByTestId } = render(<Delegators />);
     expect(container).toHaveTextContent(/deleghe.delegatorsTitle/i);

--- a/packages/pn-personafisica-webapp/src/components/Notifications/__test__/FilterNotifications.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Notifications/__test__/FilterNotifications.test.tsx
@@ -42,7 +42,7 @@ async function setFormValues(
   await testInput(form, 'iunMatch', iunMatch);
 }
 
-describe('Filter Notifications Table Component', async () => {
+describe('Filter Notifications Table Component', () => {
   let result: RenderResult;
   let form: HTMLFormElement;
 

--- a/packages/pn-personafisica-webapp/src/navigation/__test__/OnboardingGuard.test.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/__test__/OnboardingGuard.test.tsx
@@ -27,7 +27,7 @@ const Guard = () => (
   </Routes>
 );
 
-describe('OnboardingGuard', async () => {
+describe('OnboardingGuard', () => {
   let mock: MockAdapter;
   let result: RenderResult;
 

--- a/packages/pn-personafisica-webapp/src/navigation/__test__/RapidAccessGuard.test.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/__test__/RapidAccessGuard.test.tsx
@@ -17,7 +17,7 @@ const Guard = () => (
   </Routes>
 );
 
-describe('Rapid access Guard', async () => {
+describe('Rapid access Guard', () => {
   let mock: MockAdapter;
   let result: RenderResult;
 
@@ -33,7 +33,7 @@ describe('Rapid access Guard', async () => {
     mock.restore();
   });
 
-  describe('Notification from QR code', async () => {
+  describe('Notification from QR code', () => {
     it('QR code requested by a recipient', async () => {
       const mockQrCode = 'qr-code';
       mock
@@ -138,7 +138,7 @@ describe('Rapid access Guard', async () => {
     });
   });
 
-  describe('Notification from retrievalId', async () => {
+  describe('Notification from retrievalId', () => {
     it('retrievalId requested by a recipient', async () => {
       const mockRetrievalId = 'retrieval-id';
       const url = `/bff/v1/notifications/received/check-tpp?retrievalId=${mockRetrievalId}`;

--- a/packages/pn-personafisica-webapp/src/navigation/__test__/SessionGuard.test.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/__test__/SessionGuard.test.tsx
@@ -22,18 +22,14 @@ const Guard = () => (
   </Routes>
 );
 
-describe('SessionGuard Component', async () => {
+describe('SessionGuard Component', () => {
   let mock: MockAdapter;
   let result: RenderResult;
-  const originalOpen = globalThis.open;
   const mockOpenFn = vi.fn();
 
   beforeAll(() => {
     mock = new MockAdapter(authClient);
-    Object.defineProperty(globalThis, 'open', {
-      configurable: true,
-      value: mockOpenFn,
-    });
+    vi.stubGlobal('open', mockOpenFn);
   });
 
   afterEach(() => {
@@ -43,7 +39,7 @@ describe('SessionGuard Component', async () => {
 
   afterAll(() => {
     mock.restore();
-    Object.defineProperty(globalThis, 'open', { configurable: true, value: originalOpen });
+    vi.unstubAllGlobals();
   });
 
   // expected behavior: enters the app, does a navigate, launches sessionCheck, the user is deleted from redux

--- a/packages/pn-personafisica-webapp/src/navigation/__test__/ToSGuard.test.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/__test__/ToSGuard.test.tsx
@@ -34,7 +34,7 @@ const Guard = () => (
   </Routes>
 );
 
-describe('Tests the ToSGuard component', async () => {
+describe('Tests the ToSGuard component', () => {
   let mock: MockAdapter;
 
   beforeAll(() => {

--- a/packages/pn-personafisica-webapp/src/navigation/__test__/navigation.utility.test.ts
+++ b/packages/pn-personafisica-webapp/src/navigation/__test__/navigation.utility.test.ts
@@ -18,13 +18,8 @@ import {
 const mockOpenFn = vi.fn();
 
 describe('Tests navigation utility methods', () => {
-  const originalOpen = globalThis.open;
-
   beforeAll(() => {
-    Object.defineProperty(globalThis, 'open', {
-      configurable: true,
-      value: mockOpenFn,
-    });
+    vi.stubGlobal('open', mockOpenFn);
   });
 
   beforeEach(() => {
@@ -32,7 +27,7 @@ describe('Tests navigation utility methods', () => {
   });
 
   afterAll((): void => {
-    Object.defineProperty(globalThis, 'open', { configurable: true, value: originalOpen });
+    vi.unstubAllGlobals();
   });
 
   it('goToLoginPortal', () => {

--- a/packages/pn-personafisica-webapp/src/pages/__test__/AppStatus.page.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/AppStatus.page.test.tsx
@@ -1,4 +1,5 @@
 import MockAdapter from 'axios-mock-adapter';
+import { vi } from 'vitest';
 
 import { ThemeProvider } from '@mui/material';
 import { AppResponseMessage, ResponseEventDispatcher, formatDate } from '@pagopa-pn/pn-commons';
@@ -19,16 +20,12 @@ const AppStatusWithErrorHandling = () => (
   </ThemeProvider>
 );
 
-describe('AppStatus page', async () => {
+describe('AppStatus page', () => {
   let mock: MockAdapter;
-  const original = window.location;
 
   beforeAll(() => {
     mock = new MockAdapter(apiClient);
-    Object.defineProperty(window, 'location', {
-      configurable: true,
-      value: { href: '' },
-    });
+    vi.stubGlobal('location', { href: '' });
   });
 
   afterEach(() => {
@@ -38,7 +35,7 @@ describe('AppStatus page', async () => {
 
   afterAll(() => {
     mock.restore();
-    Object.defineProperty(window, 'location', { configurable: true, value: original });
+    vi.unstubAllGlobals();
   });
   /*
    * The intent of the "OK" test is to verify somehow that the result of the API calls

--- a/packages/pn-personafisica-webapp/src/pages/__test__/Contacts.page.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/Contacts.page.test.tsx
@@ -15,7 +15,7 @@ import { ChannelType } from '../../models/contacts';
 import { CONTACT_ACTIONS } from '../../redux/contact/actions';
 import Contacts from '../Contacts.page';
 
-describe('Contacts page', async () => {
+describe('Contacts page', () => {
   let mock: MockAdapter;
   let result: RenderResult;
 

--- a/packages/pn-personafisica-webapp/src/pages/__test__/Deleghe.page.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/Deleghe.page.test.tsx
@@ -11,7 +11,7 @@ import { apiClient } from '../../api/apiClients';
 import { DelegationStatus } from '../../utility/status.utility';
 import Deleghe from '../Deleghe.page';
 
-describe('Deleghe page', async () => {
+describe('Deleghe page', () => {
   const original = window.matchMedia;
   let result: RenderResult;
   let mock: MockAdapter;

--- a/packages/pn-personafisica-webapp/src/pages/__test__/DigitalContact.page.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/DigitalContact.page.test.tsx
@@ -12,7 +12,7 @@ const DigitalContactPage = () => (
   </Routes>
 );
 
-describe('DigitalContact Page', async () => {
+describe('DigitalContact Page', () => {
   it('renders the component', async () => {
     render(<DigitalContactPage />, {
       route: ['/', '/mocked-route'],

--- a/packages/pn-personafisica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
@@ -89,20 +89,22 @@ describe('NotificationDetail Page', () => {
 
   beforeAll(() => {
     mock = new MockAdapter(apiClient);
-    vi.stubGlobal('location', { href: '', assign: mockAssignFn });
     initLocalizationForTest();
+  });
+
+  beforeEach(() => {
+    vi.stubGlobal('location', { href: '', assign: mockAssignFn });
   });
 
   afterEach(() => {
     sessionStorage.removeItem(PAYMENT_CACHE_KEY);
     vi.clearAllMocks();
     mock.reset();
-    globalThis.location.href = '';
+    vi.unstubAllGlobals();
   });
 
   afterAll(() => {
     mock.restore();
-    vi.unstubAllGlobals();
   });
 
   const paymentInfoRequest = paymentInfo.map((payment) => ({

--- a/packages/pn-personafisica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
@@ -76,11 +76,10 @@ const delegator = mandatesByDelegate.find(
 /*
 ATTENZIONE: un'evenutale modifica al mock potrebbe causare il fallimento di alcuni test
 */
-describe('NotificationDetail Page', async () => {
+describe('NotificationDetail Page', () => {
   let result: RenderResult;
   let mock: MockAdapter;
   const mockLegalIds = getLegalFactIds(notificationToFe, 2);
-  const original = globalThis.location;
 
   const defaultOnboardingData = {
     hasBeenShown: false,
@@ -90,10 +89,7 @@ describe('NotificationDetail Page', async () => {
 
   beforeAll(() => {
     mock = new MockAdapter(apiClient);
-    Object.defineProperty(globalThis, 'location', {
-      configurable: true,
-      value: { href: '', assign: mockAssignFn },
-    });
+    vi.stubGlobal('location', { href: '', assign: mockAssignFn });
     initLocalizationForTest();
   });
 
@@ -106,7 +102,7 @@ describe('NotificationDetail Page', async () => {
 
   afterAll(() => {
     mock.restore();
-    Object.defineProperty(globalThis, 'location', { configurable: true, value: original });
+    vi.unstubAllGlobals();
   });
 
   const paymentInfoRequest = paymentInfo.map((payment) => ({

--- a/packages/pn-personafisica-webapp/src/pages/__test__/Notifiche.page.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/Notifiche.page.test.tsx
@@ -18,7 +18,7 @@ import { apiClient } from '../../api/apiClients';
 import { DASHBOARD_ACTIONS } from '../../redux/dashboard/actions';
 import Notifiche from '../Notifiche.page';
 
-describe('Notifiche Page', async () => {
+describe('Notifiche Page', () => {
   let result: RenderResult;
   let mock: MockAdapter;
   const originalMatchMedia = globalThis.matchMedia;

--- a/packages/pn-personafisica-webapp/src/pages/__test__/NuovaDelega.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/NuovaDelega.test.tsx
@@ -32,7 +32,7 @@ const yesterday = new Date(today);
 yesterday.setDate(yesterday.getDate() - 1);
 yesterday.setHours(0, 0, 0, 0);
 
-describe('NuovaDelega page', async () => {
+describe('NuovaDelega page', () => {
   let mock: MockAdapter;
 
   beforeEach(() => {

--- a/packages/pn-personafisica-webapp/src/pages/__test__/Support.page.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/Support.page.test.tsx
@@ -10,7 +10,7 @@ import { ZENDESK_AUTHORIZATION } from '../../api/support/support.routes';
 import * as routes from '../../navigation/routes.const';
 import SupportPage from '../Support.page';
 
-describe('Support page', async () => {
+describe('Support page', () => {
   let result: RenderResult;
   let mock: MockAdapter;
   const originalSubmit = HTMLFormElement.prototype.submit;

--- a/packages/pn-personafisica-webapp/src/pages/__test__/ToSAcceptance.page.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/ToSAcceptance.page.test.tsx
@@ -28,16 +28,12 @@ const privacyConsent: ConsentUser = {
   consentVersion: 'mocked-version-1',
 };
 
-describe('test Terms of Service page', async () => {
-  const original = globalThis.open;
+describe('test Terms of Service page', () => {
   let mock: MockAdapter;
 
   beforeAll(() => {
     mock = new MockAdapter(apiClient);
-    Object.defineProperty(globalThis, 'open', {
-      configurable: true,
-      value: mockOpenFn,
-    });
+    vi.stubGlobal('open', mockOpenFn);
   });
 
   afterEach(() => {
@@ -47,7 +43,7 @@ describe('test Terms of Service page', async () => {
 
   afterAll(() => {
     mock.restore();
-    Object.defineProperty(globalThis, 'open', { configurable: true, value: original });
+    vi.unstubAllGlobals();
   });
 
   it('checks the texts in the page - First ToS acceptance', () => {

--- a/packages/pn-personafisica-webapp/src/pages/__test__/TppLanding.page.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/TppLanding.page.test.tsx
@@ -13,18 +13,14 @@ const mockOpenFn = vi.fn();
 
 describe('TppLanding page', () => {
   const mockRetrievalId = '123456';
-  const original = globalThis.open;
 
   beforeEach(() => {
-    Object.defineProperty(globalThis, 'open', {
-      configurable: true,
-      value: mockOpenFn,
-    });
+    vi.stubGlobal('open', mockOpenFn);
   });
 
   afterEach(() => {
     vi.clearAllMocks();
-    Object.defineProperty(globalThis, 'open', { configurable: true, value: original });
+    vi.unstubAllGlobals();
   });
 
   it('should renders page with valid params', () => {

--- a/packages/pn-personafisica-webapp/src/setupTests.tsx
+++ b/packages/pn-personafisica-webapp/src/setupTests.tsx
@@ -13,6 +13,15 @@ const { getComputedStyle } = window;
 // eslint-disable-next-line functional/immutable-data
 window.getComputedStyle = (elt) => getComputedStyle(elt);
 
+const originalWarn = console.warn;
+// eslint-disable-next-line functional/immutable-data
+console.warn = (...args) => {
+  if (typeof args[0] === 'string' && args[0].includes('React Router Future Flag Warning')) {
+    return;
+  }
+  originalWarn(...args);
+};
+
 beforeAll(() => {
   Configuration.setForTest<PfConfiguration>({
     API_BASE_URL: 'https://webapi.test.notifichedigitali.it/',

--- a/packages/pn-personagiuridica-webapp/src/__test__/App.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/__test__/App.test.tsx
@@ -45,12 +45,11 @@ const reduxInitialState = {
   },
 };
 
-describe('App', async () => {
+describe('App', () => {
   let mock: MockAdapter;
   let mockAuth: MockAdapter;
   let result: RenderResult;
   const mockOpenFn = vi.fn();
-  const originalOpen = window.open;
 
   beforeAll(() => {
     mock = new MockAdapter(apiClient);
@@ -62,10 +61,7 @@ describe('App', async () => {
         json: () => Promise.resolve([]),
       }) as Promise<Response>;
 
-    Object.defineProperty(window, 'open', {
-      configurable: true,
-      value: mockOpenFn,
-    });
+    vi.stubGlobal('open', mockOpenFn);
   });
 
   afterEach(() => {
@@ -78,7 +74,7 @@ describe('App', async () => {
     mock.restore();
     mockAuth.restore();
     global.fetch = unmockedFetch;
-    Object.defineProperty(window, 'open', { configurable: true, value: originalOpen });
+    vi.unstubAllGlobals();
   });
 
   it('render component - user not logged in', async () => {

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/__test__/CancelVerificationModal.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/__test__/CancelVerificationModal.test.tsx
@@ -7,7 +7,7 @@ import CancelVerificationModal from '../CancelVerificationModal';
 
 const mockCloseHandler = vi.fn();
 
-describe('CancelVerificationModal component', async () => {
+describe('CancelVerificationModal component', () => {
   afterEach(() => {
     vi.clearAllMocks();
   });

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/__test__/CourtesyContacts.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/__test__/CourtesyContacts.test.tsx
@@ -18,7 +18,7 @@ const defaultSmsAddress = digitalCourtesyAddresses.find(
   (addr) => addr.senderId === 'default' && addr.channelType === ChannelType.SMS
 );
 
-describe('CourtesyContacts Component', async () => {
+describe('CourtesyContacts Component', () => {
   it('renders component - no contacts', async () => {
     const { container, getByTestId, getByRole } = render(<CourtesyContacts />);
     // check contacts

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/__test__/LegalContacts.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/__test__/LegalContacts.test.tsx
@@ -16,7 +16,7 @@ const defaultPecAddress = digitalLegalAddresses.find(
   (addr) => addr.senderId === 'default' && addr.pecValid && addr.channelType === ChannelType.PEC
 );
 
-describe('LegalContacts Component', async () => {
+describe('LegalContacts Component', () => {
   let mock: MockAdapter;
 
   beforeAll(() => {

--- a/packages/pn-personagiuridica-webapp/src/components/Contacts/__test__/SpecialContacts.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Contacts/__test__/SpecialContacts.test.tsx
@@ -16,7 +16,7 @@ const specialCourtesyAddresses = digitalCourtesyAddresses.filter(
   (addr) => addr.senderId !== 'default'
 );
 
-describe('SpecialContacts Component', async () => {
+describe('SpecialContacts Component', () => {
   let mock: MockAdapter;
 
   beforeAll(() => {

--- a/packages/pn-personagiuridica-webapp/src/components/Deleghe/__test__/DelegatesByCompany.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Deleghe/__test__/DelegatesByCompany.test.tsx
@@ -6,7 +6,7 @@ import { apiClient } from '../../../api/apiClients';
 import * as routes from '../../../navigation/routes.const';
 import DelegatesByCompany from '../DelegatesByCompany';
 
-describe('Delegates Component - assuming delegates API works properly', async () => {
+describe('Delegates Component - assuming delegates API works properly', () => {
   let mock: MockAdapter;
 
   beforeAll(() => {

--- a/packages/pn-personagiuridica-webapp/src/components/Deleghe/__test__/DelegationsElements.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Deleghe/__test__/DelegationsElements.test.tsx
@@ -13,7 +13,7 @@ import { AcceptButton, Menu, OrganizationsList } from '../DelegationsElements';
 
 const actionCbk = vi.fn();
 
-describe('DelegationElements', async () => {
+describe('DelegationElements', () => {
   let mock: MockAdapter;
 
   beforeAll(() => {

--- a/packages/pn-personagiuridica-webapp/src/components/Deleghe/__test__/DelegationsOfTheCompany.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Deleghe/__test__/DelegationsOfTheCompany.test.tsx
@@ -48,7 +48,7 @@ const initialState = {
   },
 };
 
-describe('DelegationsOfTheCompany Component', async () => {
+describe('DelegationsOfTheCompany Component', () => {
   let mock: MockAdapter;
 
   beforeAll(() => {

--- a/packages/pn-personagiuridica-webapp/src/components/IntegrazioneApi/__test__/PublicKeyDataInsert.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/IntegrazioneApi/__test__/PublicKeyDataInsert.test.tsx
@@ -23,13 +23,8 @@ const duplicateKeyMock = vi.fn().mockImplementation((publicKey: string | undefin
 const mockOpenFn = vi.fn();
 
 describe('PublicKeyDataInsert', () => {
-  const original = globalThis.open;
-
   beforeAll(() => {
-    Object.defineProperty(globalThis, 'open', {
-      configurable: true,
-      value: mockOpenFn,
-    });
+    vi.stubGlobal('open', mockOpenFn);
   });
 
   afterEach(() => {
@@ -37,7 +32,7 @@ describe('PublicKeyDataInsert', () => {
   });
 
   afterAll((): void => {
-    Object.defineProperty(globalThis, 'open', { configurable: true, value: original });
+    vi.unstubAllGlobals();
   });
 
   it('render component', async () => {

--- a/packages/pn-personagiuridica-webapp/src/components/Notifications/__test__/FilterNotifications.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Notifications/__test__/FilterNotifications.test.tsx
@@ -41,7 +41,7 @@ async function setFormValues(
   await testInput(form, 'iunMatch', iunMatch);
 }
 
-describe('Filter Notifications Table Component', async () => {
+describe('Filter Notifications Table Component', () => {
   let result: RenderResult;
   let form: HTMLFormElement;
 

--- a/packages/pn-personagiuridica-webapp/src/components/Notifications/__test__/GroupSelector.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Notifications/__test__/GroupSelector.test.tsx
@@ -7,7 +7,7 @@ import GroupSelector from '../GroupSelector';
 
 const onGroupSelectionCbk = vi.fn();
 
-describe('GroupSelector component', async () => {
+describe('GroupSelector component', () => {
   let mock: MockAdapter;
 
   beforeAll(() => {

--- a/packages/pn-personagiuridica-webapp/src/navigation/__test__/AARGuard.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/navigation/__test__/AARGuard.test.tsx
@@ -18,7 +18,7 @@ const Guard = () => (
   </Routes>
 );
 
-describe('Notification from QR code', async () => {
+describe('Notification from QR code', () => {
   let mock: MockAdapter;
   let result: RenderResult;
 

--- a/packages/pn-personagiuridica-webapp/src/navigation/__test__/SessionGuard.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/navigation/__test__/SessionGuard.test.tsx
@@ -24,19 +24,15 @@ const Guard = () => (
   </Routes>
 );
 
-describe('SessionGuard Component', async () => {
+describe('SessionGuard Component', () => {
   let mock: MockAdapter;
   let result: RenderResult;
 
-  const originalOpen = globalThis.open;
   const mockOpenFn = vi.fn();
 
   beforeAll(() => {
     mock = new MockAdapter(authClient);
-    Object.defineProperty(globalThis, 'open', {
-      configurable: true,
-      value: mockOpenFn,
-    });
+    vi.stubGlobal('open', mockOpenFn);
   });
 
   afterEach(() => {
@@ -47,7 +43,7 @@ describe('SessionGuard Component', async () => {
 
   afterAll(() => {
     mock.restore();
-    Object.defineProperty(globalThis, 'open', { configurable: true, value: originalOpen });
+    vi.unstubAllGlobals();
   });
 
   // expected behavior: enters the app, does a navigate, launches sessionCheck, the user is deleted from redux

--- a/packages/pn-personagiuridica-webapp/src/navigation/__test__/ToSGuard.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/navigation/__test__/ToSGuard.test.tsx
@@ -34,7 +34,7 @@ const Guard = () => (
   </Routes>
 );
 
-describe('Tests the ToSGuard component', async () => {
+describe('Tests the ToSGuard component', () => {
   let mock: MockAdapter;
 
   beforeAll(() => {

--- a/packages/pn-personagiuridica-webapp/src/navigation/__test__/navigation.utility.test.ts
+++ b/packages/pn-personagiuridica-webapp/src/navigation/__test__/navigation.utility.test.ts
@@ -10,13 +10,8 @@ import { SELFCARE_LOGOUT } from '../routes.const';
 const mockOpenFn = vi.fn();
 
 describe('Tests navigation utility methods', () => {
-  const originalOpen = globalThis.open;
-
   beforeAll(() => {
-    Object.defineProperty(globalThis, 'open', {
-      configurable: true,
-      value: mockOpenFn,
-    });
+    vi.stubGlobal('open', mockOpenFn);
   });
 
   beforeEach(() => {
@@ -24,7 +19,7 @@ describe('Tests navigation utility methods', () => {
   });
 
   afterAll((): void => {
-    Object.defineProperty(globalThis, 'open', { configurable: true, value: originalOpen });
+    vi.unstubAllGlobals();
   });
 
   it('goToLoginPortal', () => {

--- a/packages/pn-personagiuridica-webapp/src/pages/__test__/ApiIntegration.page.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/__test__/ApiIntegration.page.test.tsx
@@ -9,7 +9,7 @@ import { ConsentType } from '../../generated-client/tos-privacy';
 import { PNRole, PartyRole } from '../../models/User';
 import ApiIntegration from '../ApiIntegration.page';
 
-describe('ApiIntegration page', async () => {
+describe('ApiIntegration page', () => {
   let mock: MockAdapter;
 
   beforeAll(() => {

--- a/packages/pn-personagiuridica-webapp/src/pages/__test__/AppStatus.page.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/__test__/AppStatus.page.test.tsx
@@ -1,4 +1,5 @@
 import MockAdapter from 'axios-mock-adapter';
+import { vi } from 'vitest';
 
 import { ThemeProvider } from '@mui/material';
 import { AppResponseMessage, ResponseEventDispatcher, formatDate } from '@pagopa-pn/pn-commons';
@@ -19,16 +20,12 @@ const AppStatusWithErrorHandling = () => (
   </ThemeProvider>
 );
 
-describe('AppStatus page', async () => {
+describe('AppStatus page', () => {
   let mock: MockAdapter;
-  const original = window.location;
 
   beforeAll(() => {
     mock = new MockAdapter(apiClient);
-    Object.defineProperty(window, 'location', {
-      configurable: true,
-      value: { href: '' },
-    });
+    vi.stubGlobal('location', { href: '' });
   });
 
   afterEach(() => {
@@ -38,7 +35,7 @@ describe('AppStatus page', async () => {
 
   afterAll(() => {
     mock.restore();
-    Object.defineProperty(window, 'location', { configurable: true, value: original });
+    vi.unstubAllGlobals();
   });
   /*
    * The intent of the "OK" test is to verify somehow that the result of the API calls

--- a/packages/pn-personagiuridica-webapp/src/pages/__test__/Contacts.page.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/__test__/Contacts.page.test.tsx
@@ -16,17 +16,13 @@ import Contacts from '../Contacts.page';
 
 const mockOpenFn = vi.fn();
 
-describe('Contacts page', async () => {
+describe('Contacts page', () => {
   let mock: MockAdapter;
   let result: RenderResult;
-  const original = window.open;
 
   beforeAll(() => {
     mock = new MockAdapter(apiClient);
-    Object.defineProperty(window, 'open', {
-      configurable: true,
-      value: mockOpenFn,
-    });
+    vi.stubGlobal('open', mockOpenFn);
   });
 
   afterEach(() => {
@@ -37,7 +33,7 @@ describe('Contacts page', async () => {
   afterAll(() => {
     mock.restore();
     vi.resetAllMocks();
-    Object.defineProperty(window, 'open', { configurable: true, value: original });
+    vi.unstubAllGlobals();
   });
 
   it('renders Contacts (no contacts)', async () => {

--- a/packages/pn-personagiuridica-webapp/src/pages/__test__/Deleghe.page.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/__test__/Deleghe.page.test.tsx
@@ -10,7 +10,7 @@ import DelegationsOfTheCompany from '../../components/Deleghe/DelegationsOfTheCo
 import * as routes from '../../navigation/routes.const';
 import Deleghe from '../Deleghe.page';
 
-describe('Deleghe page', async () => {
+describe('Deleghe page', () => {
   let mock: MockAdapter;
 
   beforeAll(() => {

--- a/packages/pn-personagiuridica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
@@ -86,6 +86,9 @@ describe('NotificationDetail Page', () => {
 
   beforeAll(() => {
     mock = new MockAdapter(apiClient);
+  });
+
+  beforeEach(() => {
     vi.stubGlobal('location', { href: '', assign: mockAssignFn });
   });
 
@@ -93,12 +96,11 @@ describe('NotificationDetail Page', () => {
     sessionStorage.removeItem(PAYMENT_CACHE_KEY);
     vi.clearAllMocks();
     mock.reset();
-    globalThis.location.href = '';
+    vi.unstubAllGlobals();
   });
 
   afterAll(() => {
     mock.restore();
-    vi.unstubAllGlobals();
   });
 
   const paymentInfoRequest = paymentInfo.map((payment) => ({

--- a/packages/pn-personagiuridica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
@@ -79,18 +79,14 @@ const delegator = mandatesByDelegate.find(
 /*
 ATTENZIONE: un'evenutale modifica al mock potrebbe causare il fallimento di alcuni test
 */
-describe('NotificationDetail Page', async () => {
+describe('NotificationDetail Page', () => {
   let result: RenderResult;
   let mock: MockAdapter;
   const mockLegalIds = getLegalFactIds(notificationToFe, 1);
-  const original = globalThis.location;
 
   beforeAll(() => {
     mock = new MockAdapter(apiClient);
-    Object.defineProperty(globalThis, 'location', {
-      configurable: true,
-      value: { href: '', assign: mockAssignFn },
-    });
+    vi.stubGlobal('location', { href: '', assign: mockAssignFn });
   });
 
   afterEach(() => {
@@ -102,7 +98,7 @@ describe('NotificationDetail Page', async () => {
 
   afterAll(() => {
     mock.restore();
-    Object.defineProperty(globalThis, 'location', { configurable: true, value: original });
+    vi.unstubAllGlobals();
   });
 
   const paymentInfoRequest = paymentInfo.map((payment) => ({

--- a/packages/pn-personagiuridica-webapp/src/pages/__test__/Notifiche.page.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/__test__/Notifiche.page.test.tsx
@@ -28,7 +28,7 @@ import { apiClient } from '../../api/apiClients';
 import { DASHBOARD_ACTIONS } from '../../redux/dashboard/actions';
 import Notifiche from '../Notifiche.page';
 
-describe('Notifiche Page ', async () => {
+describe('Notifiche Page ', () => {
   let result: RenderResult;
   let mock: MockAdapter;
   const originalMatchMedia = globalThis.matchMedia;

--- a/packages/pn-personagiuridica-webapp/src/pages/__test__/NuovaDelega.page.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/__test__/NuovaDelega.page.test.tsx
@@ -32,7 +32,7 @@ const yesterday = new Date(today);
 yesterday.setDate(yesterday.getDate() - 1);
 yesterday.setHours(0, 0, 0, 0);
 
-describe('NuovaDelega page', async () => {
+describe('NuovaDelega page', () => {
   let mock: MockAdapter;
   let result: RenderResult;
 

--- a/packages/pn-personagiuridica-webapp/src/pages/__test__/ToSAcceptance.page.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/__test__/ToSAcceptance.page.test.tsx
@@ -30,14 +30,10 @@ const privacyConsent: ConsentUser = {
 
 describe('test Terms of Service page', () => {
   let mock: MockAdapter;
-  const original = globalThis.open;
 
   beforeAll(() => {
     mock = new MockAdapter(apiClient);
-    Object.defineProperty(globalThis, 'open', {
-      configurable: true,
-      value: mockOpenFn,
-    });
+    vi.stubGlobal('open', mockOpenFn);
   });
 
   afterEach(() => {
@@ -47,7 +43,7 @@ describe('test Terms of Service page', () => {
 
   afterAll(() => {
     mock.restore();
-    Object.defineProperty(globalThis, 'open', { configurable: true, value: original });
+    vi.unstubAllGlobals();
   });
 
   it('checks the texts in the page - First ToS acceptance', () => {

--- a/packages/pn-personagiuridica-webapp/src/setupTests.tsx
+++ b/packages/pn-personagiuridica-webapp/src/setupTests.tsx
@@ -17,6 +17,15 @@ const { getComputedStyle } = window;
 // eslint-disable-next-line functional/immutable-data
 window.getComputedStyle = (elt) => getComputedStyle(elt);
 
+const originalWarn = console.warn;
+// eslint-disable-next-line functional/immutable-data
+console.warn = (...args) => {
+  if (typeof args[0] === 'string' && args[0].includes('React Router Future Flag Warning')) {
+    return;
+  }
+  originalWarn(...args);
+};
+
 beforeAll(async () => {
   Configuration.setForTest<PgConfiguration>({
     API_BASE_URL: 'https://webapi.test.notifichedigitali.it/',


### PR DESCRIPTION
## Short description
- Replace Object.defineProperty(globalThis, ...) with vi.stubGlobal(...) across all test files in pn-personafisica-webapp, pn-personagiuridica-webapp, pn-pa-webapp, pn-commons, and pn-personafisica-login
- Remove async describe anti-pattern from all affected test files

## Motivation
Object.defineProperty on top-level globals (location, open) does not restore the original descriptor after the test, causing state to leak between test files and making tests order-dependent. vi.stubGlobal is the Vitest-idiomatic alternative: it snapshots the original value and restores it automatically via vi.unstubAllGlobals() in afterAll, regardless of pool type.

async describe is an anti-pattern in Vitest: the test runner expects describe callbacks to be synchronous. An async callback causes beforeAll/afterAll lifecycle hooks to be registered after the runner has already moved on, leading to deadlocks or skipped teardown — particularly visible with vmThreads pool.

## How to test
Run full test suite across all affected packages and verify no regressions