### PR TITLE
fix(PN-20200): remove EN as default

### DIFF
--- a/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
@@ -115,13 +115,13 @@ const NotificationDetail: React.FC = () => {
   const delegatorsFromStore = useAppSelector(
     (state: RootState) => state.generalInfoState.delegators
   );
+  const downtimeEvents = useAppSelector(
+    (state: RootState) => state.notificationState.downtimeEvents
+  );
   const notification = useAppSelector((state: RootState) => state.notificationState.notification);
   const notificationLanguage = notification.additionalLanguages?.[0] ?? 'IT';
   const sessionLang = getSessionLanguage()?.toUpperCase();
   const isSameLang = notificationLanguage?.includes(sessionLang);
-  const downtimeEvents = useAppSelector(
-    (state: RootState) => state.notificationState.downtimeEvents
-  );
 
   const showBilingualFacsimileSection = !isSameLang && sessionLang !== 'IT';
   const isCancelled = useIsCancelled({ notification });
@@ -627,7 +627,7 @@ const NotificationDetail: React.FC = () => {
     );
   }
 
-  const getFacSimileLink = (): string => {
+  const getFacSimileLink = (): string | undefined => {
     switch (sessionLang) {
       case 'EN':
         return FACSIMILE_EN;
@@ -638,7 +638,7 @@ const NotificationDetail: React.FC = () => {
       case 'SL':
         return FACSIMILE_SL;
       default:
-        return FACSIMILE_EN;
+        return undefined;
     }
   };
 

--- a/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
@@ -123,7 +123,10 @@ const NotificationDetail: React.FC = () => {
   const sessionLang = getSessionLanguage()?.toUpperCase();
   const isSameLang = notificationLanguage?.includes(sessionLang);
 
-  const showBilingualFacsimileSection = !isSameLang && sessionLang !== 'IT';
+  const BILINGUAL_ALLOWED_LANGUAGES = new Set(['EN', 'FR', 'DE', 'SL']);
+  const isBilingualAllowed = BILINGUAL_ALLOWED_LANGUAGES.has(sessionLang);
+
+  const showBilingualFacsimileSection = !isSameLang && sessionLang !== 'IT' && isBilingualAllowed;
   const isCancelled = useIsCancelled({ notification });
   const isCancelledOrCancelling = isCancelled.cancelled || isCancelled.cancellationInProgress;
   const currentRecipient = notification?.currentRecipient;
@@ -628,14 +631,14 @@ const NotificationDetail: React.FC = () => {
   }
 
   const getFacSimileLink = (): string | undefined => {
-    switch (sessionLang) {
-      case 'EN':
+    switch (i18n.language) {
+      case 'en':
         return FACSIMILE_EN;
-      case 'FR':
+      case 'fr':
         return FACSIMILE_FR;
-      case 'DE':
+      case 'de':
         return FACSIMILE_DE;
-      case 'SL':
+      case 'sl':
         return FACSIMILE_SL;
       default:
         return undefined;

--- a/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
@@ -41,7 +41,6 @@ import {
   downloadDocument,
   formatDate,
   getPaymentCache,
-  getSessionLanguage,
   useErrors,
   useIsCancelled,
   useIsMobile,
@@ -120,13 +119,10 @@ const NotificationDetail: React.FC = () => {
   );
   const notification = useAppSelector((state: RootState) => state.notificationState.notification);
   const notificationLanguage = notification.additionalLanguages?.[0] ?? 'IT';
-  const sessionLang = getSessionLanguage()?.toUpperCase();
-  const isSameLang = notificationLanguage?.includes(sessionLang);
+  const i18nLang = i18n.language.toUpperCase();
+  const isSameLang = notificationLanguage === i18nLang;
 
-  const BILINGUAL_ALLOWED_LANGUAGES = new Set(['EN', 'FR', 'DE', 'SL']);
-  const isBilingualAllowed = BILINGUAL_ALLOWED_LANGUAGES.has(sessionLang);
-
-  const showBilingualFacsimileSection = !isSameLang && sessionLang !== 'IT' && isBilingualAllowed;
+  const showBilingualFacsimileSection = !isSameLang && i18nLang !== 'IT';
   const isCancelled = useIsCancelled({ notification });
   const isCancelledOrCancelling = isCancelled.cancelled || isCancelled.cancellationInProgress;
   const currentRecipient = notification?.currentRecipient;

--- a/packages/pn-personafisica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
@@ -52,6 +52,7 @@ import { BffCheckTPPResponse } from '../../generated-client/notifications';
 import * as routes from '../../navigation/routes.const';
 import { NOTIFICATION_ACTIONS } from '../../redux/notification/actions';
 import { getConfiguration } from '../../services/configuration.service';
+import { mockLanguageConfig } from '../../setupTests';
 import { ServerResponseErrorCode } from '../../utility/AppError/types';
 import NotificationDetail from '../NotificationDetail.page';
 
@@ -96,6 +97,7 @@ describe('NotificationDetail Page', () => {
 
   beforeEach(() => {
     vi.stubGlobal('location', { href: '', assign: mockAssignFn });
+    mockLanguageConfig.current = 'it';
   });
 
   afterEach(() => {
@@ -1347,7 +1349,7 @@ describe('NotificationDetail Page', () => {
   });
 
   it('render bilingual section when lang is different from additional language in notification', async () => {
-    sessionStorage.setItem(LANGUAGE_SESSION_KEY, 'DE');
+    mockLanguageConfig.current = 'DE';
     mock
       .onGet(`/bff/v1/notifications/received/${bilingualNotification.iun}`)
       .reply(200, bilingualNotification);

--- a/packages/pn-personafisica-webapp/src/setupTests.tsx
+++ b/packages/pn-personafisica-webapp/src/setupTests.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable functional/no-let */
 import { ReactNode } from 'react';
 import { vi } from 'vitest';
 
@@ -20,6 +21,10 @@ console.warn = (...args) => {
     return;
   }
   originalWarn(...args);
+};
+
+export const mockLanguageConfig = {
+  current: 'it',
 };
 
 beforeAll(() => {
@@ -60,6 +65,7 @@ beforeAll(() => {
   });
   initStore(false);
   initAxiosClients();
+
   // mock translations
   vi.mock('react-i18next', () => ({
     // this mock makes sure any components using the translate hook can use it without a warning being shown
@@ -71,7 +77,7 @@ beforeAll(() => {
         return str;
       },
       i18n: {
-        language: 'it',
+        language: mockLanguageConfig.current,
         changeLanguage: () => new Promise(() => {}),
       },
     }),

--- a/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
@@ -117,8 +117,10 @@ const NotificationDetail = () => {
   const notificationLanguage = notification.additionalLanguages?.[0] ?? 'IT';
   const sessionLang = getSessionLanguage()?.toUpperCase();
   const isSameLang = notificationLanguage?.includes(sessionLang);
+  const BILINGUAL_ALLOWED_LANGUAGES = new Set(['EN', 'FR', 'DE', 'SL']);
+  const isBilingualAllowed = BILINGUAL_ALLOWED_LANGUAGES.has(sessionLang);
 
-  const showBilingualFacsimileSection = !isSameLang && sessionLang !== 'IT';
+  const showBilingualFacsimileSection = !isSameLang && sessionLang !== 'IT' && isBilingualAllowed;
 
   console.log(showBilingualFacsimileSection, notificationLanguage, sessionLang, isSameLang);
 
@@ -549,14 +551,14 @@ const NotificationDetail = () => {
   };
 
   const getFacSimileLink = (): string | undefined => {
-    switch (sessionLang) {
-      case 'EN':
+    switch (i18n.language) {
+      case 'en':
         return FACSIMILE_EN;
-      case 'FR':
+      case 'fr':
         return FACSIMILE_FR;
-      case 'DE':
+      case 'de':
         return FACSIMILE_DE;
-      case 'SL':
+      case 'sl':
         return FACSIMILE_SL;
       default:
         return undefined;

--- a/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
@@ -99,6 +99,10 @@ const NotificationDetail = () => {
     DOWNTIME_EXAMPLE_LINK,
     NOTIFICATION_CANCELLED_HELP_LINK,
     NOTIFICATION_COST_DETAILS_ASSISTANCE_LINK,
+    FACSIMILE_EN,
+    FACSIMILE_FR,
+    FACSIMILE_DE,
+    FACSIMILE_SL,
   } = getConfiguration();
   const navigate = useNavigate();
 
@@ -106,15 +110,17 @@ const NotificationDetail = () => {
   const role = currentUser.organization?.roles ? currentUser.organization?.roles[0] : null;
 
   const userHasAdminPermissions = useHasPermissions(role ? [role.role] : [], [PNRole.ADMIN]);
+  const downtimeEvents = useAppSelector(
+    (state: RootState) => state.notificationState.downtimeEvents
+  );
   const notification = useAppSelector((state: RootState) => state.notificationState.notification);
   const notificationLanguage = notification.additionalLanguages?.[0] ?? 'IT';
   const sessionLang = getSessionLanguage()?.toUpperCase();
   const isSameLang = notificationLanguage?.includes(sessionLang);
 
   const showBilingualFacsimileSection = !isSameLang && sessionLang !== 'IT';
-  const downtimeEvents = useAppSelector(
-    (state: RootState) => state.notificationState.downtimeEvents
-  );
+
+  console.log(showBilingualFacsimileSection, notificationLanguage, sessionLang, isSameLang);
 
   const currentRecipient = notification?.currentRecipient;
   const isCancelled = useIsCancelled({ notification });
@@ -542,6 +548,21 @@ const NotificationDetail = () => {
     }
   };
 
+  const getFacSimileLink = (): string | undefined => {
+    switch (sessionLang) {
+      case 'EN':
+        return FACSIMILE_EN;
+      case 'FR':
+        return FACSIMILE_FR;
+      case 'DE':
+        return FACSIMILE_DE;
+      case 'SL':
+        return FACSIMILE_SL;
+      default:
+        return undefined;
+    }
+  };
+
   return (
     <LoadingPageWrapper isInitialized={pageReady}>
       {hasNotificationReceivedApiError && (
@@ -650,6 +671,7 @@ const NotificationDetail = () => {
                       title={t('detail.bilingual.title', { ns: 'notifiche' })}
                       description={t('detail.bilingual.description', { ns: 'notifiche' })}
                       action={t('detail.bilingual.action', { ns: 'notifiche' })}
+                      link={getFacSimileLink()}
                     />
                   </Paper>
                 )}

--- a/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
@@ -33,7 +33,6 @@ import {
   downloadDocument,
   formatDate,
   getPaymentCache,
-  getSessionLanguage,
   useErrors,
   useHasPermissions,
   useIsCancelled,
@@ -115,14 +114,10 @@ const NotificationDetail = () => {
   );
   const notification = useAppSelector((state: RootState) => state.notificationState.notification);
   const notificationLanguage = notification.additionalLanguages?.[0] ?? 'IT';
-  const sessionLang = getSessionLanguage()?.toUpperCase();
-  const isSameLang = notificationLanguage?.includes(sessionLang);
-  const BILINGUAL_ALLOWED_LANGUAGES = new Set(['EN', 'FR', 'DE', 'SL']);
-  const isBilingualAllowed = BILINGUAL_ALLOWED_LANGUAGES.has(sessionLang);
+  const i18nLang = i18n.language.toUpperCase();
+  const isSameLang = notificationLanguage === i18nLang;
 
-  const showBilingualFacsimileSection = !isSameLang && sessionLang !== 'IT' && isBilingualAllowed;
-
-  console.log(showBilingualFacsimileSection, notificationLanguage, sessionLang, isSameLang);
+  const showBilingualFacsimileSection = !isSameLang && i18nLang !== 'IT';
 
   const currentRecipient = notification?.currentRecipient;
   const isCancelled = useIsCancelled({ notification });

--- a/packages/pn-personagiuridica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/__test__/NotificationDetail.page.test.tsx
@@ -49,6 +49,7 @@ import { apiClient } from '../../api/apiClients';
 import * as routes from '../../navigation/routes.const';
 import { NOTIFICATION_ACTIONS } from '../../redux/notification/actions';
 import { getConfiguration } from '../../services/configuration.service';
+import { mockLanguageConfig } from '../../setupTests';
 import NotificationDetail from '../NotificationDetail.page';
 
 const mockAssignFn = vi.fn();
@@ -92,6 +93,7 @@ describe('NotificationDetail Page', () => {
 
   beforeEach(() => {
     vi.stubGlobal('location', { href: '', assign: mockAssignFn });
+    mockLanguageConfig.current = 'it';
   });
 
   afterEach(() => {
@@ -564,7 +566,7 @@ describe('NotificationDetail Page', () => {
   });
 
   it('render bilingual section when lang is different from additional language in notification', async () => {
-    sessionStorage.setItem(LANGUAGE_SESSION_KEY, 'DE');
+    mockLanguageConfig.current = 'DE';
     mock
       .onGet(`/bff/v1/notifications/received/${bilingualNotification.iun}`)
       .reply(200, bilingualNotification);

--- a/packages/pn-personagiuridica-webapp/src/setupTests.tsx
+++ b/packages/pn-personagiuridica-webapp/src/setupTests.tsx
@@ -77,7 +77,7 @@ beforeAll(async () => {
         return str;
       },
       i18n: {
-        language: 'it',
+        language: mockLanguageConfig.current,
         changeLanguage: () => new Promise(() => {}),
       },
     }),

--- a/packages/pn-personagiuridica-webapp/src/setupTests.tsx
+++ b/packages/pn-personagiuridica-webapp/src/setupTests.tsx
@@ -26,6 +26,10 @@ console.warn = (...args) => {
   originalWarn(...args);
 };
 
+export const mockLanguageConfig = {
+  current: 'it',
+};
+
 beforeAll(async () => {
   Configuration.setForTest<PgConfiguration>({
     API_BASE_URL: 'https://webapi.test.notifichedigitali.it/',


### PR DESCRIPTION
## Short description
Remove EN as default language in facsimile documents

## How to test
- Login as PF/PG, set lang in footer in EN and set sessionLang to CH → go in a notification and check the bilingual section is not present
- Login as PF/PG, set lang in footer in EN and set sessionLang to DE → go in a notification and check the bilingual section link to EN document without refer to the lang in session storage