### PR TITLE
fix(PN-20859): fix notification list loading flow and empty states

### DIFF
--- a/packages/pn-personafisica-webapp/public/locales/de/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/de/notifiche.json
@@ -43,7 +43,7 @@
     "filtered": "Keine Benachrichtigungen oder Mitteilungen für die ausgewählten Filter",
     "filtered-description": "Entferne sie oder versuche es mit einer anderen Kombination.",
     "clean-filters-cta": "Filter entfernen",
-    "delegate": "Hier siehst du die rechtlichen Mitteilungen von {{name}}",
+    "delegate": "Hier siehst du die rechtsgültigen Zustellungen von {{name}}",
     "title": "Hier siehst du deine rechtlichen Benachrichtigungen und andere Mitteilungen",
     "description-onboarding": "Wusstest du, dass du Geld sparen kannst, wenn du dich dafür entscheidest, rechtliche Mitteilungen nur digital zu erhalten?",
     "description": "Aktualisiere jetzt deine Kontaktdaten, damit du sofort erfährst, wenn du eine erhältst.",

--- a/packages/pn-personafisica-webapp/public/locales/en/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/en/notifiche.json
@@ -43,7 +43,7 @@
     "filtered": "No notifications or communications for the selected filters",
     "filtered-description": "Remove them or try another combination.",
     "clean-filters-cta": "Remove filters",
-    "delegate": "Here you will see the legally binding communications of {{name}}",
+    "delegate": "Here you will see the legally binding notifications of {{name}}",
     "title": "Here you will see your legally binding notifications and other communications",
     "description-onboarding": "Did you know you can save money by choosing to receive legally binding communications only digitally?",
     "description": "Update your contact details now and you will immediately know when you receive one.",

--- a/packages/pn-personafisica-webapp/public/locales/fr/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/fr/notifiche.json
@@ -43,7 +43,7 @@
     "filtered": "No notifications or communications for the selected filters",
     "filtered-description": "Remove them or try another combination.",
     "clean-filters-cta": "Remove filters",
-    "delegate": "Here you will see the legally binding communications of {{name}}",
+    "delegate": "Ici, tu verras les notifications à valeur juridique de {{name}}",
     "title": "Here you will see your legally binding notifications and other communications",
     "description-onboarding": "Saviez-vous que vous pouvez économiser en choisissant de recevoir les communications à valeur juridique uniquement au format numérique ?",
     "description": "Mettez à jour vos coordonnées dès maintenant et vous saurez immédiatement quand vous en recevrez une.",

--- a/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
@@ -42,7 +42,7 @@
     "filtered": "Nessuna notifica o comunicazione per i filtri selezionati",
     "filtered-description": "Rimuovili o prova con un’altra combinazione.",
     "clean-filters-cta": "Rimuovi filtri",
-    "delegate": "Qui vedrai le comunicazioni a valore legale di {{name}}",
+    "delegate": "Qui vedrai le notifiche a valore legale di {{name}}",
     "title": "Qui vedrai le tue notifiche a valore legale e le altre comunicazioni",
     "description-onboarding": "Sapevi che puoi risparmiare se scegli di ricevere le comunicazioni a valore legale solo in digitale?",
     "description": "Aggiorna ora i tuoi recapiti e saprai subito quando ne riceverai una.",

--- a/packages/pn-personafisica-webapp/public/locales/sl/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/sl/notifiche.json
@@ -43,7 +43,7 @@
     "filtered": "Ni obvestil ali sporočil za izbrane filtre",
     "filtered-description": "Odstranite jih ali poskusite z drugo kombinacijo.",
     "clean-filters-cta": "Odstranite filtre",
