### PR TITLE
feat(PN-20886): implemented data lake maintenance alert

### DIFF
--- a/packages/pn-commons/package.json
+++ b/packages/pn-commons/package.json
@@ -72,7 +72,7 @@
     "eslint-plugin-sonarjs": "^0.10.0",
     "jsdom": "^29.0.0",
     "prettier": "^2.8.8",
-    "sonarqube-scanner": "^3.3.0",
+    "sonarqube-scanner": "^4.3.8",
     "vite": "^5.1.4",
     "vitest": "^1.6.1",
     "vitest-sonar-reporter": "^2.0.0"

--- a/packages/pn-commons/sonarqube-scanner.cjs
+++ b/packages/pn-commons/sonarqube-scanner.cjs
@@ -1,4 +1,4 @@
-const scanner = require('sonarqube-scanner');
+const scanner = require('sonarqube-scanner').default;
 
 const options = {
   'sonar.organization': 'pagopa',
@@ -20,5 +20,11 @@ scanner(
     token: process.env.SONAR_TOKEN,
     options,
   },
-  () => process.exit()
+  (error) => {
+    if (error) {
+      console.error(error);
+      process.exit(1);
+    }
+    process.exit();
+  }
 );

--- a/packages/pn-commons/src/utility/__test__/date.utility.test.ts
+++ b/packages/pn-commons/src/utility/__test__/date.utility.test.ts
@@ -290,9 +290,26 @@ describe('Date utility', () => {
     futureDateDays.setDate(now.getDate() + 7);
 
     const futureDateMonth = new Date(now);
-    futureDateMonth.setDate(now.getMonth() + 1);
+    futureDateMonth.setMonth(now.getMonth() + 1);
 
     const result = isDateInRange(now, futureDateDays.toISOString(), futureDateMonth.toISOString());
+    expect(result).toBeFalsy();
+  });
+
+  it('isDateInRange - returns true when date is not in range (no time specified)', () => {
+    const now = new Date();
+
+    const futureDateDays = new Date(now);
+    futureDateDays.setDate(now.getDate() + 7);
+
+    const futureDateMonth = new Date(now);
+    futureDateMonth.setMonth(now.getMonth() + 1);
+
+    const result = isDateInRange(
+      now,
+      formatToSlicedISOString(futureDateDays),
+      formatToSlicedISOString(futureDateMonth)
+    );
     expect(result).toBeFalsy();
   });
 });

--- a/packages/pn-commons/src/utility/__test__/date.utility.test.ts
+++ b/packages/pn-commons/src/utility/__test__/date.utility.test.ts
@@ -18,6 +18,7 @@ import {
   getEndOfDay,
   getStartOfDay,
   getWeeksFromDateRange,
+  isDateInRange,
   isToday,
   minutesBeforeNow,
   subtractMonthsFromDate,
@@ -267,5 +268,31 @@ describe('Date utility', () => {
 
     const result = clampMax(dateBefore, max);
     expect(result).toBe(dateBefore);
+  });
+
+  it('isDateInRange - returns true when date is in range', () => {
+    const now = new Date();
+
+    const futureDateDays = new Date(now);
+    futureDateDays.setDate(now.getDate() + 7);
+
+    const pastDateDays = new Date(now);
+    pastDateDays.setDate(now.getDate() - 5);
+
+    const result = isDateInRange(now, pastDateDays.toISOString(), futureDateDays.toISOString());
+    expect(result).toBeTruthy();
+  });
+
+  it('isDateInRange - returns false when date is not in range', () => {
+    const now = new Date();
+
+    const futureDateDays = new Date(now);
+    futureDateDays.setDate(now.getDate() + 7);
+
+    const futureDateMonth = new Date(now);
+    futureDateMonth.setDate(now.getMonth() + 1);
+
+    const result = isDateInRange(now, futureDateDays.toISOString(), futureDateMonth.toISOString());
+    expect(result).toBeFalsy();
   });
 });

