### PR TITLE
fix(PN-20958): fix long names in drawer

### DIFF
--- a/packages/pn-pa-webapp/src/components/Notifications/NotificationDetailsDrawer.tsx
+++ b/packages/pn-pa-webapp/src/components/Notifications/NotificationDetailsDrawer.tsx
@@ -52,7 +52,12 @@ const NotificationDetailsDrawer: React.FC<Props> = ({ open, title, details, onCl
               <Typography variant="body2" color="text.secondary">
                 {detail.label}
               </Typography>
-              <Typography component="div" variant="body2" color="text" fontWeight={600}>
+              <Typography
+                variant="body2"
+                color="text"
+                fontWeight={600}
+                sx={{ wordBreak: 'break-word' }}
+              >
                 {detail.value}
               </Typography>
             </Box>


### PR DESCRIPTION
## Short description
Fix break word in PA detail drawer

## How to test
Run PA and check with very very long detail

## Checklist

- [ ] No real people names are present in mock data, examples, fixtures, screenshots, or sample content.
- [ ] No real company names are present unless explicitly required and approved.
- [ ] No real public institution names, agencies, municipalities, or other real entities are present in fake/demo/mock content.
- [ ] All placeholder content, examples, mock entities, and sample data are clearly fake and unmistakably non-real.
- [ ] Any potentially ambiguous name has been reviewed and flagged if needed.