### PR TITLE
fix(PN-20939): show onboarding when the unread notifications are only those in EFFECTIVE_DATE

### DIFF
--- a/packages/pn-personafisica-webapp/src/navigation/OnboardingGuard.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/OnboardingGuard.tsx
@@ -17,7 +17,7 @@ import * as routes from './routes.const';
 
 const hasNotificationsToRead = (notifications: Array<RecipientNotification>): boolean =>
   notifications.some(
-    (n) => n.isNewNotification || n.notificationStatus === NotificationStatus.EFFECTIVE_DATE
+    (n) => n.isNewNotification || n.notificationStatus !== NotificationStatus.EFFECTIVE_DATE
   );
 
 const OnboardingGuard: React.FC = () => {

--- a/packages/pn-personafisica-webapp/src/navigation/OnboardingGuard.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/OnboardingGuard.tsx
@@ -17,7 +17,7 @@ import * as routes from './routes.const';
 
 const hasNotificationsToRead = (notifications: Array<RecipientNotification>): boolean =>
   notifications.some(
-    (n) => n.isNewNotification || n.notificationStatus !== NotificationStatus.EFFECTIVE_DATE
+    (n) => n.isNewNotification && n.notificationStatus !== NotificationStatus.EFFECTIVE_DATE
   );
 
 const OnboardingGuard: React.FC = () => {

--- a/packages/pn-personafisica-webapp/src/navigation/SessionGuard.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/SessionGuard.tsx
@@ -17,8 +17,17 @@ import {
 
 import { useRapidAccessParam } from '../hooks/useRapidAccessParam';
 import { PFEventsType } from '../models/PFEventsType';
-import { FimsTokenExchangeRequest, OneIdentityExchangeCodeBody, TokenExchangeRequest } from '../models/User';
-import { apiLogout, exchangeFimsToken, exchangeOneIdentityCode, exchangeToken } from '../redux/auth/actions';
+import {
+  FimsTokenExchangeRequest,
+  OneIdentityExchangeCodeBody,
+  TokenExchangeRequest,
+} from '../models/User';
+import {
+  apiLogout,
+  exchangeFimsToken,
+  exchangeOneIdentityCode,
+  exchangeToken,
+} from '../redux/auth/actions';
 import { resetState as resetUserState, setIsFreshLogin } from '../redux/auth/reducers';
 import { useAppDispatch, useAppSelector } from '../redux/hooks';
 import { resetState as resetGeneralState } from '../redux/sidemenu/reducers';
@@ -114,6 +123,7 @@ const SessionGuard = () => {
     AppResponsePublisher.error.subscribe('exchangeTokenOneIdentity', manageUnforbiddenError);
     try {
       const response = await dispatch(exchangeOneIdentityCode(exchangeCodeParams)).unwrap();
+      dispatch(setIsFreshLogin(true));
       sessionCheck(response.exp);
 
       PFEventStrategyFactory.triggerEvent(PFEventsType.SEND_LOGIN_METHOD, {

--- a/packages/pn-personafisica-webapp/src/navigation/__test__/OnboardingGuard.test.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/__test__/OnboardingGuard.test.tsx
@@ -156,7 +156,7 @@ describe('OnboardingGuard', () => {
     expect(result.router.state.location.pathname).toBe('/');
   });
 
-  it('does not redirect when user has EFFECTIVE_DATE notifications', async () => {
+  it('redirects to onboarding when user has EFFECTIVE_DATE notifications', async () => {
     const unreadNotificationsResponse = {
       ...emptyNotificationsFromBe,
       resultsPage: [
@@ -177,9 +177,8 @@ describe('OnboardingGuard', () => {
     });
 
     await waitFor(() => {
-      expect(screen.queryByText('Onboarding Page')).toBeInTheDocument();
+      expect(result.router.state.location.pathname).toBe(routes.ONBOARDING);
     });
-    expect(result.router.state.location.pathname).toBe('/');
   });
 
   it('does not redirect when IS_ONBOARDING_ENABLED is false', async () => {


### PR DESCRIPTION
## Short description
If we have an user that have notifications to read, but those notifications are in status EFFECTIVE_DATE, the Onboarding must be shown.

## List of changes proposed in this pull request
- Changed the condition in OnboardingGuard, so notifications in status EFFECTIVE_DATE doesn't affect the Onboarding
- Added isFreshLogin check when login with OI

## How to test
Login with PA -> simulate with netify a call to the notification list where the notifications to read (isNewNotification = true) are only those in status EFFECTIVE_DATE