### PR TITLE
feat(PN-19761): add missing properties to notification status tracking counts

### DIFF
--- a/packages/pn-pa-webapp/src/models/PAEventPayloads.ts
+++ b/packages/pn-pa-webapp/src/models/PAEventPayloads.ts
@@ -53,6 +53,7 @@ export type PANotificationsListPayload = {
   effective_date_count: number;
   filed_count: number;
   sending_count: number;
+  back_to_sender_count: number;
 };
 
 export type PADocumentDownloadPayload = {

--- a/packages/pn-pa-webapp/src/utility/MixpanelUtils/__test__/notificationEvents.test.ts
+++ b/packages/pn-pa-webapp/src/utility/MixpanelUtils/__test__/notificationEvents.test.ts
@@ -28,6 +28,7 @@ describe('notificationTrackingConfigs', () => {
         effective_date_count: 2,
         filed_count: 1,
         sending_count: 0,
+        back_to_sender_count: 0,
         event_category: EventCategory.UX,
         event_type: EventAction.SCREEN_VIEW,
       },

--- a/packages/pn-pa-webapp/src/utility/MixpanelUtils/mappers/__test__/notificationPayloadMappers.test.ts
+++ b/packages/pn-pa-webapp/src/utility/MixpanelUtils/mappers/__test__/notificationPayloadMappers.test.ts
@@ -25,6 +25,7 @@ describe('notificationPayloadMappers', () => {
       effective_date_count: 2,
       filed_count: 1,
       sending_count: 0,
+      back_to_sender_count: 0,
     });
   });
 

--- a/packages/pn-pa-webapp/src/utility/MixpanelUtils/mappers/notificationPayloadMappers.ts
+++ b/packages/pn-pa-webapp/src/utility/MixpanelUtils/mappers/notificationPayloadMappers.ts
@@ -23,7 +23,7 @@ export const mapNotificationListToEventPayload = ({
     (notification) => notification.notificationStatus === NotificationStatus.VIEWED
   ).length,
   not_found_count: notifications.filter(
-    (notification) => notification.notificationStatus === NotificationStatus.RETURNED_TO_SENDER
+    (notification) => notification.notificationStatus === NotificationStatus.UNREACHABLE
   ).length,
   cancelled_count: notifications.filter(
     (notification) => notification.notificationStatus === NotificationStatus.CANCELLED
@@ -36,6 +36,9 @@ export const mapNotificationListToEventPayload = ({
   ).length,
   sending_count: notifications.filter(
     (notification) => notification.notificationStatus === NotificationStatus.DELIVERING
+  ).length,
+  back_to_sender_count: notifications.filter(
+    (notification) => notification.notificationStatus === NotificationStatus.RETURNED_TO_SENDER
   ).length,
 });
 

--- a/packages/pn-personagiuridica-webapp/src/models/PGEventPayloads.ts
+++ b/packages/pn-personagiuridica-webapp/src/models/PGEventPayloads.ts
@@ -135,6 +135,8 @@ export type PGNotificationsListPayload = {
   cancelled_count: number;
   effective_date_count: number;
   filed_count: number;
+  sending_count: number;
+  back_to_sender_count: number;
   banner?: string;
 };
 

--- a/packages/pn-personagiuridica-webapp/src/utility/MixpanelUtils/__test__/notificationEvents.test.ts
+++ b/packages/pn-personagiuridica-webapp/src/utility/MixpanelUtils/__test__/notificationEvents.test.ts
@@ -33,6 +33,8 @@ const notificationListPayload = {
   cancelled_count: 0,
   effective_date_count: 1,
   filed_count: 0,
+  sending_count: 0,
+  back_to_sender_count: 0,
 };
 
 describe('notificationTrackingConfigs', () => {

--- a/packages/pn-personagiuridica-webapp/src/utility/MixpanelUtils/mappers/__test__/notificationPayloadMappers.test.ts
+++ b/packages/pn-personagiuridica-webapp/src/utility/MixpanelUtils/mappers/__test__/notificationPayloadMappers.test.ts
@@ -34,6 +34,8 @@ describe('notificationPayloadMappers', () => {
       cancelled_count: 0,
       effective_date_count: 1,
       filed_count: 0,
+      sending_count: 0,
+      back_to_sender_count: 0,
       banner: 'SERCQ_SEND',
     });
   });

--- a/packages/pn-personagiuridica-webapp/src/utility/MixpanelUtils/mappers/notificationPayloadMappers.ts
+++ b/packages/pn-personagiuridica-webapp/src/utility/MixpanelUtils/mappers/notificationPayloadMappers.ts
@@ -100,6 +100,12 @@ export const mapNotificationListToEventPayload = ({
   filed_count: notifications.filter(
     (notification) => notification.notificationStatus === NotificationStatus.ACCEPTED
   ).length,
+  sending_count: notifications.filter(
+    (notification) => notification.notificationStatus === NotificationStatus.DELIVERING
+  ).length,
+  back_to_sender_count: notifications.filter(
+    (notification) => notification.notificationStatus === NotificationStatus.RETURNED_TO_SENDER
+  ).length,
   ...(domicileBannerType && { banner: domicileBannerType }),
 });
 


### PR DESCRIPTION
## Short description
Complete notification status tracking counts based on CX validation feedback.

## List of changes proposed in this pull request
- add `sending_count` and `back_to_sender_count` to PG notification list tracking events
- add `back_to_sender_count` to PA notification list tracking event
- fix PA `not_found_count` mapping
- update tests 

## How to test
Run PG and PA web apps and verify notification list events include the expected status count properties