### PR TITLE
fix(PN-21037): add link to informal notification and update cancelled content

### DIFF
--- a/packages/pn-commons/src/components/NotificationDetail/AbstractPaper.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/AbstractPaper.tsx
@@ -31,7 +31,7 @@ interface AbstractPaperProps {
   abstract?: string; // todo: to sanitize and format the abstract content before passing it to the component
   isLegal?: boolean;
   filedAt: string;
-  senderLogoUrl?: string;
+  selfcareCdnUrl?: string;
   details?: Array<AbstractPaperDetail>;
   onDetailsClick?: () => void;
   detailsAriaLabel?: string;
@@ -43,13 +43,13 @@ interface AbstractPaperProps {
 interface InstitutionLogoProps {
   id?: string;
   name?: string;
-  senderLogoUrl?: string;
+  selfcareCdnUrl?: string;
 }
 
-const InstitutionLogo = ({ id, name, senderLogoUrl }: InstitutionLogoProps) => {
+const InstitutionLogo = ({ id, name, selfcareCdnUrl }: InstitutionLogoProps) => {
   const [hasError, setHasError] = useState(false);
   const logoSrc =
-    id && !hasError && senderLogoUrl ? `${senderLogoUrl}/institutions/${id}/logo.png` : undefined;
+    id && !hasError && selfcareCdnUrl ? `${selfcareCdnUrl}/institutions/${id}/logo.png` : undefined;
 
   return (
     <Avatar
@@ -80,7 +80,7 @@ const AbstractPaper = ({
   abstract,
   isLegal = true,
   filedAt,
-  senderLogoUrl,
+  selfcareCdnUrl,
   details,
   onDetailsClick,
   detailsAriaLabel,
@@ -259,7 +259,7 @@ const AbstractPaper = ({
               <InstitutionLogo
                 id={senderPaId}
                 name={senderDenomination}
-                senderLogoUrl={senderLogoUrl}
+                selfcareCdnUrl={selfcareCdnUrl}
               />
               <Box>
                 <Typography variant="sidenav" color="text">

--- a/packages/pn-personafisica-webapp/public/locales/de/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/de/notifiche.json
@@ -99,7 +99,7 @@
     "disclaimer-link": "Mehr hierzu",
     "pec-unreachable": "Halten Sie Ihr zertifiziertes E-Mail-Postfach (PEC) frei und aktiv, um alles digital zu erhalten!",
     "cancelled": {
-      "message": "Diese Zustellung wurde von der sendenden Körperschaft storniert.",
+      "message": "Diese Zustellung wurde von der Absenderbehörde annulliert, daher sind die Dokumente nicht mehr verfügbar.",
       "cta": "Was muss ich tun?"
     },
     "payment": {

--- a/packages/pn-personafisica-webapp/public/locales/en/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/en/notifiche.json
@@ -99,7 +99,7 @@
     "disclaimer-link": "Discover more",
     "pec-unreachable": "Keep your certified email (PEC) mailbox free and active to receive everything digitally!",
     "cancelled": {
-      "message": "This notification has been cancelled by the issuing institution.",
+      "message": "This notification was cancelled by the sending authority, so the documents are no longer available.",
       "cta": "What should I do?"
     },
     "payment": {

--- a/packages/pn-personafisica-webapp/public/locales/fr/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/fr/notifiche.json
@@ -99,7 +99,7 @@
     "disclaimer-link": "En savoir plus",
     "pec-unreachable": "Maintenez votre adresse PEC libre et active pour tout recevoir au format numérique !",
     "cancelled": {
-      "message": "Cette notification a été annulée par l'organisme émetteur.",
+      "message": "Cette notification a été annulée par l'organisme expéditeur, les documents ne sont donc plus disponibles.",
       "cta": "Que dois-je faire ?"
     },
     "payment": {

--- a/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
@@ -98,7 +98,7 @@
     "disclaimer-link": "Scopri di più",
     "pec-unreachable": "Mantieni la PEC libera e attiva per ricevere tutto in digitale!",
     "cancelled": {
-      "message": "Questa notifica è stata annullata dall’ente mittente.",
+      "message": "Questa notifica è stata annullata dall’ente mittente per cui i documenti non sono più disponibili.",
       "cta": "Cosa devo fare?"
     },
     "payment": {

--- a/packages/pn-personafisica-webapp/public/locales/sl/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/sl/notifiche.json
@@ -99,7 +99,7 @@
     "disclaimer-link": "Izvedite več",
     "pec-unreachable": "Vaš predal PEC naj bo prost in aktiven, da boste vse prejemali v digitalni obliki!",
     "cancelled": {
-      "message": "To obvestilo je preklical organ pošiljatelj.",
+      "message": "To obvestilo je preklical organ pošiljatelj, zato dokumenti niso več na voljo.",
       "cta": "Kaj moram storiti?"
     },
     "payment": {

--- a/packages/pn-personafisica-webapp/src/pages/InformalNotificationDetail.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/InformalNotificationDetail.page.tsx
@@ -32,6 +32,9 @@ import {
   getReceivedInformalNotificationPayment,
   getReceivedInformalNotificationPaymentInfo,
 } from '../redux/notification/informalActions';
+import { getConfiguration } from '../services/configuration.service';
+
+const { SELFCARE_CDN_URL } = getConfiguration();
 
 const InformalNotificationDetail: React.FC = () => {
   const { id } = useParams();
@@ -252,6 +255,7 @@ const InformalNotificationDetail: React.FC = () => {
             recipientDenomination={currentRecipient?.denomination}
             hasAttachments={documentsAvailable}
             hasPayment={hasPayments}
+            selfcareCdnUrl={SELFCARE_CDN_URL}
           />
 
           <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems="flex-start">

--- a/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/NotificationDetail.page.tsx
@@ -597,7 +597,7 @@ const NotificationDetail: React.FC = () => {
                     filedAt={notification.sentAt}
                     iun={notification.iun}
                     abstract={notification.abstract}
-                    senderLogoUrl={SELFCARE_CDN_URL}
+                    selfcareCdnUrl={SELFCARE_CDN_URL}
                   />
                   {banner}
                   {pecUnreachableAlert}

--- a/packages/pn-personagiuridica-webapp/public/locales/de/notifiche.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/de/notifiche.json
@@ -94,7 +94,7 @@
     "disclaimer-link": "Mehr erfahren",
     "pec-unreachable": "Halten Sie Ihr zertifiziertes E-Mail-Postfach (PEC) frei und aktiv, um alles digital zu erhalten!",
     "cancelled": {
-      "message": "Diese Zustellung wurde von der sendenden Körperschaft storniert.",
+      "message": "Diese Zustellung wurde von der Absenderbehörde annulliert, daher sind die Dokumente nicht mehr verfügbar.",
       "cta": "Was muss ich tun?"
     },
     "payment": {

--- a/packages/pn-personagiuridica-webapp/public/locales/en/notifiche.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/en/notifiche.json
@@ -94,7 +94,7 @@
     "disclaimer-link": "Learn more",
     "pec-unreachable": "Keep your certified email (PEC) mailbox free and active to receive everything digitally!",
     "cancelled": {
-      "message": "This notification has been cancelled by the issuing institution.",
+      "message": "This notification was cancelled by the sending authority, so the documents are no longer available.",
       "cta": "What should I do?"
     },
     "payment": {

--- a/packages/pn-personagiuridica-webapp/public/locales/fr/notifiche.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/fr/notifiche.json
@@ -94,7 +94,7 @@
     "disclaimer-link": "En savoir plus",
     "pec-unreachable": "Maintenez votre adresse PEC libre et active pour tout recevoir au format numérique !",
     "cancelled": {
-      "message": "Cette notification a été annulée par l'organisme émetteur.",
+      "message": "Cette notification a été annulée par l'organisme expéditeur, les documents ne sont donc plus disponibles.",
       "cta": "Que dois-je faire ?"
     },
     "payment": {

--- a/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
@@ -94,7 +94,7 @@
     "disclaimer-link": "Scopri di più",
     "pec-unreachable": "Mantieni la PEC libera e attiva per ricevere tutto in digitale!",
     "cancelled": {
-      "message": "Questa notifica è stata annullata dall’ente mittente.",
+      "message": "Questa notifica è stata annullata dall’ente mittente per cui i documenti non sono più disponibili.",
       "cta": "Cosa devo fare?"
     },
     "payment": {

--- a/packages/pn-personagiuridica-webapp/public/locales/sl/notifiche.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/sl/notifiche.json
@@ -94,7 +94,7 @@
     "disclaimer-link": "Izvedite več",
     "pec-unreachable": "Vaš predal PEC naj bo prost in aktiven, da boste vse prejemali v digitalni obliki!",
     "cancelled": {
-      "message": "To obvestilo je preklical organ pošiljatelj.",
+      "message": "To obvestilo je preklical organ pošiljatelj, zato dokumenti niso več na voljo.",
       "cta": "Kaj moram storiti?"
     },
     "payment": {

--- a/packages/pn-personagiuridica-webapp/src/pages/InformalNotificationDetail.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/InformalNotificationDetail.page.tsx
@@ -34,8 +34,6 @@ import {
 } from '../redux/notification/informalActions';
 import { getConfiguration } from '../services/configuration.service';
 
-const { SELFCARE_CDN_URL } = getConfiguration();
-
 const InformalNotificationDetail: React.FC = () => {
   const { id } = useParams();
   const { t, i18n } = useTranslation(['common', 'notifiche']);
@@ -43,6 +41,7 @@ const InformalNotificationDetail: React.FC = () => {
   const [pageReady, setPageReady] = useState(false);
   const { hasApiErrors } = useErrors();
   const navigate = useNavigate();
+  const { SELFCARE_CDN_URL } = getConfiguration();
 
   const [informalNotification, setInformalNotification] =
     React.useState<BffFullInformalNotificationV1>();

--- a/packages/pn-personagiuridica-webapp/src/pages/InformalNotificationDetail.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/InformalNotificationDetail.page.tsx
@@ -32,6 +32,9 @@ import {
   getReceivedInformalNotificationPayment,
   getReceivedInformalNotificationPaymentInfo,
 } from '../redux/notification/informalActions';
+import { getConfiguration } from '../services/configuration.service';
+
+const { SELFCARE_CDN_URL } = getConfiguration();
 
 const InformalNotificationDetail: React.FC = () => {
   const { id } = useParams();
@@ -251,6 +254,7 @@ const InformalNotificationDetail: React.FC = () => {
             recipientDenomination={currentRecipient?.denomination}
             hasAttachments={documentsAvailable}
             hasPayment={hasPayments}
+            selfcareCdnUrl={SELFCARE_CDN_URL}
           />
 
           <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems="flex-start">

--- a/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/NotificationDetail.page.tsx
@@ -508,7 +508,7 @@ const NotificationDetail = () => {
                   filedAt={notification.filedAt}
                   iun={notification.iun}
                   abstract={notification.abstract}
-                  senderLogoUrl={SELFCARE_CDN_URL}
+                  selfcareCdnUrl={SELFCARE_CDN_URL}
                 />
                 {banner}
                 {pecUnreachableAlert}


### PR DESCRIPTION
## Short description
add link to informal notification and update cancelled content

## List of changes proposed in this pull request
- Add selfcare link to informalNotification PG and PF (https://pagopa.atlassian.net/browse/PN-21037)
- Update cancelled content alert (https://pagopa.atlassian.net/browse/PN-21028)

## How to test
- Login as PF and PG and check that logo is present for PA that have logo
- Login as PF and PG and check cancelled alert has content as in [Figma](https://www.figma.com/design/ZFpWJMFvzFpAmCLG66nREW/Comunicazioni-Bonarie?node-id=3032-31082&t=ubuaioV5jINQK0OV-4)