### PR TITLE
fix(PN-21196): add clear icon in communication type field

### DIFF
--- a/packages/pn-personafisica-webapp/public/locales/de/common.json
+++ b/packages/pn-personafisica-webapp/public/locales/de/common.json
@@ -21,6 +21,7 @@
     "disable": "Deaktivieren",
     "start": "Starten",
     "continue": "Weiter",
+    "clear-field": "Feld leeren",
     "go-on": "Weiter",
     "go-to-home": "Zur Startseite",
     "go-to-login": "Anmelden",

--- a/packages/pn-personafisica-webapp/public/locales/en/common.json
+++ b/packages/pn-personafisica-webapp/public/locales/en/common.json
@@ -21,6 +21,7 @@
     "disable": "Disable",
     "start": "Start",
     "continue": "Continue",
+    "clear-field": "Clear field",
     "go-on": "Next",
     "go-to-home": "Go to homepage",
     "go-to-login": "Login",

--- a/packages/pn-personafisica-webapp/public/locales/fr/common.json
+++ b/packages/pn-personafisica-webapp/public/locales/fr/common.json
@@ -21,6 +21,7 @@
     "disable": "Désactiver",
     "start": "Commencer",
     "continue": "Continuer",
+    "clear-field": "Vider le champ",
     "go-on": "Suivant",
     "go-to-home": "Aller à la page d'accueil",
     "go-to-login": "Se connecter",

--- a/packages/pn-personafisica-webapp/public/locales/it/common.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/common.json
@@ -21,6 +21,7 @@
     "disable": "Disattiva",
     "start": "Inizia",
     "continue": "Continua",
+    "clear-field": "Svuota campo",
     "go-on": "Avanti",
     "go-to-home": "Vai alla homepage",
     "go-to-login": "Accedi",

--- a/packages/pn-personafisica-webapp/public/locales/sl/common.json
+++ b/packages/pn-personafisica-webapp/public/locales/sl/common.json
@@ -21,6 +21,7 @@
     "disable": "Onemogoči",
     "start": "Začni",
     "continue": "Nadaljuj",
+    "clear-field": "Počisti polje",
     "go-on": "Naprej",
     "go-to-home": "Pojdi na domačo stran",
     "go-to-login": "Prijava",

