### PR TITLE
refactor: return a new array from sortDelegations instead of sorting in place

### DIFF
--- a/packages/pn-personafisica-webapp/src/utility/delegation.utility.ts
+++ b/packages/pn-personafisica-webapp/src/utility/delegation.utility.ts
@@ -39,8 +39,7 @@ export function sortDelegations<T extends Delegate | Delegator>(
   if (sortAttr === '') {
     return values;
   }
-  /* eslint-disable-next-line functional/immutable-data */
-  return values.sort((a: T, b: T) => {
+  return [...values].sort((a: T, b: T) => {
     const orderDirection = order === 'desc' ? 1 : -1;
     if (sortAttr === 'endDate') {
       const dateA = new Date(a.dateto).getTime();

--- a/packages/pn-personagiuridica-webapp/src/utility/delegation.utility.ts
+++ b/packages/pn-personagiuridica-webapp/src/utility/delegation.utility.ts
@@ -37,8 +37,7 @@ export function sortDelegations<T extends Delegate | Delegator>(
   sortAttr: string,
   values: Array<T>
 ) {
-  /* eslint-disable-next-line functional/immutable-data */
-  return values.sort((a: T, b: T) => {
+  return [...values].sort((a: T, b: T) => {
     const orderDirection = order === 'desc' ? 1 : -1;
     if (sortAttr === 'endDate') {
       const dateA = new Date(a.dateto).getTime();


### PR DESCRIPTION
## Short description
`sortDelegations` sorted the incoming array in place (`values.sort()`), mutating the caller's array and requiring an `eslint-disable functional/immutable-data`. It now sorts a copy and returns a new array.

## List of changes proposed in this pull request
- `pn-personafisica-webapp`: `sortDelegations` uses `[...values].sort(...)`, removed the `eslint-disable-next-line functional/immutable-data`
- `pn-personagiuridica-webapp`: same change, to keep the two implementations aligned

## How to test
No behavioural change expected.

- PF: the only production caller is the `setDelegatesSorting` / `setDelegatorsSorting` reducer, which already reassigns the result (`state.delegations.delegates = sortDelegations(...)`); Immer finalizes the draft correctly even when starting from the copy.
- PG: the function has no production callers, it is only used in tests.
- Manual check: Deleghe dashboard, sorting the delegates/delegators tables by name and by end date, both asc and desc.
- Tests: `yarn vitest run src/utility/__test__/delegation.utility.test.ts src/components/Deleghe src/redux/delegation` on both packages (28 + 70 tests passing).
