### PR TITLE
fix(PN-20950): show F24 section when there are only payments of this type

### DIFF
--- a/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentRecipient.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentRecipient.tsx
@@ -311,7 +311,7 @@ const NotificationPaymentRecipient: React.FC<Props> = ({
         </>
       )}
 
-      {!isCancelled && f24Only.length > 0 && (
+      {!isCancelled && f24Only.length > 0 && pagoPaF24.length > 0 && (
         <Divider
           component="div"
           role="presentation"
@@ -321,7 +321,7 @@ const NotificationPaymentRecipient: React.FC<Props> = ({
         </Divider>
       )}
 
-      {!isCancelled && f24Only.length > 0 && pagoPaF24.length > 0 && (
+      {!isCancelled && f24Only.length > 0 && (
         <>
           {f24Only.length > 0 && pagoPaF24.length > 0 && (
             <Typography variant="overline" component="h3">

--- a/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentRecipient.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentRecipient.tsx
@@ -323,7 +323,7 @@ const NotificationPaymentRecipient: React.FC<Props> = ({
 
       {!isCancelled && f24Only.length > 0 && (
         <>
-          {f24Only.length > 0 && pagoPaF24.length > 0 && (
+          {pagoPaF24.length > 0 && (
             <Typography variant="overline" component="h3">
               {getLocalizedOrDefaultLabel('notifications', 'detail.payment.f24Models')}
             </Typography>


### PR DESCRIPTION
## Short description
When a notification has only f24 payments, the section is not shown. This pr fixes this bug.

## List of changes proposed in this pull request
- Changed the condition in NotificationPaymentRecipient

## How to test
Login with PF, user franco -> check that for notification with pagoPA payments, notification with pagoPA + F24 payments and notification with F24 payments, the section is correctly shown