### PR TITLE
test(PN-19561): test events in banner component and reducer middleware

### DIFF
--- a/packages/pn-personafisica-webapp/src/components/DomicileBanner/__test__/mixpanel/DomicileBanner.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/DomicileBanner/__test__/mixpanel/DomicileBanner.mixpanel.test.tsx
@@ -1,0 +1,41 @@
+import { MockInstance, vi } from 'vitest';
+
+import { appStorage } from '@pagopa-pn/pn-commons';
+
+import { fireEvent, render } from '../../../../__test__/test-utils';
+import { ContactSource } from '../../../../models/contacts';
+import { PFEventsType } from '../../../../models/PFEventsType';
+import PFEventStrategyFactory from '../../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import DomicileBanner from '../../DomicileBanner';
+
+describe('DomicileBanner component - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    appStorage.domicileBanner.enable();
+    triggerEventSpy.mockRestore();
+  });
+
+  it('fires SEND_ADD_SERCQ_SEND_ENTER_FLOW when CTA is clicked on no-sercq-send banner', () => {
+    const { getByText } = render(<DomicileBanner source={ContactSource.HOME_NOTIFICHE} />);
+    fireEvent.click(getByText('domicile-banner.no-sercq-cta'));
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ADD_SERCQ_SEND_ENTER_FLOW,
+      expect.objectContaining({ source: ContactSource.HOME_NOTIFICHE })
+    );
+  });
+
+  it('fires SEND_VIEW_CONTACT_DETAILS when CTA is clicked on no-courtesy-no-sercq-send banner', () => {
+    appStorage.domicileBanner.disable();
+    const { getByText } = render(<DomicileBanner source={ContactSource.HOME_NOTIFICHE} />);
+    fireEvent.click(getByText('domicile-banner.no-courtesy-no-sercq-send-cta'));
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_VIEW_CONTACT_DETAILS, {
+      source: ContactSource.HOME_NOTIFICHE,
+    });
+  });
+});

--- a/packages/pn-personafisica-webapp/src/components/Notifications/__test__/mixpanel/NotificationCostBanner.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Notifications/__test__/mixpanel/NotificationCostBanner.mixpanel.test.tsx
@@ -1,0 +1,43 @@
+import { MockInstance, vi } from 'vitest';
+
+import { DeliveryOutcomeType, EventAction } from '@pagopa-pn/pn-commons';
+
+import { fireEvent, render } from '../../../../__test__/test-utils';
+import { PFEventsType } from '../../../../models/PFEventsType';
+import PFEventStrategyFactory from '../../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import { NotificationCostBanner } from '../../NotificationCostBanner';
+
+describe('NotificationCostBanner component - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    triggerEventSpy.mockRestore();
+  });
+
+  it('fires SEND_BANNER on mount', () => {
+    render(<NotificationCostBanner deliveryOutcome={null} />, {
+      preloadedState: { contactsState: { digitalAddresses: [] } },
+    });
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_BANNER,
+      expect.objectContaining({ event_type: EventAction.SCREEN_VIEW })
+    );
+  });
+
+  it('fires SEND_TAP_BANNER when CTA is clicked', () => {
+    const deliveryOutcome = { type: DeliveryOutcomeType.ANALOG } as any;
+    const { getByText } = render(
+      <NotificationCostBanner deliveryOutcome={deliveryOutcome} />,
+      { preloadedState: { contactsState: { digitalAddresses: [] } } }
+    );
+    fireEvent.click(getByText('notification-cost-banner.enable-sercq.cta'));
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_TAP_BANNER,
+      expect.objectContaining({ event_type: EventAction.ACTION })
+    );
+  });
+});

