### PR TITLE
feat(PN-20560): Add FIMS token exchange flow to PF

### DIFF
--- a/packages/pn-personafisica-webapp/src/api/auth/Auth.api.ts
+++ b/packages/pn-personafisica-webapp/src/api/auth/Auth.api.ts
@@ -1,5 +1,6 @@
 /* eslint-disable functional/immutable-data */
 import {
+  FimsTokenExchangeRequest,
   OneIdentityExchangeCodeBody,
   OneIdentityUser,
   TokenExchangeBody,
@@ -8,7 +9,7 @@ import {
   paramsToSourceType,
 } from '../../models/User';
 import { authClient } from '../apiClients';
-import { AUTH_LOGOUT, AUTH_TOKEN_EXCHANGE, ONE_IDENTITY_TOKEN_EXCHANGE } from './auth.routes';
+import { AUTH_LOGOUT, AUTH_TOKEN_EXCHANGE, FIMS_TOKEN_EXCHANGE, ONE_IDENTITY_TOKEN_EXCHANGE } from './auth.routes';
 
 export const AuthApi = {
   exchangeToken: async ({ spidToken, rapidAccess }: TokenExchangeRequest): Promise<User> => {
@@ -21,6 +22,13 @@ export const AuthApi = {
       };
     }
     const response = await authClient.post<User>(AUTH_TOKEN_EXCHANGE(), body);
+
+    return response.data;
+  },
+  exchangeFimsToken: async ({ fimsToken }: FimsTokenExchangeRequest): Promise<User> => {
+    const response = await authClient.post<User>(FIMS_TOKEN_EXCHANGE(), {
+      authorizationToken: fimsToken,
+    });
 
     return response.data;
   },

--- a/packages/pn-personafisica-webapp/src/api/auth/__test__/Auth.api.test.ts
+++ b/packages/pn-personafisica-webapp/src/api/auth/__test__/Auth.api.test.ts
@@ -5,7 +5,7 @@ import { AppRouteParams } from '@pagopa-pn/pn-commons';
 import { userResponse, userResponseWithRetrievalId } from '../../../__mocks__/Auth.mock';
 import { authClient } from '../../apiClients';
 import { AuthApi } from '../Auth.api';
-import { AUTH_TOKEN_EXCHANGE, ONE_IDENTITY_TOKEN_EXCHANGE } from '../auth.routes';
+import { AUTH_TOKEN_EXCHANGE, FIMS_TOKEN_EXCHANGE, ONE_IDENTITY_TOKEN_EXCHANGE } from '../auth.routes';
 
 describe('Auth api tests', () => {
   let mock: MockAdapter;
@@ -26,6 +26,19 @@ describe('Auth api tests', () => {
     const spidToken = 'mocked-token';
     mock.onPost(AUTH_TOKEN_EXCHANGE(), { authorizationToken: spidToken }).reply(200, userResponse);
     const res = await AuthApi.exchangeToken({ spidToken });
+    expect(res).toStrictEqual(userResponse);
+  });
+
+  it('exchangeFimsToken', async () => {
+    const fimsToken = 'mocked-fims-token';
+
+    mock
+      .onPost(FIMS_TOKEN_EXCHANGE(), {
+        authorizationToken: fimsToken
+      })
+      .reply(200, userResponse);
+
+    const res = await AuthApi.exchangeFimsToken({ fimsToken });
     expect(res).toStrictEqual(userResponse);
   });
 

--- a/packages/pn-personafisica-webapp/src/api/auth/__test__/auth.routes.test.ts
+++ b/packages/pn-personafisica-webapp/src/api/auth/__test__/auth.routes.test.ts
@@ -1,9 +1,14 @@
-import { AUTH_LOGOUT, AUTH_TOKEN_EXCHANGE, ONE_IDENTITY_TOKEN_EXCHANGE } from '../auth.routes';
+import { AUTH_LOGOUT, AUTH_TOKEN_EXCHANGE, FIMS_TOKEN_EXCHANGE, ONE_IDENTITY_TOKEN_EXCHANGE } from '../auth.routes';
 
 describe('Authentication routes', () => {
   it('should compile AUTH_TOKEN_EXCHANGE', () => {
     const route = AUTH_TOKEN_EXCHANGE();
     expect(route).toEqual('/token-exchange');
+  });
+
+  it('should compile FIMS_TOKEN_EXCHANGE', () => {
+    const route = FIMS_TOKEN_EXCHANGE();
+    expect(route).toEqual('/fims/exchange');
   });
 
   it('should compile ONE_IDENTITY_TOKEN_EXCHANGE', () => {

--- a/packages/pn-personafisica-webapp/src/api/auth/auth.routes.ts
+++ b/packages/pn-personafisica-webapp/src/api/auth/auth.routes.ts
@@ -2,6 +2,7 @@ import { compileRoute } from '@pagopa-pn/pn-commons';
 
 // Segments
 const API_AUTH_TOKEN_EXCHANGE = 'token-exchange';
+const API_AUTH_FIMS_TOKEN_EXCHANGE = 'fims/exchange';
 const API_AUTH_ONE_IDENTITY_TOKEN_EXCHANGE = 'oidc-token';
 const API_AUTH_LOGOUT = 'logout';
 
@@ -10,6 +11,13 @@ export function AUTH_TOKEN_EXCHANGE() {
   return compileRoute({
     prefix: '',
     path: API_AUTH_TOKEN_EXCHANGE,
+  });
+}
+
+export function FIMS_TOKEN_EXCHANGE() {
+  return compileRoute({
+    prefix: '',
+    path: API_AUTH_FIMS_TOKEN_EXCHANGE,
   });
 }
 

--- a/packages/pn-personafisica-webapp/src/models/PFEventsType.ts
+++ b/packages/pn-personafisica-webapp/src/models/PFEventsType.ts
@@ -282,6 +282,7 @@ export const eventsActionsMap: Record<string, PFEventsType> = {
   'getReceivedNotificationOtherDocument/fulfilled': PFEventsType.SEND_DOWNLOAD_RESPONSE,
   'getReceivedNotificationLegalfact/fulfilled': PFEventsType.SEND_DOWNLOAD_RESPONSE,
   'exchangeToken/fulfilled': PFEventsType.SEND_AUTH_SUCCESS,
+  'exchangeFimsToken/fulfilled': PFEventsType.SEND_AUTH_SUCCESS,
   'exchangeOneIdentityCode/fulfilled': PFEventsType.SEND_AUTH_SUCCESS,
 
   // --- PROFILE_PROPERTY

--- a/packages/pn-personafisica-webapp/src/models/User.ts
+++ b/packages/pn-personafisica-webapp/src/models/User.ts
@@ -27,7 +27,7 @@ export enum SourceChannel {
 export interface UserSource {
   channel: SourceChannel;
   details: string;
-  retrievalId: string;
+  retrievalId?: string;
 }
 
 export interface BodySourceRequest {
@@ -51,6 +51,10 @@ export interface TokenExchangeRequest {
   rapidAccess?: [AppRouteParams, string];
 }
 
+export interface FimsTokenExchangeRequest {
+  fimsToken: string;
+}
+
 export const paramsToSourceType: Record<AppRouteParams, 'TPP' | 'QR'> = {
   [AppRouteParams.AAR]: 'QR',
   [AppRouteParams.RETRIEVAL_ID]: 'TPP',
@@ -58,5 +62,6 @@ export const paramsToSourceType: Record<AppRouteParams, 'TPP' | 'QR'> = {
 
 export enum LoginProvider {
   SPIDHUB = 'SPIDHUB',
+  FIMS = 'FIMS',
   ONEIDENTITY = 'ONEIDENTITY',
 }

--- a/packages/pn-personafisica-webapp/src/navigation/SessionGuard.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/SessionGuard.tsx
@@ -108,22 +108,6 @@ const SessionGuard = () => {
     }
   };
 
-  const removeFimsTokenFromHash = () => {
-    const nextHashParams = new URLSearchParams(location.hash.substring(1));
-    nextHashParams.delete('fimsToken');
-
-    const nextHash = nextHashParams.toString();
-
-    navigate(
-      {
-        pathname: location.pathname,
-        search: location.search,
-        hash: nextHash ? `#${nextHash}` : '',
-      },
-      { replace: true }
-    );
-  };
-
   const performOneIdentityTokenExchange = async (
     exchangeCodeParams: OneIdentityExchangeCodeBody
   ) => {
@@ -176,7 +160,6 @@ const SessionGuard = () => {
 
   useEffect(() => {
     if (fimsToken) {
-      removeFimsTokenFromHash();
       void performFimsTokenExchange({ fimsToken });
     } else if (spidToken) {
       void performExchangeToken({ spidToken, rapidAccess });

--- a/packages/pn-personafisica-webapp/src/navigation/SessionGuard.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/SessionGuard.tsx
@@ -17,8 +17,8 @@ import {
 
 import { useRapidAccessParam } from '../hooks/useRapidAccessParam';
 import { PFEventsType } from '../models/PFEventsType';
-import { OneIdentityExchangeCodeBody, TokenExchangeRequest } from '../models/User';
-import { apiLogout, exchangeOneIdentityCode, exchangeToken } from '../redux/auth/actions';
+import { FimsTokenExchangeRequest, OneIdentityExchangeCodeBody, TokenExchangeRequest } from '../models/User';
+import { apiLogout, exchangeFimsToken, exchangeOneIdentityCode, exchangeToken } from '../redux/auth/actions';
 import { resetState as resetUserState, setIsFreshLogin } from '../redux/auth/reducers';
 import { useAppDispatch, useAppSelector } from '../redux/hooks';
 import { resetState as resetGeneralState } from '../redux/sidemenu/reducers';
@@ -56,6 +56,7 @@ const SessionGuard = () => {
   const hashParams = new URLSearchParams(location.hash.substring(1)); // https://github.com/remix-run/history/blob/main/docs/api-reference.md#location.hash
 
   const spidToken = hashParams.get('token');
+  const fimsToken = hashParams.get('fimsToken');
 
   // Get One Identity params from URL hash
   const code = hashParams.get('code');
@@ -93,6 +94,34 @@ const SessionGuard = () => {
     } catch (error) {
       handleTokenExchangeError(error);
     }
+  };
+
+  const performFimsTokenExchange = async (token: FimsTokenExchangeRequest) => {
+    AppResponsePublisher.error.subscribe('exchangeFimsToken', manageUnforbiddenError);
+
+    try {
+      const user = await dispatch(exchangeFimsToken(token)).unwrap();
+      dispatch(setIsFreshLogin(true));
+      sessionCheck(user.exp);
+    } catch (error) {
+      handleTokenExchangeError(error);
+    }
+  };
+
+  const removeFimsTokenFromHash = () => {
+    const nextHashParams = new URLSearchParams(location.hash.substring(1));
+    nextHashParams.delete('fimsToken');
+
+    const nextHash = nextHashParams.toString();
+
+    navigate(
+      {
+        pathname: location.pathname,
+        search: location.search,
+        hash: nextHash ? `#${nextHash}` : '',
+      },
+      { replace: true }
+    );
   };
 
   const performOneIdentityTokenExchange = async (
@@ -146,7 +175,10 @@ const SessionGuard = () => {
   };
 
   useEffect(() => {
-    if (spidToken) {
+    if (fimsToken) {
+      removeFimsTokenFromHash();
+      void performFimsTokenExchange({ fimsToken });
+    } else if (spidToken) {
       void performExchangeToken({ spidToken, rapidAccess });
     } else if (code && state) {
       void performOneIdentityTokenExchange({ code, state });
@@ -168,6 +200,7 @@ const SessionGuard = () => {
 
     return () => {
       AppResponsePublisher.error.unsubscribe('exchangeToken', manageUnforbiddenError);
+      AppResponsePublisher.error.unsubscribe('exchangeFimsToken', manageUnforbiddenError);
       AppResponsePublisher.error.unsubscribe('exchangeTokenOneIdentity', manageUnforbiddenError);
     };
   }, []);

--- a/packages/pn-personafisica-webapp/src/navigation/__test__/SessionGuard.test.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/__test__/SessionGuard.test.tsx
@@ -8,7 +8,8 @@ import { AppRouteParams } from '@pagopa-pn/pn-commons';
 import { userResponse } from '../../__mocks__/Auth.mock';
 import { RenderResult, act, render, screen, waitFor } from '../../__test__/test-utils';
 import { authClient } from '../../api/apiClients';
-import { AUTH_TOKEN_EXCHANGE, ONE_IDENTITY_TOKEN_EXCHANGE } from '../../api/auth/auth.routes';
+import { AUTH_TOKEN_EXCHANGE, FIMS_TOKEN_EXCHANGE, ONE_IDENTITY_TOKEN_EXCHANGE } from '../../api/auth/auth.routes';
+import { SourceChannel } from '../../models/User';
 import { AAR_UTM, UTM_KEY } from '../../utility/utm.utility';
 import SessionGuard from '../SessionGuard';
 import * as routes from '../routes.const';
@@ -152,6 +153,72 @@ describe('SessionGuard Component', () => {
     expect(pageComponent).toBeTruthy();
   });
 
+  it('FIMS token exchange - successful', async () => {
+    const fimsToken = 'mocked-fims-token';
+    const fimsUserResponse = {
+      ...userResponse,
+      source: {
+        channel: SourceChannel.WEB,
+        details: 'FIMS',
+      },
+    };
+
+    mock
+      .onPost(FIMS_TOKEN_EXCHANGE(), { authorizationToken: fimsToken })
+      .reply(200, fimsUserResponse);
+
+    await act(async () => {
+      result = render(<Guard />, {
+        route: `/?utm_source=ioapp&utm_medium=app&utm_campaign=visita_send#fimsToken=${fimsToken}`,
+      });
+    });
+
+    await waitFor(() => {
+      expect(mock.history.post).toHaveLength(1);
+      expect(mock.history.post[0].url).toBe(FIMS_TOKEN_EXCHANGE());
+      expect(JSON.parse(mock.history.post[0].data)).toStrictEqual({
+        authorizationToken: fimsToken,
+      });
+    });
+
+    const pageComponent = screen.queryByText('Generic Page');
+    expect(pageComponent).toBeTruthy();
+
+    await waitFor(() => {
+      expect(result.router.state.location.search).toBe(
+        '?utm_source=ioapp&utm_medium=app&utm_campaign=visita_send'
+      );
+      expect(result.router.state.location.hash).toBe('');
+    });
+  });
+
+  it('FIMS token exchange - error', async () => {
+    const fimsToken = '403-fims-token';
+
+    mock.onPost(FIMS_TOKEN_EXCHANGE()).reply(403, { authorizationToken: fimsToken });
+
+    await act(async () => {
+      render(<Guard />, {
+        route: `/#fimsToken=${fimsToken}`,
+      });
+    });
+
+    await waitFor(() => {
+      expect(mock.history.post).toHaveLength(1);
+      expect(mock.history.post[0].url).toBe(FIMS_TOKEN_EXCHANGE());
+      expect(JSON.parse(mock.history.post[0].data)).toStrictEqual({
+        authorizationToken: fimsToken,
+      });
+    });
+
+    expect(result.router.state.location.hash).toBe('');
+
+    const logoutComponent = screen.queryByTestId('session-modal');
+    expect(logoutComponent).toBeTruthy();
+    const logoutTitleComponent = screen.queryByText('leaving-app.title');
+    expect(logoutTitleComponent).toBeNull();
+  });
+
   // expected behavior: enters the app with session token already present
   it('reload - session token already present', async () => {
     const mockReduxState = {
@@ -216,9 +283,7 @@ describe('SessionGuard Component', () => {
     });
     expect(mock.history.post).toHaveLength(1);
     await waitFor(() => {
-      expect(result.router.state.location.search).toBe(
-        `?${AppRouteParams.AAR}=mock-aar-value`
-      );
+      expect(result.router.state.location.search).toBe(`?${AppRouteParams.AAR}=mock-aar-value`);
       expect(result.router.state.historyAction).toBe('REPLACE');
     });
   });

--- a/packages/pn-personafisica-webapp/src/navigation/__test__/SessionGuard.test.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/__test__/SessionGuard.test.tsx
@@ -188,7 +188,7 @@ describe('SessionGuard Component', () => {
       expect(result.router.state.location.search).toBe(
         '?utm_source=ioapp&utm_medium=app&utm_campaign=visita_send'
       );
-      expect(result.router.state.location.hash).toBe('');
+      expect(result.router.state.location.hash).toBe(`#fimsToken=${fimsToken}`);
     });
   });
 
@@ -198,7 +198,7 @@ describe('SessionGuard Component', () => {
     mock.onPost(FIMS_TOKEN_EXCHANGE()).reply(403, { authorizationToken: fimsToken });
 
     await act(async () => {
-      render(<Guard />, {
+      result = render(<Guard />, {
         route: `/#fimsToken=${fimsToken}`,
       });
     });
@@ -211,7 +211,7 @@ describe('SessionGuard Component', () => {
       });
     });
 
-    expect(result.router.state.location.hash).toBe('');
+    expect(result.router.state.location.hash).toBe(`#fimsToken=${fimsToken}`);
 
     const logoutComponent = screen.queryByTestId('session-modal');
     expect(logoutComponent).toBeTruthy();

--- a/packages/pn-personafisica-webapp/src/navigation/__test__/navigation.utility.test.ts
+++ b/packages/pn-personafisica-webapp/src/navigation/__test__/navigation.utility.test.ts
@@ -36,6 +36,13 @@ describe('Tests navigation utility methods', () => {
     expect(mockOpenFn).toHaveBeenCalledWith(`${LOGOUT}`, '_self');
   });
 
+  it('goToLoginPortal - from FIMS', () => {
+    goToLoginPortal({ loginProvider: LoginProvider.FIMS });
+
+    expect(mockOpenFn).toHaveBeenCalledTimes(1);
+    expect(mockOpenFn).toHaveBeenCalledWith(LOGOUT, '_self');
+  });
+
   it('goToLoginPortal - aar (preserves only utm_*)', () => {
     goToLoginPortal({
       rapidAccess: [AppRouteParams.AAR, 'fake-aar-token'],

--- a/packages/pn-personafisica-webapp/src/redux/auth/__test__/reducers.test.ts
+++ b/packages/pn-personafisica-webapp/src/redux/auth/__test__/reducers.test.ts
@@ -14,24 +14,28 @@ import {
 } from '../../../__mocks__/Consents.mock';
 import { errorMock } from '../../../__mocks__/Errors.mock';
 import { apiClient, authClient } from '../../../api/apiClients';
-import { ONE_IDENTITY_TOKEN_EXCHANGE } from '../../../api/auth/auth.routes';
-import { LoginProvider } from '../../../models/User';
+import { FIMS_TOKEN_EXCHANGE, ONE_IDENTITY_TOKEN_EXCHANGE } from '../../../api/auth/auth.routes';
+import { LoginProvider, SourceChannel } from '../../../models/User';
 import { store } from '../../store';
-import { acceptTosPrivacy, exchangeOneIdentityCode, getTosPrivacyApproval } from '../actions';
+import { acceptTosPrivacy, exchangeFimsToken, exchangeOneIdentityCode, getTosPrivacyApproval } from '../actions';
 
 describe('Auth redux state tests', () => {
-  let mock: MockAdapter;
+  let apiMock: MockAdapter;
+  let authMock: MockAdapter;
 
   beforeAll(() => {
-    mock = new MockAdapter(apiClient);
+    apiMock = new MockAdapter(apiClient);
+    authMock = new MockAdapter(authClient);
   });
 
   afterEach(() => {
-    mock.reset();
+    apiMock.reset();
+    authMock.reset();
   });
 
   afterAll(() => {
-    mock.restore();
+    apiMock.restore();
+    authMock.restore();
   });
 
   it('Initial state', () => {
@@ -75,12 +79,31 @@ describe('Auth redux state tests', () => {
     const action = await mockLogin();
     expect(action.type).toBe('exchangeToken/fulfilled');
     expect(action.payload).toEqual(userResponse);
-    expect(store.getState().userState.loginProvider).toBe('SPIDHUB');
+    expect(store.getState().userState.loginProvider).toBe(LoginProvider.SPIDHUB);
+  });
+
+  it('Should be able to exchange FIMS token', async () => {
+    const fimsToken = 'mocked-fims-token';
+    const fimsUserResponse = {
+      ...userResponse,
+      source: {
+        channel: SourceChannel.WEB,
+        details: 'FIMS',
+      },
+    };
+
+    authMock
+      .onPost(FIMS_TOKEN_EXCHANGE(), { authorizationToken: fimsToken })
+      .reply(200, fimsUserResponse);
+    const action = await store.dispatch(exchangeFimsToken({ fimsToken }));
+
+    expect(action.type).toBe('exchangeFimsToken/fulfilled');
+    expect(action.payload).toEqual(fimsUserResponse);
+    expect(store.getState().userState.loginProvider).toBe(LoginProvider.FIMS);
   });
 
   it('Should be able to exchange code with One Identity', async () => {
-    const mock = new MockAdapter(authClient);
-    mock.onPost(ONE_IDENTITY_TOKEN_EXCHANGE()).reply(200, oneIdentityUserResponse);
+    authMock.onPost(ONE_IDENTITY_TOKEN_EXCHANGE()).reply(200, oneIdentityUserResponse);
     const action = await store.dispatch(
       exchangeOneIdentityCode({
         code: 'mocked-code',
@@ -90,12 +113,11 @@ describe('Auth redux state tests', () => {
 
     expect(action.type).toBe('exchangeOneIdentityCode/fulfilled');
     expect(action.payload).toEqual(oneIdentityUserResponse);
-    expect(store.getState().userState.loginProvider).toBe('ONEIDENTITY');
+    expect(store.getState().userState.loginProvider).toBe(LoginProvider.ONEIDENTITY);
   });
 
   it('Should strip idp, aar and retrievalId before saving One Identity user to redux and sessionStorage', async () => {
-    const mock = new MockAdapter(authClient);
-    mock.onPost(ONE_IDENTITY_TOKEN_EXCHANGE()).reply(200, oneIdentityUserResponse);
+    authMock.onPost(ONE_IDENTITY_TOKEN_EXCHANGE()).reply(200, oneIdentityUserResponse);
     await store.dispatch(exchangeOneIdentityCode({ code: 'mocked-code', state: 'mocked-state' }));
 
     const userFromStorage = JSON.parse(sessionStorage.getItem('user')!);
@@ -132,7 +154,7 @@ describe('Auth redux state tests', () => {
   });
 
   it('Should fetch ToS and Privacy approved', async () => {
-    mock.onGet(/\/bff\/v2\/tos-privacy.*/).reply(200, tosPrivacyConsentMock(true, true));
+    apiMock.onGet(/\/bff\/v2\/tos-privacy.*/).reply(200, tosPrivacyConsentMock(true, true));
 
     const action = await store.dispatch(getTosPrivacyApproval());
     expect(action.type).toBe('getTosPrivacyApproval/fulfilled');
@@ -145,7 +167,7 @@ describe('Auth redux state tests', () => {
     const tosPrivacyErrorResponse = {
       response: errorMock,
     };
-    mock.onGet(/\/bff\/v2\/tos-privacy.*/).reply(errorMock.status, errorMock.data);
+    apiMock.onGet(/\/bff\/v2\/tos-privacy.*/).reply(errorMock.status, errorMock.data);
     const action = await store.dispatch(getTosPrivacyApproval());
     expect(action.type).toBe('getTosPrivacyApproval/rejected');
     expect(action.payload).toEqual(tosPrivacyErrorResponse);
@@ -160,7 +182,7 @@ describe('Auth redux state tests', () => {
   });
 
   it('Should be able to fetch tos and privacy acceptance', async () => {
-    mock.onPut('/bff/v2/tos-privacy').reply(200);
+    apiMock.onPut('/bff/v2/tos-privacy').reply(200);
 
     const action = await store.dispatch(acceptTosPrivacy(acceptTosPrivacyConsentBodyMock()));
 
@@ -170,7 +192,7 @@ describe('Auth redux state tests', () => {
   });
 
   it('Should NOT be able to fetch tos and privacy acceptance', async () => {
-    mock.onPut('/bff/v2/tos-privacy').reply(errorMock.status, errorMock.data);
+    apiMock.onPut('/bff/v2/tos-privacy').reply(errorMock.status, errorMock.data);
 
     const action = await store.dispatch(acceptTosPrivacy(acceptTosPrivacyConsentBodyMock()));
 

--- a/packages/pn-personafisica-webapp/src/redux/auth/actions.ts
+++ b/packages/pn-personafisica-webapp/src/redux/auth/actions.ts
@@ -7,12 +7,7 @@ import {
   BffTosPrivacyActionBody,
   UserConsentsApiFactory,
 } from '../../generated-client/tos-privacy';
-import {
-  OneIdentityExchangeCodeBody,
-  OneIdentityUser,
-  TokenExchangeRequest,
-  User,
-} from '../../models/User';
+import { FimsTokenExchangeRequest, OneIdentityExchangeCodeBody, OneIdentityUser, TokenExchangeRequest, User } from '../../models/User';
 import { userDataMatcher } from '../../utility/user.utility';
 
 export enum AUTH_ACTIONS {
@@ -29,6 +24,28 @@ export const exchangeToken = createAsyncThunk<User, TokenExchangeRequest>(
   async (request: TokenExchangeRequest, { rejectWithValue }) => {
     try {
       const result = await AuthApi.exchangeToken(request);
+      userDataMatcher.validateSync(result, { stripUnknown: false });
+      return result;
+    } catch (e: any) {
+      if (e?.name === 'ValidationError') {
+        return rejectWithValue({
+          code: 'USER_VALIDATION_FAILED',
+          message: e.message,
+        });
+      }
+      return rejectWithValue(parseError(e));
+    }
+  }
+);
+
+/**
+ * Exchange the short-lived FIMS token for a SEND token.
+ */
+export const exchangeFimsToken = createAsyncThunk<User, FimsTokenExchangeRequest>(
+  'exchangeFimsToken',
+  async (request: FimsTokenExchangeRequest, { rejectWithValue }) => {
+    try {
+      const result = await AuthApi.exchangeFimsToken(request);
       userDataMatcher.validateSync(result, { stripUnknown: false });
       return result;
     } catch (e: any) {

--- a/packages/pn-personafisica-webapp/src/redux/auth/reducers.ts
+++ b/packages/pn-personafisica-webapp/src/redux/auth/reducers.ts
@@ -7,6 +7,7 @@ import { LoginProvider, User } from '../../models/User';
 import { userDataMatcher } from '../../utility/user.utility';
 import {
   acceptTosPrivacy,
+  exchangeFimsToken,
   exchangeOneIdentityCode,
   exchangeToken,
   getTosPrivacyApproval,
@@ -117,7 +118,7 @@ const userSlice = createSlice({
 
     builder
       .addMatcher(
-        isAnyOf(exchangeToken.pending, exchangeOneIdentityCode.pending),
+        isAnyOf(exchangeToken.pending, exchangeFimsToken.pending, exchangeOneIdentityCode.pending),
         (state, action) => {
           state.loading = true;
 
@@ -125,11 +126,13 @@ const userSlice = createSlice({
             state.loginProvider = LoginProvider.SPIDHUB;
           } else if (action.type === exchangeOneIdentityCode.pending.type) {
             state.loginProvider = LoginProvider.ONEIDENTITY;
+          } else if (action.type === exchangeFimsToken.pending.type) {
+            state.loginProvider = LoginProvider.FIMS;
           }
         }
       )
       .addMatcher(
-        isAnyOf(exchangeToken.fulfilled, exchangeOneIdentityCode.fulfilled),
+        isAnyOf(exchangeToken.fulfilled, exchangeFimsToken.fulfilled, exchangeOneIdentityCode.fulfilled),
         (state, action) => {
           const user =
             action.type === exchangeOneIdentityCode.fulfilled.type
@@ -141,7 +144,7 @@ const userSlice = createSlice({
           state.loading = false;
         }
       )
-      .addMatcher(isAnyOf(exchangeToken.rejected, exchangeOneIdentityCode.rejected), (state) => {
+      .addMatcher(isAnyOf(exchangeToken.rejected, exchangeFimsToken.rejected, exchangeOneIdentityCode.rejected), (state) => {
         state.loading = false;
       });
   },

--- a/packages/pn-personafisica-webapp/src/utility/__test__/mixpanel/mixpanel.mixpanel.test.ts
+++ b/packages/pn-personafisica-webapp/src/utility/__test__/mixpanel/mixpanel.mixpanel.test.ts
@@ -41,6 +41,17 @@ describe('trackingMiddleware - Mixpanel events', () => {
     );
   });
 
+  it('fires SEND_AUTH_SUCCESS on exchangeFimsToken/fulfilled', () => {
+    dispatch('exchangeFimsToken/fulfilled', userResponse, { fimsToken: 'mocked-fims-token' });
+    expect(triggerEventSpy).toHaveBeenCalledWith(
+      PFEventsType.SEND_AUTH_SUCCESS,
+      expect.objectContaining({
+        payload: userResponse,
+        params: { fimsToken: 'mocked-fims-token' },
+      })
+    );
+  });
+
   it('fires SEND_AUTH_SUCCESS on exchangeOneIdentityCode/fulfilled', () => {
     dispatch('exchangeOneIdentityCode/fulfilled', oneIdentityUserResponse, {
       code: 'mock-code',

--- a/packages/pn-personafisica-webapp/src/utility/user.utility.ts
+++ b/packages/pn-personafisica-webapp/src/utility/user.utility.ts
@@ -20,7 +20,7 @@ export const userDataMatcher = yup
       .object({
         channel: yup.string().oneOf(Object.values(SourceChannel)), // UserSource.channel
         details: yup.string(),
-        retrievalId: yup.string().matches(/^[ -~]{1,50}$/),
+        retrievalId: yup.string().matches(/^[ -~]{1,50}$/).optional(),
       })
       .optional(),
     idp: yup.string().optional(),


### PR DESCRIPTION
## Short description
Adds the frontend FIMS token exchange flow for PF.
When the user lands on PF with a `fimsToken` in the URL hash, the `SesionGuard` exchanges it through `/fims/exchange` and creates the SEND session.