-    "delegate": "Tukaj boste videli uradna sporočila od {{name}}",
+    "delegate": "Tukaj boš videl/a pravno veljavna obvestila osebe {{name}}",
     "title": "Tukaj boste videli svoja uradna obvestila in druga sporočila",
     "description-onboarding": "Ali ste vedeli, da lahko prihranite, če se odločite za prejemanje uradnih sporočil le v digitalni obliki?",
     "description": "Posodobite svoje kontaktne podatke zdaj in takoj boste obveščeni, ko prejmete novo.",

--- a/packages/pn-personafisica-webapp/src/components/Notifications/DesktopNotifications.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Notifications/DesktopNotifications.tsx
@@ -77,7 +77,7 @@ const DesktopNotifications = ({
     id: n.iun,
   }));
 
-  const filtersApplied: boolean = filterNotificationsRef.current.filtersApplied;
+  const filtersApplied: boolean = filterNotificationsRef.current?.filtersApplied ?? false;
 
   const showFilters = notifications?.length > 0 || filtersApplied;
 

--- a/packages/pn-personafisica-webapp/src/components/Notifications/MobileNotifications.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Notifications/MobileNotifications.tsx
@@ -104,7 +104,7 @@ const MobileNotifications = ({ notifications, sort, onChangeSorting, currentDele
     return arr;
   }, [] as Array<CardSort<RecipientNotification>>);
 
