### PR TITLE
fix(PN-21374, PN-21339): show recipient label on multi recipient notifications and fix background color of timeline page

### DIFF
--- a/packages/pn-commons/src/utility/__test__/notificationTimeline.utility.test.ts
+++ b/packages/pn-commons/src/utility/__test__/notificationTimeline.utility.test.ts
@@ -139,7 +139,7 @@ describe('notificationTimeline utility', () => {
       ]);
     });
 
-    it('shows nothing at all when only a single recipient is involved, even mixing events and groups', () => {
+    it('still flags the first occurrence even when only a single recipient is involved, mixing events and groups', () => {
       const steps = [
         eventStepOfRecIndex(0),
         groupStepOfRecIndex(0, 'group0'),
@@ -147,13 +147,13 @@ describe('notificationTimeline utility', () => {
       ];
 
       expect(getRecipientPerStep(steps, recipients)).toStrictEqual([
-        undefined,
+        recipients[0],
         undefined,
         undefined,
       ]);
     });
 
-    it('ignores steps with no recIndex, both for the "more than one recipient" check and the tracked recIndex', () => {
+    it('ignores steps with no recIndex and does not alter the tracked recIndex', () => {
       const steps = [
         groupStepOfRecIndex(0, 'group0'),
         eventStepOfRecIndex(undefined),

--- a/packages/pn-commons/src/utility/notificationTimeline.utility.ts
+++ b/packages/pn-commons/src/utility/notificationTimeline.utility.ts
@@ -45,23 +45,14 @@ const getStepRecIndex = (step: NotificationTimelineStep): number | undefined =>
 
 /**
  * For each step, the recipient to display as a header above it, or undefined if none should be
- * shown there. Returns all undefined when the steps involve a single recipient; otherwise flags
- * a recipient the first time it's met and every time it changes, on event steps and group steps
- * alike.
+ * shown there. Flags a recipient the first time it's met and every time it changes, on event
+ * steps and group steps alike. Callers are expected to only use this for multi-recipient
+ * notifications, since every recipient encountered ends up flagged at least once.
  */
 export const getRecipientPerStep = (
   steps: Array<NotificationTimelineStep>,
   recipients: Array<NotificationDetailRecipient>
 ): Array<NotificationDetailRecipient | undefined> => {
-  const distinctRecIndexes = new Set(
-    steps.map(getStepRecIndex).filter((recIndex): recIndex is number => recIndex !== undefined)
-  );
-
-  // If there is only one recipient involved in the steps, we don't need to show any recipient headers.
-  if (distinctRecIndexes.size < 2) {
-    return steps.map(() => undefined);
-  }
-
   // eslint-disable-next-line functional/no-let
   let lastRecIndex: number | undefined;
 

--- a/packages/pn-pa-webapp/src/pages/NotificationTimeline.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/NotificationTimeline.page.tsx
@@ -159,20 +159,20 @@ const NotificationTimeline: React.FC = () => {
       {!hasNotificationSentApiError && pageReady && (
         <Box sx={{ p: 3, display: 'flex', flexDirection: 'column' }} gap={3}>
           {properBreadcrumb}
-          <Stack gap={3}>
+          <Stack>
             <Typography variant="h4" component="h1">
               {t('detail.notification-timeline-section.title', { ns: 'notifiche' })}
             </Typography>
-            <MIPaper>
-              {IS_NEW_TIMELINE_ENABLED ? (
-                <NotificationEventsTimeline
-                  language={i18n.language}
-                  recipients={notificationTimeline.recipients}
-                  statusHistory={notificationTimeline.notificationStatusHistory}
-                  clickHandler={legalFactDownloadHandler}
-                  isSenderTimeline
-                />
-              ) : (
+            {IS_NEW_TIMELINE_ENABLED ? (
+              <NotificationEventsTimeline
+                language={i18n.language}
+                recipients={notificationTimeline.recipients}
+                statusHistory={notificationTimeline.notificationStatusHistory}
+                clickHandler={legalFactDownloadHandler}
+                isSenderTimeline
+              />
+            ) : (
+              <MIPaper sx={{ mt: 3 }}>
                 <NotificationDetailTimeline
                   language={i18n.language}
                   recipients={notification.recipients}
@@ -182,8 +182,8 @@ const NotificationTimeline: React.FC = () => {
                   showLessButtonLabel={t('detail.show-less', { ns: 'notifiche' })}
                   handleTrackShowMoreLess={trackTimelineShowMore}
                 />
-              )}
-            </MIPaper>
+              </MIPaper>
+            )}
           </Stack>
         </Box>
       )}

--- a/packages/pn-personafisica-webapp/src/pages/NotificationTimeline.page.tsx
+++ b/packages/pn-personafisica-webapp/src/pages/NotificationTimeline.page.tsx
@@ -225,7 +225,7 @@ const NotificationTimeline: React.FC = () => {
     <MIAlert
       data-testid="cancelledAlertText"
       severity="warning"
-      sx={{ mb: { xs: 2, lg: 0 } }}
+      sx={{ mt: 3, mb: { xs: 2, lg: 0 } }}
       action={{
         label: t('detail.cancelled.cta', { ns: 'notifiche' }),
         onClick: () => {
@@ -274,21 +274,21 @@ const NotificationTimeline: React.FC = () => {
         {!hasNotificationTimelineApiError && (
           <Box sx={{ p: 3, display: 'flex', flexDirection: 'column' }} gap={3}>
             {properBreadcrumb}
-            <Stack gap={3}>
+            <Stack>
               <Typography variant="h4" component="h1">
                 {t('detail.notification-timeline-section.title', { ns: 'notifiche' })}
               </Typography>
-              {isCancelledOrCancelling && cancelledAlert}
-              <MIPaper>
-                {IS_NEW_TIMELINE_ENABLED ? (
-                  <NotificationEventsTimeline
-                    language={i18n.language}
-                    recipients={notificationTimeline.recipients}
-                    statusHistory={notificationTimeline.notificationStatusHistory}
-                    clickHandler={legalFactDownloadHandler}
-                    disableDownloads={isCancelled.cancellationInTimeline}
-                  />
-                ) : (
+              {cancelledAlert}
+              {IS_NEW_TIMELINE_ENABLED ? (
+                <NotificationEventsTimeline
+                  language={i18n.language}
+                  recipients={notificationTimeline.recipients}
+                  statusHistory={notificationTimeline.notificationStatusHistory}
+                  clickHandler={legalFactDownloadHandler}
+                  disableDownloads={isCancelled.cancellationInTimeline}
+                />
+              ) : (
+                <MIPaper sx={{ mt: 3 }}>
                   <NotificationDetailTimeline
                     language={i18n.language}
                     recipients={notification.recipients}
@@ -300,8 +300,8 @@ const NotificationTimeline: React.FC = () => {
                     disableDownloads={isCancelled.cancellationInTimeline}
                     isParty={false}
                   />
-                )}
-              </MIPaper>
+                </MIPaper>
+              )}
             </Stack>
           </Box>
         )}

--- a/packages/pn-personagiuridica-webapp/src/pages/NotificationTimeline.page.tsx
+++ b/packages/pn-personagiuridica-webapp/src/pages/NotificationTimeline.page.tsx
@@ -180,7 +180,7 @@ const NotificationTimeline: React.FC = () => {
     <MIAlert
       data-testid="cancelledAlertText"
       severity="warning"
-      sx={{ mb: { xs: 2, lg: 0 } }}
+      sx={{ mt: 3, mb: { xs: 2, lg: 0 } }}
       action={{
         label: t('detail.cancelled.cta', { ns: 'notifiche' }),
         href: NOTIFICATION_CANCELLED_HELP_LINK,
@@ -203,21 +203,21 @@ const NotificationTimeline: React.FC = () => {
       {!hasNotificationTimelineApiError && (
         <Box sx={{ p: 3, display: 'flex', flexDirection: 'column' }} gap={3}>
           {properBreadcrumb}
-          <Stack gap={3}>
+          <Stack>
             <Typography variant="h4" component="h1">
               {t('detail.notification-timeline-section.title', { ns: 'notifiche' })}
             </Typography>
-            {isCancelledOrCancelling && cancelledAlert}
-            <MIPaper>
-              {IS_NEW_TIMELINE_ENABLED ? (
-                <NotificationEventsTimeline
-                  language={i18n.language}
-                  recipients={notificationTimeline.recipients}
-                  statusHistory={notificationTimeline.notificationStatusHistory}
-                  clickHandler={legalFactDownloadHandler}
-                  disableDownloads={isCancelled.cancellationInTimeline}
-                />
-              ) : (
+            {cancelledAlert}
+            {IS_NEW_TIMELINE_ENABLED ? (
+              <NotificationEventsTimeline
+                language={i18n.language}
+                recipients={notificationTimeline.recipients}
+                statusHistory={notificationTimeline.notificationStatusHistory}
+                clickHandler={legalFactDownloadHandler}
+                disableDownloads={isCancelled.cancellationInTimeline}
+              />
+            ) : (
+              <MIPaper sx={{ mt: 3 }}>
                 <NotificationDetailTimeline
                   language={i18n.language}
                   recipients={notification.recipients}
@@ -229,8 +229,8 @@ const NotificationTimeline: React.FC = () => {
                   disableDownloads={isCancelled.cancellationInTimeline}
                   isParty={false}
                 />
-              )}
-            </MIPaper>
+              </MIPaper>
+            )}
           </Stack>
         </Box>
       )}


### PR DESCRIPTION
## Short description

Show recipient label on multi recipient notifications and fix background color of timeline page.

## List of changes proposed in this pull request
- Display recipient name on multi recipient notifications also if there is only one event 
- Fix background color of timeline page and some spacings

## How to test
- Start PA, PF and PG and check the layout of the timeline
- Start PA, in TEST environment with `ggiorgi` - Comune di Viggiu and check LZNW-WNXJ-KTMK-202609-E-1. On the effective date step you should see the recipient name related to the event

## Checklist

- [x] No real people names are present in mock data, examples, fixtures, screenshots, or sample content.
- [x] No real company names are present unless explicitly required and approved.
- [x] No real public institution names, agencies, municipalities, or other real entities are present in fake/demo/mock content.
- [x] All placeholder content, examples, mock entities, and sample data are clearly fake and unmistakably non-real.
- [x] Any potentially ambiguous name has been reviewed and flagged if needed.