### PR TITLE
fix(PN-20781): hide "new attachment" timeline message when the analog event has no attachments

### DIFF
--- a/packages/pn-commons/src/utility/TimelineUtils/SendAnalogFlowStep.ts
+++ b/packages/pn-commons/src/utility/TimelineUtils/SendAnalogFlowStep.ts
@@ -25,6 +25,27 @@ const SEND_ANALOG_FEEDBACK_KO_DETAIL_CODES = [
   'RECRI004C',
 ];
 
+// CODES with "C'è un nuovo documento allegato." description
+const SEND_ANALOG_FLOW_NEW_ATTACHMENT_DETAIL_CODES = [
+  'RECRN001B',
+  'RECRN002B',
+  'RECRN002E',
+  'RECRN003B',
+  'RECRN004B',
+  'RECRN005B',
+  'RECAG001B',
+  'RECAG002B',
+  'RECAG003B',
+  'RECAG003E',
+  'RECAG005B',
+  'RECAG006B',
+  'RECAG007B',
+  'RECAG008B',
+  'RECAG011B',
+  'RECRI003B',
+  'RECRI004B',
+];
+
 function i18nLabelEntry(category: TimelineCategory, deliveryDetailCode: string | undefined) {
   const sendAnalogFeedbackEntry = () =>
     deliveryDetailCode
@@ -111,21 +132,30 @@ export class SendAnalogFlowStep extends TimelineStep {
       ? this.completePhysicalAddressFromStep(originatingStep)
       : {};
 
+    const attachments = (payload.step.details as SendPaperDetails).attachments;
+    const hideDescriptionNewAttachment =
+      !!deliveryDetailCode &&
+      SEND_ANALOG_FLOW_NEW_ATTACHMENT_DETAIL_CODES.includes(deliveryDetailCode) &&
+      !(attachments && attachments.length > 0);
+
+    const multiRecipientSuffix = payload.isMultiRecipient ? '-multirecipient' : '';
+
     // eslint-disable-next-line functional/no-let
-    let description = getLocalizedOrDefaultLabel(
-      'notifications',
-      `detail.timeline.send-analog-flow-${deliveryDetailCode}-description${
-        payload.isMultiRecipient ? '-multirecipient' : ''
-      }`,
-      '',
-      {
-        ...this.nameAndTaxId(payload),
-        ...physicalAddress,
-        registeredLetterKind: registeredLetterKindText,
-        deliveryFailureCause: deliveryFailureCauseText,
-        registeredLetterNumber,
-      }
-    );
+    let description = '';
+    if (!hideDescriptionNewAttachment) {
+      description = getLocalizedOrDefaultLabel(
+        'notifications',
+        `detail.timeline.send-analog-flow-${deliveryDetailCode}-description${multiRecipientSuffix}`,
+        '',
+        {
+          ...this.nameAndTaxId(payload),
+          ...physicalAddress,
+          registeredLetterKind: registeredLetterKindText,
+          deliveryFailureCause: deliveryFailureCauseText,
+          registeredLetterNumber,
+        }
+      );
+    }
 
     if (description.length === 0) {
       description = getLocalizedOrDefaultLabel(

--- a/packages/pn-commons/src/utility/TimelineUtils/SendAnalogFlowStep.ts
+++ b/packages/pn-commons/src/utility/TimelineUtils/SendAnalogFlowStep.ts
@@ -25,7 +25,7 @@ const SEND_ANALOG_FEEDBACK_KO_DETAIL_CODES = [
   'RECRI004C',
 ];
 
-// CODES with "C'è un nuovo documento allegato." description
+// CODES (PF,PG,PA) with description: "C'è un nuovo documento allegato." 
 const SEND_ANALOG_FLOW_NEW_ATTACHMENT_DETAIL_CODES = [
   'RECRN001B',
   'RECRN002B',

--- a/packages/pn-commons/src/utility/TimelineUtils/__test__/SendAnalogFlowStep.test.ts
+++ b/packages/pn-commons/src/utility/TimelineUtils/__test__/SendAnalogFlowStep.test.ts
@@ -114,6 +114,47 @@ describe('SendAnalogFlowStep', () => {
     });
   });
 
+  it('getTimelineStepInfo SEND_ANALOG_PROGRESS - "new attachment" code without attachments falls back to generic description', () => {
+    const sendAnalogFlowStep = new SendAnalogFlowStep();
+    // RECRN001B is a "new attachment" code, but the step carries no attachment
+    timelineElem = getTimelineElem(TimelineCategory.SEND_ANALOG_PROGRESS, {
+      deliveryDetailCode: 'RECRN001B',
+      sendRequestId: 'SEND_ANALOG_DOMICILE_0',
+      attachments: [],
+    });
+    payload.step = timelineElem;
+    payload.allStepsForThisStatus = [];
+    payload.isMultiRecipient = false;
+    expect(sendAnalogFlowStep.getTimelineStepInfo(payload)).toStrictEqual({
+      description: `notifiche - detail.timeline.send-analog-flow-description`,
+      label: sendAnalogFlowStep.getTimelineStepLabel(payload),
+    });
+  });
+
+  it('getTimelineStepInfo SEND_ANALOG_PROGRESS - "new attachment" code with attachments keeps its description', () => {
+    const sendAnalogFlowStep = new SendAnalogFlowStep();
+    // RECRN001B is a "new attachment" code and the step carries an attachment
+    timelineElem = getTimelineElem(TimelineCategory.SEND_ANALOG_PROGRESS, {
+      deliveryDetailCode: 'RECRN001B',
+      sendRequestId: 'SEND_ANALOG_DOMICILE_0',
+      attachments: [{ id: 'doc-1', documentType: 'AR', url: 'https://example.com/doc-1' }],
+    });
+    payload.step = timelineElem;
+    payload.allStepsForThisStatus = [];
+    payload.isMultiRecipient = false;
+    expect(sendAnalogFlowStep.getTimelineStepInfo(payload)).toStrictEqual({
+      description: `notifiche - detail.timeline.send-analog-flow-RECRN001B-description - ${JSON.stringify(
+        {
+          ...sendAnalogFlowStep.nameAndTaxId(payload),
+          registeredLetterKind: '',
+          deliveryFailureCause: '',
+          registeredLetterNumber: '',
+        }
+      )}`,
+      label: sendAnalogFlowStep.getTimelineStepLabel(payload),
+    });
+  });
+
   it('getTimelineStepInfo SEND_ANALOG_PROGRESS - with extra data', () => {
     const sendAnalogFlowStep = new SendAnalogFlowStep();
     const sendAnalogDomicileElem = getTimelineElem(TimelineCategory.SEND_ANALOG_DOMICILE, {


### PR DESCRIPTION
## Short description
Fix the notification timeline showing `"C'è un nuovo documento allegato."` on `SEND_ANALOG_PROGRESS` events that have no attachments.
With attachments → still shows "C'è un nuovo documento allegato." (unchanged).
Without attachments → falls back to the existing generic message "C'è un aggiornamento sull'invio cartaceo.".
All other delivery codes are unaffected.

## List of changes proposed in this pull request
- `packages/pn-commons/src/utility/TimelineUtils/SendAnalogFlowStep.ts`: add the attachment-code list and the attachments guard.
- `packages/pn-commons/src/utility/TimelineUtils/__test__/SendAnalogFlowStep.test.ts`: 2 new tests (code with/without attachments).

## How to test
Log in PF dev with "fieramosca" and check `GZLZ-MQJM-EKLH-202607-M-1` invalid event in delivering status