-  const filtersApplied: boolean = filterNotificationsRef.current.filtersApplied;
+  const filtersApplied: boolean = filterNotificationsRef.current?.filtersApplied ?? false;
 
   // Navigation handlers
   const handleRowClick = (row: Row<RecipientNotification>) => {

--- a/packages/pn-personafisica-webapp/src/pages/Notifiche.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/Notifiche.page.tsx
@@ -131,25 +131,23 @@ const Notifiche = () => {
   };
 
   useEffect(() => {
-    if (filters.mandateId !== currentDelegator?.mandateId) {
-      dispatch(setMandateId(currentDelegator?.mandateId));
+    if (filters.mandateId !== mandateId) {
+      setPageReady(false);
+      dispatch(setMandateId(mandateId));
       return;
     }
     if (isFirstSearch) {
       dispatch(setFirstSearch(false));
-      setPageReady(true);
-      PFEventStrategyFactory.triggerEvent(
-        currentDelegator
-          ? PFEventsType.SEND_NOTIFICATION_DELEGATED
-          : PFEventsType.SEND_YOUR_NOTIFICATIONS,
-        {
+      if (!mandateId) {
+        setPageReady(true);
+        PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_YOUR_NOTIFICATIONS, {
           notifications,
           delegators,
           pagination,
           domicileBannerType: domicileBannerTypeRef.current,
-        }
-      );
-      return;
+        });
+        return;
+      }
     }
     fetchNotifications();
   }, [fetchNotifications, currentDelegator]);
@@ -176,52 +174,54 @@ const Notifiche = () => {
 
   return (
     <LoadingPageWrapper isInitialized={pageReady}>
-      <Box p={3}>
-        <TitleBox variantTitle="h4" title={getPageTitle()} mbTitle={isMobile ? 3 : 0} />
-        {!mandateId && <DomicileBanner source={ContactSource.HOME_NOTIFICHE} my={3} />}
-        <ApiErrorWrapper
-          apiId={DASHBOARD_ACTIONS.GET_RECEIVED_NOTIFICATIONS}
-          reloadAction={fetchNotifications}
-        >
-          {isMobile ? (
-            <MobileNotifications
-              notifications={notifications}
-              sort={sort}
-              onChangeSorting={handleChangeSorting}
-              currentDelegator={currentDelegator}
-            />
-          ) : (
-            <DesktopNotifications
-              notifications={notifications}
-              sort={sort}
-              onChangeSorting={handleChangeSorting}
-              currentDelegator={currentDelegator}
-            />
-          )}
-          {notifications.length > 0 && (
-            <CustomPagination
-              paginationData={{
-                size: pagination.size,
-                page: pagination.page,
-                totalElements,
-              }}
-              onPageRequest={handleChangePage}
-              pagesToShow={pagesToShow}
-              sx={
-                isMobile
-                  ? {
-                      padding: '0',
-                      '& .items-per-page-selector button': {
-                        paddingLeft: 0,
-                        height: '24px',
-                      },
-                    }
-                  : { padding: '0' }
-              }
-            />
-          )}
-        </ApiErrorWrapper>
-      </Box>
+      {pageReady && !loading && (
+        <Box p={3}>
+          <TitleBox variantTitle="h4" title={getPageTitle()} mbTitle={isMobile ? 3 : 0} />
+          {!mandateId && <DomicileBanner source={ContactSource.HOME_NOTIFICHE} my={3} />}
+          <ApiErrorWrapper
+            apiId={DASHBOARD_ACTIONS.GET_RECEIVED_NOTIFICATIONS}
+            reloadAction={fetchNotifications}
+          >
+            {isMobile ? (
+              <MobileNotifications
+                notifications={notifications}
+                sort={sort}
+                onChangeSorting={handleChangeSorting}
+                currentDelegator={currentDelegator}
+              />
+            ) : (
+              <DesktopNotifications
+                notifications={notifications}
+                sort={sort}
+                onChangeSorting={handleChangeSorting}
+                currentDelegator={currentDelegator}
+              />
+            )}
+            {notifications.length > 0 && (
+              <CustomPagination
+                paginationData={{
+                  size: pagination.size,
+                  page: pagination.page,
+                  totalElements,
+                }}
+                onPageRequest={handleChangePage}
+                pagesToShow={pagesToShow}
+                sx={
+                  isMobile
+                    ? {
+                        padding: '0',
+                        '& .items-per-page-selector button': {
+                          paddingLeft: 0,
+                          height: '24px',
+                        },
+                      }
+                    : { padding: '0' }
+                }
+              />
+            )}
+          </ApiErrorWrapper>
+        </Box>
+      )}
     </LoadingPageWrapper>
   );
 };

--- a/packages/pn-personagiuridica-webapp/public/locales/de/notifiche.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/de/notifiche.json
@@ -45,7 +45,7 @@
     "filtered": "Keine Benachrichtigungen oder Mitteilungen für die ausgewählten Filter",
     "filtered-description": "Entferne sie oder versuche es mit einer anderen Kombination.",
     "clean-filters-cta": "Filter entfernen",
-    "delegate": "Hier siehst du die rechtsgültigen Mitteilungen, die an dein Unternehmen delegiert wurden.",
+    "delegate": "Hier siehst du die rechtsgültigen Zustellungen, die an dein Unternehmen übertragen wurden.",
     "title": "Hier siehst du die rechtsgültigen Zustellungen und andere Mitteilungen",
     "description": "Aktualisiere jetzt die digitalen Kontaktdaten, damit du sofort erfährst, wenn dein Unternehmen eine erhält.",
     "go-to-contacts-cta": "Zu den Kontaktdaten",

--- a/packages/pn-personagiuridica-webapp/public/locales/en/notifiche.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/en/notifiche.json
@@ -45,7 +45,7 @@
     "filtered": "No notifications or communications for the selected filters",
     "filtered-description": "Remove them or try another combination.",
     "clean-filters-cta": "Remove filters",
-    "delegate": "Here you will see the legally-binding communications that have been delegated to your business.",
+    "delegate": "Here you will see the legally binding notifications that have been delegated to your company.",
     "title": "Here you will see legally-binding notifications and other communications",
     "description": "Update your digital contact details now to immediately know when your business receives one.",
     "go-to-contacts-cta": "Go to contact details",

--- a/packages/pn-personagiuridica-webapp/public/locales/fr/notifiche.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/fr/notifiche.json
@@ -45,7 +45,7 @@
     "filtered": "Aucune notification ou communication pour les filtres sélectionnés",
     "filtered-description": "Supprimez-les ou essayez une autre combinaison.",
     "clean-filters-cta": "Supprimer les filtres",
-    "delegate": "Ici, vous verrez les communications à valeur juridique qui ont été déléguées à votre entreprise.",
+    "delegate": "Ici, tu verras les notifications à valeur juridique qui ont été déléguées à ton entreprise.",
     "title": "Ici, vous verrez les notifications à valeur juridique et les autres communications",
     "description": "Mettez à jour vos coordonnées numériques dès maintenant pour savoir immédiatement quand votre entreprise en recevra une.",
     "go-to-contacts-cta": "Aller aux coordonnées",

--- a/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
@@ -45,7 +45,7 @@
     "filtered": "Nessuna notifica o comunicazione per i filtri selezionati",
     "filtered-description": "Rimuovili o prova con un’altra combinazione.",
     "clean-filters-cta": "Rimuovi filtri",
-    "delegate": "Qui vedrai le comunicazioni a valore legale che sono state delegate alla tua impresa.",
+    "delegate": "Qui vedrai le notifiche a valore legale che sono state delegate alla tua impresa.",
     "title": "Qui vedrai le notifiche a valore legale e le altre comunicazioni",
     "description": "Aggiorna ora i recapiti digitali per sapere subito quando la tua impresa ne riceverà una.",
     "go-to-contacts-cta": "Vai ai recapiti",

--- a/packages/pn-personagiuridica-webapp/public/locales/sl/notifiche.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/sl/notifiche.json
@@ -45,7 +45,7 @@
     "filtered": "Za izbrane filtre ni obvestil ali sporočil",
     "filtered-description": "Odstranite jih ali poskusite z drugo kombinacijo.",
     "clean-filters-cta": "Odstrani filtre",
-    "delegate": "Tukaj boste videli uradna sporočila, ki so bila pooblaščena za vaše podjetje.",
+    "delegate": "Tukaj boš videl/a pravno veljavna obvestila, ki so bila dodeljena tvojemu podjetju.",
     "title": "Tukaj boste videli uradna obvestila in druga sporočila",
     "description": "Posodobite digitalne kontaktne podatke zdaj in takoj boste izvedeli, ko bo vaše podjetje prejelo novo.",
     "go-to-contacts-cta": "Pojdite na kontaktne podatke",


### PR DESCRIPTION
## Short description
Align the notification list loading flow and empty states by fixing the
delegated refresh flow, preventing transient empty states during loading and
updating the empty state copy.

Refs: PN-20829, PN-20859

## List of changes proposed in this pull request
- update the empty state copy from "comunicazioni" to "notifiche" in both PF and PG
- prevent the page from crashing after refreshing a delegated notification list and switching to personal notifications
- prevent delegated notification lists from remaining empty after a direct refresh by avoiding the reuse of the personal notifications prefetch
- prevent transient empty states while switching between personal and delegated notification lists

## How to test
To reproduce the original issues, use the `TEST` environment (or the `develop` branch in `DEV`) with a user with notifications that has at least one delegator with notifications as well.

### 1. Incorrect empty state in the delegated notification list
- open the "Your inbox" notification list
- switch to the "Inbox for <DELEGATOR>" notification list
- verify that the latter one contains notifications
- perform a hard refresh of the page
- BUG: the list is not loaded and the empty state is incorrectly displayed

### 2. Crash returning to the "Your inbox" notification list
- starting from the previous scenario (after hard refresh), switch back to the "Your inbox" list
- BUG: the application crashes and the error boundary is displayed instead of the notification list

### 3. UI flickering while switching between notification lists (PN-20859)
- switch repeatedly between the "Your inbox" and "Inbox for <DELEGATOR>" notification lists
- BUG: the empty state is briefly displayed while the notification list is loading

### Verify the fix
Switch to the fix branch and verify that all three issues described above have been resolved.

Finally, verify also that, on both PF and PG, the delegated list empty state copy was properly updated as descibed by PN-20829