### PR TITLE
feat(PN-20879): serve the OneIdentity login flow from the institutional /login route

### DIFF
--- a/packages/pn-personafisica-login/src/__test__/App.test.tsx
+++ b/packages/pn-personafisica-login/src/__test__/App.test.tsx
@@ -6,6 +6,8 @@ import App from '../App';
 import { ROUTE_LOGIN_ERROR, ROUTE_LOGOUT } from '../navigation/routes.const';
 import { render } from './test-utils';
 
+let oneIdentityLoginEnabled = true;
+
 // mock imports
 // This is needed to test the logout page.
 // If we don't mock the useNavigate, when logout page is shown an immediate redirect happens and the test fails.
@@ -14,28 +16,75 @@ vi.mock('react-router-dom', async () => ({
   useNavigate: () => vi.fn(),
 }));
 
+vi.mock('../services/configuration.service', async () => {
+  const actual = await vi.importActual<any>('../services/configuration.service');
+  return {
+    ...actual,
+    getConfiguration: () => ({
+      ...actual.getConfiguration(),
+      ONE_IDENTITY_LOGIN_ENABLED: oneIdentityLoginEnabled,
+    }),
+  };
+});
+
 describe('App', () => {
-  it('inital page', () => {
-    const { container } = render(<App />);
-    const loginPage = getById(container, 'loginPage');
-    expect(loginPage).toBeInTheDocument();
-    const errorDialog = queryById(document.body, 'errorDialog');
-    expect(errorDialog).not.toBeInTheDocument();
+  describe('with one identity login enabled', () => {
+    beforeAll(() => {
+      oneIdentityLoginEnabled = true;
+    });
+
+    it('inital page', () => {
+      const { container } = render(<App />);
+      const loginPage = getById(container, 'loginPage');
+      expect(loginPage).toBeInTheDocument();
+      const errorDialog = queryById(document.body, 'oneIdentityErrorDialog');
+      expect(errorDialog).not.toBeInTheDocument();
+    });
+
+    it('logout page', () => {
+      const { container } = render(<App />, { route: ROUTE_LOGOUT });
+      const loginPage = queryById(container, 'loginPage');
+      expect(loginPage).not.toBeInTheDocument();
+      const errorDialog = queryById(document.body, 'oneIdentityErrorDialog');
+      expect(errorDialog).not.toBeInTheDocument();
+    });
+
+    it('login error', () => {
+      const { container } = render(<App />, { route: ROUTE_LOGIN_ERROR });
+      const loginPage = queryById(container, 'loginPage');
+      expect(loginPage).not.toBeInTheDocument();
+      const errorDialog = getById(document.body, 'oneIdentityErrorDialog');
+      expect(errorDialog).toBeInTheDocument();
+    });
   });
 
-  it('logout page', () => {
-    const { container } = render(<App />, { route: ROUTE_LOGOUT });
-    const loginPage = queryById(container, 'loginPage');
-    expect(loginPage).not.toBeInTheDocument();
-    const errorDialog = queryById(document.body, 'errorDialog');
-    expect(errorDialog).not.toBeInTheDocument();
-  });
+  describe('with one identity login disabled', () => {
+    beforeAll(() => {
+      oneIdentityLoginEnabled = false;
+    });
 
-  it('login error', () => {
-    const { container } = render(<App />, { route: ROUTE_LOGIN_ERROR });
-    const loginPage = queryById(container, 'loginPage');
-    expect(loginPage).not.toBeInTheDocument();
-    const errorDialog = getById(document.body, 'errorDialog');
-    expect(errorDialog).toBeInTheDocument();
+    it('inital page', () => {
+      const { container } = render(<App />);
+      const loginPage = getById(container, 'loginPage');
+      expect(loginPage).toBeInTheDocument();
+      const errorDialog = queryById(document.body, 'errorDialog');
+      expect(errorDialog).not.toBeInTheDocument();
+    });
+
+    it('logout page', () => {
+      const { container } = render(<App />, { route: ROUTE_LOGOUT });
+      const loginPage = queryById(container, 'loginPage');
+      expect(loginPage).not.toBeInTheDocument();
+      const errorDialog = queryById(document.body, 'errorDialog');
+      expect(errorDialog).not.toBeInTheDocument();
+    });
+
+    it('login error', () => {
+      const { container } = render(<App />, { route: ROUTE_LOGIN_ERROR });
+      const loginPage = queryById(container, 'loginPage');
+      expect(loginPage).not.toBeInTheDocument();
+      const errorDialog = getById(document.body, 'errorDialog');
+      expect(errorDialog).toBeInTheDocument();
+    });
   });
 });

--- a/packages/pn-personafisica-login/src/navigation/routes.const.ts
+++ b/packages/pn-personafisica-login/src/navigation/routes.const.ts
@@ -2,9 +2,6 @@ export const ROUTE_LOGOUT = '/logout';
 export const ROUTE_LOGIN = '/login';
 export const ROUTE_LOGIN_ERROR = '/login/error';
 export const ROUTE_SUCCESS = '/login/success';
-export const ROUTE_ONE_IDENTITY_LOGIN = '/login-oi';
 export const ROUTE_ONE_IDENTITY_CALLBACK = '/callback';
-export const ROUTE_ONE_IDENTITY_LOGIN_ERROR = '/login-oi/error';
-export const ROUTE_ONE_IDENTITY_LOGOUT = '/logout-oi';
 
 export const oneIdentityRedirectUriPath = '/auth/callback';

--- a/packages/pn-personafisica-login/src/navigation/routes.tsx
+++ b/packages/pn-personafisica-login/src/navigation/routes.tsx
@@ -14,30 +14,29 @@ import {
   ROUTE_LOGIN_ERROR,
   ROUTE_LOGOUT,
   ROUTE_ONE_IDENTITY_CALLBACK,
-  ROUTE_ONE_IDENTITY_LOGIN,
-  ROUTE_ONE_IDENTITY_LOGIN_ERROR,
-  ROUTE_ONE_IDENTITY_LOGOUT,
   ROUTE_SUCCESS,
 } from './routes.const';
-
-const onLoginRequest = () => <Login />;
 
 const Router: React.FC = () => {
   const { ONE_IDENTITY_LOGIN_ENABLED } = getConfiguration();
 
   return (
     <Routes>
-      <Route path={ROUTE_LOGIN} element={onLoginRequest()} />
-      <Route path={ROUTE_LOGIN_ERROR} element={<LoginError />} />
-      <Route path={ROUTE_LOGOUT} element={<Logout />} />
+      <Route
+        path={ROUTE_LOGIN}
+        element={ONE_IDENTITY_LOGIN_ENABLED ? <OneIdentityLogin /> : <Login />}
+      />
+      <Route
+        path={ROUTE_LOGIN_ERROR}
+        element={ONE_IDENTITY_LOGIN_ENABLED ? <OneIdentityLoginError /> : <LoginError />}
+      />
+      <Route
+        path={ROUTE_LOGOUT}
+        element={ONE_IDENTITY_LOGIN_ENABLED ? <OneIdentityLogout /> : <Logout />}
+      />
       <Route path={ROUTE_SUCCESS} element={<SuccessPage />} />
       {ONE_IDENTITY_LOGIN_ENABLED && (
-        <>
-          <Route path={ROUTE_ONE_IDENTITY_LOGIN} element={<OneIdentityLogin />} />
-          <Route path={ROUTE_ONE_IDENTITY_CALLBACK} element={<OneIdentityCallback />} />
-          <Route path={ROUTE_ONE_IDENTITY_LOGIN_ERROR} element={<OneIdentityLoginError />} />
-          <Route path={ROUTE_ONE_IDENTITY_LOGOUT} element={<OneIdentityLogout />} />
-        </>
+        <Route path={ROUTE_ONE_IDENTITY_CALLBACK} element={<OneIdentityCallback />} />
       )}
       <Route path="*" element={<Navigate to={ROUTE_LOGIN} replace />} />
     </Routes>

--- a/packages/pn-personafisica-login/src/pages/oneIdentityCallback/OneIdentityCallback.tsx
+++ b/packages/pn-personafisica-login/src/pages/oneIdentityCallback/OneIdentityCallback.tsx
@@ -4,7 +4,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { getLangCode, sanitizeString } from '@pagopa-pn/pn-commons';
 
-import { ROUTE_ONE_IDENTITY_LOGIN_ERROR } from '../../navigation/routes.const';
+import { ROUTE_LOGIN_ERROR } from '../../navigation/routes.const';
 import { getConfiguration } from '../../services/configuration.service';
 
 const OneIdentityCallback: React.FC = () => {
@@ -31,10 +31,7 @@ const OneIdentityCallback: React.FC = () => {
     if (errorDescription) {
       params.set('error_description', errorDescription);
     }
-    navigate(
-      { pathname: ROUTE_ONE_IDENTITY_LOGIN_ERROR, search: params.toString() },
-      { replace: true }
-    );
+    navigate({ pathname: ROUTE_LOGIN_ERROR, search: params.toString() }, { replace: true });
   };
 
   const handleOidcCallback = () => {

--- a/packages/pn-personafisica-login/src/pages/oneIdentityCallback/__test__/OneIdentityCallback.test.tsx
+++ b/packages/pn-personafisica-login/src/pages/oneIdentityCallback/__test__/OneIdentityCallback.test.tsx
@@ -3,7 +3,7 @@ import { vi } from 'vitest';
 import { waitFor } from '@testing-library/react';
 
 import { render } from '../../../__test__/test-utils';
-import { ROUTE_ONE_IDENTITY_LOGIN_ERROR } from '../../../navigation/routes.const';
+import { ROUTE_LOGIN_ERROR } from '../../../navigation/routes.const';
 import { getConfiguration } from '../../../services/configuration.service';
 import OneIdentityCallback from '../OneIdentityCallback';
 
@@ -48,9 +48,7 @@ describe('OneIdentityCallback component', () => {
   it('should navigate to error route when code is missing', async () => {
     const { router } = render(<OneIdentityCallback />, { route: `/?state=${mockState}` });
 
-    await waitFor(() =>
-      expect(router.state.location.pathname).toBe(ROUTE_ONE_IDENTITY_LOGIN_ERROR)
-    );
+    await waitFor(() => expect(router.state.location.pathname).toBe(ROUTE_LOGIN_ERROR));
     expect(router.state.location.search).toBe(`?state=${mockState}`);
     expect(router.state.historyAction).toBe('REPLACE');
     expect(mockLocationReplace).not.toHaveBeenCalled();
@@ -59,9 +57,7 @@ describe('OneIdentityCallback component', () => {
   it('should navigate to error route when state is missing', async () => {
     const { router } = render(<OneIdentityCallback />, { route: `/?code=${mockCode}` });
 
-    await waitFor(() =>
-      expect(router.state.location.pathname).toBe(ROUTE_ONE_IDENTITY_LOGIN_ERROR)
-    );
+    await waitFor(() => expect(router.state.location.pathname).toBe(ROUTE_LOGIN_ERROR));
     expect(router.state.location.search).toBe('');
     expect(router.state.historyAction).toBe('REPLACE');
     expect(mockLocationReplace).not.toHaveBeenCalled();
@@ -72,9 +68,7 @@ describe('OneIdentityCallback component', () => {
       route: '/auth/callback?error=invalid_scope',
     });
 
-    await waitFor(() =>
-      expect(router.state.location.pathname).toBe(ROUTE_ONE_IDENTITY_LOGIN_ERROR)
-    );
+    await waitFor(() => expect(router.state.location.pathname).toBe(ROUTE_LOGIN_ERROR));
     expect(router.state.location.search).toBe('?error=invalid_scope');
     expect(router.state.historyAction).toBe('REPLACE');
     expect(mockLocationReplace).not.toHaveBeenCalled();
@@ -85,9 +79,7 @@ describe('OneIdentityCallback component', () => {
       route: `/auth/callback?error=invalid_scope&code=${mockCode}&state=${mockState}`,
     });
 
-    await waitFor(() =>
-      expect(router.state.location.pathname).toBe(ROUTE_ONE_IDENTITY_LOGIN_ERROR)
-    );
+    await waitFor(() => expect(router.state.location.pathname).toBe(ROUTE_LOGIN_ERROR));
     expect(router.state.location.search).toBe(`?state=${mockState}&error=invalid_scope`);
     expect(router.state.historyAction).toBe('REPLACE');
     expect(mockLocationReplace).not.toHaveBeenCalled();

--- a/packages/pn-personafisica-login/src/pages/oneIdentityLogin/OneIdentityLogin.tsx
+++ b/packages/pn-personafisica-login/src/pages/oneIdentityLogin/OneIdentityLogin.tsx
@@ -17,7 +17,7 @@ import IOSmartAppBanner from '../../components/IoSmartAppBanner';
 import LoginButtons from '../../components/OneIdentity/LoginButtons';
 import { useRapidAccessParam } from '../../hooks/useRapidAccessParam';
 import { PFLoginEventsType } from '../../models/PFLoginEventsType';
-import { ROUTE_ONE_IDENTITY_LOGIN_ERROR } from '../../navigation/routes.const';
+import { ROUTE_LOGIN_ERROR } from '../../navigation/routes.const';
 import { getConfiguration } from '../../services/configuration.service';
 import PFLoginEventStrategyFactory from '../../utility/MixpanelUtils/PFLoginEventStrategyFactory';
 
@@ -90,7 +90,7 @@ const OneIdentityLogin: React.FC = () => {
         window.location.assign(location);
       })
       .catch(() => {
-        navigate(ROUTE_ONE_IDENTITY_LOGIN_ERROR);
+        navigate(ROUTE_LOGIN_ERROR);
       })
       .finally(() => {
         handleCloseIdpSelect();

--- a/packages/pn-personafisica-login/src/pages/oneIdentityLogin/__test__/OneIdentityLogin.test.tsx
+++ b/packages/pn-personafisica-login/src/pages/oneIdentityLogin/__test__/OneIdentityLogin.test.tsx
@@ -12,7 +12,7 @@ import {
 import { IDPS_MOCK } from '../../../__mocks__/IDPS.mock';
 import { render } from '../../../__test__/test-utils';
 import { OneIdentityApi } from '../../../api/OneIdentity/OneIdentity.api';
-import { ROUTE_ONE_IDENTITY_LOGIN_ERROR } from '../../../navigation/routes.const';
+import { ROUTE_LOGIN_ERROR } from '../../../navigation/routes.const';
 import { storageRapidAccessOps } from '../../../utility/storage';
 import OneIdentityLogin from '../OneIdentityLogin';
 
@@ -109,9 +109,7 @@ describe('OneIdentityLogin component', () => {
       vi.mocked(OneIdentityApi.authorize).mockRejectedValue(new Error('Auth failed'));
       const { container, router } = render(<OneIdentityLogin />);
       fireEvent.click(getById(container, 'cieButton'));
-      await waitFor(() =>
-        expect(router.state.location.pathname).toBe(ROUTE_ONE_IDENTITY_LOGIN_ERROR)
-      );
+      await waitFor(() => expect(router.state.location.pathname).toBe(ROUTE_LOGIN_ERROR));
     });
 
     it('passes aar to authorize when AAR param is in the URL', async () => {

--- a/packages/pn-personafisica-login/src/pages/oneIdentityLoginError/OneIdentityLoginError.tsx
+++ b/packages/pn-personafisica-login/src/pages/oneIdentityLoginError/OneIdentityLoginError.tsx
@@ -6,7 +6,7 @@ import { Box, Button, Dialog, Typography } from '@mui/material';
 import { IllusError } from '@pagopa/mui-italia';
 
 import { PFLoginEventsType } from '../../models/PFLoginEventsType';
-import { ROUTE_ONE_IDENTITY_LOGIN } from '../../navigation/routes.const';
+import { ROUTE_LOGIN } from '../../navigation/routes.const';
 import PFLoginEventStrategyFactory from '../../utility/MixpanelUtils/PFLoginEventStrategyFactory';
 
 const KNOWN_ERROR_CODES = [
@@ -23,7 +23,7 @@ const OneIdentityLoginError: React.FC = () => {
   const [searchParams] = useSearchParams();
   const error = searchParams.get('error');
 
-  const goToLogin = () => navigate(ROUTE_ONE_IDENTITY_LOGIN);
+  const goToLogin = () => navigate(ROUTE_LOGIN);
 
   useEffect(() => {
     PFLoginEventStrategyFactory.triggerEvent(PFLoginEventsType.SEND_LOGIN_FAILURE, {

--- a/packages/pn-personafisica-login/src/pages/oneIdentityLoginError/__test__/OneIdentityLoginError.test.tsx
+++ b/packages/pn-personafisica-login/src/pages/oneIdentityLoginError/__test__/OneIdentityLoginError.test.tsx
@@ -2,7 +2,7 @@ import { getById } from '@pagopa-pn/pn-commons/src/test-utils';
 import { waitFor } from '@testing-library/react';
 
 import { fireEvent, render } from '../../../__test__/test-utils';
-import { ROUTE_ONE_IDENTITY_LOGIN } from '../../../navigation/routes.const';
+import { ROUTE_LOGIN } from '../../../navigation/routes.const';
 import OneIdentityLoginError from '../OneIdentityLoginError';
 
 describe('OneIdentityLoginError component', () => {
@@ -16,17 +16,17 @@ describe('OneIdentityLoginError component', () => {
   it('navigates to login on button click', async () => {
     const { router } = render(<OneIdentityLoginError />, { route: '/?error=server_error' });
     fireEvent.click(getById(document.body, 'login-button'));
-    await waitFor(() => expect(router.state.location.pathname).toBe(ROUTE_ONE_IDENTITY_LOGIN));
+    await waitFor(() => expect(router.state.location.pathname).toBe(ROUTE_LOGIN));
     expect(router.state.location.search).toBe('');
   });
 
   it('redirects to login immediately when error is unknown', async () => {
     const { router } = render(<OneIdentityLoginError />, { route: '/?error=unknown_error' });
-    await waitFor(() => expect(router.state.location.pathname).toBe(ROUTE_ONE_IDENTITY_LOGIN));
+    await waitFor(() => expect(router.state.location.pathname).toBe(ROUTE_LOGIN));
   });
 
   it('redirects to login immediately when error param is missing', async () => {
     const { router } = render(<OneIdentityLoginError />);
-    await waitFor(() => expect(router.state.location.pathname).toBe(ROUTE_ONE_IDENTITY_LOGIN));
+    await waitFor(() => expect(router.state.location.pathname).toBe(ROUTE_LOGIN));
   });
 });

--- a/packages/pn-personafisica-login/src/pages/oneIdentityLogout/OneIdentityLogout.tsx
+++ b/packages/pn-personafisica-login/src/pages/oneIdentityLogout/OneIdentityLogout.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
-import { ROUTE_ONE_IDENTITY_LOGIN } from '../../navigation/routes.const';
+import { ROUTE_LOGIN } from '../../navigation/routes.const';
 
 const OneIdentityLogout: React.FC = () => {
   const navigate = useNavigate();
@@ -10,9 +10,7 @@ const OneIdentityLogout: React.FC = () => {
   useEffect(() => {
     const queryString = searchParams.toString();
 
-    const route = queryString
-      ? `${ROUTE_ONE_IDENTITY_LOGIN}?${queryString}`
-      : ROUTE_ONE_IDENTITY_LOGIN;
+    const route = queryString ? `${ROUTE_LOGIN}?${queryString}` : ROUTE_LOGIN;
 
     navigate(route, { replace: true });
   }, []);

--- a/packages/pn-personafisica-login/src/pages/oneIdentityLogout/__test__/OneIdentityLogout.test.tsx
+++ b/packages/pn-personafisica-login/src/pages/oneIdentityLogout/__test__/OneIdentityLogout.test.tsx
@@ -1,24 +1,21 @@
 import { render } from '../../../__test__/test-utils';
-import {
-  ROUTE_ONE_IDENTITY_LOGIN,
-  ROUTE_ONE_IDENTITY_LOGOUT,
-} from '../../../navigation/routes.const';
+import { ROUTE_LOGIN, ROUTE_LOGOUT } from '../../../navigation/routes.const';
 import OneIdentityLogout from '../OneIdentityLogout';
 
 describe('One Identity Logout Page', () => {
   it('should handle one identity logout successfully', () => {
     const { router } = render(<OneIdentityLogout />);
 
-    expect(router.state.location.pathname).toBe(ROUTE_ONE_IDENTITY_LOGIN);
+    expect(router.state.location.pathname).toBe(ROUTE_LOGIN);
     expect(router.state.historyAction).toBe('REPLACE');
   });
 
   it('should handle one identity logout with query params', () => {
     const { router } = render(<OneIdentityLogout />, {
-      route: ROUTE_ONE_IDENTITY_LOGOUT + '?aar=123456',
+      route: ROUTE_LOGOUT + '?aar=123456',
     });
 
-    expect(router.state.location.pathname).toBe(ROUTE_ONE_IDENTITY_LOGIN);
+    expect(router.state.location.pathname).toBe(ROUTE_LOGIN);
     expect(router.state.location.search).toBe('?aar=123456');
     expect(router.state.historyAction).toBe('REPLACE');
   });

--- a/packages/pn-personafisica-webapp/src/App.tsx
+++ b/packages/pn-personafisica-webapp/src/App.tsx
@@ -79,7 +79,7 @@ const App = () => {
   const [openModal, setOpenModal] = useState(false);
   const loggedUser = useAppSelector((state: RootState) => state.userState.user);
   const lastError = useAppSelector((state: RootState) => state.appState.lastError);
-  const { tosConsent, fetchedTos, privacyConsent, fetchedPrivacy, loginProvider } = useAppSelector(
+  const { tosConsent, fetchedTos, privacyConsent, fetchedPrivacy } = useAppSelector(
     (state: RootState) => state.userState
   );
   const { pendingDelegators, delegators, hasNewNotifications } = useAppSelector(
@@ -274,7 +274,7 @@ const App = () => {
     await dispatch(apiLogout(loggedUser.sessionToken));
     dispatch(resetUserState());
     dispatch(resetGeneralState());
-    goToLoginPortal({ loginProvider });
+    goToLoginPortal();
     setOpenModal(false);
   };
 

--- a/packages/pn-personafisica-webapp/src/__test__/App.test.tsx
+++ b/packages/pn-personafisica-webapp/src/__test__/App.test.tsx
@@ -11,8 +11,7 @@ import { userResponse } from '../__mocks__/Auth.mock';
 import { tosPrivacyConsentMock } from '../__mocks__/Consents.mock';
 import { mandatesByDelegate } from '../__mocks__/Delegations.mock';
 import { apiClient, authClient } from '../api/apiClients';
-import { LoginProvider } from '../models/User';
-import { LOGOUT, LOGOUT_OI } from '../navigation/routes.const';
+import { LOGOUT } from '../navigation/routes.const';
 import { RenderResult, act, fireEvent, render, screen, waitFor, within } from './test-utils';
 
 vi.mock('../pages/Notifiche.page', () => ({ default: () => <div>Generic Page</div> }));
@@ -44,7 +43,6 @@ const reduxInitialState = {
       currentVersion: 'mocked-version-1',
     },
     tosPrivacyApiError: false,
-    loginProvider: LoginProvider.SPIDHUB,
   },
 };
 
@@ -148,56 +146,6 @@ describe('App', () => {
       expect(sessionStorage.getItem('user')).toBeNull();
       expect(mockOpenFn).toHaveBeenCalledTimes(1);
       expect(mockOpenFn).toHaveBeenCalledWith(`${LOGOUT}`, '_self');
-      expect(mockAuth.history.post.length).toBe(1);
-    });
-  });
-
-  it('redirect to One Identity login portal on logout', async () => {
-    mock.onGet(/\/bff\/v2\/tos-privacy.*/).reply(200, tosPrivacyConsentMock(true, true));
-    mock.onGet('/bff/v1/downtime/status').reply(200, currentStatusDTO);
-    mock.onGet('/bff/v1/mandate/delegate').reply(200, mandatesByDelegate);
-    mockAuth.onPost('/logout').reply(200);
-
-    await act(async () => {
-      result = render(<Component />, {
-        preloadedState: {
-          ...reduxInitialState,
-          userState: {
-            ...reduxInitialState.userState,
-            loginProvider: LoginProvider.ONEIDENTITY,
-          },
-        },
-      });
-    });
-
-    const header = document.querySelector('header');
-    const userButton = header?.querySelector(
-      `[aria-label="Area utente ${userResponse.name} ${userResponse.family_name}"]`
-    );
-    fireEvent.click(userButton!);
-
-    let menu = await waitFor(() => screen.getByRole('presentation'));
-    let menuItems = within(menu).getAllByRole('menuitem');
-    fireEvent.click(menuItems[0]);
-
-    await waitFor(() => {
-      expect(result.container).toHaveTextContent('Profile Page');
-    });
-
-    fireEvent.click(userButton!);
-    menu = await waitFor(() => screen.getByRole('presentation'));
-    menuItems = within(menu).getAllByRole('menuitem');
-    fireEvent.click(menuItems[1]);
-
-    const logoutDialog = await waitFor(() => screen.getByTestId('dialog'));
-    expect(logoutDialog).toBeInTheDocument();
-    const confirmLogoutButton = within(logoutDialog).getByTestId('confirm-button');
-    fireEvent.click(confirmLogoutButton);
-
-    await waitFor(() => {
-      expect(sessionStorage.getItem('user')).toBeNull();
-      expect(mockOpenFn).toHaveBeenCalledTimes(1);
-      expect(mockOpenFn).toHaveBeenCalledWith(`${LOGOUT_OI}`, '_self');
       expect(mockAuth.history.post.length).toBe(1);
     });
   });

--- a/packages/pn-personafisica-webapp/src/__test__/mixpanel/App.mixpanel.test.tsx
+++ b/packages/pn-personafisica-webapp/src/__test__/mixpanel/App.mixpanel.test.tsx
@@ -12,7 +12,6 @@ import { tosPrivacyConsentMock } from '../../__mocks__/Consents.mock';
 import { mandatesByDelegate } from '../../__mocks__/Delegations.mock';
 import { apiClient, authClient } from '../../api/apiClients';
 import { PFEventsType } from '../../models/PFEventsType';
-import { LoginProvider } from '../../models/User';
 import PFEventStrategyFactory from '../../utility/MixpanelUtils/PFEventStrategyFactory';
 import { PFTriggerEventSpy, act, fireEvent, render, screen, waitFor, within } from '../test-utils';
 
@@ -35,7 +34,6 @@ const reduxInitialState = {
     tosConsent: { accepted: false, isFirstAccept: false, currentVersion: 'mocked-version-1' },
     privacyConsent: { accepted: false, isFirstAccept: false, currentVersion: 'mocked-version-1' },
     tosPrivacyApiError: false,
-    loginProvider: LoginProvider.SPIDHUB,
   },
 };
 

--- a/packages/pn-personafisica-webapp/src/models/User.ts
+++ b/packages/pn-personafisica-webapp/src/models/User.ts
@@ -59,9 +59,3 @@ export const paramsToSourceType: Record<AppRouteParams, 'TPP' | 'QR'> = {
   [AppRouteParams.AAR]: 'QR',
   [AppRouteParams.RETRIEVAL_ID]: 'TPP',
 };
-
-export enum LoginProvider {
-  SPIDHUB = 'SPIDHUB',
-  FIMS = 'FIMS',
-  ONEIDENTITY = 'ONEIDENTITY',
-}

--- a/packages/pn-personafisica-webapp/src/navigation/SessionGuard.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/SessionGuard.tsx
@@ -33,7 +33,7 @@ const SessionGuard = () => {
   const location = useLocation();
   const dispatch = useAppDispatch();
   const rapidAccess = useRapidAccessParam();
-  const { loading, loginProvider } = useAppSelector((state: RootState) => state.userState);
+  const { loading } = useAppSelector((state: RootState) => state.userState);
   const { sessionToken, exp } = useAppSelector((state: RootState) => state.userState.user);
   const navigate = useNavigate();
   const { WORK_IN_PROGRESS, INACTIVITY_HANDLER_MINUTES } = getConfiguration();
@@ -155,7 +155,7 @@ const SessionGuard = () => {
 
     dispatch(resetUserState());
     dispatch(resetGeneralState());
-    goToLoginPortal({ loginProvider, search: location.search });
+    goToLoginPortal({ search: location.search });
   };
 
   useEffect(() => {
@@ -176,7 +176,6 @@ const SessionGuard = () => {
     } else {
       goToLoginPortal({
         rapidAccess,
-        loginProvider,
         search: aarSearchWithUtm ?? location.search,
       });
     }

--- a/packages/pn-personafisica-webapp/src/navigation/ToSGuard.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/ToSGuard.tsx
@@ -12,14 +12,8 @@ import { goToLoginPortal } from './navigation.utility';
 
 const ToSGuard = () => {
   const dispatch = useAppDispatch();
-  const {
-    tosConsent,
-    privacyConsent,
-    fetchedTos,
-    fetchedPrivacy,
-    tosPrivacyApiError,
-    loginProvider,
-  } = useAppSelector((state: RootState) => state.userState);
+  const { tosConsent, privacyConsent, fetchedTos, fetchedPrivacy, tosPrivacyApiError } =
+    useAppSelector((state: RootState) => state.userState);
   const { sessionToken } = useAppSelector((state: RootState) => state.userState.user);
   const { t } = useTranslation(['common']);
 
@@ -37,7 +31,7 @@ const ToSGuard = () => {
           open={tosPrivacyApiError}
           title={t('error-when-fetching-tos-status.title')}
           message={t('error-when-fetching-tos-status.message')}
-          handleClose={() => goToLoginPortal({ loginProvider })}
+          handleClose={() => goToLoginPortal()}
           initTimeout
         />
       </>

--- a/packages/pn-personafisica-webapp/src/navigation/__test__/SessionGuard.test.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/__test__/SessionGuard.test.tsx
@@ -233,7 +233,7 @@ describe('SessionGuard Component', () => {
     });
   });
 
-  // expected behavior: enters the app, exp token -> logout message, redirects to LOGOUT (not OI)
+  // expected behavior: enters the app, exp token -> logout message, redirects to LOGOUT
   it('logout', async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
 
@@ -384,7 +384,7 @@ describe('SessionGuard Component', () => {
     expect(mock.history.post).toHaveLength(0);
   });
 
-  it('One Identity Exchange Token - logout redirects to LOGOUT_OI', async () => {
+  it('One Identity Exchange Token - logout redirects to LOGOUT', async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
 
     const exp = sub(new Date(), { minutes: 5 }).getTime() / 1000;
@@ -404,7 +404,7 @@ describe('SessionGuard Component', () => {
     await act(async () => {
       await vi.advanceTimersByTimeAsync(2500);
     });
-    expect(mockOpenFn).toHaveBeenCalledWith(routes.LOGOUT_OI, '_self');
+    expect(mockOpenFn).toHaveBeenCalledWith(routes.LOGOUT, '_self');
     vi.useRealTimers();
   });
 

--- a/packages/pn-personafisica-webapp/src/navigation/__test__/navigation.utility.test.ts
+++ b/packages/pn-personafisica-webapp/src/navigation/__test__/navigation.utility.test.ts
@@ -2,7 +2,6 @@ import { vi } from 'vitest';
 
 import { AppRouteParams, EventPageType } from '@pagopa-pn/pn-commons';
 
-import { LoginProvider } from '../../models/User';
 import { UTM_KEY } from '../../utility/utm.utility';
 import { getCurrentEventTypePage, goToLoginPortal } from '../navigation.utility';
 import {
@@ -10,7 +9,6 @@ import {
   DELEGHE,
   DETTAGLIO_NOTIFICA,
   LOGOUT,
-  LOGOUT_OI,
   NOTIFICHE,
   RECAPITI,
 } from '../routes.const';
@@ -31,22 +29,14 @@ describe('Tests navigation utility methods', () => {
   });
 
   it('goToLoginPortal', () => {
-    goToLoginPortal({ loginProvider: LoginProvider.SPIDHUB });
+    goToLoginPortal();
     expect(mockOpenFn).toHaveBeenCalledTimes(1);
     expect(mockOpenFn).toHaveBeenCalledWith(`${LOGOUT}`, '_self');
-  });
-
-  it('goToLoginPortal - from FIMS', () => {
-    goToLoginPortal({ loginProvider: LoginProvider.FIMS });
-
-    expect(mockOpenFn).toHaveBeenCalledTimes(1);
-    expect(mockOpenFn).toHaveBeenCalledWith(LOGOUT, '_self');
   });
 
   it('goToLoginPortal - aar (preserves only utm_*)', () => {
     goToLoginPortal({
       rapidAccess: [AppRouteParams.AAR, 'fake-aar-token'],
-      loginProvider: LoginProvider.SPIDHUB,
       search: `?${UTM_KEY.SOURCE}=s&${UTM_KEY.MEDIUM}=m&${UTM_KEY.CAMPAIGN}=c&invalid_param=value`,
     });
 
@@ -66,7 +56,6 @@ describe('Tests navigation utility methods', () => {
   it('goToLoginPortal - retrievalId (preserves only utm_*)', () => {
     goToLoginPortal({
       rapidAccess: [AppRouteParams.RETRIEVAL_ID, 'fake-id'],
-      loginProvider: LoginProvider.SPIDHUB,
       search: `?${UTM_KEY.SOURCE}=s&${UTM_KEY.MEDIUM}=m&${UTM_KEY.CAMPAIGN}=c&invalid_param=value`,
     });
 
@@ -86,7 +75,6 @@ describe('Tests navigation utility methods', () => {
   it('goToLoginPortal - aar with malicious code', () => {
     goToLoginPortal({
       rapidAccess: [AppRouteParams.AAR, '<script>malicious code</script>malicious-aar-token'],
-      loginProvider: LoginProvider.SPIDHUB,
     });
 
     expect(mockOpenFn).toHaveBeenCalledTimes(1);
@@ -96,42 +84,6 @@ describe('Tests navigation utility methods', () => {
 
     expect(parsed.pathname).toBe(LOGOUT);
     expect(parsed.searchParams.get(AppRouteParams.AAR)).toBe('malicious-aar-token');
-  });
-
-  it('goToLoginPortal - from One Identity', () => {
-    goToLoginPortal({ loginProvider: LoginProvider.ONEIDENTITY });
-    expect(mockOpenFn).toHaveBeenCalledTimes(1);
-    expect(mockOpenFn).toHaveBeenCalledWith(`${LOGOUT_OI}`, '_self');
-  });
-
-  it('goToLoginPortal - from One Identity with aar', () => {
-    goToLoginPortal({
-      rapidAccess: [AppRouteParams.AAR, 'fake-aar-token'],
-      loginProvider: LoginProvider.ONEIDENTITY,
-    });
-
-    expect(mockOpenFn).toHaveBeenCalledTimes(1);
-
-    const [redirectUrl] = mockOpenFn.mock.calls[0];
-    const parsed = new URL(redirectUrl as string, 'https://test.pagopa.it');
-
-    expect(parsed.pathname).toBe(LOGOUT_OI);
-    expect(parsed.searchParams.get(AppRouteParams.AAR)).toBe('fake-aar-token');
-  });
-
-  it('goToLoginPortal - from One Identity with retrievalId', () => {
-    goToLoginPortal({
-      rapidAccess: [AppRouteParams.RETRIEVAL_ID, 'fake-id'],
-      loginProvider: LoginProvider.ONEIDENTITY,
-    });
-
-    expect(mockOpenFn).toHaveBeenCalledTimes(1);
-
-    const [redirectUrl] = mockOpenFn.mock.calls[0];
-    const parsed = new URL(redirectUrl as string, 'https://test.pagopa.it');
-
-    expect(parsed.pathname).toBe(LOGOUT_OI);
-    expect(parsed.searchParams.get(AppRouteParams.RETRIEVAL_ID)).toBe('fake-id');
   });
 
   it('getCurrentPage - test for notifications list page', () => {

--- a/packages/pn-personafisica-webapp/src/navigation/navigation.utility.ts
+++ b/packages/pn-personafisica-webapp/src/navigation/navigation.utility.ts
@@ -2,32 +2,28 @@ import { matchPath } from 'react-router-dom';
 
 import { AppRouteParams, EventPageType, sanitizeString } from '@pagopa-pn/pn-commons';
 
-import { LoginProvider, OneIdentityUser } from '../models/User';
+import { OneIdentityUser } from '../models/User';
 import {
   APP_STATUS,
   DELEGHE,
   DETTAGLIO_NOTIFICA,
   DETTAGLIO_NOTIFICA_DELEGATO,
   LOGOUT,
-  LOGOUT_OI,
   NOTIFICHE,
   NOTIFICHE_DELEGATO,
   RECAPITI,
 } from './routes.const';
 
 type GoToLoginProps = {
-  loginProvider: LoginProvider;
   rapidAccess?: [AppRouteParams, string];
   search?: string;
 };
 
-export function goToLoginPortal({ rapidAccess, loginProvider, search = '' }: GoToLoginProps) {
-  const logoutPath = loginProvider === LoginProvider.ONEIDENTITY ? `${LOGOUT_OI}` : `${LOGOUT}`;
-
+export function goToLoginPortal({ rapidAccess, search = '' }: GoToLoginProps = {}) {
   // eslint-disable-next-line functional/no-let
-  let urlToRedirect = `${logoutPath}`;
+  let urlToRedirect = `${LOGOUT}`;
   // the startsWith check is to prevent xss attacks
-  if (urlToRedirect.startsWith(logoutPath)) {
+  if (urlToRedirect.startsWith(LOGOUT)) {
     const currentParams = new URLSearchParams(search);
     const filteredParams = new URLSearchParams();
 

--- a/packages/pn-personafisica-webapp/src/navigation/routes.const.ts
+++ b/packages/pn-personafisica-webapp/src/navigation/routes.const.ts
@@ -37,7 +37,6 @@ export const DIGITAL_DOMICILE = `${RECAPITI}/domicilio-digitale`;
 export const DIGITAL_DOMICILE_ACTIVATION = `${DIGITAL_DOMICILE}/attivazione`;
 export const DIGITAL_DOMICILE_MANAGEMENT = `${DIGITAL_DOMICILE}/gestione`;
 export const LOGOUT = '/auth/logout';
-export const LOGOUT_OI = '/auth/logout-oi';
 export const TPP_LANDING = '/nuova-notifica-send';
 export const ONBOARDING = '/onboarding';
 export const ONBOARDING_DIGITAL_DOMICILE = 'domicilio-digitale';

--- a/packages/pn-personafisica-webapp/src/pages/TppLanding.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/TppLanding.page.tsx
@@ -30,7 +30,6 @@ const TppLanding: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { sessionToken } = useAppSelector((state: RootState) => state.userState.user);
-  const { loginProvider } = useAppSelector((state: RootState) => state.userState);
 
   const whatIsSendFaqTitle = t('faq.what-is-send.question');
   const whatAreNotificationsFaqTitle = t('faq.what-are-notifications.question');
@@ -48,7 +47,6 @@ const TppLanding: React.FC = () => {
     } else {
       goToLoginPortal({
         rapidAccess: [AppRouteParams.RETRIEVAL_ID, value],
-        loginProvider,
         search: nextSearch,
       });
     }

--- a/packages/pn-personafisica-webapp/src/redux/auth/__test__/reducers.test.ts
+++ b/packages/pn-personafisica-webapp/src/redux/auth/__test__/reducers.test.ts
@@ -15,7 +15,7 @@ import {
 import { errorMock } from '../../../__mocks__/Errors.mock';
 import { apiClient, authClient } from '../../../api/apiClients';
 import { FIMS_TOKEN_EXCHANGE, ONE_IDENTITY_TOKEN_EXCHANGE } from '../../../api/auth/auth.routes';
-import { LoginProvider, SourceChannel } from '../../../models/User';
+import { SourceChannel } from '../../../models/User';
 import { store } from '../../store';
 import { acceptTosPrivacy, exchangeFimsToken, exchangeOneIdentityCode, getTosPrivacyApproval } from '../actions';
 
@@ -70,7 +70,6 @@ describe('Auth redux state tests', () => {
         consentVersion: '',
       },
       tosPrivacyApiError: false,
-      loginProvider: LoginProvider.SPIDHUB,
       isFreshLogin: false,
     });
   });
@@ -79,7 +78,6 @@ describe('Auth redux state tests', () => {
     const action = await mockLogin();
     expect(action.type).toBe('exchangeToken/fulfilled');
     expect(action.payload).toEqual(userResponse);
-    expect(store.getState().userState.loginProvider).toBe(LoginProvider.SPIDHUB);
   });
 
   it('Should be able to exchange FIMS token', async () => {
@@ -99,7 +97,6 @@ describe('Auth redux state tests', () => {
 
     expect(action.type).toBe('exchangeFimsToken/fulfilled');
     expect(action.payload).toEqual(fimsUserResponse);
-    expect(store.getState().userState.loginProvider).toBe(LoginProvider.FIMS);
   });
 
   it('Should be able to exchange code with One Identity', async () => {
@@ -113,7 +110,6 @@ describe('Auth redux state tests', () => {
 
     expect(action.type).toBe('exchangeOneIdentityCode/fulfilled');
     expect(action.payload).toEqual(oneIdentityUserResponse);
-    expect(store.getState().userState.loginProvider).toBe(LoginProvider.ONEIDENTITY);
   });
 
   it('Should strip idp, aar and retrievalId before saving One Identity user to redux and sessionStorage', async () => {

--- a/packages/pn-personafisica-webapp/src/redux/auth/reducers.ts
+++ b/packages/pn-personafisica-webapp/src/redux/auth/reducers.ts
@@ -3,7 +3,7 @@ import { omit } from 'lodash-es';
 import { ConsentType, basicInitialUserData, basicNoLoggedUserData } from '@pagopa-pn/pn-commons';
 import { createSlice, isAnyOf } from '@reduxjs/toolkit';
 
-import { LoginProvider, User } from '../../models/User';
+import { User } from '../../models/User';
 import { userDataMatcher } from '../../utility/user.utility';
 import {
   acceptTosPrivacy,
@@ -29,7 +29,6 @@ type AuthInitialState = {
     consentVersion: string;
   };
   tosPrivacyApiError: boolean;
-  loginProvider: LoginProvider;
   // isFreshLogin is used to track if the user has just logged in, to show the onboarding only on the first login after authentication
   isFreshLogin: boolean;
 };
@@ -65,7 +64,6 @@ const initialState: AuthInitialState = {
     consentVersion: '',
   },
   tosPrivacyApiError: false,
-  loginProvider: LoginProvider.SPIDHUB,
   isFreshLogin: false,
 };
 
@@ -119,16 +117,8 @@ const userSlice = createSlice({
     builder
       .addMatcher(
         isAnyOf(exchangeToken.pending, exchangeFimsToken.pending, exchangeOneIdentityCode.pending),
-        (state, action) => {
+        (state) => {
           state.loading = true;
-
-          if (action.type === exchangeToken.pending.type) {
-            state.loginProvider = LoginProvider.SPIDHUB;
-          } else if (action.type === exchangeOneIdentityCode.pending.type) {
-            state.loginProvider = LoginProvider.ONEIDENTITY;
-          } else if (action.type === exchangeFimsToken.pending.type) {
-            state.loginProvider = LoginProvider.FIMS;
-          }
         }
       )
       .addMatcher(


### PR DESCRIPTION
## Short description
Dismisses the provisional `/login-oi` route and serves the OneIdentity (OI) login flow from
the institutional `/login` route.

`ONE_IDENTITY_LOGIN_ENABLED` no longer enables a parallel set of routes: it now switches
between the two providers on the same route. When `true`, `/login` serves the OneIdentity
flow; when `false`, it keeps serving the SPID Hub one.

The OI redirect URI (`/auth/callback`) is unchanged, and there are no changes to the BE
contract (`authorize`, token exchange) or to the Mixpanel events.

## List of changes proposed in this pull request

**pn-personafisica-login**
- Removed the routes `/login-oi`, `/login-oi/error` and `/logout-oi`.
- `/login`, `/login/error` and `/logout` now resolve to the OneIdentity or the SPID Hub
  component depending on `ONE_IDENTITY_LOGIN_ENABLED`. `/callback` is unchanged.
- The OneIdentity pages navigate to `ROUTE_LOGIN` / `ROUTE_LOGIN_ERROR` instead of the
  removed OI-specific constants.
- `App.test.tsx` now covers both branches of the feature flag.
- The two logout components are intentionally left separate: `Logout` clears
  `storageRapidAccessOps`, `OneIdentityLogout` only forwards the query string.

**pn-personafisica-webapp**
- Removed the `LOGOUT_OI = '/auth/logout-oi'` route: `goToLoginPortal` always redirects to
  `/auth/logout`.
- Dropped the `loginProvider` parameter from `GoToLoginProps` and the branch that picked the
  logout path. Sanitization and `utm_*` / rapid-access param forwarding are unchanged.
- Removed `loginProvider` from the auth slice (state field, initial state and the assignments
  in the `pending` matcher) and the now-unused `LoginProvider` enum: the state was only ever
  read to feed `goToLoginPortal`.
- Removed the tests covering the per-provider branch that no longer exists and that would
  have become exact duplicates of the SPID Hub ones.

## How to test
- `pn-personafisica-login`: 120/120 tests passing.
- `pn-personafisica-webapp`: 1104/1104 tests passing (3 skipped, as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
