### PR TITLE
feat(PN-19099): use MUI Italia code input and add copy action

### DIFF
--- a/packages/pn-personafisica-webapp/src/components/Deleghe/VerificationCodeComponent.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Deleghe/VerificationCodeComponent.tsx
@@ -1,35 +1,32 @@
-import { Box, Stack, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+
+import { Box, Stack } from '@mui/material';
+import { CopyToClipboard } from '@pagopa-pn/pn-commons';
+import { CodeInput } from '@pagopa/mui-italia';
 
 interface VerificationCodeProps {
   code: string;
 }
 
-const VerificationCodeComponent = ({ code }: VerificationCodeProps) => (
-  <Stack direction="row" spacing={1}>
-    {code.split('').map((codeDigit: string, i: number) => (
-      <Box
-        id={`digit-${i}`}
-        key={i}
-        sx={{
-          display: 'flex',
-          borderRadius: '4px',
-          borderColor: 'primary.main',
-          width: '2.5rem',
-          height: '4rem',
-          borderWidth: '2px',
-          borderStyle: 'solid',
-          justifyContent: 'center',
-          alignItems: 'center',
-          textAlign: 'center',
-        }}
-        data-testid="codeDigit"
-      >
-        <Typography color="primary" fontWeight={600}>
-          {codeDigit}
-        </Typography>
-      </Box>
-    ))}
-  </Stack>
-);
+const VerificationCodeComponent = ({ code }: VerificationCodeProps) => {
+  const { t } = useTranslation('deleghe');
+
+  return (
+    <Box data-testid="verificationCode">
+      <Stack direction="row" spacing={1} alignItems="center">
+        <CodeInput
+          length={code.length}
+          value={code}
+          readOnly
+          inputMode="numeric"
+          onChange={() => undefined}
+          ariaLabel={t('deleghe.verification_code')}
+        />
+
+        <CopyToClipboard getValue={() => code} tooltipMode tooltip={t('deleghe.code_copied')} />
+      </Stack>
+    </Box>
+  );
+};
 
 export default VerificationCodeComponent;

--- a/packages/pn-personafisica-webapp/src/components/Deleghe/__test__/VerificationCodeComponent.test.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Deleghe/__test__/VerificationCodeComponent.test.tsx
@@ -2,14 +2,14 @@ import { render } from '../../../__test__/test-utils';
 import VerificationCodeComponent from '../VerificationCodeComponent';
 
 describe('VerificationCodeComponent', () => {
-  it('renders the component and checks the digits', () => {
+  it('renders the component and checks the code value', () => {
     const fiveDigits = '12345';
-    const { queryAllByTestId } = render(<VerificationCodeComponent code={fiveDigits} />);
-    const digitsElements = queryAllByTestId('codeDigit');
-    const codes = fiveDigits.split('');
-    expect(digitsElements).toHaveLength(fiveDigits.length);
-    digitsElements.forEach((code, index) => {
-      expect(code).toHaveTextContent(codes[index]);
-    });
+
+    const { container } = render(<VerificationCodeComponent code={fiveDigits} />);
+
+    const input = container.querySelector('input');
+
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveValue(fiveDigits);
   });
 });

--- a/packages/pn-personafisica-webapp/src/pages/__test__/NuovaDelega.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/NuovaDelega.test.tsx
@@ -53,7 +53,7 @@ describe('NuovaDelega page', () => {
   });
 
   it('renders the component desktop view', async () => {
-    const { container, getAllByTestId, getByTestId } = render(<NuovaDelega />);
+    const { container, getByTestId } = render(<NuovaDelega />);
     expect(container).toHaveTextContent(/nuovaDelega.title/i);
     expect(container).toHaveTextContent(/nuovaDelega.subtitle/i);
     expect(mock.history.get).toHaveLength(0);
@@ -80,11 +80,12 @@ describe('NuovaDelega page', () => {
       'nuovaDelega.form.endDate',
       formatDate(tomorrow.toISOString())
     );
-    const codeDigit = getAllByTestId('codeDigit');
-    const codes = '34153'.split('');
-    codeDigit.forEach((code, index) => {
-      expect(code).toHaveTextContent(codes[index]);
-    });
+    const verificationCode = getByTestId('verificationCode');
+
+    const input = verificationCode.querySelector('input');
+
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveValue('34153');
     const createButton = getByTestId('createButton');
     expect(createButton).toBeEnabled();
   });

--- a/packages/pn-personagiuridica-webapp/src/components/Deleghe/VerificationCodeComponent.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Deleghe/VerificationCodeComponent.tsx
@@ -1,37 +1,32 @@
-import { Box, Stack, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+
+import { Box, Stack } from '@mui/material';
+import { CopyToClipboard } from '@pagopa-pn/pn-commons';
+import { CodeInput } from '@pagopa/mui-italia';
 
 interface VerificationCodeProps {
   code: string;
 }
 
-const VerificationCodeComponent = ({ code }: VerificationCodeProps) => (
-  <Box data-testid="verificationCode">
-    <Stack direction="row" spacing={1}>
-      {code.split('').map((codeDigit: string, i: number) => (
-        <Box
-          id={`digit-${i}`}
-          key={i}
-          sx={{
-            display: 'flex',
-            borderRadius: '4px',
-            borderColor: 'primary.main',
-            width: '2.5rem',
-            height: '4rem',
-            borderWidth: '2px',
-            borderStyle: 'solid',
-            justifyContent: 'center',
-            alignItems: 'center',
-            textAlign: 'center',
-          }}
-          data-testid="codeDigit"
-        >
-          <Typography color="primary" fontWeight={600}>
-            {codeDigit}
-          </Typography>
-        </Box>
-      ))}
-    </Stack>
-  </Box>
-);
+const VerificationCodeComponent = ({ code }: VerificationCodeProps) => {
+  const { t } = useTranslation('deleghe');
+
+  return (
+    <Box data-testid="verificationCode">
+      <Stack direction="row" spacing={1} alignItems="center">
+        <CodeInput
+          length={code.length}
+          value={code}
+          readOnly
+          inputMode="numeric"
+          onChange={() => undefined}
+          ariaLabel={t('deleghe.verification_code')}
+        />
+
+        <CopyToClipboard getValue={() => code} tooltipMode tooltip={t('deleghe.code_copied')} />
+      </Stack>
+    </Box>
+  );
+};
 
 export default VerificationCodeComponent;

--- a/packages/pn-personagiuridica-webapp/src/components/Deleghe/__test__/VerificationCodeComponent.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Deleghe/__test__/VerificationCodeComponent.test.tsx
@@ -4,12 +4,12 @@ import VerificationCodeComponent from '../VerificationCodeComponent';
 describe('VerificationCodeComponent', () => {
   it('renders the component and checks the digits', () => {
     const fiveDigits = '12345';
-    const { queryAllByTestId } = render(<VerificationCodeComponent code={fiveDigits} />);
-    const digitsElements = queryAllByTestId('codeDigit');
-    const codes = fiveDigits.split('');
-    expect(digitsElements).toHaveLength(fiveDigits.length);
-    digitsElements.forEach((code, index) => {
-      expect(code).toHaveTextContent(codes[index]);
-    });
+
+    const { container } = render(<VerificationCodeComponent code={fiveDigits} />);
+
+    const input = container.querySelector('input');
+
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveValue(fiveDigits);
   });
 });

--- a/packages/pn-personagiuridica-webapp/src/pages/__test__/NuovaDelega.page.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/__test__/NuovaDelega.page.test.tsx
@@ -54,7 +54,7 @@ describe('NuovaDelega page', () => {
   });
 
   it('renders the component desktop view', async () => {
-    const { container, getAllByTestId, getByTestId } = render(<NuovaDelega />);
+    const { container, getByTestId } = render(<NuovaDelega />);
     expect(container).toHaveTextContent(/nuovaDelega.title/i);
     expect(container).toHaveTextContent(/nuovaDelega.subtitle/i);
     expect(mock.history.get).toHaveLength(0);
@@ -81,11 +81,12 @@ describe('NuovaDelega page', () => {
       'nuovaDelega.form.endDate',
       formatDate(tomorrow.toISOString())
     );
-    const codeDigit = getAllByTestId('codeDigit');
-    const codes = '34153'.split('');
-    codeDigit.forEach((code, index) => {
-      expect(code).toHaveTextContent(codes[index]);
-    });
+    const verificationCode = getByTestId('verificationCode');
+
+    const input = verificationCode.querySelector('input');
+
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveValue('34153');
     const createButton = getByTestId('createButton');
     expect(createButton).toBeEnabled();
   });


### PR DESCRIPTION
## Short description
Update the delegation verification code component according to the MUI Italia 2.0 design system.

## List of changes proposed in this pull request
- Replaced the custom verification code component with MUI Italia `CodeInput`
- Added copy-to-clipboard action for the verification code
- Applied the change to both Persona Fisica and Persona Giuridica flows
- Added translated tooltip message for successful copy action

## How to test

1. Open the "Nuova Delega" page
2. Create a new delegation request
3. Verify that the verification code is displayed using the MUI Italia `CodeInput` component
4. Click the copy icon next to the verification code
5. Verify that the code is copied to the clipboard
6. Verify that the "Codice copiato" feedback is displayed

**P.S.** Repeat the verification for both Persona Fisica and Persona Giuridica flows