### PR TITLE
feat(PN-19761): refine PG notification and API key tracking

### DIFF
--- a/packages/pn-personagiuridica-webapp/src/components/IntegrazioneApi/PublicKeys.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/IntegrazioneApi/PublicKeys.tsx
@@ -56,7 +56,9 @@ const PublicKeys: React.FC = () => {
 
   const handleGeneratePublicKey = (publicKeyId?: string) => {
     if (!publicKeyId) {
-      PGEventStrategyFactory.triggerEvent(PGEventsType.SEND_PG_ADD_API_START);
+      PGEventStrategyFactory.triggerEvent(PGEventsType.SEND_PG_ADD_API_START, {
+        API_type: 'public',
+      });
     }
     handleCloseModal();
     const pathStr = publicKeyId ? `/${publicKeyId}` : '';

--- a/packages/pn-personagiuridica-webapp/src/components/IntegrazioneApi/VirtualKeys.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/IntegrazioneApi/VirtualKeys.tsx
@@ -18,6 +18,7 @@ import {
   VirtualKeyStatus,
 } from '../../generated-client/pg-apikeys';
 import { ModalApiKeyView } from '../../models/ApiKeys';
+import { PGEventsType } from '../../models/PGEventsType';
 import { PNRole } from '../../models/User';
 import {
   changeVirtualApiKeyStatus,
@@ -27,6 +28,7 @@ import {
 } from '../../redux/apikeys/actions';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import { RootState } from '../../redux/store';
+import PGEventStrategyFactory from '../../utility/MixpanelUtils/PGEventStrategyFactory';
 import ApiKeyModal from './ApiKeyModal';
 import { ShowCodesInput } from './ShowCodesInput';
 import VirtualKeysTable from './VirtualKeysTable';
@@ -69,6 +71,10 @@ const VirtualKeys: React.FC = () => {
   }, []);
 
   const handleGenerateVirtualKey = () => {
+    PGEventStrategyFactory.triggerEvent(PGEventsType.SEND_PG_ADD_API_START, {
+      API_type: 'personal',
+    });
+
     dispatch(
       createVirtualApiKey({
         name: `${t('virtualKeys.default')}${formatDate(today.toISOString(), false, '')}`,
@@ -76,6 +82,10 @@ const VirtualKeys: React.FC = () => {
     )
       .unwrap()
       .then((response) => {
+        PGEventStrategyFactory.triggerEvent(PGEventsType.SEND_PG_ADD_API_UX_SUCCESS, {
+          API_type: 'personal',
+        });
+
         const newVirtualKey: VirtualKey = { value: response.virtualKey };
         setModal({ view: ModalApiKeyView.VIEW, virtualKey: newVirtualKey });
         fetchVirtualKeys();

--- a/packages/pn-personagiuridica-webapp/src/models/PGEventPayloads.ts
+++ b/packages/pn-personagiuridica-webapp/src/models/PGEventPayloads.ts
@@ -31,11 +31,17 @@ export type MandatePersonType = 'PF' | 'PG';
 
 export type MandatePartySelection = 'tuttiGliEnti' | 'entiSelezionati';
 
+export type ApiKeyType = 'personal' | 'public';
+
 /**
  * Application-level data passed by pages/components to the tracking layer.
  * These types should not mirror Mixpanel properties necessarily.
  * They, instead, follow the domain model.
  */
+
+export type PGApiKeyEventData = {
+  API_type: ApiKeyType;
+};
 
 export type PGNotificationsListEventData = {
   notifications: Array<Notification>;
@@ -128,6 +134,7 @@ export type PGNotificationsListPayload = {
   not_found_count: number;
   cancelled_count: number;
   effective_date_count: number;
+  filed_count: number;
   banner?: string;
 };
 
@@ -188,8 +195,8 @@ export type PGUserRolePayload = {
 export type PGEventPayloads = {
   /* API KEYS */
   [PGEventsType.SEND_PG_API_INTEGRATION]: undefined;
-  [PGEventsType.SEND_PG_ADD_API_START]: undefined;
-  [PGEventsType.SEND_PG_ADD_API_UX_SUCCESS]: undefined;
+  [PGEventsType.SEND_PG_ADD_API_START]: PGApiKeyEventData;
+  [PGEventsType.SEND_PG_ADD_API_UX_SUCCESS]: PGApiKeyEventData;
 
   /* CONTACT */
   [PGEventsType.SEND_PG_YOUR_CONTACT_DETAILS]: PGContactDetailsEventData;

--- a/packages/pn-personagiuridica-webapp/src/pages/NewPublicKey.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/NewPublicKey.page.tsx
@@ -186,7 +186,9 @@ const NewPublicKey = () => {
       .then((response: BffPublicKeyResponse) => {
         if (response.issuer) {
           if (!kid) {
-            PGEventStrategyFactory.triggerEvent(PGEventsType.SEND_PG_ADD_API_UX_SUCCESS);
+            PGEventStrategyFactory.triggerEvent(PGEventsType.SEND_PG_ADD_API_UX_SUCCESS, {
+              API_type: 'public',
+            });
           }
           setActiveStep((previousStep) => previousStep + 1);
           setCreationResponse(response);

--- a/packages/pn-personagiuridica-webapp/src/utility/MixpanelUtils/__test__/apiKeyEvents.test.ts
+++ b/packages/pn-personagiuridica-webapp/src/utility/MixpanelUtils/__test__/apiKeyEvents.test.ts
@@ -16,10 +16,13 @@ describe('apiKeyTrackingConfigs', () => {
   });
 
   it('should build SEND_PG_ADD_API_START event', () => {
-    const result = apiKeyTrackingConfigs[PGEventsType.SEND_PG_ADD_API_START](undefined);
+    const result = apiKeyTrackingConfigs[PGEventsType.SEND_PG_ADD_API_START]({
+      API_type: 'personal',
+    });
 
     expect(result).toStrictEqual({
       [EventPropertyType.TRACK]: {
+        API_type: 'personal',
         event_category: EventCategory.UX,
         event_type: EventAction.ACTION,
       },
@@ -27,10 +30,13 @@ describe('apiKeyTrackingConfigs', () => {
   });
 
   it('should build SEND_PG_ADD_API_UX_SUCCESS event', () => {
-    const result = apiKeyTrackingConfigs[PGEventsType.SEND_PG_ADD_API_UX_SUCCESS](undefined);
+    const result = apiKeyTrackingConfigs[PGEventsType.SEND_PG_ADD_API_UX_SUCCESS]({
+      API_type: 'public',
+    });
 
     expect(result).toStrictEqual({
       [EventPropertyType.TRACK]: {
+        API_type: 'public',
         event_category: EventCategory.UX,
         event_type: EventAction.CONFIRM,
       },

--- a/packages/pn-personagiuridica-webapp/src/utility/MixpanelUtils/__test__/notificationEvents.test.ts
+++ b/packages/pn-personagiuridica-webapp/src/utility/MixpanelUtils/__test__/notificationEvents.test.ts
@@ -32,6 +32,7 @@ const notificationListPayload = {
   not_found_count: 0,
   cancelled_count: 0,
   effective_date_count: 1,
+  filed_count: 0,
 };
 
 describe('notificationTrackingConfigs', () => {

--- a/packages/pn-personagiuridica-webapp/src/utility/MixpanelUtils/apiKeyEvents.ts
+++ b/packages/pn-personagiuridica-webapp/src/utility/MixpanelUtils/apiKeyEvents.ts
@@ -10,6 +10,6 @@ type ApiKeyEventType =
 
 export const apiKeyTrackingConfigs: TrackingConfigs<ApiKeyEventType> = {
   [PGEventsType.SEND_PG_API_INTEGRATION]: () => uxScreenView(),
-  [PGEventsType.SEND_PG_ADD_API_START]: () => uxAction(),
-  [PGEventsType.SEND_PG_ADD_API_UX_SUCCESS]: () => uxConfirm(),
+  [PGEventsType.SEND_PG_ADD_API_START]: (data) => uxAction(data),
+  [PGEventsType.SEND_PG_ADD_API_UX_SUCCESS]: (data) => uxConfirm(data),
 };

--- a/packages/pn-personagiuridica-webapp/src/utility/MixpanelUtils/mappers/__test__/notificationPayloadMappers.test.ts
+++ b/packages/pn-personagiuridica-webapp/src/utility/MixpanelUtils/mappers/__test__/notificationPayloadMappers.test.ts
@@ -33,6 +33,7 @@ describe('notificationPayloadMappers', () => {
       not_found_count: 0,
       cancelled_count: 0,
       effective_date_count: 1,
+      filed_count: 0,
       banner: 'SERCQ_SEND',
     });
   });

--- a/packages/pn-personagiuridica-webapp/src/utility/MixpanelUtils/mappers/notificationPayloadMappers.ts
+++ b/packages/pn-personagiuridica-webapp/src/utility/MixpanelUtils/mappers/notificationPayloadMappers.ts
@@ -97,6 +97,9 @@ export const mapNotificationListToEventPayload = ({
   effective_date_count: notifications.filter(
     (notification) => notification.notificationStatus === NotificationStatus.EFFECTIVE_DATE
   ).length,
+  filed_count: notifications.filter(
+    (notification) => notification.notificationStatus === NotificationStatus.ACCEPTED
+  ).length,
   ...(domicileBannerType && { banner: domicileBannerType }),
 });
 


### PR DESCRIPTION
## Short description
Refine PG mixpanel tracking based on CX validation feedback.

## List of changes proposed in this pull request
- add `filed_count` to PG notification list tracking events (`SEND_PG_YOUR_NOTIFICATION` and `SEND_PG_NOTIFICATION_DELEGATED`)
- extend API key creation tracking to both personal and public keys
- add the `API_type` property to API key start and success events
- update tests

## How to test
Run the PG web app and verify:
- notification list events include the expected `filed_count` property
- personal and public key creation trigger start and succes events with the expected `API_type` property