--- a/packages/pn-commons/src/utility/date.utility.ts
+++ b/packages/pn-commons/src/utility/date.utility.ts
@@ -244,3 +244,33 @@ export function subtractMonthsFromDate(
 export function clampMax(date: Date, max: Date): Date {
   return date.getTime() > max.getTime() ? max : date;
 }
+
+/**
+ * Checks if the date is within a date range
+ *
+ * @param {Date} date current date
+ * @param {string} startDate start date in format YYYY-MM-DD
+ * @param {string} endDate end date in format YYYY-MM-DD
+ * @returns {boolean} True if the date is in the date range, false otherwise
+ */
+export const isDateInRange = (date: Date, startDate: string, endDate: string): boolean => {
+  const current = new Date(date);
+
+  // Note: Month is 0-based in JavaScript Date constructor (August = 7)
+  // const startDate = new Date(2026, 7, 14, 0, 0, 0);
+  // const endDate = new Date(2026, 7, 25, 23, 59, 59);
+  const start = new Date(startDate);
+  // If startDate does NOT contain 'T', set it to the beginning of the day (00:00:00.000)
+  if (!startDate.includes('T')) {
+    start.setHours(0, 0, 0, 0);
+  }
+
+  // at the end of the day
+  const end = new Date(endDate);
+  // If endDate does NOT contain 'T', set it to the end of the day (23:59:59.999)
+  if (!endDate.includes('T')) {
+    end.setHours(23, 59, 59, 999);
+  }
+
+  return current >= start && current <= end;
+};

--- a/packages/pn-commons/src/utility/date.utility.ts
+++ b/packages/pn-commons/src/utility/date.utility.ts
@@ -1,4 +1,4 @@
-import { add, addDays, compareAsc } from 'date-fns';
+import { add, addDays, compareAsc, parseISO } from 'date-fns';
 
 import DateFnsAdapter from '@date-io/date-fns';
 
@@ -256,21 +256,11 @@ export function clampMax(date: Date, max: Date): Date {
 export const isDateInRange = (date: Date, startDate: string, endDate: string): boolean => {
   const current = new Date(date);
 
-  // Note: Month is 0-based in JavaScript Date constructor (August = 7)
-  // const startDate = new Date(2026, 7, 14, 0, 0, 0);
-  // const endDate = new Date(2026, 7, 25, 23, 59, 59);
-  const start = new Date(startDate);
   // If startDate does NOT contain 'T', set it to the beginning of the day (00:00:00.000)
-  if (!startDate.includes('T')) {
-    start.setHours(0, 0, 0, 0);
-  }
+  const start = startDate.includes('T') ? parseISO(startDate) : getStartOfDay(parseISO(startDate));
 
-  // at the end of the day
-  const end = new Date(endDate);
   // If endDate does NOT contain 'T', set it to the end of the day (23:59:59.999)
-  if (!endDate.includes('T')) {
-    end.setHours(23, 59, 59, 999);
-  }
+  const end = endDate.includes('T') ? parseISO(endDate) : getEndOfDay(parseISO(endDate));
 
   return current >= start && current <= end;
 };

--- a/packages/pn-commons/src/utility/index.ts
+++ b/packages/pn-commons/src/utility/index.ts
@@ -1,27 +1,20 @@
 export { Configuration } from '../services/configuration.service';
-export { default as EventStrategyFactory } from './MixpanelUtils/EventStrategyFactory';
-export {
-  koError,
-  superProperty,
-  uxAction,
-  uxConfirm,
-  uxScreenView,
-} from './MixpanelUtils/CommonTrackingEvents';
-export type { TrackingProperties } from './MixpanelUtils/CommonTrackingEvents';
 export { default as AppError } from './AppError/AppError';
 export { default as AppErrorFactory } from './AppError/AppErrorFactory';
 export { default as errorFactoryManager } from './AppError/ErrorFactoryManager';
 export { default as UnknownAppError } from './AppError/UnknownAppError';
-export { default as AppResponsePublisher } from './AppResponse/AppResponsePublisher';
-export { ResponseEventDispatcher } from './AppResponse/AppResponsePublisher';
-export * as screenshot from './Screenshot';
+export {
+  default as AppResponsePublisher,
+  ResponseEventDispatcher,
+} from './AppResponse/AppResponsePublisher';
 export { validateCurrentStatus, validateHistory, validateLegaFact } from './appStatus.utility';
 export { appStorage } from './appStorage.utility';
-export { PRIVACY_LINK_RELATIVE_PATH, TOS_LINK_RELATIVE_PATH, LANGUAGES } from './costants';
+export { LANGUAGES, PRIVACY_LINK_RELATIVE_PATH, TOS_LINK_RELATIVE_PATH } from './costants';
 export { formatCurrency, formatEurocentToCurrency } from './currency.utility';
 export {
-  DATE_FORMAT,
+  clampMax,
   convertHoursToDays,
+  DATE_FORMAT,
   dateIsDefined,
   dateIsLessThan10Years,
   formatDate,
@@ -34,35 +27,44 @@ export {
   formatToTimezoneString,
   getDateFromString,
   getDaysFromDateRange,
+  getElapsedTime,
   getEndOfDay,
   getStartOfDay,
   getWeeksFromDateRange,
+  isDateInRange,
   isToday,
   minutesBeforeNow,
   oneMonthAgo,
   oneYearAgo,
   sixMonthsAgo,
+  subtractMonthsFromDate,
   tenYearsAgo,
   threeMonthsAgo,
   today,
   twelveMonthsAgo,
-  subtractMonthsFromDate,
-  clampMax,
-  getElapsedTime,
 } from './date.utility';
 export { waitForElement } from './dom.utility';
 export { APP_VERSION, IS_DEVELOP } from './environment.utility';
 export { calcUnit8Array } from './file.utility';
 export { filtersApplied, getValidValue, sortArray } from './genericFunctions.utility';
-export { IUN_regex, formatIun } from './iun.utility';
+export { formatIun, IUN_regex } from './iun.utility';
 export { lazyRetry } from './lazyRetry.utility';
 export { initLocalization } from './localization.utility';
 export {
+  koError,
+  superProperty,
+  uxAction,
+  uxConfirm,
+  uxScreenView,
+} from './MixpanelUtils/CommonTrackingEvents';
+export type { TrackingProperties } from './MixpanelUtils/CommonTrackingEvents';
+export { default as EventStrategyFactory } from './MixpanelUtils/EventStrategyFactory';
+export {
   getLangCode,
   getSessionLanguage,
+  getValidLanguage,
   hashDetectorLookup,
   setSessionLanguage,
-  getValidLanguage,
 } from './multilanguage.utility';
 export { addParamToUrl } from './navigation.utility';
 export {
@@ -74,18 +76,20 @@ export {
   getPagoPaF24Payments,
   populatePaymentsPagoPaF24,
 } from './notification.utility';
-export * from './StatusHistory';
 export { compileOneTrustPath, rewriteLinks } from './onetrust.utility';
 export { calculatePages } from './pagination.utility';
 export {
-  PAYMENT_CACHE_KEY,
   checkIfPaymentsIsAlreadyInCache,
   getPaymentCache,
+  PAYMENT_CACHE_KEY,
   setPaymentCache,
   setPaymentsInCache,
 } from './paymentCaching.utility';
 export { parseError } from './redux.utility';
 export { AppRouteParams, compileRoute, getRapidAccessParam } from './routes.utility';
+export * as screenshot from './Screenshot';
+export { searchStringLimitReachedText, useSearchStringChangeInput } from './searchString.utility';
+export * from './StatusHistory';
 export { storageOpsBuilder } from './storage.utility';
 export { dataRegex, formatFiscalCode, fromStringToBase64, sanitizeString } from './string.utility';
 export { extractRootTraceId } from './support.utility';
@@ -95,4 +99,3 @@ export {
   basicUserDataMatcherContents,
   removeNullProperties,
 } from './user.utility';
-export { searchStringLimitReachedText, useSearchStringChangeInput } from './searchString.utility';

--- a/packages/pn-data-viz/sonarqube-scanner.js
+++ b/packages/pn-data-viz/sonarqube-scanner.js
@@ -1,4 +1,4 @@
-const scanner = require('sonarqube-scanner');
+const scanner = require('sonarqube-scanner').default;
 
 const options = {
   'sonar.organization': 'pagopa',
@@ -20,5 +20,11 @@ scanner(
     token: process.env.SONAR_TOKEN,
     options,
   },
-  () => process.exit()
+  (error) => {
+    if (error) {
+      console.error(error);
+      process.exit(1);
+    }
+    process.exit();
+  }
 );

--- a/packages/pn-pa-webapp/package.json
+++ b/packages/pn-pa-webapp/package.json
@@ -80,7 +80,7 @@
     "eslint-plugin-sonarjs": "^0.10.0",
     "jsdom": "^29.0.0",
     "prettier": "^2.8.8",
-    "sonarqube-scanner": "^3.3.0",
+    "sonarqube-scanner": "^4.3.8",
     "vite": "^5.1.4",
     "vitest": "^1.6.1",
     "vitest-canvas-mock": "^0.3.3",

--- a/packages/pn-pa-webapp/public/conf/config-dev.json
+++ b/packages/pn-pa-webapp/public/conf/config-dev.json
@@ -22,5 +22,6 @@
   "DEVELOPER_API_DOCUMENTATION_LINK": "https://developer.pagopa.it/send/api",
   "PHYSICAL_ADDRESS_LOOKUP": "on",
   "ACCESSIBILITY_LINK": "https://form.agid.gov.it/view/978876c0-df2d-11ef-8637-9f856ac3da10",
-  "SERCQ_SERVICE_STATEMENT_LINK": "https://notifichedigitali.it/assets/MO_006_Service_Practice_Statement_Pago_PA_S_p_A_v_1_6_signed_0d50fefc36.pdf"
+  "SERCQ_SERVICE_STATEMENT_LINK": "https://notifichedigitali.it/assets/MO_006_Service_Practice_Statement_Pago_PA_S_p_A_v_1_6_signed_0d50fefc36.pdf",
+  "DATA_LAKE_MAINTENANCE_DATES": "2026-08-14_2026-08-25"
 }

--- a/packages/pn-pa-webapp/public/conf/config-dev.json
+++ b/packages/pn-pa-webapp/public/conf/config-dev.json
@@ -23,5 +23,5 @@
   "PHYSICAL_ADDRESS_LOOKUP": "on",
   "ACCESSIBILITY_LINK": "https://form.agid.gov.it/view/978876c0-df2d-11ef-8637-9f856ac3da10",
   "SERCQ_SERVICE_STATEMENT_LINK": "https://notifichedigitali.it/assets/MO_006_Service_Practice_Statement_Pago_PA_S_p_A_v_1_6_signed_0d50fefc36.pdf",
-  "DATA_LAKE_MAINTENANCE_DATES": "2026-08-14_2026-08-25"
+  "STATISTICS_MAINTENANCE_DATES": "2026-08-14_2026-08-25"
 }

--- a/packages/pn-pa-webapp/public/locales/de/statistics.json
+++ b/packages/pn-pa-webapp/public/locales/de/statistics.json
@@ -93,6 +93,6 @@
   },
   "maintenance_alert": {
     "title": "Wartungsarbeiten im Gange",
-    "description": "Aufgrund einer geplanten Wartung kann es zu Verzögerungen bei der Aktualisierung der Daten im Dashboard. Bitte beachten Sie das auf dieser Seite angegebene Datum für den Stand der letzten Aktualisierung. Nach Abschluss der Wartung werden die Daten wieder regelmäßig aktualisiert."
+    "description": "Aufgrund einer geplanten Wartung kann es zu Verzögerungen bei der Aktualisierung der Daten im Dashboard kommen. Bitte beachten Sie das auf dieser Seite angegebene Datum für den Stand der letzten Aktualisierung. Nach Abschluss der Wartung werden die Daten wieder regelmäßig aktualisiert."
   }
 }

