### PR TITLE
fix(PN-20855): prevent ToS and Privacy links from toggling acceptance switch

### DIFF
--- a/packages/pn-personafisica-webapp/src/pages/ToSAcceptance.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/ToSAcceptance.page.tsx
@@ -1,4 +1,5 @@
-import { ChangeEvent, ReactNode, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
+import type { ChangeEvent, MouseEventHandler, ReactNode } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 
@@ -40,8 +41,14 @@ const TermsOfService = ({ tosConsent, privacyConsent }: TermsOfServiceProps) => 
   Andrea Cimini, 2024.03.13
   ----------------------
   */
-  const redirectPrivacyLink = () => window.open(`${PRIVACY_LINK_RELATIVE_PATH}`, '_blank');
-  const redirectToSLink = () => window.open(`${TOS_LINK_RELATIVE_PATH}`, '_blank');
+  const redirectPrivacyLink: MouseEventHandler<HTMLAnchorElement> = (e) => {
+    e.preventDefault();
+    window.open(PRIVACY_LINK_RELATIVE_PATH, '_blank');
+  };
+  const redirectToSLink: MouseEventHandler<HTMLAnchorElement> = (e) => {
+    e.preventDefault();
+    window.open(TOS_LINK_RELATIVE_PATH, '_blank');
+  };
 
   const PrivacyLink = ({ children }: { children?: ReactNode }) => (
     <Link

--- a/packages/pn-personafisica-webapp/src/pages/__test__/ToSAcceptance.page.test.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/__test__/ToSAcceptance.page.test.tsx
@@ -114,6 +114,28 @@ describe('test Terms of Service page', () => {
     });
   });
 
+  it('does not toggle the acceptance switch when clicking ToS and Privacy links', () => {
+    const { getByRole, getByTestId } = render(
+      <ToSAcceptance tosConsent={tosConsent} privacyConsent={privacyConsent} />
+    );
+    const switchElement = getByRole('checkbox');
+    const privacyLink = getByTestId('privacy-link');
+    const tosLink = getByTestId('terms-and-conditions');
+
+    fireEvent.click(privacyLink);
+    expect(switchElement).not.toBeChecked();
+    fireEvent.click(tosLink);
+    expect(switchElement).not.toBeChecked();
+
+    fireEvent.click(switchElement);
+    expect(switchElement).toBeChecked();
+
+    fireEvent.click(privacyLink);
+    expect(switchElement).toBeChecked();
+    fireEvent.click(tosLink);
+    expect(switchElement).toBeChecked();
+  });
+
   it('navigate to dashboard if tos and privacy are accepted', async () => {
     const { router } = render(
       <ToSAcceptance

--- a/packages/pn-personagiuridica-webapp/src/pages/ToSAcceptance.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/ToSAcceptance.page.tsx
@@ -1,4 +1,5 @@
-import { ChangeEvent, ReactNode, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
+import type { ChangeEvent, MouseEventHandler, ReactNode } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 
@@ -40,8 +41,14 @@ const TermsOfService = ({ tosConsent, privacyConsent }: TermsOfServiceProps) => 
   Andrea Cimini, 2024.03.13
   ----------------------
   */
-  const redirectPrivacyLink = () => window.open(`${PRIVACY_LINK_RELATIVE_PATH}`, '_blank');
-  const redirectToSLink = () => window.open(`${TOS_LINK_RELATIVE_PATH}`, '_blank');
+  const redirectPrivacyLink: MouseEventHandler<HTMLAnchorElement> = (e) => {
+    e.preventDefault();
+    window.open(PRIVACY_LINK_RELATIVE_PATH, '_blank');
+  };
+  const redirectToSLink: MouseEventHandler<HTMLAnchorElement> = (e) => {
+    e.preventDefault();
+    window.open(TOS_LINK_RELATIVE_PATH, '_blank');
+  };
 
   const PrivacyLink = ({ children }: { children?: ReactNode }) => (
     <Link

--- a/packages/pn-personagiuridica-webapp/src/pages/__test__/ToSAcceptance.page.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/__test__/ToSAcceptance.page.test.tsx
@@ -114,6 +114,28 @@ describe('test Terms of Service page', () => {
     });
   });
 
+  it('does not toggle the acceptance switch when clicking ToS and Privacy links', () => {
+    const { getByRole, getByTestId } = render(
+      <ToSAcceptance tosConsent={tosConsent} privacyConsent={privacyConsent} />
+    );
+    const switchElement = getByRole('checkbox');
+    const privacyLink = getByTestId('privacy-link');
+    const tosLink = getByTestId('terms-and-conditions');
+
+    fireEvent.click(privacyLink);
+    expect(switchElement).not.toBeChecked();
+    fireEvent.click(tosLink);
+    expect(switchElement).not.toBeChecked();
+
+    fireEvent.click(switchElement);
+    expect(switchElement).toBeChecked();
+
+    fireEvent.click(privacyLink);
+    expect(switchElement).toBeChecked();
+    fireEvent.click(tosLink);
+    expect(switchElement).toBeChecked();
+  });
+
   it('navigate to dashboard if tos and privacy are accepted', async () => {
     const { router } = render(
       <ToSAcceptance


### PR DESCRIPTION
## Short description
Fix applied to PF and PG acceptance pages by preventing link clicks from triggering the parend label behavior.

## List of changes proposed in this pull request
- Prevent ToS and Privacy link click from affecting the acceptance switch
- Add regression tests

## How to test
Log in to PF and PG and mock the `tos-privacy` response by setting `accepted: false` on least one of the two consent objects, then verify that clicking on ToS and Privacy links doesn't change the switch state.

## Checklist

- [x] No real people names are present in mock data, examples, fixtures, screenshots, or sample content.
- [x] No real company names are present unless explicitly required and approved.
- [x] No real public institution names, agencies, municipalities, or other real entities are present in fake/demo/mock content.
- [x] All placeholder content, examples, mock entities, and sample data are clearly fake and unmistakably non-real.
- [x] Any potentially ambiguous name has been reviewed and flagged if needed.