### PR TITLE
fix(PN-20762): reset pagination when switching to delegated notifications

### DIFF
--- a/packages/pn-personagiuridica-webapp/src/__mocks__/Dashboard.mock.ts
+++ b/packages/pn-personagiuridica-webapp/src/__mocks__/Dashboard.mock.ts
@@ -1,0 +1,38 @@
+import {
+  GetNotificationsParams,
+  NotificationColumnData,
+  RecipientNotification,
+  Sort,
+} from '@pagopa-pn/pn-commons';
+
+export const dashboardInitialState = {
+  loading: false,
+  notifications: [] as Array<RecipientNotification>,
+  filters: {
+    startDate: undefined,
+    endDate: undefined,
+    communicationType: '',
+    iunMatch: '',
+  } as GetNotificationsParams,
+  isDelegatedPage: false,
+  pagination: {
+    nextPagesKey: [] as Array<string>,
+    size: 10,
+    page: 0,
+    moreResult: false,
+  },
+  sort: {
+    orderBy: '',
+    order: 'asc',
+  } as Sort<NotificationColumnData<RecipientNotification>>,
+};
+
+export const dashboardPaginatedState = {
+  ...dashboardInitialState,
+  pagination: {
+    ...dashboardInitialState.pagination,
+    nextPagesKey: ['stale-page-key'],
+    page: 1,
+    moreResult: true,
+  },
+};

--- a/packages/pn-personagiuridica-webapp/src/pages/Notifiche.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/Notifiche.page.tsx
@@ -27,7 +27,12 @@ import { PNRole } from '../models/User';
 import { ContactSource } from '../models/contacts';
 import { contactsSelectors } from '../redux/contact/reducers';
 import { DASHBOARD_ACTIONS, getReceivedNotifications } from '../redux/dashboard/actions';
-import { setNotificationFilters, setPagination, setSorting } from '../redux/dashboard/reducers';
+import {
+  setIsDelegatedPage,
+  setNotificationFilters,
+  setPagination,
+  setSorting,
+} from '../redux/dashboard/reducers';
 import { useAppDispatch, useAppSelector } from '../redux/hooks';
 import { setHasNewNotifications } from '../redux/sidemenu/reducers';
 import { RootState } from '../redux/store';