--- a/packages/pn-pa-webapp/public/locales/de/statistics.json
+++ b/packages/pn-pa-webapp/public/locales/de/statistics.json
@@ -90,5 +90,9 @@
     "no_data_found": "Für das gewählte Zeitintervall stehen keine Daten zur Verfügung",
     "not_enough_data": "Die Anzahl der von der Körperschaft auf SEND geladenen Zustellungen reicht derzeit nicht aus, um die Versandstatistiken zu verarbeiten und anzuzeigen. Erkunde den <0>Abschnitt Zustellungen</0>, um die bisher geladenen einzusehen.",
     "notification_section_aria_label": "Abschnitt Zustellungen"
+  },
+  "maintenance_alert": {
+    "title": "Wartungsarbeiten im Gange",
+    "description": "Aufgrund einer geplanten Wartung kann es zu Verzögerungen bei der Aktualisierung der Daten im Dashboard. Bitte beachten Sie das auf dieser Seite angegebene Datum für den Stand der letzten Aktualisierung. Nach Abschluss der Wartung werden die Daten wieder regelmäßig aktualisiert."
   }
 }

--- a/packages/pn-pa-webapp/public/locales/en/statistics.json
+++ b/packages/pn-pa-webapp/public/locales/en/statistics.json
@@ -90,5 +90,9 @@
     "no_data_found": "No data is available for the selected time period",
     "not_enough_data": "The number of notifications uploaded on SEND by the institution at the moment is not sufficient for processing and displaying sending statistics. Explore the <0>Notifications section</0> to consult those uploaded up until now.",
     "notification_section_aria_label": "Notifications section"
+  },
+  "maintenance_alert": {
+    "title": "Maintenance in progress",
+    "description": "Scheduled maintenance is in progress and may delay data updates on the dashboard. Please refer to the date shown on this page to check the latest update. Regular updates will resume once maintenance is complete."
   }
 }

--- a/packages/pn-pa-webapp/public/locales/fr/statistics.json
+++ b/packages/pn-pa-webapp/public/locales/fr/statistics.json
@@ -90,5 +90,9 @@
     "no_data_found": "Aucune donnée disponible pour l’intervalle de temps sélectionné",
     "not_enough_data": "Le nombre de notifications téléchargées par l’organisme sur SEND n’est pas encore suffisant pour élaborer et  montrer les statistiques d’envoi. Explorez la <0>section Notifications</0> pour consulter celles téléchargées jusqu’à présent.",
     "notification_section_aria_label": "Section notifications"
+  },
+  "maintenance_alert": {
+    "title": "Maintenance en cours",
+    "description": "Une maintenance programmée est en cours. Elle pourrait entraîner des retards dans la mise à jour des données du tableau de bord. Veuillez vous référer à la date indiquée sur cette page pour vérifier la dernière mise à jour disponible. Les mises à jour reprendront normalement à la fin de l'intervention."
   }
 }

--- a/packages/pn-pa-webapp/public/locales/it/statistics.json
+++ b/packages/pn-pa-webapp/public/locales/it/statistics.json
@@ -99,5 +99,9 @@
     "no_data_found": "Non ci sono dati a disposizione per l'intervallo di tempo selezionato",
     "not_enough_data": "Il numero di notifiche caricate dall’ente su SEND al momento non è sufficiente per elaborare e mostrare le statistiche di invio. Esplora la <0>sezione Notifiche</0> per consultare quelle caricate finora.",
     "notification_section_aria_label": "Sezione notifiche"
+  },
+  "maintenance_alert": {
+    "title": "Manutenzione in corso",
+    "description": "È in corso una manutenzione programmata che potrebbe comportare dei ritardi nella disponibilità dei dati su dashboard. Fai riferimento alla data indicata su questa pagina per verificare l'ultimo aggiornamento disponibile. Gli aggiornamenti riprenderanno regolarmente al termine dell'intervento."
   }
 }

--- a/packages/pn-pa-webapp/public/locales/sl/statistics.json
+++ b/packages/pn-pa-webapp/public/locales/sl/statistics.json
@@ -90,5 +90,9 @@
     "no_data_found": "Za izbrano časovno obdobje ni podatkov",
     "not_enough_data": "Število obvestil, ki jih je organizacija naložila na SEND, trenutno ne zadostuje za obdelavo in prikaz statistike pošiljanja. Raziščite <0>razdelek Obvestil</0> in si oglejte do zdaj naložena obvestila.",
     "notification_section_aria_label": "Razdelek obvestil"
+  },
+  "maintenance_alert": {
+    "title": "Vzdrževanje v teku",
+    "description": "Poteka načrtovano vzdrževanje, ki lahko povzroči zamude pri razpoložljivosti podatkov na nadzorni plošči. Za preverjanje zadnje razpoložljive posodobitve glejte datum, naveden na tej strani. Posodobitve se bodo normalno nadaljevale po končanem vzdrževanju."
   }
 }

--- a/packages/pn-pa-webapp/sonarqube-scanner.js
+++ b/packages/pn-pa-webapp/sonarqube-scanner.js
@@ -1,4 +1,4 @@
-const scanner = require('sonarqube-scanner');
+const scanner = require('sonarqube-scanner').default;
 
 const options = {
   'sonar.organization': 'pagopa',
@@ -20,5 +20,11 @@ scanner(
     token: process.env.SONAR_TOKEN,
     options,
   },
-  () => process.exit()
+  (error) => {
+    if (error) {
+      console.error(error);
+      process.exit(1);
+    }
+    process.exit();
+  }
 );

--- a/packages/pn-pa-webapp/src/pages/Statistics.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/Statistics.page.tsx
@@ -73,9 +73,9 @@ const Statistics = () => {
     (state: RootState) => state.userState.user?.organization
   );
   const isSupportUser = useAppSelector(authSelectors.selectIsSupportUser);
-  const dataLakeMaintenanceDates = getConfiguration().DATA_LAKE_MAINTENANCE_DATES;
-  const [dataLakeMaintenanceStartDate, dataLakeMaintenanceEndDate] =
-    dataLakeMaintenanceDates.split('_');
+  const statisticsMaintenanceDates = getConfiguration().STATISTICS_MAINTENANCE_DATES;
+  const [statisticsMaintenanceStartDate, statisticsMaintenanceEndDate] =
+    statisticsMaintenanceDates.split('_');
 
   const cxId = loggedUserOrganizationParty.id;
   const cxType = isSupportUser ? CxType.BS : CxType.PA;
