### PR TITLE
fix(PN-20838): translate party role in header on footer language change

### DIFF
--- a/packages/pn-commons/src/components/Header/Header.tsx
+++ b/packages/pn-commons/src/components/Header/Header.tsx
@@ -40,6 +40,8 @@ type HeaderProps = {
   enableAssistanceButton?: boolean;
   /** Label of the chip displayed next to product switch */
   chipLabel?: string;
+  /** Current language */
+  currentLanguage?: string;
 };
 
 const Header: React.FC<HeaderProps> = ({
@@ -56,6 +58,7 @@ const Header: React.FC<HeaderProps> = ({
   isLogged,
   enableAssistanceButton,
   chipLabel,
+  currentLanguage,
 }) => {
   const pagoPAHeaderLink: RootLinkType = {
     ...pagoPALink(),
@@ -117,7 +120,7 @@ const Header: React.FC<HeaderProps> = ({
       />
       {enableHeaderProduct && (
         <HeaderProduct
-          key={partyId}
+          key={`${partyId}-${currentLanguage}`}
           productId={productId}
           partyId={partyId}
           productsList={productsList}

--- a/packages/pn-commons/src/components/Header/__test__/Header.test.tsx
+++ b/packages/pn-commons/src/components/Header/__test__/Header.test.tsx
@@ -274,6 +274,29 @@ describe('Header Component', () => {
     expect(headers[1]).toHaveTextContent(partyWithParent?.parentName as string);
   });
 
+  it('updates the party role on PartySwitch when language changes', () => {
+    const props = {
+      productsList,
+      loggedUser,
+      partyId: partyList[1].id,
+      partyList,
+      productId: productsList[0].id,
+    };
+    const { container, rerender } = render(<Header {...props} currentLanguage="it" />);
+
+    let headers = container.querySelectorAll('.MuiContainer-root');
+    expect(headers[1]).toHaveTextContent(partyList[1].productRole);
+
+    const translatedPartyList = partyList.map((party) => ({
+      ...party,
+      productRole: `${party.productRole} - translated`,
+    }));
+    rerender(<Header {...props} partyList={translatedPartyList} currentLanguage="en" />);
+
+    headers = container.querySelectorAll('.MuiContainer-root');
+    expect(headers[1]).toHaveTextContent(translatedPartyList[1].productRole);
+  });
+
   it('clicks on assistanceEmail when value is passed', async () => {
     // render component
     const { getByText } = render(

--- a/packages/pn-commons/src/components/Layout/Layout.tsx
+++ b/packages/pn-commons/src/components/Layout/Layout.tsx
@@ -123,6 +123,7 @@ const Layout: React.FC<Props> = ({
             isLogged={isLogged}
             enableAssistanceButton={enableAssistanceButton}
             chipLabel={chipLabel}
+            currentLanguage={currentLanguage}
           />
         )}
         <Stack


### PR DESCRIPTION
## Short description

The party role label in the top-right header now is translated when the language was changed from the footer selector.

## List of changes proposed in this pull request

- `pn-commons/Header`: new optional `currentLanguage` prop, included in the `HeaderProduct` key.
- `pn-commons/Layout`: forward `currentLanguage` to `Header`. It was already a required `Layout` prop passed by every webapp, so no changes are needed on the application side.

The fix lives in `pn-commons`, so it applies to PA, PF and PG.

## How to test

1. Log into the SEND PA portal with a user associated to **more than one institution**.
2. From the notifications homepage, select a foreign language from the footer selector.
3. Check that the role label (and the institution name) in the top-right button is translated, without reloading the page.
4. Check institution selection from the party switch drawer and product switching.

Automated tests: `pn-commons` `src/components/Header` and `src/components/Layout` pass.

## Checklist

- [x] No real people names are present in mock data, examples, fixtures, screenshots, or sample content.
- [x] No real company names are present unless explicitly required and approved.
- [x] No real public institution names, agencies, municipalities, or other real entities are present in fake/demo/mock content.
- [x] All placeholder content, examples, mock entities, and sample data are clearly fake and unmistakably non-real.
- [x] Any potentially ambiguous name has been reviewed and flagged if needed.
