### PR TITLE
test(PN-19561): test delegate components

### DIFF
--- a/packages/pn-personafisica-webapp/src/components/Deleghe/__test__/mixpanel/Delegates.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Deleghe/__test__/mixpanel/Delegates.mixpanel.test.tsx
@@ -1,0 +1,38 @@
+import { MockInstance, vi } from 'vitest';
+
+import { mandatesByDelegator } from '../../../../__mocks__/Delegations.mock';
+import { fireEvent, render } from '../../../../__test__/test-utils';
+import { PFEventsType } from '../../../../models/PFEventsType';
+import PFEventStrategyFactory from '../../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import Delegates from '../../Delegates';
+
+describe('Delegates component - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    triggerEventSpy.mockRestore();
+  });
+
+  it('fires SEND_ADD_MANDATE_START when add delegation button is clicked', () => {
+    const { getByTestId } = render(<Delegates />);
+    fireEvent.click(getByTestId('add-delegation'));
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ADD_MANDATE_START);
+  });
+
+  it('fires SEND_ADD_MANDATE_START when empty state link is clicked', () => {
+    const { getByTestId } = render(<Delegates />);
+    fireEvent.click(getByTestId('link-add-delegate'));
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ADD_MANDATE_START);
+  });
+
+  it('does not fire SEND_ADD_MANDATE_START on render with delegates', () => {
+    render(<Delegates />, {
+      preloadedState: { delegationsState: { delegations: { delegates: mandatesByDelegator } } },
+    });
+    expect(triggerEventSpy).not.toHaveBeenCalledWith(PFEventsType.SEND_ADD_MANDATE_START);
+  });
+});

--- a/packages/pn-personafisica-webapp/src/components/Deleghe/__test__/mixpanel/DelegationsElements.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Deleghe/__test__/mixpanel/DelegationsElements.mixpanel.test.tsx
@@ -1,0 +1,45 @@
+import { MockInstance, vi } from 'vitest';
+
+import { fireEvent, render } from '../../../../__test__/test-utils';
+import { PFEventsType } from '../../../../models/PFEventsType';
+import PFEventStrategyFactory from '../../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import { Menu } from '../../DelegationsElements';
+
+const mockSetCodeModal = vi.fn();
+
+describe('DelegationsElements - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    triggerEventSpy.mockRestore();
+  });
+
+  it('fires SEND_SHOW_MANDATE_CODE when show code menu item is clicked', () => {
+    const { getByTestId } = render(
+      <Menu
+        menuType="delegates"
+        id="111"
+        setCodeModal={mockSetCodeModal}
+        name="mocked-name"
+        verificationCode="01234"
+      />
+    );
+    fireEvent.click(getByTestId('delegationMenuIcon'));
+    fireEvent.click(getByTestId('menuItem-showCode'));
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_SHOW_MANDATE_CODE);
+  });
+
+  it('does not fire SEND_SHOW_MANDATE_CODE when revoke menu item is clicked', () => {
+    const { getByTestId } = render(
+      <Menu menuType="delegates" id="111" setCodeModal={mockSetCodeModal} name="mocked-name" />
+    );
+    fireEvent.click(getByTestId('delegationMenuIcon'));
+    fireEvent.click(getByTestId('menuItem-revokeDelegate'));
+    expect(triggerEventSpy).not.toHaveBeenCalledWith(PFEventsType.SEND_SHOW_MANDATE_CODE);
+  });
+});

--- a/packages/pn-personafisica-webapp/src/components/Deleghe/__test__/mixpanel/MobileDelegates.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Deleghe/__test__/mixpanel/MobileDelegates.mixpanel.test.tsx
@@ -1,0 +1,38 @@
+import { MockInstance, vi } from 'vitest';
+
+import { mandatesByDelegator } from '../../../../__mocks__/Delegations.mock';
+import { fireEvent, render } from '../../../../__test__/test-utils';
+import { PFEventsType } from '../../../../models/PFEventsType';
+import PFEventStrategyFactory from '../../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import MobileDelegates from '../../MobileDelegates';
+
+describe('MobileDelegates component - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    triggerEventSpy.mockRestore();
+  });
+
+  it('fires SEND_ADD_MANDATE_START when add delegation button is clicked', () => {
+    const { getByTestId } = render(<MobileDelegates />);
+    fireEvent.click(getByTestId('add-delegation'));
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ADD_MANDATE_START);
+  });
+
+  it('fires SEND_ADD_MANDATE_START when empty state link is clicked', () => {
+    const { getByTestId } = render(<MobileDelegates />);
+    fireEvent.click(getByTestId('link-add-delegate'));
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_ADD_MANDATE_START);
+  });
+
+  it('does not fire SEND_ADD_MANDATE_START on render with delegates', () => {
+    render(<MobileDelegates />, {
+      preloadedState: { delegationsState: { delegations: { delegates: mandatesByDelegator } } },
+    });
+    expect(triggerEventSpy).not.toHaveBeenCalledWith(PFEventsType.SEND_ADD_MANDATE_START);
+  });
+});