@@ -143,12 +143,16 @@ const Statistics = () => {
             </Typography>
             {isDateInRange(
               new Date(),
-              dataLakeMaintenanceStartDate,
-              dataLakeMaintenanceEndDate
+              statisticsMaintenanceStartDate,
+              statisticsMaintenanceEndDate
             ) && (
-              <MIAlert severity="warning" title={t('maintenance_alert.title')} sx={{ mt: 4 }}>
-                {t('maintenance_alert.description')}
-              </MIAlert>
+              <MIAlert
+                data-testid="maintenanceAlert"
+                severity="warning"
+                title={t('maintenance_alert.title')}
+                sx={{ mt: 4 }}
+                description={t('maintenance_alert.description')}
+              />
             )}
             <Box ref={exportJpgNode}>
               <Typography variant="h6" component="h5" mt={7}>

--- a/packages/pn-pa-webapp/src/pages/Statistics.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/Statistics.page.tsx
@@ -11,10 +11,12 @@ import {
   formatDate,
   formatToSlicedISOString,
   getDateFromString,
+  isDateInRange,
   oneYearAgo,
   screenshot,
   today,
 } from '@pagopa-pn/pn-commons';
+import { MIAlert } from '@pagopa/mui-italia';
 
 import DeliveryModeStatistics from '../components/Statistics/DeliveryModeStatistics';
 import DigitalErrorsDetailStatistics from '../components/Statistics/DigitalErrorsDetailStatistics';
@@ -31,6 +33,7 @@ import { useAppDispatch, useAppSelector } from '../redux/hooks';
 import { STATISTICS_ACTIONS, getStatistics } from '../redux/statistics/actions';
 import { hasData } from '../redux/statistics/reducers';
 import { RootState } from '../redux/store';
+import { getConfiguration } from '../services/configuration.service';
 import PAEventStrategyFactory from '../utility/MixpanelUtils/PAEventStrategyFactory';
 
 const filter = (node: HTMLElement) => {
@@ -70,6 +73,9 @@ const Statistics = () => {
     (state: RootState) => state.userState.user?.organization
   );
   const isSupportUser = useAppSelector(authSelectors.selectIsSupportUser);
+  const dataLakeMaintenanceDates = getConfiguration().DATA_LAKE_MAINTENANCE_DATES;
+  const [dataLakeMaintenanceStartDate, dataLakeMaintenanceEndDate] =
+    dataLakeMaintenanceDates.split('_');
 
   const cxId = loggedUserOrganizationParty.id;
   const cxType = isSupportUser ? CxType.BS : CxType.PA;
@@ -135,6 +141,15 @@ const Statistics = () => {
             <Typography variant="caption" sx={{ color: GraphColors.greyBlue }}>
               {getLastUpdateText()}
             </Typography>
+            {isDateInRange(
+              new Date(),
+              dataLakeMaintenanceStartDate,
+              dataLakeMaintenanceEndDate
+            ) && (
+              <MIAlert severity="warning" title={t('maintenance_alert.title')} sx={{ mt: 4 }}>
+                {t('maintenance_alert.description')}
+              </MIAlert>
+            )}
             <Box ref={exportJpgNode}>
               <Typography variant="h6" component="h5" mt={7}>
                 {t('section_1')}

--- a/packages/pn-pa-webapp/src/pages/Statistics.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/Statistics.page.tsx
@@ -74,8 +74,9 @@ const Statistics = () => {
   );
   const isSupportUser = useAppSelector(authSelectors.selectIsSupportUser);
   const statisticsMaintenanceDates = getConfiguration().STATISTICS_MAINTENANCE_DATES;
-  const [statisticsMaintenanceStartDate, statisticsMaintenanceEndDate] =
-    statisticsMaintenanceDates.split('_');
+  const [statisticsMaintenanceStartDate, statisticsMaintenanceEndDate] = statisticsMaintenanceDates
+    ? statisticsMaintenanceDates.split('_')
+    : [];
 
   const cxId = loggedUserOrganizationParty.id;
   const cxType = isSupportUser ? CxType.BS : CxType.PA;
@@ -141,19 +142,20 @@ const Statistics = () => {
             <Typography variant="caption" sx={{ color: GraphColors.greyBlue }}>
               {getLastUpdateText()}
             </Typography>
-            {isDateInRange(
-              new Date(),
-              statisticsMaintenanceStartDate,
-              statisticsMaintenanceEndDate
-            ) && (
-              <MIAlert
-                data-testid="maintenanceAlert"
-                severity="warning"
-                title={t('maintenance_alert.title')}
-                sx={{ mt: 4 }}
-                description={t('maintenance_alert.description')}
-              />
-            )}
+            {statisticsMaintenanceDates &&
+              isDateInRange(
+                new Date(),
+                statisticsMaintenanceStartDate,
+                statisticsMaintenanceEndDate
+              ) && (
+                <MIAlert
+                  data-testid="maintenanceAlert"
+                  severity="warning"
+                  title={t('maintenance_alert.title')}
+                  sx={{ mt: 4 }}
+                  description={t('maintenance_alert.description')}
+                />
+              )}
             <Box ref={exportJpgNode}>
               <Typography variant="h6" component="h5" mt={7}>
                 {t('section_1')}

--- a/packages/pn-pa-webapp/src/pages/__test__/Statistics.page.test.tsx
+++ b/packages/pn-pa-webapp/src/pages/__test__/Statistics.page.test.tsx
@@ -326,7 +326,7 @@ describe('Statistics Page tests', () => {
     expect(maintenanceAlert).toBeInTheDocument();
     expect(maintenanceAlert).toHaveTextContent('maintenance_alert.title');
     expect(maintenanceAlert).toHaveTextContent('maintenance_alert.description');
-    vi.getRealSystemTime();
+    vi.useRealTimers();
   });
 
   it('api returns error', async () => {

--- a/packages/pn-pa-webapp/src/pages/__test__/Statistics.page.test.tsx
+++ b/packages/pn-pa-webapp/src/pages/__test__/Statistics.page.test.tsx
@@ -26,24 +26,6 @@ const dateFormatter = (date: Date) => {
   return `${day}/${month}/${date.getFullYear()}`;
 };
 
-let statisticsUnderMaintenance = false;
-const now = new Date();
-const futureDateDays = new Date(now);
-futureDateDays.setDate(now.getDate() + 7);
-const pastDateDays = new Date(now);
-pastDateDays.setDate(now.getDate() - 5);
-
-vi.mock('../../services/configuration.service', async () => {
-  return {
-    ...(await vi.importActual<any>('../../services/configuration.service')),
-    getConfiguration: () => ({
-      STATISTICS_MAINTENANCE_DATES: statisticsUnderMaintenance
-        ? `${pastDateDays.toISOString()}_${futureDateDays.toISOString()}`
-        : '2025-08-14_2025-08-25',
-    }),
-  };
-});
-
 describe('Statistics Page tests', () => {
   let mock: MockAdapter;
 
@@ -331,7 +313,7 @@ describe('Statistics Page tests', () => {
   });
 
   it('show maintenance alert', async () => {
-    statisticsUnderMaintenance = true;
+    vi.setSystemTime(new Date('2025-08-20'));
     mock.onGet(/\/bff\/v1\/sender-dashboard\/dashboard-data-request*/).reply(200, rawResponseMock);
 
     const { findByTestId } = render(<Statistics />, {
@@ -344,6 +326,7 @@ describe('Statistics Page tests', () => {
     expect(maintenanceAlert).toBeInTheDocument();
     expect(maintenanceAlert).toHaveTextContent('maintenance_alert.title');
     expect(maintenanceAlert).toHaveTextContent('maintenance_alert.description');
+    vi.getRealSystemTime();
   });
 
   it('api returns error', async () => {

--- a/packages/pn-pa-webapp/src/pages/__test__/Statistics.page.test.tsx
+++ b/packages/pn-pa-webapp/src/pages/__test__/Statistics.page.test.tsx
@@ -26,6 +26,24 @@ const dateFormatter = (date: Date) => {
   return `${day}/${month}/${date.getFullYear()}`;
 };
 
+let statisticsUnderMaintenance = false;
+const now = new Date();
+const futureDateDays = new Date(now);
+futureDateDays.setDate(now.getDate() + 7);
+const pastDateDays = new Date(now);
+pastDateDays.setDate(now.getDate() - 5);
+
+vi.mock('../../services/configuration.service', async () => {
+  return {
+    ...(await vi.importActual<any>('../../services/configuration.service')),
+    getConfiguration: () => ({
+      STATISTICS_MAINTENANCE_DATES: statisticsUnderMaintenance
+        ? `${pastDateDays.toISOString()}_${futureDateDays.toISOString()}`
+        : '2025-08-14_2025-08-25',
+    }),
+  };
+});
+
 describe('Statistics Page tests', () => {
   let mock: MockAdapter;
 
@@ -310,6 +328,22 @@ describe('Statistics Page tests', () => {
           `&endDate=${rawResponseMock.lastDate}`
       );
     });
+  });
+
+  it('show maintenance alert', async () => {
+    statisticsUnderMaintenance = true;
+    mock.onGet(/\/bff\/v1\/sender-dashboard\/dashboard-data-request*/).reply(200, rawResponseMock);
+
+    const { findByTestId } = render(<Statistics />, {
+      preloadedState: {
+        userState: { user: userResponse },
+      },
+    });
+
+    const maintenanceAlert = await findByTestId('maintenanceAlert');
+    expect(maintenanceAlert).toBeInTheDocument();
+    expect(maintenanceAlert).toHaveTextContent('maintenance_alert.title');
+    expect(maintenanceAlert).toHaveTextContent('maintenance_alert.description');
   });
 
   it('api returns error', async () => {

--- a/packages/pn-pa-webapp/src/services/configuration.service.ts
+++ b/packages/pn-pa-webapp/src/services/configuration.service.ts
@@ -28,10 +28,13 @@ export interface PaConfiguration {
   PHYSICAL_ADDRESS_LOOKUP: PhysicalAddressLookupConfig;
   ACCESSIBILITY_LINK: string;
   SERCQ_SERVICE_STATEMENT_LINK: string;
-  STATISTICS_MAINTENANCE_DATES: string;
+  STATISTICS_MAINTENANCE_DATES?: string;
 }
 
 function statisticsMaintenanceDatesValidator(value: string): ValidationResult<string> {
+  if (!value) {
+    return null;
+  }
   // 1. Split the string by the underscore separator
   const parts = value.split('_');
   if (parts.length !== 2) {
@@ -87,7 +90,6 @@ class PaConfigurationValidator extends Validator<PaConfiguration> {
     this.ruleFor('SERCQ_SERVICE_STATEMENT_LINK').isString().isRequired();
     this.ruleFor('STATISTICS_MAINTENANCE_DATES')
       .isString()
-      .isRequired()
       .customValidator(statisticsMaintenanceDatesValidator);
   }
 }

--- a/packages/pn-pa-webapp/src/services/configuration.service.ts
+++ b/packages/pn-pa-webapp/src/services/configuration.service.ts
@@ -28,14 +28,14 @@ export interface PaConfiguration {
   PHYSICAL_ADDRESS_LOOKUP: PhysicalAddressLookupConfig;
   ACCESSIBILITY_LINK: string;
   SERCQ_SERVICE_STATEMENT_LINK: string;
-  DATA_LAKE_MAINTENANCE_DATES: string;
+  STATISTICS_MAINTENANCE_DATES: string;
 }
 
-function dataLakeMaintenanceDatesValidator(value: string): ValidationResult<string> {
+function statisticsMaintenanceDatesValidator(value: string): ValidationResult<string> {
   // 1. Split the string by the underscore separator
   const parts = value.split('_');
   if (parts.length !== 2) {
-    return 'Wrong DATA_LAKE_MAINTENANCE_DATES format';
+    return 'Wrong STATISTICS_MAINTENANCE_DATES format';
   }
 
   const [startDateStr, endDateStr] = parts;
@@ -46,7 +46,7 @@ function dataLakeMaintenanceDatesValidator(value: string): ValidationResult<stri
 
   // 3. Verify that both dates are valid Date objects (not NaN)
   if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
-    return 'Invalid DATA_LAKE_MAINTENANCE_DATES values';
+    return 'Invalid STATISTICS_MAINTENANCE_DATES values';
   }
 
   return null;
@@ -85,10 +85,10 @@ class PaConfigurationValidator extends Validator<PaConfiguration> {
       .isOneOf(Object.values(PhysicalAddressLookupConfig));
     this.ruleFor('ACCESSIBILITY_LINK').isString().isRequired();
     this.ruleFor('SERCQ_SERVICE_STATEMENT_LINK').isString().isRequired();
-    this.ruleFor('DATA_LAKE_MAINTENANCE_DATES')
+    this.ruleFor('STATISTICS_MAINTENANCE_DATES')
       .isString()
       .isRequired()
-      .customValidator(dataLakeMaintenanceDatesValidator);
+      .customValidator(statisticsMaintenanceDatesValidator);
   }
 }
 

--- a/packages/pn-pa-webapp/src/services/configuration.service.ts
+++ b/packages/pn-pa-webapp/src/services/configuration.service.ts
@@ -1,5 +1,5 @@
 import { Configuration, IS_DEVELOP, dataRegex } from '@pagopa-pn/pn-commons';
-import { Validator } from '@pagopa-pn/pn-validator';
+import { ValidationResult, Validator } from '@pagopa-pn/pn-validator';
 
 import { PhysicalAddressLookupConfig } from '../models/NewNotification';
 
@@ -28,6 +28,28 @@ export interface PaConfiguration {
   PHYSICAL_ADDRESS_LOOKUP: PhysicalAddressLookupConfig;
   ACCESSIBILITY_LINK: string;
   SERCQ_SERVICE_STATEMENT_LINK: string;
+  DATA_LAKE_MAINTENANCE_DATES: string;
+}
+
+function dataLakeMaintenanceDatesValidator(value: string): ValidationResult<string> {
+  // 1. Split the string by the underscore separator
+  const parts = value.split('_');
+  if (parts.length !== 2) {
+    return 'Wrong DATA_LAKE_MAINTENANCE_DATES format';
+  }
+
+  const [startDateStr, endDateStr] = parts;
+
+  // 2. Parse both dates
+  const start = new Date(startDateStr);
+  const end = new Date(endDateStr);
+
+  // 3. Verify that both dates are valid Date objects (not NaN)
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+    return 'Invalid DATA_LAKE_MAINTENANCE_DATES values';
+  }
+
+  return null;
 }
 
 class PaConfigurationValidator extends Validator<PaConfiguration> {
@@ -63,6 +85,10 @@ class PaConfigurationValidator extends Validator<PaConfiguration> {
       .isOneOf(Object.values(PhysicalAddressLookupConfig));
     this.ruleFor('ACCESSIBILITY_LINK').isString().isRequired();
     this.ruleFor('SERCQ_SERVICE_STATEMENT_LINK').isString().isRequired();
+    this.ruleFor('DATA_LAKE_MAINTENANCE_DATES')
+      .isString()
+      .isRequired()
+      .customValidator(dataLakeMaintenanceDatesValidator);
   }
 }
 

--- a/packages/pn-pa-webapp/src/setupTests.tsx
+++ b/packages/pn-pa-webapp/src/setupTests.tsx
@@ -49,6 +49,7 @@ beforeAll(() => {
     PHYSICAL_ADDRESS_LOOKUP: PhysicalAddressLookupConfig.ON,
     ACCESSIBILITY_LINK: 'https://accessibility-link.it',
     SERCQ_SERVICE_STATEMENT_LINK: 'https://fake.sercq-service-statement.pagopa.it',
+    STATISTICS_MAINTENANCE_DATES: '2025-08-14_2025-08-25',
   });
   initStore(false);
   initAxiosClients();

--- a/packages/pn-personafisica-login/package.json
+++ b/packages/pn-personafisica-login/package.json
@@ -71,7 +71,7 @@
     "eslint-plugin-sonarjs": "^0.10.0",
     "jsdom": "^29.0.0",
     "prettier": "^2.8.8",
-    "sonarqube-scanner": "^3.3.0",
+    "sonarqube-scanner": "^4.3.8",
     "vite": "^5.1.4",
     "vitest": "^1.6.1",
     "vitest-sonar-reporter": "^2.0.0"

--- a/packages/pn-personafisica-login/sonarqube-scanner.js
+++ b/packages/pn-personafisica-login/sonarqube-scanner.js
@@ -1,4 +1,4 @@
-const scanner = require('sonarqube-scanner');
+const scanner = require('sonarqube-scanner').default;
 
 const options = {
   'sonar.organization': 'pagopa',
@@ -20,5 +20,11 @@ scanner(
     token: process.env.SONAR_TOKEN,
     options,
   },
-  () => process.exit()
+  (error) => {
+    if (error) {
+      console.error(error);
+      process.exit(1);
+    }
+    process.exit();
+  }
 );

--- a/packages/pn-personafisica-webapp/package.json
+++ b/packages/pn-personafisica-webapp/package.json
@@ -85,7 +85,7 @@
     "eslint-plugin-sonarjs": "^0.10.0",
     "jsdom": "^29.0.0",
     "prettier": "^2.8.8",
-    "sonarqube-scanner": "^3.3.0",
+    "sonarqube-scanner": "^4.3.8",
     "vite": "^5.1.4",
     "vitest": "^1.6.1",
     "vitest-sonar-reporter": "^2.0.0"

--- a/packages/pn-personafisica-webapp/sonarqube-scanner.js
+++ b/packages/pn-personafisica-webapp/sonarqube-scanner.js
@@ -1,4 +1,4 @@
-const scanner = require('sonarqube-scanner');
+const scanner = require('sonarqube-scanner').default;
 
 const options = {
   'sonar.organization': 'pagopa',
@@ -20,5 +20,11 @@ scanner(
     token: process.env.SONAR_TOKEN,
     options,
   },
-  () => process.exit()
+  (error) => {
+    if (error) {
+      console.error(error);
+      process.exit(1);
+    }
+    process.exit();
+  }
 );

--- a/packages/pn-personagiuridica-webapp/package.json
+++ b/packages/pn-personagiuridica-webapp/package.json
@@ -85,7 +85,7 @@
     "eslint-plugin-sonarjs": "^0.10.0",
     "jsdom": "^29.0.0",
     "prettier": "^2.8.8",
-    "sonarqube-scanner": "^3.3.0",
+    "sonarqube-scanner": "^4.3.8",
     "vite": "^5.1.4",
     "vitest": "^1.6.1",
     "vitest-sonar-reporter": "^2.0.0"

--- a/packages/pn-personagiuridica-webapp/sonarqube-scanner.js
+++ b/packages/pn-personagiuridica-webapp/sonarqube-scanner.js
@@ -1,4 +1,4 @@
-const scanner = require('sonarqube-scanner');
+const scanner = require('sonarqube-scanner').default;
 
 const options = {
   'sonar.organization': 'pagopa',
@@ -20,5 +20,11 @@ scanner(
     token: process.env.SONAR_TOKEN,
     options,
   },
-  () => process.exit()
+  (error) => {
+    if (error) {
+      console.error(error);
+      process.exit(1);
+    }
+    process.exit();
+  }
 );

--- a/packages/pn-validator/package.json
+++ b/packages/pn-validator/package.json
@@ -25,7 +25,7 @@
     "eslint-plugin-functional": "^3.7.2",
     "eslint-plugin-import": "^2.25.3",
     "eslint-plugin-sonarjs": "^0.10.0",
-    "sonarqube-scanner": "^3.3.0",
+    "sonarqube-scanner": "^4.3.8",
     "vitest": "^1.6.1",
     "vitest-sonar-reporter": "^2.0.0"
   }

--- a/packages/pn-validator/sonarqube-scanner.cjs
+++ b/packages/pn-validator/sonarqube-scanner.cjs
@@ -1,4 +1,4 @@
-const scanner = require('sonarqube-scanner');
+const scanner = require('sonarqube-scanner').default;
 
 const options = {
   'sonar.organization': 'pagopa',
@@ -6,7 +6,6 @@ const options = {
   'sonar.sources': './src',
   'sonar.javascript.lcov.reportPaths': './coverage/lcov.info',
 };
-
 
 if (typeof process.env.PR_NUM !== 'undefined') {
   options['sonar.pullrequest.base'] = process.env.BRANCH_TARGET;
@@ -23,5 +22,11 @@ scanner(
     token: process.env.SONAR_TOKEN,
     options,
   },
-  () => process.exit()
+  (error) => {
+    if (error) {
+      console.error(error);
+      process.exit(1);
+    }
+    process.exit();
+  }
 );

--- a/packages/pn-validator/src/index.ts
+++ b/packages/pn-validator/src/index.ts
@@ -1,5 +1,3 @@
-import { Validator } from './Validator';
-import { ValidationError } from './types/ValidationError';
-
-export { Validator };
-export type { ValidationError };
+export type { ValidationError } from './types/ValidationError';
+export type { ValidationResult } from './types/ValidationResult';
+export { Validator } from './Validator';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2964,10 +2964,17 @@ add-stream@^1.0.0:
   resolved "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz"
   integrity sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=
 
-adm-zip@^0.5.10:
-  version "0.5.10"
-  resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.5.10.tgz#4a51d5ab544b1f5ce51e1b9043139b639afff45b"
-  integrity sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==
+adm-zip@0.5.17:
+  version "0.5.17"
+  resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.5.17.tgz#5c0b65f37aeec5c2a94995c024f931f62e4bbc5a"
+  integrity sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==
+
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
 
 agent-base@^7.0.2, agent-base@^7.1.0:
   version "7.1.0"
@@ -3168,6 +3175,16 @@ axios-mock-adapter@^1.22.0:
     fast-deep-equal "^3.1.3"
     is-buffer "^2.0.5"
 
+axios@1.17.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.17.0.tgz#ae5a1164a4f719942cd73c67e6a3f62d3ccb8f2b"
+  integrity sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==
+  dependencies:
+    follow-redirects "^1.16.0"
+    form-data "^4.0.5"
+    https-proxy-agent "^5.0.1"
+    proxy-from-env "^2.1.0"
+
 axios@^1.12.0:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.15.0.tgz#0fcee91ef03d386514474904b27863b2c683bf4f"
@@ -3185,6 +3202,11 @@ axios@^1.15.0:
     follow-redirects "^1.16.0"
     form-data "^4.0.5"
     proxy-from-env "^2.1.0"
+
+b4a@^1.6.4, b4a@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/b4a/-/b4a-1.8.1.tgz#7f16334ca80127aeb26064a28841acbf174840a4"
+  integrity sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==
 
 babel-plugin-macros@^3.1.0:
   version "3.1.0"
@@ -3204,6 +3226,43 @@ balanced-match@^4.0.2:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
   integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
+
+bare-events@^2.5.4, bare-events@^2.7.0:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/bare-events/-/bare-events-2.9.1.tgz#5c86616966343bcb03a1b3155feab253eadbf349"
+  integrity sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==
+
+bare-fs@^4.5.5:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/bare-fs/-/bare-fs-4.8.0.tgz#8c0f916833ae11e6d9d347f9e0a7f46f7375bb8f"
+  integrity sha512-fM+MhCvdQhZ7NV6S95a07gPSqjIYKn6mFaXfx266wN3ajZGl/+1AzH+ubkXQ0fFZvOe2nk9VHkzdYkQE5zMV3Q==
+  dependencies:
+    bare-events "^2.5.4"
+    bare-path "^3.0.0"
+    bare-stream "^2.6.4"
+    bare-url "^2.2.2"
+    fast-fifo "^1.3.2"
+
+bare-path@^3.0.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/bare-path/-/bare-path-3.1.1.tgz#d4a207c088609b4663a7556a46a97342398bf7e2"
+  integrity sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==
+
+bare-stream@^2.6.4:
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/bare-stream/-/bare-stream-2.13.3.tgz#f6186c7cbb4bbf53a4560f35e48b16373ba51ce6"
+  integrity sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==
+  dependencies:
+    b4a "^1.8.1"
+    streamx "^2.25.0"
+    teex "^1.0.1"
+
+bare-url@^2.2.2:
+  version "2.4.7"
+  resolved "https://registry.yarnpkg.com/bare-url/-/bare-url-2.4.7.tgz#e1fb1ba891d58bebc6bec6b3fcbdf9898bd963b8"
+  integrity sha512-o8CRCiJtib+ycO3mE4A5UChtGX4dDP2XxsWVu9P+Zc3H8tcmKwNVEDoDTXmwN+uuMhfKeT7/i7Y26xS8W7ohoA==
+  dependencies:
+    bare-path "^3.0.0"
 
 base64-arraybuffer@^1.0.1:
   version "1.0.2"
@@ -3571,7 +3630,7 @@ color-name@^1.1.4, color-name@~1.1.4:
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-color-support@1.1.3, color-support@^1.1.3:
+color-support@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
   integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
@@ -3590,6 +3649,11 @@ combined-stream@^1.0.8:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+commander@14.0.3:
+  version "14.0.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-14.0.3.tgz#425d79b48f9af82fcd9e4fc1ea8af6c5ec07bbc2"
+  integrity sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==
 
 commander@8.3.0:
   version "8.3.0"
@@ -4515,6 +4579,13 @@ eventemitter3@^4.0.4:
   resolved "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
+events-universal@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/events-universal/-/events-universal-1.0.1.tgz#b56a84fd611b6610e0a2d0f09f80fdf931e2dfe6"
+  integrity sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==
+  dependencies:
+    bare-events "^2.7.0"
+
 execa@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-5.0.0.tgz#4029b0007998a841fbd1032e5f4de86a3c1e3376"
@@ -4561,17 +4632,15 @@ exponential-backoff@^3.1.1:
   resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.3.tgz#51cf92c1c0493c766053f9d3abee4434c244d2f6"
   integrity sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==
 
-fancy-log@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/fancy-log/-/fancy-log-2.0.0.tgz#cad207b8396d69ae4796d74d17dff5f68b2f7343"
-  integrity sha512-9CzxZbACXMUXW13tS0tI8XsGGmxWzO2DmYrGuBJOJ8k8q2K7hwfJA5qHjuPPe8wtsco33YR9wc+Rlr5wYFvhSA==
-  dependencies:
-    color-support "^1.1.3"
-
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-fifo@^1.2.0, fast-fifo@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/fast-fifo/-/fast-fifo-1.3.2.tgz#286e31de96eb96d38a97899815740ba2a4f3640c"
+  integrity sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==
 
 fast-glob@^3.2.9:
   version "3.2.11"
@@ -5194,6 +5263,11 @@ hosted-git-info@^9.0.0:
   dependencies:
     lru-cache "^11.1.0"
 
+hpagent@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/hpagent/-/hpagent-1.2.0.tgz#0ae417895430eb3770c03443456b8d90ca464903"
+  integrity sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==
+
 html-encoding-sniffer@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz#f8d9390b3b348b50d4f61c16dd2ef5c05980a882"
@@ -5225,6 +5299,14 @@ http-proxy-agent@^7.0.0, http-proxy-agent@^7.0.1:
   dependencies:
     agent-base "^7.1.0"
     debug "^4.3.4"
+
+https-proxy-agent@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
+  dependencies:
+    agent-base "6"
+    debug "4"
 
 https-proxy-agent@^7.0.1:
   version "7.0.2"
@@ -5750,13 +5832,6 @@ jest-message-util@^29.7.0:
     pretty-format "^29.7.0"
     slash "^3.0.0"
     stack-utils "^2.0.3"
-
-jest-sonar-reporter@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/jest-sonar-reporter/-/jest-sonar-reporter-2.0.0.tgz#faa54a7d2af7198767ee246a82b78c576789cf08"
-  integrity sha512-ZervDCgEX5gdUbdtWsjdipLN3bKJwpxbvhkYNXTAYvAckCihobSLr9OT/IuyNIRT1EZMDDwR6DroWtrq+IL64w==
-  dependencies:
-    xml "^1.0.1"
 
 jest-util@^29.7.0:
   version "29.7.0"
@@ -6497,11 +6572,6 @@ mkdirp@^1.0.3:
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-mkdirp@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-3.0.1.tgz#e44e4c5607fb279c168241713cc6e0fea9adcb50"
-  integrity sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==
-
 mlly@^1.2.0:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/mlly/-/mlly-1.4.2.tgz#7cf406aa319ff6563d25da6b36610a93f2a8007e"
@@ -6605,17 +6675,17 @@ netmask@^2.0.2:
   resolved "https://registry.yarnpkg.com/netmask/-/netmask-2.1.1.tgz#80043d265b53aa521b3bd01e8fcdf353f9e1e81e"
   integrity sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==
 
-node-downloader-helper@^2.1.9:
-  version "2.1.9"
-  resolved "https://registry.yarnpkg.com/node-downloader-helper/-/node-downloader-helper-2.1.9.tgz#a59ee7276b2bf708bbac2cc5872ad28fc7cd1b0e"
-  integrity sha512-FSvAol2Z8UP191sZtsUZwHIN0eGoGue3uEXGdWIH5228e9KH1YHXT7fN8Oa33UGf+FbqGTQg3sJfrRGzmVCaJA==
-
 node-fetch@^2.6.1, node-fetch@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
+
+node-forge@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.4.0.tgz#1c7b7d8bdc2d078739f58287d589d903a11b2fc2"
+  integrity sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==
 
 node-gyp@^11.0.0:
   version "11.4.2"
@@ -7411,7 +7481,7 @@ proggy@^3.0.0:
   resolved "https://registry.yarnpkg.com/proggy/-/proggy-3.0.0.tgz#874e91fed27fe00a511758e83216a6b65148bd6c"
   integrity sha512-QE8RApCM3IaRRxVzxrjbgNMpQEX6Wu0p0KBeoSiSEw5/bsGwZHsshF4LCxH2jp/r6BU+bqA3LrMDEYNfJnpD8Q==
 
-progress@^2.0.0, progress@^2.0.3:
+progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
@@ -7450,6 +7520,11 @@ prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
+properties-file@5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/properties-file/-/properties-file-5.0.5.tgz#2f28b2d167cd5e209c569d912da9addbd82a3250"
+  integrity sha512-Gfi6UgMENAzww1P4hloKhLIQxqcYmUS5z+Lhm/jmFV+ushbE416NalT42oEfJbF9vd0a02B3AaLHiQGmNSQ9EA==
+
 property-expr@^2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.6.tgz#f77bc00d5928a6c748414ad12882e83f24aec1e8"
@@ -7474,15 +7549,15 @@ proxy-agent@6.5.0:
     proxy-from-env "^1.1.0"
     socks-proxy-agent "^8.0.5"
 
+proxy-from-env@2.1.0, proxy-from-env@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz#a7487568adad577cfaaa7e88c49cab3ab3081aba"
+  integrity sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==
+
 proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
-
-proxy-from-env@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz#a7487568adad577cfaaa7e88c49cab3ab3081aba"
-  integrity sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==
 
 punycode@^2.1.0:
   version "2.1.1"
@@ -7925,6 +8000,11 @@ semver@7.7.2:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.2.tgz#67d99fdcd35cec21e6f8b87a7fd515a33f982b58"
   integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
 
+semver@7.8.4:
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.4.tgz#c73eceebae0616934be8dff28a7fd70757c8e696"
+  integrity sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==
+
 semver@^6.3.0, semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
@@ -7968,11 +8048,6 @@ shell-quote@1.8.3:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.3.tgz#55e40ef33cf5c689902353a3d8cd1a6725f08b4b"
   integrity sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==
-
-shell-quote@^1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.1.tgz#6dbf4db75515ad5bac63b4f1894c3a154c766680"
-  integrity sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==
 
 side-channel@^1.0.4:
   version "1.0.4"
@@ -8036,10 +8111,10 @@ slice-ansi@^2.1.0:
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
 
-slugify@^1.6.6:
-  version "1.6.6"
-  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.6.6.tgz#2d4ac0eacb47add6af9e04d3be79319cbcc7924b"
-  integrity sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==
+slugify@1.6.9:
+  version "1.6.9"
+  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.6.9.tgz#610957dea21e56b65e3a153215ef7b265715c8e8"
+  integrity sha512-vZ7rfeehZui7wQs438JXBckYLkIIdfHOXsaVEUMyS5fHo1483l1bMdo0EDSWYclY0yZKFOipDy4KHuKs6ssvdg==
 
 smart-buffer@^4.2.0:
   version "4.2.0"
@@ -8063,20 +8138,21 @@ socks@^2.8.3:
     ip-address "^10.0.1"
     smart-buffer "^4.2.0"
 
-sonarqube-scanner@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/sonarqube-scanner/-/sonarqube-scanner-3.3.0.tgz#6fdb4e529db538aad6c3acca6870ec2e1e9dc4c9"
-  integrity sha512-G1A6nXT3GwoK5eRwHfFrR/7ThiDfaRefWPIFQ+ifwFOQ/V9OwziLpZBdWZgmZp21kBRnzAMvjcTzgZMqGBXQKA==
+sonarqube-scanner@^4.3.8:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/sonarqube-scanner/-/sonarqube-scanner-4.4.0.tgz#8939a946092b0841a1b075ef1cc48f8f57b0ad14"
+  integrity sha512-j1hXSmkTCrFQbOL2BurcvLXS92uI+SetwLzwed11H0QJkFMam9nLvZM2hgg/QNelO/D902R+jJ09yLc7HhS/Yw==
   dependencies:
-    adm-zip "^0.5.10"
-    fancy-log "^2.0.0"
-    https-proxy-agent "^7.0.1"
-    jest-sonar-reporter "^2.0.0"
-    mkdirp "^3.0.1"
-    node-downloader-helper "^2.1.9"
-    progress "^2.0.3"
-    shell-quote "^1.8.1"
-    slugify "^1.6.6"
+    adm-zip "0.5.17"
+    axios "1.17.0"
+    commander "14.0.3"
+    hpagent "1.2.0"
+    node-forge "1.4.0"
+    properties-file "5.0.5"
+    proxy-from-env "2.1.0"
+    semver "7.8.4"
+    slugify "1.6.9"
+    tar-stream "3.2.0"
 
 sort-keys@^2.0.0:
   version "2.0.0"
@@ -8168,6 +8244,15 @@ std-env@^3.5.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.7.0.tgz#c9f7386ced6ecf13360b6c6c55b8aaa4ef7481d2"
   integrity sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==
+
+streamx@^2.12.5, streamx@^2.15.0, streamx@^2.25.0:
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/streamx/-/streamx-2.28.0.tgz#035ab56057b7ed2211b51d532e6973f0f99fbf11"
+  integrity sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==
+  dependencies:
+    events-universal "^1.0.0"
+    fast-fifo "^1.3.2"
+    text-decoder "^1.1.0"
 
 "string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
@@ -8369,6 +8454,16 @@ table@^5.2.3:
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
 
+tar-stream@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-3.2.0.tgz#0d0064d9b67ea3c9f5abde155e35faab0df37591"
+  integrity sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==
+  dependencies:
+    b4a "^1.6.4"
+    bare-fs "^4.5.5"
+    fast-fifo "^1.2.0"
+    streamx "^2.15.0"
+
 tar-stream@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
@@ -8403,6 +8498,13 @@ tar@^7.4.3:
     minizlib "^3.1.0"
     yallist "^5.0.0"
 
+teex@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/teex/-/teex-1.0.1.tgz#b8fa7245ef8e8effa8078281946c85ab780a0b12"
+  integrity sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==
+  dependencies:
+    streamx "^2.12.5"
+
 temp-dir@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-1.0.0.tgz#0a7c0ea26d3a39afa7e0ebea9c1fc0bc4daa011d"
@@ -8416,6 +8518,13 @@ test-exclude@^6.0.0:
     "@istanbuljs/schema" "^0.1.2"
     glob "^7.1.4"
     minimatch "^3.0.4"
+
+text-decoder@^1.1.0:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/text-decoder/-/text-decoder-1.2.7.tgz#5d073a9a74b9c0a9d28dfadcab96b604af57d8ba"
+  integrity sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==
+  dependencies:
+    b4a "^1.6.4"
 
 text-extensions@^1.0.0:
   version "1.9.0"
@@ -9069,11 +9178,6 @@ xml-name-validator@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-5.0.0.tgz#82be9b957f7afdacf961e5980f1bf227c0bf7673"
   integrity sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==
-
-xml@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
-  integrity sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==
 
 xmlchars@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
## Short description
When data lake is under maintenance an alert should be shown in the statistics page.

## List of changes proposed in this pull request
- Added new function in date.utility that check if a date is in a range
- Added new configuration to set the date range when the alert must be shown
- Added new localizations for the alert title and content -> the phrase "e open data" must be removed from the description
- Added the alert to the Statistics.page

## How to test
- Add new configuration DATA_LAKE_MAINTENANCE_DATES in your config.json
- Set the value of DATA_LAKE_MAINTENANCE_DATES as `[startDate]_[endDate]` where startDate and endDate are in the format YYYY-MM-DD or YYYY-MM-DDTHH:mm:ssZ or YYYY-MM-DDTHH:mm:ss:ssss
- Login with PA -> go to statistics -> check that the alert is shown.

N.B. to simulate the date you can set dates near the moment you are testing or use a chrome extension that simulate time. In this second case you have to modify the expiration of the token, otherwise you will be logged out