--- a/packages/pn-personafisica-webapp/src/components/Notifications/__test__/mixpanel/NotificationsEmptyState.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Notifications/__test__/mixpanel/NotificationsEmptyState.mixpanel.test.tsx
@@ -1,0 +1,42 @@
+import { MockInstance, vi } from 'vitest';
+
+import { digitalAddressesSercq } from '../../../../__mocks__/Contacts.mock';
+import { fireEvent, render } from '../../../../__test__/test-utils';
+import { ChannelType, ContactSource } from '../../../../models/contacts';
+import { PFEventsType } from '../../../../models/PFEventsType';
+import PFEventStrategyFactory from '../../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import NotificationsEmptyState from '../../NotificationsEmptyState';
+
+const sercqSendDefault = digitalAddressesSercq.find(
+  (addr) => addr.senderId === 'default' && addr.channelType === ChannelType.SERCQ_SEND
+);
+
+const filterNotificationsRef = {
+  current: { filtersApplied: false, cleanFilters: vi.fn() },
+};
+
+describe('NotificationsEmptyState component - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    triggerEventSpy.mockRestore();
+  });
+
+  it('fires SEND_VIEW_CONTACT_DETAILS when go-to-contacts link is clicked', () => {
+    const { getByTestId } = render(
+      <NotificationsEmptyState
+        filtersApplied={false}
+        filterNotificationsRef={filterNotificationsRef as any}
+      />,
+      { preloadedState: { contactsState: { digitalAddresses: [sercqSendDefault] } } }
+    );
+    fireEvent.click(getByTestId('link-route-contacts'));
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_VIEW_CONTACT_DETAILS, {
+      source: ContactSource.HOME_NOTIFICHE,
+    });
+  });
+});

--- a/packages/pn-personafisica-webapp/src/redux/notification/__test__/mixpanel/getReceivedNotificationPaymentInfo.mixpanel.test.ts
+++ b/packages/pn-personafisica-webapp/src/redux/notification/__test__/mixpanel/getReceivedNotificationPaymentInfo.mixpanel.test.ts
@@ -1,0 +1,107 @@
+import MockAdapter from 'axios-mock-adapter';
+import { MockInstance, vi } from 'vitest';
+
+import { PAYMENT_CACHE_KEY, PaymentStatus, setPaymentCache } from '@pagopa-pn/pn-commons';
+
+import { paymentInfo } from '../../../../__mocks__/ExternalRegistry.mock';
+import { notificationToFe, paymentsData, recipients } from '../../../../__mocks__/NotificationDetail.mock';
+import { createMockedStore } from '../../../../__test__/test-utils';
+import { apiClient } from '../../../../api/apiClients';
+import { PFEventsType } from '../../../../models/PFEventsType';
+import PFEventStrategyFactory from '../../../../utility/MixpanelUtils/PFEventStrategyFactory';
+import { getReceivedNotificationPaymentInfo } from '../../actions';
+
+const failedPayment = paymentInfo.find((p) => p.status === PaymentStatus.FAILED)!;
+const succeededPayment = paymentInfo.find((p) => p.status === PaymentStatus.SUCCEEDED)!;
+
+const currentPayment = {
+  creditorTaxId: failedPayment.creditorTaxId,
+  noticeCode: failedPayment.noticeCode,
+};
+
+describe('getReceivedNotificationPaymentInfo - Mixpanel events', () => {
+  let mock: MockAdapter;
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+
+  beforeAll(() => {
+    mock = new MockAdapter(apiClient);
+  });
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    mock.reset();
+    sessionStorage.removeItem(PAYMENT_CACHE_KEY);
+    triggerEventSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  it('fires SEND_PAYMENT_OUTCOME when returning from payment page', async () => {
+    const mockedStore = createMockedStore({
+      notificationState: { notification: notificationToFe, paymentsData },
+    });
+
+    setPaymentCache(
+      { iun: notificationToFe.iun, timestamp: new Date().toISOString(), currentPayment, payments: [] },
+      notificationToFe.iun
+    );
+
+    mock
+      .onPost('/bff/v1/payments/info', [currentPayment])
+      .reply(200, [{ ...failedPayment, status: PaymentStatus.FAILED }]);
+
+    await mockedStore.dispatch(
+      getReceivedNotificationPaymentInfo({
+        taxId: recipients[2].taxId,
+        paymentInfoRequest: [currentPayment],
+      })
+    );
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_PAYMENT_OUTCOME, {
+      outcome: PaymentStatus.FAILED,
+    });
+    expect(triggerEventSpy).not.toHaveBeenCalledWith(PFEventsType.SEND_PAYMENTS_COUNT);
+  });
+
+  it('fires SEND_PAYMENT_OUTCOME and SEND_PAYMENTS_COUNT when payment succeeds', async () => {
+    const currentSucceededPayment = {
+      creditorTaxId: succeededPayment.creditorTaxId,
+      noticeCode: succeededPayment.noticeCode,
+    };
+
+    const mockedStore = createMockedStore({
+      notificationState: { notification: notificationToFe, paymentsData },
+    });
+
+    setPaymentCache(
+      {
+        iun: notificationToFe.iun,
+        timestamp: new Date().toISOString(),
+        currentPayment: currentSucceededPayment,
+        payments: [],
+      },
+      notificationToFe.iun
+    );
+
+    mock
+      .onPost('/bff/v1/payments/info', [currentSucceededPayment])
+      .reply(200, [{ ...succeededPayment, status: PaymentStatus.SUCCEEDED }]);
+
+    await mockedStore.dispatch(
+      getReceivedNotificationPaymentInfo({
+        taxId: recipients[2].taxId,
+        paymentInfoRequest: [currentSucceededPayment],
+      })
+    );
+
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_PAYMENT_OUTCOME, {
+      outcome: PaymentStatus.SUCCEEDED,
+    });
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFEventsType.SEND_PAYMENTS_COUNT);
+  });
+});

