### PR TITLE
fix(PN-20069): redirect to login when error is already handled by OneIdentity

### DIFF
--- a/packages/pn-personafisica-login/src/pages/oneIdentityLoginError/OneIdentityLoginError.tsx
+++ b/packages/pn-personafisica-login/src/pages/oneIdentityLoginError/OneIdentityLoginError.tsx
@@ -9,6 +9,13 @@ import { PFLoginEventsType } from '../../models/PFLoginEventsType';
 import { ROUTE_ONE_IDENTITY_LOGIN } from '../../navigation/routes.const';
 import PFLoginEventStrategyFactory from '../../utility/MixpanelUtils/PFLoginEventStrategyFactory';
 
+const KNOWN_ERROR_CODES = [
+  'invalid_scope',
+  'unsupported_response_type',
+  'server_error',
+  'invalid_request',
+];
+
 const OneIdentityLoginError: React.FC = () => {
   const { t } = useTranslation(['login', 'common']);
   const navigate = useNavigate();
@@ -22,6 +29,9 @@ const OneIdentityLoginError: React.FC = () => {
     PFLoginEventStrategyFactory.triggerEvent(PFLoginEventsType.SEND_LOGIN_FAILURE, {
       reason: error,
     });
+    if (!error || !KNOWN_ERROR_CODES.includes(error)) {
+      goToLogin();
+    }
   }, []);
 
   return (

--- a/packages/pn-personafisica-login/src/pages/oneIdentityLoginError/__test__/OneIdentityLoginError.test.tsx
+++ b/packages/pn-personafisica-login/src/pages/oneIdentityLoginError/__test__/OneIdentityLoginError.test.tsx
@@ -7,16 +7,26 @@ import OneIdentityLoginError from '../OneIdentityLoginError';
 
 describe('OneIdentityLoginError component', () => {
   it('renders the error dialog with title and default message', () => {
-    render(<OneIdentityLoginError />);
+    render(<OneIdentityLoginError />, { route: '/?error=server_error' });
     const errorDialog = getById(document.body, 'oneIdentityErrorDialog');
     expect(errorDialog).toHaveTextContent('loginError.title');
     expect(getById(errorDialog, 'message')).toHaveTextContent('loginError.message');
   });
 
   it('navigates to login on button click', async () => {
-    const { router } = render(<OneIdentityLoginError />);
+    const { router } = render(<OneIdentityLoginError />, { route: '/?error=server_error' });
     fireEvent.click(getById(document.body, 'login-button'));
     await waitFor(() => expect(router.state.location.pathname).toBe(ROUTE_ONE_IDENTITY_LOGIN));
     expect(router.state.location.search).toBe('');
+  });
+
+  it('redirects to login immediately when error is unknown', async () => {
+    const { router } = render(<OneIdentityLoginError />, { route: '/?error=unknown_error' });
+    await waitFor(() => expect(router.state.location.pathname).toBe(ROUTE_ONE_IDENTITY_LOGIN));
+  });
+
+  it('redirects to login immediately when error param is missing', async () => {
+    const { router } = render(<OneIdentityLoginError />);
+    await waitFor(() => expect(router.state.location.pathname).toBe(ROUTE_ONE_IDENTITY_LOGIN));
   });
 });

--- a/packages/pn-personafisica-login/src/pages/oneIdentityLoginError/__test__/mixpanel/OneIdentityLoginError.mixpanel.test.tsx
+++ b/packages/pn-personafisica-login/src/pages/oneIdentityLoginError/__test__/mixpanel/OneIdentityLoginError.mixpanel.test.tsx
@@ -17,10 +17,24 @@ describe('One Identity Login Error page - Mixpanel events', () => {
     triggerEventSpy.mockRestore();
   });
 
-  it('fires SEND_LOGIN_FAILURE on mount with error reason from search param', async () => {
-    await act(async () => render(<OneIdentityLoginError />, { route: '/?error=access_denied' }));
+  it('fires SEND_LOGIN_FAILURE on mount with a known error code', async () => {
+    await act(async () => render(<OneIdentityLoginError />, { route: '/?error=server_error' }));
     expect(triggerEventSpy).toHaveBeenCalledWith(PFLoginEventsType.SEND_LOGIN_FAILURE, {
-      reason: 'access_denied',
+      reason: 'server_error',
+    });
+  });
+
+  it('fires SEND_LOGIN_FAILURE on mount with an unknown error code', async () => {
+    await act(async () => render(<OneIdentityLoginError />, { route: '/?error=random_error' }));
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFLoginEventsType.SEND_LOGIN_FAILURE, {
+      reason: 'random_error',
+    });
+  });
+
+  it('fires SEND_LOGIN_FAILURE on mount when error param is missing', async () => {
+    await act(async () => render(<OneIdentityLoginError />));
+    expect(triggerEventSpy).toHaveBeenCalledWith(PFLoginEventsType.SEND_LOGIN_FAILURE, {
+      reason: null,
     });
   });
 });


### PR DESCRIPTION
## Short description

Redirect to login when error is already handled by OneIdentity

## List of changes proposed in this pull request
- Handle OneIdentity errors

## How to test
- Start both PF and PF Login 
- On IDP form click on "Nego il consenso" 
- From the OneIdentity error page click "close" and check that you are redirected directly to Login page (with Mixpanel event)