### PR TITLE
fix(PN-20461): rename oidc api

### DIFF
--- a/packages/pn-personafisica-login/src/api/OneIdentity/OneIdentity.api.ts
+++ b/packages/pn-personafisica-login/src/api/OneIdentity/OneIdentity.api.ts
@@ -24,7 +24,7 @@ export const OneIdentityApi = {
       params.set('retrievalId', retrievalId);
     }
 
-    const response = await fetch(`${API_BASE_URL}oidc-authorize?${params.toString()}`);
+    const response = await fetch(`${API_BASE_URL}oidc/authorize?${params.toString()}`);
 
     if (!response.ok) {
       throw new Error('Error during OIDC authorize');

--- a/packages/pn-personafisica-login/src/api/OneIdentity/__test__/OneIdentity.api.test.ts
+++ b/packages/pn-personafisica-login/src/api/OneIdentity/__test__/OneIdentity.api.test.ts
@@ -36,7 +36,7 @@ describe('OneIdentity api tests', () => {
       const res = await OneIdentityApi.authorize({ entityId: 'spid-idp-test' });
 
       expect(fetch).toHaveBeenCalledWith(
-        'https://mock-api-base-url/oidc-authorize?idp=spid-idp-test'
+        'https://mock-api-base-url/oidc/authorize?idp=spid-idp-test'
       );
       expect(res).toStrictEqual(mockResponse);
     });
@@ -50,7 +50,7 @@ describe('OneIdentity api tests', () => {
       await OneIdentityApi.authorize({ entityId: 'spid-idp-test', aar: 'aar-token-123' });
 
       expect(fetch).toHaveBeenCalledWith(
-        'https://mock-api-base-url/oidc-authorize?idp=spid-idp-test&aar=aar-token-123'
+        'https://mock-api-base-url/oidc/authorize?idp=spid-idp-test&aar=aar-token-123'
       );
     });
 
@@ -66,7 +66,7 @@ describe('OneIdentity api tests', () => {
       });
 
       expect(fetch).toHaveBeenCalledWith(
-        'https://mock-api-base-url/oidc-authorize?idp=spid-idp-test&retrievalId=retrieval-id-456'
+        'https://mock-api-base-url/oidc/authorize?idp=spid-idp-test&retrievalId=retrieval-id-456'
       );
     });
 

--- a/packages/pn-personafisica-webapp/src/api/auth/__test__/auth.routes.test.ts
+++ b/packages/pn-personafisica-webapp/src/api/auth/__test__/auth.routes.test.ts
@@ -8,7 +8,7 @@ describe('Authentication routes', () => {
 
   it('should compile ONE_IDENTITY_TOKEN_EXCHANGE', () => {
     const route = ONE_IDENTITY_TOKEN_EXCHANGE();
-    expect(route).toEqual('/oidc-token');
+    expect(route).toEqual('/oidc/token');
   });
 
   it('should compile AUTH_LOGOUT', () => {

--- a/packages/pn-personafisica-webapp/src/api/auth/auth.routes.ts
+++ b/packages/pn-personafisica-webapp/src/api/auth/auth.routes.ts
@@ -2,7 +2,7 @@ import { compileRoute } from '@pagopa-pn/pn-commons';
 
 // Segments
 const API_AUTH_TOKEN_EXCHANGE = 'token-exchange';
-const API_AUTH_ONE_IDENTITY_TOKEN_EXCHANGE = 'oidc-token';
+const API_AUTH_ONE_IDENTITY_TOKEN_EXCHANGE = 'oidc/token';
 const API_AUTH_LOGOUT = 'logout';
 
 // APIs


### PR DESCRIPTION
## List of changes proposed in this pull request
- `/oidc-authroize` -> `/oidc/authorize`
- `/oidc-token` -> `/oidc/token`
