### PR TITLE
fix(PN-21019): redirects to the notifications list when clicking the breadcrumb on the timeline page

### DIFF
--- a/packages/pn-personagiuridica-webapp/src/navigation/routes.const.ts
+++ b/packages/pn-personagiuridica-webapp/src/navigation/routes.const.ts
@@ -30,7 +30,6 @@ export const GET_DETTAGLIO_COMUNICAZIONE_PATH = (id: string) =>
 export const GET_DETTAGLIO_NOTIFICA_DELEGATO_PATH = (id: string, mandateId: string) =>
   `${NOTIFICHE_DELEGATO}/${mandateId}/${id}${DETTAGLIO}`;
 export const RECAPITI = '/recapiti';
-export const GET_NOTIFICHE_DELEGATO_PATH = (mandateId: string) => `${NOTIFICHE}/${mandateId}`;
 export const GET_DETTAGLIO_NOTIFICA_TIMELINE_PATH = (id: string) =>
   `${NOTIFICHE}/${id}${DETTAGLIO}/timeline`;
 export const GET_DETTAGLIO_NOTIFICA_DELEGATO_TIMELINE_PATH = (id: string, mandateId: string) =>

--- a/packages/pn-personagiuridica-webapp/src/pages/NotificationTimeline.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/NotificationTimeline.page.tsx
@@ -145,7 +145,7 @@ const NotificationTimeline: React.FC = () => {
 
     return (
       <PnBreadcrumb
-        linkRoute={mandateId ? routes.GET_NOTIFICHE_DELEGATO_PATH(mandateId) : routes.NOTIFICHE}
+        linkRoute={mandateId ? routes.NOTIFICHE_DELEGATO : routes.NOTIFICHE}
         linkLabel={t('menu.notifiche')}
         currentLocationLabel={notification.subject ?? ''}
         goBackAction={() => navigate(backRoute)}


### PR DESCRIPTION
## Short description
Clicking the "In arrivo" on the timeline page, redirected to the notification detail instead of the notifications list. Now it has been fixed.

## List of changes proposed in this pull request
- Changed breadcrumb behaviour in NotificationTimeline.page

## How to test
Login with PG -> go to delegated notifications -> go to notification detail and then to timeline page -> click on "In arrivo" and check that you are redirected to the delegated notifications list page