--- a/packages/pn-personafisica-webapp/src/components/Notifications/FilterNotificationsFormBody.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Notifications/FilterNotificationsFormBody.tsx
@@ -88,7 +88,7 @@ const FilterNotificationsFormBody = ({ formikInstance, showCommunicationType }: 
       ? () => (
           <IconButton
             size="small"
-            aria-label={t('button.clean-field', { ns: 'common' })}
+            aria-label={t('button.clear-field', { ns: 'common' })}
             onClick={(e) => {
               e.stopPropagation();
               void formikInstance.setFieldValue('communicationType', '', false);

--- a/packages/pn-personafisica-webapp/src/components/Notifications/FilterNotificationsFormBody.tsx
+++ b/packages/pn-personafisica-webapp/src/components/Notifications/FilterNotificationsFormBody.tsx
@@ -2,8 +2,17 @@ import { FormikErrors, FormikTouched, FormikValues } from 'formik';
 import { ChangeEvent, Fragment } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import ClearRoundedIcon from '@mui/icons-material/ClearRounded';
 import VerifiedRounded from '@mui/icons-material/VerifiedRounded';
-import { Box, Grid, ListItemIcon, ListItemText, MenuItem, TextField } from '@mui/material';
+import {
+  Box,
+  Grid,
+  IconButton,
+  ListItemIcon,
+  ListItemText,
+  MenuItem,
+  TextField,
+} from '@mui/material';
 import {
   CustomDatePicker,
   DATE_FORMAT,
@@ -30,6 +39,7 @@ type Props = {
   showCommunicationType: boolean;
 };
 
+// eslint-disable-next-line sonarjs/cognitive-complexity
 const FilterNotificationsFormBody = ({ formikInstance, showCommunicationType }: Props) => {
   const { t, i18n } = useTranslation(['notifiche']);
   const isMobile = useIsMobile();
@@ -73,6 +83,27 @@ const FilterNotificationsFormBody = ({ formikInstance, showCommunicationType }: 
     }
   };
 
+  const communicationTypeIcon = () =>
+    formikInstance.values.communicationType
+      ? () => (
+          <IconButton
+            size="small"
+            aria-label={t('button.clean-field', { ns: 'common' })}
+            onClick={(e) => {
+              e.stopPropagation();
+              void formikInstance.setFieldValue('communicationType', '', false);
+            }}
+            sx={{
+              pointerEvents: 'auto',
+              position: 'absolute',
+              right: 8,
+            }}
+          >
+            <ClearRoundedIcon fontSize="small" />
+          </IconButton>
+        )
+      : undefined;
+
   return (
     <Fragment>
       {showCommunicationType && (
@@ -97,6 +128,7 @@ const FilterNotificationsFormBody = ({ formikInstance, showCommunicationType }: 
                 ) : (
                   communicationTypeLabels[value as keyof typeof communicationTypeLabels] || ''
                 ),
+              IconComponent: communicationTypeIcon(),
             }}
             fullWidth
             sx={{ marginBottom: isMobile ? '20px' : '0' }}

--- a/packages/pn-personagiuridica-webapp/public/locales/de/common.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/de/common.json
@@ -24,6 +24,7 @@
     "manage": "Verwalten",
     "start": "Starten",
     "continue": "Weiter",
+    "clear-field": "Feld leeren",
     "not-now": "Nicht jetzt",
     "do-later": "Später erledigen",
     "add": "Hinzufügen",
@@ -243,7 +244,13 @@
     "action": "Angemeldet bleiben"
   },
   "code-modal": {
-    "digits": ["Erste Ziffer", "Zweite Ziffer", "Dritte Ziffer", "Vierte Ziffer", "Letzte Ziffer"]
+    "digits": [
+      "Erste Ziffer",
+      "Zweite Ziffer",
+      "Dritte Ziffer",
+      "Vierte Ziffer",
+      "Letzte Ziffer"
+    ]
   },
   "user-validation-failed": {
     "title": "Die eingegebenen Daten sind ungültig",

--- a/packages/pn-personagiuridica-webapp/public/locales/en/common.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/en/common.json
@@ -22,6 +22,7 @@
     "disable": "Deactivate",
     "start": "Start",
     "continue": "Continue",
+    "clear-field": "Clear field",
     "go-to-home": "Go to home page",
     "go-to-login": "Login",
     "not-now": "Not now",
@@ -243,7 +244,13 @@
     "action": "Keep access"
   },
   "code-modal": {
-    "digits": ["First digit", "Second digit", "Third digit", "Fourth digit", "Last digit"]
+    "digits": [
+      "First digit",
+      "Second digit",
+      "Third digit",
+      "Fourth digit",
+      "Last digit"
+    ]
   },
   "user-validation-failed": {
     "title": "The data entered is invalid",

--- a/packages/pn-personagiuridica-webapp/public/locales/fr/common.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/fr/common.json
@@ -22,6 +22,7 @@
     "disable": "Désactiver",
     "start": "Démarrer",
     "continue": "Continuer",
+    "clear-field": "Vider le champ",
     "go-to-home": "Aller à la page d’accueil",
     "go-to-login": "Se connecter",
     "not-now": "Pas maintenant",

--- a/packages/pn-personagiuridica-webapp/public/locales/it/common.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/it/common.json
@@ -22,6 +22,7 @@
     "disable": "Disattiva",
     "start": "Inizia",
     "continue": "Continua",
+    "clear-field": "Svuota campo",
     "go-to-home": "Vai alla homepage",
     "go-to-login": "Accedi",
     "not-now": "Non ora",
@@ -243,7 +244,13 @@
     "action": "Mantieni l’accesso"
   },
   "code-modal": {
-    "digits": ["prima cifra", "seconda cifra", "terza cifra", "quarta cifra", "ultima cifra"]
+    "digits": [
+      "prima cifra",
+      "seconda cifra",
+      "terza cifra",
+      "quarta cifra",
+      "ultima cifra"
+    ]
   },
   "user-validation-failed": {
     "title": "I dati inseriti non sono validi",

--- a/packages/pn-personagiuridica-webapp/public/locales/sl/common.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/sl/common.json
@@ -22,6 +22,7 @@
     "disable": "Deaktiviraj",
     "start": "Začni",
     "continue": "Nadaljuj",
+    "clear-field": "Počisti polje",
     "go-to-home": "Pojdi na domačo stran",
     "go-to-login": "Prijava",
     "not-now": "Ne zdaj",

--- a/packages/pn-personagiuridica-webapp/src/components/Notifications/FilterNotificationsFormBody.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Notifications/FilterNotificationsFormBody.tsx
@@ -2,8 +2,17 @@ import { FormikErrors, FormikTouched, FormikValues } from 'formik';
 import { ChangeEvent, Fragment } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import ClearRoundedIcon from '@mui/icons-material/ClearRounded';
 import VerifiedRounded from '@mui/icons-material/VerifiedRounded';
-import { Box, Grid, ListItemIcon, ListItemText, MenuItem, TextField } from '@mui/material';
+import {
+  Box,
+  Grid,
+  IconButton,
+  ListItemIcon,
+  ListItemText,
+  MenuItem,
+  TextField,
+} from '@mui/material';
 import {
   CustomDatePicker,
   DATE_FORMAT,
@@ -56,6 +65,7 @@ const getGridSizes = (showCommunicationType: boolean) => ({
   date: showCommunicationType ? 1.75 : 2,
 });
 
+// eslint-disable-next-line sonarjs/cognitive-complexity
 const FilterNotificationsFormBody = ({ formikInstance, showCommunicationType }: Props) => {
   const { t, i18n } = useTranslation(['notifiche']);
   const isMobile = useIsMobile();
@@ -100,6 +110,27 @@ const FilterNotificationsFormBody = ({ formikInstance, showCommunicationType }: 
     }
   };
 
+  const communicationTypeIcon = () =>
+    formikInstance.values.communicationType
+      ? () => (
+          <IconButton
+            size="small"
+            aria-label={t('button.clean-field', { ns: 'common' })}
+            onClick={(e) => {
+              e.stopPropagation();
+              void formikInstance.setFieldValue('communicationType', '', false);
+            }}
+            sx={{
+              pointerEvents: 'auto',
+              position: 'absolute',
+              right: 8,
+            }}
+          >
+            <ClearRoundedIcon fontSize="small" />
+          </IconButton>
+        )
+      : undefined;
+
   return (
     <Fragment>
       {showCommunicationType && (
@@ -116,6 +147,7 @@ const FilterNotificationsFormBody = ({ formikInstance, showCommunicationType }: 
             }}
             SelectProps={{
               renderValue: (value) => renderCommunicationTypeValue(value, communicationTypeLabels),
+              IconComponent: communicationTypeIcon(),
             }}
             fullWidth
             sx={{ marginBottom: isMobile ? '20px' : '0' }}

--- a/packages/pn-personagiuridica-webapp/src/components/Notifications/FilterNotificationsFormBody.tsx
+++ b/packages/pn-personagiuridica-webapp/src/components/Notifications/FilterNotificationsFormBody.tsx
@@ -115,7 +115,7 @@ const FilterNotificationsFormBody = ({ formikInstance, showCommunicationType }: 
       ? () => (
           <IconButton
             size="small"
-            aria-label={t('button.clean-field', { ns: 'common' })}
+            aria-label={t('button.clear-field', { ns: 'common' })}
             onClick={(e) => {
               e.stopPropagation();
               void formikInstance.setFieldValue('communicationType', '', false);


### PR DESCRIPTION
## Short description
add clear icon in communication type field

## How to test
Run PF/PG and check the clear icon appears when you choose communication type

## Checklist

- [x] No real people names are present in mock data, examples, fixtures, screenshots, or sample content.
- [x] No real company names are present unless explicitly required and approved.
- [x] No real public institution names, agencies, municipalities, or other real entities are present in fake/demo/mock content.
- [x] All placeholder content, examples, mock entities, and sample data are clearly fake and unmistakably non-real.
- [x] Any potentially ambiguous name has been reviewed and flagged if needed.