--- a/packages/pn-personafisica-webapp/src/utility/__test__/mixpanel/mixpanel.mixpanel.test.ts
+++ b/packages/pn-personafisica-webapp/src/utility/__test__/mixpanel/mixpanel.mixpanel.test.ts
@@ -1,0 +1,122 @@
+import { MockInstance, vi } from 'vitest';
+
+import { configureStore } from '@reduxjs/toolkit';
+
+import { PFEventsType } from '../../../models/PFEventsType';
+import { appReducers } from '../../../redux/store';
+import PFEventStrategyFactory from '../../MixpanelUtils/PFEventStrategyFactory';
+import { trackingMiddleware } from '../../mixpanel';
+
+const store = configureStore({
+  reducer: appReducers,
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware({ serializableCheck: false }).concat(trackingMiddleware),
+});
+
+const dispatch = (type: string, payload: unknown = {}) =>
+  store.dispatch({ type, payload, meta: { arg: {} } } as any);
+
+describe('trackingMiddleware - Mixpanel events', () => {
+  let triggerEventSpy: MockInstance<[PFEventsType, unknown?], void>;
+
+  beforeEach(() => {
+    triggerEventSpy = vi.spyOn(PFEventStrategyFactory, 'triggerEvent');
+  });
+
+  afterEach(() => {
+    triggerEventSpy.mockRestore();
+  });
+
+  it('fires SEND_AUTH_SUCCESS on exchangeToken/fulfilled', () => {
+    dispatch('exchangeToken/fulfilled', { sessionToken: 'mock-token' });
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_AUTH_SUCCESS,
+      expect.any(Object)
+    );
+  });
+
+  it('fires SEND_DOWNLOAD_RESPONSE on getReceivedNotificationOtherDocument/fulfilled', () => {
+    dispatch('getReceivedNotificationOtherDocument/fulfilled');
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_DOWNLOAD_RESPONSE,
+      expect.any(Object)
+    );
+  });
+
+  it('fires SEND_DOWNLOAD_RESPONSE on getReceivedNotificationLegalfact/fulfilled', () => {
+    dispatch('getReceivedNotificationLegalfact/fulfilled');
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_DOWNLOAD_RESPONSE,
+      expect.any(Object)
+    );
+  });
+
+  it('fires SEND_HAS_ADDRESSES on getDigitalAddresses/fulfilled', () => {
+    dispatch('getDigitalAddresses/fulfilled', []);
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_HAS_ADDRESSES,
+      expect.any(Object)
+    );
+  });
+
+  it('fires SEND_HAS_MANDATE_LOGIN on getSidemenuInformation/fulfilled', () => {
+    dispatch('getSidemenuInformation/fulfilled', []);
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_HAS_MANDATE_LOGIN,
+      expect.any(Object)
+    );
+  });
+
+  it('fires SEND_MANDATE_GIVEN on getMandatesByDelegator/fulfilled', () => {
+    dispatch('getMandatesByDelegator/fulfilled', []);
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_MANDATE_GIVEN,
+      expect.any(Object)
+    );
+  });
+
+  it('fires SEND_ENABLE_IO on enableIOAddress/fulfilled', () => {
+    dispatch('enableIOAddress/fulfilled');
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ENABLE_IO,
+      expect.any(Object)
+    );
+  });
+
+  it('fires SEND_DISABLE_IO on disableIOAddress/fulfilled', () => {
+    dispatch('disableIOAddress/fulfilled');
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_DISABLE_IO,
+      expect.any(Object)
+    );
+  });
+
+  it('fires SEND_ACCEPT_DELEGATION on acceptMandate/fulfilled', () => {
+    dispatch('acceptMandate/fulfilled');
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ACCEPT_DELEGATION,
+      expect.any(Object)
+    );
+  });
+
+  it('fires SEND_ADD_ADDRESS on createOrUpdateAddress/fulfilled', () => {
+    dispatch('createOrUpdateAddress/fulfilled');
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_ADD_ADDRESS,
+      expect.any(Object)
+    );
+  });
+
+  it('fires SEND_DELETE_ADDRESS on deleteAddress/fulfilled', () => {
+    dispatch('deleteAddress/fulfilled');
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_DELETE_ADDRESS,
+      expect.any(Object)
+    );
+  });
+
+  it('does not fire any event for unknown action types', () => {
+    dispatch('someUnknownAction/fulfilled');
+    expect(triggerEventSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Short description

Add Mixpanel event coverage for notification components and Redux middleware.

### Group 6 — Notification components

DomicileBanner — SEND_ADD_SERCQ_SEND_ENTER_FLOW, SEND_VIEW_CONTACT_DETAILS
NotificationCostBanner — SEND_BANNER, SEND_TAP_BANNER
NotificationsEmptyState — SEND_VIEW_CONTACT_DETAILS

### Group 7 — Redux

trackingMiddleware — all 11 entries in eventsActionsMap (auth, download, addresses, mandates, IO, delegation, contacts)
getReceivedNotificationPaymentInfo thunk — SEND_PAYMENT_OUTCOME (FAILED/SUCCEEDED) and SEND_PAYMENTS_COUNT


Evento | Trigger | File
-- | -- | --
SEND_ADD_SERCQ_SEND_ENTER_FLOW | DomicileBanner CTA (no SERCQ send active) | DomicileBanner.mixpanel.test.tsx
SEND_VIEW_CONTACT_DETAILS | DomicileBanner CTA (no courtesy + no SERCQ send) | DomicileBanner.mixpanel.test.tsx
SEND_BANNER | NotificationCostBanner on mount | NotificationCostBanner.mixpanel.test.tsx
SEND_TAP_BANNER | NotificationCostBanner CTA click | NotificationCostBanner.mixpanel.test.tsx
SEND_VIEW_CONTACT_DETAILS | NotificationsEmptyState go-to-contacts link | NotificationsEmptyState.mixpanel.test.tsx
SEND_AUTH_SUCCESS | exchangeToken/fulfilled | mixpanel.mixpanel.test.ts
SEND_DOWNLOAD_RESPONSE | getReceivedNotificationOtherDocument/fulfilled | mixpanel.mixpanel.test.ts
SEND_DOWNLOAD_RESPONSE | getReceivedNotificationLegalfact/fulfilled | mixpanel.mixpanel.test.ts
SEND_HAS_ADDRESSES | getDigitalAddresses/fulfilled | mixpanel.mixpanel.test.ts
SEND_HAS_MANDATE_LOGIN | getSidemenuInformation/fulfilled | mixpanel.mixpanel.test.ts
SEND_MANDATE_GIVEN | getMandatesByDelegator/fulfilled | mixpanel.mixpanel.test.ts
SEND_ENABLE_IO | enableIOAddress/fulfilled | mixpanel.mixpanel.test.ts
SEND_DISABLE_IO | disableIOAddress/fulfilled | mixpanel.mixpanel.test.ts
SEND_ACCEPT_DELEGATION | acceptMandate/fulfilled | mixpanel.mixpanel.test.ts
SEND_ADD_ADDRESS | createOrUpdateAddress/fulfilled | mixpanel.mixpanel.test.ts
SEND_DELETE_ADDRESS | deleteAddress/fulfilled | mixpanel.mixpanel.test.ts
SEND_PAYMENT_OUTCOME | getReceivedNotificationPaymentInfo thunk (FAILED) | getReceivedNotificationPaymentInfo.mixpanel.test.ts
SEND_PAYMENT_OUTCOME + SEND_PAYMENTS_COUNT | getReceivedNotificationPaymentInfo thunk (SUCCEEDED) | getReceivedNotificationPaymentInfo.mixpanel.test.ts

