### PR TITLE
fix(PN-20892): move support route out of the ToS guard

### DIFF
--- a/packages/pn-personafisica-webapp/src/navigation/__test__/routes.test.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/__test__/routes.test.tsx
@@ -1,0 +1,70 @@
+import MockAdapter from 'axios-mock-adapter';
+
+import { userResponse } from '../../__mocks__/Auth.mock';
+import { tosPrivacyConsentMock } from '../../__mocks__/Consents.mock';
+import { act, render, screen, waitFor } from '../../__test__/test-utils';
+import { apiClient } from '../../api/apiClients';
+import Router from '../routes';
+import * as routes from '../routes.const';
+
+// the user has a valid session, but has accepted neither the tos nor the privacy policy
+const reduxState = {
+  userState: {
+    loading: false,
+    user: userResponse,
+    fetchedTos: false,
+    fetchedPrivacy: false,
+    tosConsent: {
+      accepted: false,
+      isFirstAccept: false,
+      consentVersion: '',
+    },
+    privacyConsent: {
+      accepted: false,
+      isFirstAccept: false,
+      consentVersion: '',
+    },
+    tosPrivacyApiError: false,
+  },
+};
+
+describe('Tests the Router component', () => {
+  let mock: MockAdapter;
+
+  beforeAll(() => {
+    mock = new MockAdapter(apiClient);
+  });
+
+  afterEach(() => {
+    mock.reset();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  it('renders the support page if tos and privacy are not accepted', async () => {
+    await act(async () => {
+      render(<Router />, { preloadedState: reduxState, route: routes.SUPPORT });
+    });
+    // the support page is lazy loaded, so we have to wait for it
+    await waitFor(() => {
+      expect(screen.queryByTestId('supportForm')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('tos-acceptance-page')).toBeNull();
+    // the support route is out of the ToSGuard, so the consents are not even fetched
+    expect(mock.history.get).toHaveLength(0);
+  });
+
+  it('renders the tos page instead of a guarded page if tos and privacy are not accepted', async () => {
+    mock.onGet(/\/bff\/v2\/tos-privacy.*/).reply(200, tosPrivacyConsentMock(false, false));
+    await act(async () => {
+      render(<Router />, { preloadedState: reduxState, route: routes.NOTIFICHE });
+    });
+    const supportForm = screen.queryByTestId('supportForm');
+    const tosComponent = screen.queryByTestId('tos-acceptance-page');
+    expect(tosComponent).toBeInTheDocument();
+    expect(supportForm).toBeNull();
+    expect(mock.history.get).toHaveLength(1);
+  });
+});

--- a/packages/pn-personafisica-webapp/src/navigation/routes.tsx
+++ b/packages/pn-personafisica-webapp/src/navigation/routes.tsx
@@ -50,6 +50,7 @@ const Router: React.FC = () => {
     <Suspense fallback={<LoadingPage />}>
       <Routes>
         <Route element={<SessionGuard />}>
+          <Route path={routes.SUPPORT} element={<SupportPage />} />
           <Route element={<ToSGuard />}>
             <Route element={<RapidAccessGuard />}>
               <Route element={<OnboardingGuard />}>
@@ -72,7 +73,6 @@ const Router: React.FC = () => {
                 <Route path={routes.RECAPITI} element={<Contacts />} />
                 <Route path={routes.PROFILO} element={<Profile />} />
                 <Route path={routes.APP_STATUS} element={<AppStatus />} />
-                <Route path={routes.SUPPORT} element={<SupportPage />} />
                 {IS_ONBOARDING_ENABLED && (
                   <Route path={routes.ONBOARDING} element={<Onboarding />}>
                     <Route index element={<OnboardingHome />} />


### PR DESCRIPTION
## Short description

On the ToS acceptance page, clicking the *Assistenza* button in the header did nothing and the button disappeared right after the click.

The `/assistenza` route was declared inside `ToSGuard`, so navigating to it rendered `ToSAcceptancePage` again, while the layout already hides the assistance button on that path. The support page itself needs no user consent: it reads no user state, and the email is entered manually in the form.

## List of changes proposed in this pull request

- Moved the `/assistenza` route out of `ToSGuard` (and out of `RapidAccessGuard`/`OnboardingGuard`), keeping it under `SessionGuard` so the session token is still attached to the Zendesk authorization call
- Added `navigation/__test__/routes.test.tsx`, covering the support route with ToS and privacy not accepted, plus the counter-check that a guarded route still shows the ToS page

## How to test

Log in with a user that has not accepted the ToS, or mock `https://webapi.dev.notifichedigitali.it/bff/v2/tos-privacy?type=TOS%2CDATAPRIVACY` with Netify, returning an empty array `[]` in the response body.

Then, on the ToS acceptance page:

1. Click *Assistenza* in the header: the support page opens instead of the ToS page reloading
2. Submit the form with a valid email: the redirect to Zendesk works
3. Go back: the ToS acceptance page is shown again

## Checklist

- [x] No real people names are present in mock data, examples, fixtures, screenshots, or sample content.
- [x] No real company names are present unless explicitly required and approved.
- [x] No real public institution names, agencies, municipalities, or other real entities are present in fake/demo/mock content.
- [x] All placeholder content, examples, mock entities, and sample data are clearly fake and unmistakably non-real.
- [x] Any potentially ambiguous name has been reviewed and flagged if needed.
