### PR TITLE
fix(PN-21198): fix Youtube link in pre-login footer

### DIFF
--- a/packages/pn-commons/src/utility/costants.tsx
+++ b/packages/pn-commons/src/utility/costants.tsx
@@ -192,7 +192,7 @@ export const preLoginLinks = ({
         {
           icon: 'youtube',
           title: 'Youtube',
-          href: 'https://www.youtube.com/channel/@pagopaspa',
+          href: 'https://www.youtube.com/@pagopaspa',
           ariaLabel: getLocalizedOrDefaultLabel(
             'common',
             'footer.social',


### PR DESCRIPTION
## Short description
The YouTube link in the pre-login footer pointed to `https://www.youtube.com/channel/@pagopaspa`, which loads a broken/half-rendered YouTube page. The correct URL for the handle is `https://www.youtube.com/@pagopaspa` (the `/channel/` path only works with channel IDs, not with `@handles`).

## List of changes proposed in this pull request
- `pn-commons`: fixed the YouTube `href` in `preLoginLinks` (`packages/pn-commons/src/utility/costants.tsx`), removing the `/channel/` segment.

## How to test
1. Open the login page of any webapp (pf/pa/pg).
2. Click the YouTube icon in the footer.
3. The PagoPA YouTube channel page should open correctly at `https://www.youtube.com/@pagopaspa`.

## Checklist

- [x] No real people names are present in mock data, examples, fixtures, screenshots, or sample content.
- [x] No real company names are present unless explicitly required and approved.
- [x] No real public institution names, agencies, municipalities, or other real entities are present in fake/demo/mock content.
- [x] All placeholder content, examples, mock entities, and sample data are clearly fake and unmistakably non-real.
- [x] Any potentially ambiguous name has been reviewed and flagged if needed.
