### PR TITLE
feat(PN-20242): improve sender contacts rendering for PF and PG

### DIFF
--- a/packages/pn-personafisica-webapp/src/pages/InformalNotificationDetail.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/InformalNotificationDetail.page.tsx
@@ -81,9 +81,8 @@ const InformalNotificationDetail: React.FC = () => {
     INFORMAL_NOTIFICATION_ACTIONS.GET_RECEIVED_INFORMAL_NOTIFICATION
   );
 
-  // TODO da sistemare quando ci saranno i contatti
-  const phone = (currentRecipient as any)?.senderContacts?.phone;
-  const site = (currentRecipient as any)?.senderContacts?.site;
+  const phone = informalNotification?.senderContacts?.phone;
+  const site = informalNotification?.senderContacts?.site;
 
   const fetchPaymentsInfo = (payments: Array<NotificationDetailPayment>) => {
     const paymentInfoRequest = payments.reduce((acc, payment) => {

--- a/packages/pn-personagiuridica-webapp/src/pages/InformalNotificationDetail.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/InformalNotificationDetail.page.tsx
@@ -81,9 +81,8 @@ const InformalNotificationDetail: React.FC = () => {
     INFORMAL_NOTIFICATION_ACTIONS.GET_RECEIVED_INFORMAL_NOTIFICATION
   );
 
-  // TODO da sistemare quando ci saranno i contatti
-  const phone = (currentRecipient as any)?.senderContacts?.phone;
-  const site = (currentRecipient as any)?.senderContacts?.site;
+  const phone = informalNotification?.senderContacts?.phone;
+  const site = informalNotification?.senderContacts?.site;
 
   const fetchPaymentsInfo = (payments: Array<NotificationDetailPayment>) => {
     const paymentInfoRequest = payments.reduce((acc, payment) => {


### PR DESCRIPTION
## Short description
Improve the rendering of sender contacts for both Persona Fisica (PF) and Persona Giuridica (PG), showing the contact section only when at least one contact is available.

## List of changes proposed in this pull request
- Update the sender contacts rendering logic for PF and PG.

## How to test
- Open the Informal Notification Detail page for both PF and PG.
- Verify that the sender contacts section is displayed when at least one contact (phone or website) is available.
- Verify that the section is not rendered when no sender contact information is provided.