### PR TITLE
fix(PN-20828): align PF notifications title with navigation labels

### DIFF
--- a/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
@@ -1,5 +1,4 @@
 {
-  "title": "Le tue notifiche",
   "go-to-detail": "Vai al dettaglio",
   "table": {
     "data": "Data",
@@ -423,7 +422,6 @@
       "action": "Consulta i modelli"
     }
   },
-  "delegatorTitle": "In arrivo per {{name}}",
   "status": {
     "recipient": "destinatario",
     "delegate": "delegato {{name}}",

--- a/packages/pn-personafisica-webapp/src/pages/Notifiche.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/Notifiche.page.tsx
@@ -39,7 +39,7 @@ import { hasActiveFilters } from '../utility/notification.utility';
 
 const Notifiche = () => {
   const dispatch = useAppDispatch();
-  const { t } = useTranslation(['notifiche']);
+  const { t } = useTranslation(['notifiche', 'common']);
   const { mandateId } = useParams();
   const [pageReady, setPageReady] = useState(false);
   const domicileBannerTypeRef = useRef('');
@@ -53,12 +53,23 @@ const Notifiche = () => {
   const currentDelegator = delegators.find(
     (delegation: Delegator) => delegation.mandateId === mandateId
   );
+
   const isMobile = useIsMobile();
-  const pageTitle = currentDelegator
-    ? t('delegatorTitle', {
-        name: currentDelegator.delegator ? currentDelegator.delegator.displayName : '',
-      })
-    : t('title');
+
+  const getPageTitle = () => {
+    if (currentDelegator) {
+      return t('menu.notifiche-delegato', {
+        ns: 'common',
+        delegator: currentDelegator.delegator ? currentDelegator.delegator.displayName : '',
+      });
+    }
+    if (delegators.length > 0) {
+      return t('menu.notifiche-utente', { ns: 'common' });
+    }
+
+    return t('menu.notifiche', { ns: 'common' });
+  };
+
   // back end return at most the next three pages
   // we have flag moreResult to check if there are more pages
   // the minum number of pages, to have ellipsis in the paginator, is 8
@@ -166,7 +177,7 @@ const Notifiche = () => {
   return (
     <LoadingPageWrapper isInitialized={pageReady}>
       <Box p={3}>
-        <TitleBox variantTitle="h4" title={pageTitle} mbTitle={isMobile ? 3 : 0} />
+        <TitleBox variantTitle="h4" title={getPageTitle()} mbTitle={isMobile ? 3 : 0} />
         {!mandateId && <DomicileBanner source={ContactSource.HOME_NOTIFICHE} my={3} />}
         <ApiErrorWrapper
           apiId={DASHBOARD_ACTIONS.GET_RECEIVED_NOTIFICATIONS}

--- a/packages/pn-personafisica-webapp/src/pages/__test__/Notifiche.page.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/Notifiche.page.test.tsx
@@ -29,6 +29,20 @@ describe('Notifiche Page', () => {
     formatToTimezoneString(tenYearsAgo)
   )}&endDate=${encodeURIComponent(formatToTimezoneString(today))}&size=10&communicationType=ALL`;
 
+  const generalInfoState = (overrides: Record<string, unknown>) => ({
+    pendingDelegators: 0,
+    delegators: [],
+    domicileBannerOpened: true,
+    paymentTpp: {},
+    hasNewNotifications: false,
+    onboardingData: {
+      hasBeenShown: false,
+      hasSkippedOnboarding: false,
+      exitReminderShown: false,
+    },
+    ...overrides,
+  });
+
   beforeAll(() => {
     mock = new MockAdapter(apiClient);
     globalThis.ResizeObserver = vi.fn().mockImplementation(() => ({
@@ -54,7 +68,7 @@ describe('Notifiche Page', () => {
     await act(async () => {
       result = render(<Notifiche />);
     });
-    expect(screen.getByTestId('titleBox')).toHaveTextContent(/title/i);
+    expect(screen.getByTestId('titleBox')).toHaveTextContent('menu.notifiche');
     expect(mock.history.get).toHaveLength(1);
     expect(mock.history.get[0].url).toContain('/bff/v1/notifications/received');
     const filterForm = result.getByTestId('filter-form');
@@ -254,7 +268,7 @@ describe('Notifiche Page', () => {
     await act(async () => {
       result = render(<Notifiche />);
     });
-    expect(screen.getByTestId('titleBox')).toHaveTextContent(/title/i);
+    expect(screen.getByTestId('titleBox')).toHaveTextContent('menu.notifiche');
     expect(mock.history.get).toHaveLength(1);
     expect(mock.history.get[0].url).toContain('/bff/v1/notifications/received');
     const filterForm = result.getByTestId('dialogToggle');
@@ -267,6 +281,42 @@ describe('Notifiche Page', () => {
     expect(pageSelector).toBeInTheDocument();
   });
 
+  it('renders personal notifications title when delegators are available', async () => {
+    mock.onGet(notificationsPath).reply(200, notificationsDTO);
+
+    await act(async () => {
+      result = render(<Notifiche />, {
+        preloadedState: {
+          generalInfoState: generalInfoState({
+            delegators: [mandatesByDelegate[1]],
+          }),
+        },
+      });
+    });
+
+    expect(screen.getByTestId('titleBox')).toHaveTextContent('menu.notifiche-utente');
+  });
+
+  it('renders delegated notifications title', async () => {
+    const delegator = mandatesByDelegate[1];
+
+    mock.onGet(/\/bff\/v1\/notifications\/received.*/).reply(200, notificationsDTO);
+
+    await act(async () => {
+      result = render(<Notifiche />, {
+        route: `/notifiche/${delegator.mandateId}`,
+        path: '/notifiche/:mandateId',
+        preloadedState: {
+          generalInfoState: generalInfoState({
+            delegators: [delegator],
+          }),
+        },
+      });
+    });
+
+    expect(screen.getByTestId('titleBox')).toHaveTextContent('menu.notifiche-delegato');
+  });
+
   describe('new notifications dot', () => {
     const receivedRegExp = new RegExp('/bff/v1/notifications/received');
     const notificationsWithNew = notificationsDTO;
@@ -274,19 +324,6 @@ describe('Notifiche Page', () => {
       ...notificationsDTO,
       resultsPage: notificationsDTO.resultsPage.map((n) => ({ ...n, isNewNotification: false })),
     };
-    const generalInfoState = (overrides: Record<string, unknown>) => ({
-      pendingDelegators: 0,
-      delegators: [],
-      domicileBannerOpened: true,
-      paymentTpp: {},
-      hasNewNotifications: false,
-      onboardingData: {
-        hasBeenShown: false,
-        hasSkippedOnboarding: false,
-        exitReminderShown: false,
-      },
-      ...overrides,
-    });
 
     it('sets hasNewNotifications to true when the first page has unread notifications', async () => {
       mock.onGet(receivedRegExp).reply(200, notificationsWithNew);


### PR DESCRIPTION
## Short description
Align the PF notifications page title with the navigation labels.

## How to test
- Log in with a PF user without delegations and verify the title is "In arrivo"
- Create a delegation from another user to verify the title changes to "In arrivo per te"