--- a/packages/pn-personafisica-webapp/src/pages/__test__/mixpanel/Deleghe.page.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/mixpanel/Deleghe.page.mixpanel.test.tsx
@@ -1,8 +1,11 @@
 import MockAdapter from 'axios-mock-adapter';
 import { MockInstance, vi } from 'vitest';
 
+import { ResponseEventDispatcher } from '@pagopa-pn/pn-commons';
+import userEvent from '@testing-library/user-event';
+
 import { mandatesByDelegate, mandatesByDelegator } from '../../../__mocks__/Delegations.mock';
-import { act, render, waitFor } from '../../../__test__/test-utils';
+import { act, render, waitFor, within } from '../../../__test__/test-utils';
 import { apiClient } from '../../../api/apiClients';
 import { PFEventsType } from '../../../models/PFEventsType';
 import PFEventStrategyFactory from '../../../utility/MixpanelUtils/PFEventStrategyFactory';
@@ -45,6 +48,127 @@ describe('Deleghe.page - Mixpanel events', () => {
           delegators: expect.any(Array),
         })
       );
+    });
+  });
+
+  it('fires SEND_MANDATE_REVOKED and SEND_MANDATE_GIVEN when a delegation is revoked', async () => {
+    mock.onGet('/bff/v1/mandate/delegate').reply(200, mandatesByDelegate);
+    mock.onGet('/bff/v1/mandate/delegator').reply(200, mandatesByDelegator);
+    mock.onPatch(`/bff/v1/mandate/${mandatesByDelegator[0].mandateId}/revoke`).reply(204);
+
+    await act(async () => {
+      render(<Deleghe />);
+    });
+
+    const delegatesRows = await waitFor(() =>
+      document.querySelectorAll('[data-testid="delegatesTable.body.row"]')
+    );
+    const menuIcon = within(delegatesRows[0] as HTMLElement).getByTestId('delegationMenuIcon');
+    await userEvent.click(menuIcon);
+    await userEvent.click(await waitFor(() => document.querySelector('[data-testid="menuItem-revokeDelegate"]') as HTMLElement));
+    const dialog = await waitFor(() => document.querySelector('[data-testid="confirmationDialog"]') as HTMLElement);
+    const confirmButton = within(dialog).getByRole('button', { name: 'deleghe.confirm_revocation' });
+    await userEvent.click(confirmButton);
+
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_MANDATE_REVOKED);
+    });
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_MANDATE_GIVEN,
+        expect.objectContaining({ delegators: expect.any(Array) })
+      );
+    });
+  });
+
+  it('fires SEND_MANDATE_REJECTED and SEND_HAS_MANDATE when a delegator is rejected', async () => {
+    mock.onGet('/bff/v1/mandate/delegate').reply(200, mandatesByDelegate);
+    mock.onGet('/bff/v1/mandate/delegator').reply(200, mandatesByDelegator);
+    mock.onPatch(`/bff/v1/mandate/${mandatesByDelegate[1].mandateId}/reject`).reply(204);
+
+    await act(async () => {
+      render(<Deleghe />);
+    });
+
+    const delegatorsRows = await waitFor(() =>
+      document.querySelectorAll('[data-testid="delegatorsTable.body.row"]')
+    );
+    const menuIcon = within(delegatorsRows[1] as HTMLElement).getByTestId('delegationMenuIcon');
+    await userEvent.click(menuIcon);
+    await userEvent.click(await waitFor(() => document.querySelector('[data-testid="menuItem-rejectDelegator"]') as HTMLElement));
+    const dialog = await waitFor(() => document.querySelector('[data-testid="confirmationDialog"]') as HTMLElement);
+    const confirmButton = within(dialog).getByRole('button', { name: 'deleghe.confirm_rejection' });
+    await userEvent.click(confirmButton);
+
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_MANDATE_REJECTED);
+    });
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(
+        PFEventsType.SEND_HAS_MANDATE,
+        expect.objectContaining({ delegates: expect.any(Array) })
+      );
+    });
+  });
+
+  it('fires SEND_MANDATE_ACCEPTED when a delegation is accepted', async () => {
+    mock.onGet('/bff/v1/mandate/delegate').reply(200, mandatesByDelegate);
+    mock.onGet('/bff/v1/mandate/delegator').reply(200, mandatesByDelegator);
+    mock
+      .onPatch(`/bff/v1/mandate/${mandatesByDelegate[0].mandateId}/accept`, {
+        verificationCode: mandatesByDelegate[0].verificationCode,
+      })
+      .reply(204);
+
+    await act(async () => {
+      render(<Deleghe />);
+    });
+
+    const delegatorsRows = await waitFor(() =>
+      document.querySelectorAll('[data-testid="delegatorsTable.body.row"]')
+    );
+    await userEvent.click(within(delegatorsRows[0] as HTMLElement).getByTestId('acceptButton'));
+    const dialog = await waitFor(() => document.querySelector('[data-testid="codeDialog"]') as HTMLElement);
+    const textbox = within(dialog).getByRole('textbox');
+    textbox.focus();
+    await userEvent.keyboard(mandatesByDelegate[0].verificationCode);
+    await userEvent.click(within(dialog).getByRole('button', { name: 'deleghe.accept' }));
+
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_MANDATE_ACCEPTED);
+    });
+  });
+
+  it('fires SEND_MANDATE_ACCEPT_CODE_ERROR when accept API returns an error', async () => {
+    mock.onGet('/bff/v1/mandate/delegate').reply(200, mandatesByDelegate);
+    mock.onGet('/bff/v1/mandate/delegator').reply(200, mandatesByDelegator);
+    mock
+      .onPatch(`/bff/v1/mandate/${mandatesByDelegate[0].mandateId}/accept`, {
+        verificationCode: mandatesByDelegate[0].verificationCode,
+      })
+      .reply(500, { status: 500, title: 'error', detail: 'error' });
+
+    await act(async () => {
+      render(
+        <>
+          <ResponseEventDispatcher />
+          <Deleghe />
+        </>
+      );
+    });
+
+    const delegatorsRows = await waitFor(() =>
+      document.querySelectorAll('[data-testid="delegatorsTable.body.row"]')
+    );
+    await userEvent.click(within(delegatorsRows[0] as HTMLElement).getByTestId('acceptButton'));
+    const dialog = await waitFor(() => document.querySelector('[data-testid="codeDialog"]') as HTMLElement);
+    const textbox = within(dialog).getByRole('textbox');
+    textbox.focus();
+    await userEvent.keyboard(mandatesByDelegate[0].verificationCode);
+    await userEvent.click(within(dialog).getByRole('button', { name: 'deleghe.accept' }));
+
+    await waitFor(() => {
+      expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_MANDATE_ACCEPT_CODE_ERROR);
     });
   });
 });


### PR DESCRIPTION
## Short description
Tests for events

Evento | Trigger | Sorgente
-- | -- | --
SEND_ADD_MANDATE_START | Click su "aggiungi delega" (button o empty state link) | Delegates.tsx, MobileDelegates.tsx
SEND_SHOW_MANDATE_CODE | Click su "mostra codice" nel menu contestuale di una delega | DelegationsElements.tsx → Menu
SEND_MANDATE_REVOKED | Click su "conferma revoca" nel dialog di conferma | Deleghe.page.tsx
SEND_MANDATE_GIVEN | Dopo che la chiamata revoca va a buon fine | Deleghe.page.tsx
SEND_MANDATE_REJECTED | Click su "conferma rifiuto" nel dialog di conferma | Deleghe.page.tsx
SEND_HAS_MANDATE | Dopo che la chiamata rifiuto va a buon fine | Deleghe.page.tsx
SEND_MANDATE_ACCEPTED | Click su "accetta" nel CodeModal con il codice inserito | Deleghe.page.tsx
SEND_MANDATE_ACCEPT_CODE_ERROR | Risposta API 500 su acceptMandate (via AppResponsePublisher) | Deleghe.page.tsx