@@ -44,9 +49,13 @@ const Notifiche = ({ isDelegatedPage = false }: Props) => {
   const [pageReady, setPageReady] = useState(false);
   const domicileBannerTypeRef = useRef('');
 
-  const { notifications, filters, sort, pagination } = useAppSelector(
-    (state: RootState) => state.dashboardState
-  );
+  const {
+    notifications,
+    filters,
+    sort,
+    pagination,
+    isDelegatedPage: storedIsDelegatedPage,
+  } = useAppSelector((state: RootState) => state.dashboardState);
   const { defaultEMAILAddress, defaultSMSAddress, addresses } = useAppSelector(
     contactsSelectors.selectAddresses
   );
@@ -196,13 +205,17 @@ const Notifiche = ({ isDelegatedPage = false }: Props) => {
   }, []);
 
   useEffect(() => {
+    if (storedIsDelegatedPage !== isDelegatedPage) {
+      dispatch(setIsDelegatedPage(isDelegatedPage));
+      return;
+    }
     if (isDelegatedPage && filters.communicationType) {
       dispatch(setNotificationFilters({ ...filters, communicationType: '' }));
       return;
     }
 
     fetchNotifications();
-  }, [fetchNotifications, isDelegatedPage, filters, dispatch]);
+  }, [fetchNotifications, isDelegatedPage, filters, dispatch, storedIsDelegatedPage]);
 
   // Announce every time loading goes from true -> false
   useEffect(() => {

--- a/packages/pn-personagiuridica-webapp/src/pages/__test__/Notifiche.page.test.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/__test__/Notifiche.page.test.tsx
@@ -13,6 +13,7 @@ import {
 import { createMatchMedia, testInput } from '@pagopa-pn/pn-commons/src/test-utils';
 
 import { userResponse } from '../../__mocks__/Auth.mock';
+import { dashboardPaginatedState } from '../../__mocks__/Dashboard.mock';
 import { errorMock } from '../../__mocks__/Errors.mock';
 import { emptyNotificationsFromBe, notificationsDTO } from '../../__mocks__/Notifications.mock';
 import {
@@ -330,6 +331,40 @@ describe('Notifiche Page ', () => {
     });
     notificationsTableRows = result.getAllByTestId('notificationsTable.body.row');
     expect(notificationsTableRows).toHaveLength(notificationGroup3.length);
+  });
+
+  it('resets pagination when switching to delegated notifications', async () => {
+    const delegatedNotificationsDTO = {
+      ...notificationsDTO,
+      nextPagesKey: [],
+      moreResult: false,
+    };
+
+    mock.onGet(notificationsDelegatedPath).reply(200, delegatedNotificationsDTO);
+
+    await act(async () => {
+      result = render(<Notifiche isDelegatedPage />, {
+        preloadedState: {
+          userState: {
+            user: userResponse,
+          },
+          dashboardState: dashboardPaginatedState,
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(mock.history.get).toHaveLength(1);
+    });
+
+    expect(mock.history.get[0].url).toBe(notificationsDelegatedPath);
+
+    const dashboardState = result.testStore.getState().dashboardState;
+
+    expect(dashboardState.isDelegatedPage).toBe(true);
+    expect(dashboardState.pagination.page).toBe(0);
+    expect(dashboardState.pagination.nextPagesKey).toEqual([]);
+    expect(dashboardState.pagination.moreResult).toBe(false);
   });
 
   it('renders page - mobile', async () => {

--- a/packages/pn-personagiuridica-webapp/src/redux/dashboard/__test__/reducers.test.ts
+++ b/packages/pn-personagiuridica-webapp/src/redux/dashboard/__test__/reducers.test.ts
@@ -15,7 +15,7 @@ import { notificationsDTO, notificationsToFe } from '../../../__mocks__/Notifica
 import { apiClient } from '../../../api/apiClients';
 import { store } from '../../store';
 import { getReceivedNotifications } from '../actions';
-import { setNotificationFilters, setPagination, setSorting } from '../reducers';
+import { setIsDelegatedPage, setNotificationFilters, setPagination, setSorting } from '../reducers';
 
 describe('Dashbaord redux state tests', () => {
   let mock: MockAdapter;
@@ -26,6 +26,15 @@ describe('Dashbaord redux state tests', () => {
 
   afterEach(() => {
     mock.reset();
+
+    store.dispatch(setIsDelegatedPage(false));
+
+    store.dispatch(
+      setPagination({
+        page: 0,
+        size: 10,
+      })
+    );
   });
 
   afterAll(() => {
@@ -45,6 +54,7 @@ describe('Dashbaord redux state tests', () => {
         communicationType: '',
         iunMatch: '',
       },
+      isDelegatedPage: false,
       pagination: {
         nextPagesKey: [],
         size: 10,
@@ -137,6 +147,54 @@ describe('Dashbaord redux state tests', () => {
       page: 2,
       size: 50,
     });
+  });
+
+  it('Should reset pagination when switching to delegated page', async () => {
+    const paginatedNotificationsDTO = {
+      ...notificationsDTO,
+      moreResult: true,
+    };
+
+    mock
+      .onGet(
+        `/bff/v1/notifications/received?startDate=${encodeURIComponent(
+          formatToTimezoneString(tenYearsAgo)
+        )}&endDate=${encodeURIComponent(
+          formatToTimezoneString(today)
+        )}&size=10&communicationType=ALL`
+      )
+      .reply(200, paginatedNotificationsDTO);
+
+    await store.dispatch(
+      getReceivedNotifications({
+        startDate: tenYearsAgo,
+        endDate: today,
+        isDelegatedPage: false,
+        size: 10,
+      })
+    );
+
+    store.dispatch(
+      setPagination({
+        page: 1,
+        size: 10,
+      })
+    );
+
+    const stateBeforeReset = store.getState().dashboardState;
+
+    expect(stateBeforeReset.pagination.page).toBe(1);
+    expect(stateBeforeReset.pagination.nextPagesKey).toHaveLength(1);
+    expect(stateBeforeReset.pagination.moreResult).toBe(true);
+
+    store.dispatch(setIsDelegatedPage(true));
+
+    const stateAfterReset = store.getState().dashboardState;
+
+    expect(stateAfterReset.isDelegatedPage).toBe(true);
+    expect(stateAfterReset.pagination.page).toBe(0);
+    expect(stateAfterReset.pagination.nextPagesKey).toEqual([]);
+    expect(stateAfterReset.pagination.moreResult).toBe(false);
   });
 
   it('Should be able to change sort', () => {

--- a/packages/pn-personagiuridica-webapp/src/redux/dashboard/reducers.ts
+++ b/packages/pn-personagiuridica-webapp/src/redux/dashboard/reducers.ts
@@ -8,29 +8,40 @@ import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
 import { getReceivedNotifications } from './actions';
 
+const initialState = {
+  loading: false,
+  notifications: [] as Array<RecipientNotification>,
+  filters: {
+    startDate: undefined,
+    endDate: undefined,
+    communicationType: '',
+    iunMatch: '',
+  } as GetNotificationsParams,
+  isDelegatedPage: false,
+  pagination: {
+    nextPagesKey: [] as Array<string>,
+    size: 10,
+    page: 0,
+    moreResult: false,
+  },
+  sort: {
+    orderBy: '',
+    order: 'asc',
+  } as Sort<NotificationColumnData<RecipientNotification>>,
+};
+
+type DashboardState = typeof initialState;
+
 /* eslint-disable functional/immutable-data */
+const resetPaginationState = (state: DashboardState) => {
+  state.pagination.page = 0;
+  state.pagination.nextPagesKey = [];
+  state.pagination.moreResult = false;
+};
+
 const dashboardSlice = createSlice({
   name: 'dashboardSlice',
-  initialState: {
-    loading: false,
-    notifications: [] as Array<RecipientNotification>,
-    filters: {
-      startDate: undefined,
-      endDate: undefined,
-      communicationType: '',
-      iunMatch: '',
-    } as GetNotificationsParams,
-    pagination: {
-      nextPagesKey: [] as Array<string>,
-      size: 10,
-      page: 0,
-      moreResult: false,
-    },
-    sort: {
-      orderBy: '',
-      order: 'asc',
-    } as Sort<NotificationColumnData<RecipientNotification>>,
-  },
+  initialState,
   reducers: {
     setPagination: (state, action: PayloadAction<{ page: number; size: number }>) => {
       if (state.pagination.size !== action.payload.size) {
@@ -41,6 +52,12 @@ const dashboardSlice = createSlice({
       state.pagination.size = action.payload.size;
       state.pagination.page = action.payload.page;
     },
+    setIsDelegatedPage: (state, action: PayloadAction<boolean>) => {
+      if (state.isDelegatedPage !== action.payload) {
+        state.isDelegatedPage = action.payload;
+        resetPaginationState(state);
+      }
+    },
     setSorting: (
       state,
       action: PayloadAction<Sort<NotificationColumnData<RecipientNotification>>>
@@ -49,10 +66,7 @@ const dashboardSlice = createSlice({
     },
     setNotificationFilters: (state, action: PayloadAction<GetNotificationsParams>) => {
       state.filters = action.payload;
-      // reset pagination
-      state.pagination.page = 0;
-      state.pagination.nextPagesKey = [];
-      state.pagination.moreResult = false;
+      resetPaginationState(state);
     },
   },
   extraReducers: (builder) => {
@@ -71,6 +85,7 @@ const dashboardSlice = createSlice({
   },
 });
 
-export const { setPagination, setSorting, setNotificationFilters } = dashboardSlice.actions;
+export const { setPagination, setIsDelegatedPage, setSorting, setNotificationFilters } =
+  dashboardSlice.actions;
 
 export default dashboardSlice;


### PR DESCRIPTION
## Short description
Fixes an issue where pagination state from the organization's notification list was incorrectly reused when switching to delegated notifications, causing unavailable pages to be displayed.

## List of changes proposed in this pull request
- reset pagination when switching between onw and delagated notifications
- add regression coverage for pagination reset

## How to test
1. Choose a delegator with few notifications in the last 120 days and create a mandate for a PG
2. Open the organization's notification list and navigate to a page after the first one
3. Switch to "Incoming from delegations" and verify the pagination is recalculated for the delegated list an no stale pages are shown
4. Switch back to organization's list and verify the pagination is correctly reset

## Checklist

- [ ] No real people names are present in mock data, examples, fixtures, screenshots, or sample content.
- [ ] No real company names are present unless explicitly required and approved.
- [ ] No real public institution names, agencies, municipalities, or other real entities are present in fake/demo/mock content.
- [ ] All placeholder content, examples, mock entities, and sample data are clearly fake and unmistakably non-real.
- [ ] Any potentially ambiguous name has been reviewed and flagged if needed.