### PR TITLE
fix(PN-21163): PA hide notification filters on empty state

### DIFF
--- a/packages/pn-pa-webapp/src/pages/Dashboard.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/Dashboard.page.tsx
@@ -70,6 +70,9 @@ const Dashboard = () => {
     cleanFilters: () => void 0,
   });
 
+  const filtersApplied = filterNotificationsRef.current.filtersApplied;
+  const showFilters = (notifications.length > 0 || filtersApplied) && !hasTimeoutError;
+
   // Pagination handlers
   const handleChangePage = (paginationData: PaginationData) => {
     dispatch(setPagination({ size: paginationData.size, page: paginationData.page }));
@@ -212,9 +215,11 @@ const Dashboard = () => {
 
       {isSmallScreen && getTitleButtonContent()}
 
-      <Box sx={{ mb: { xs: 0, lg: 3 } }}>
-        <FilterNotifications ref={filterNotificationsRef} showFilters />
-      </Box>
+      {showFilters && (
+        <Box sx={{ mb: { xs: 0, lg: 3 } }}>
+          <FilterNotifications ref={filterNotificationsRef} showFilters />
+        </Box>
+      )}
 
       <ApiErrorWrapper
         apiId={DASHBOARD_ACTIONS.GET_SENT_NOTIFICATIONS}

--- a/packages/pn-pa-webapp/src/pages/__test__/Dashboard.page.test.tsx
+++ b/packages/pn-pa-webapp/src/pages/__test__/Dashboard.page.test.tsx
@@ -228,6 +228,35 @@ describe('Dashboard Page', () => {
     expect(rows[0]).toHaveTextContent(notificationsDTO.resultsPage[1].iun);
   });
 
+  it('keeps filters visible when active filter returns no notifications', async () => {
+    mock.onGet(notificationsPath).reply(200, notificationsDTO);
+
+    const filteredRecipient = notificationsDTO.resultsPage[0].recipients[0];
+    const notificationsPathFiltered = `/bff/v1/notifications/sent?startDate=${startParam}&endDate=${endParam}&recipientId=${filteredRecipient}&size=10`;
+
+    mock.onGet(notificationsPathFiltered).reply(200, emptyNotificationsFromBe);
+
+    await act(async () => {
+      result = render(<Dashboard />);
+    });
+
+    // apply filter
+    const form = result.getByTestId('filter-form') as HTMLFormElement;
+    await testInput(form, 'recipientId', filteredRecipient);
+
+    const submitButton = form.querySelector('button[type="submit"]');
+    expect(submitButton).toBeEnabled();
+    fireEvent.click(submitButton!);
+
+    await waitFor(() => {
+      expect(mock.history.get).toHaveLength(2);
+      expect(mock.history.get[1].url).toContain(`recipientId=${filteredRecipient}`);
+    });
+
+    // no notifications returned, but filters must remain visible
+    expect(result.queryByTestId('filter-form')).toBeInTheDocument();
+  });
+
   it('errors on api', async () => {
     mock.onGet(notificationsPath).reply(errorMock.status, errorMock.data);
 

--- a/packages/pn-pa-webapp/src/pages/__test__/Dashboard.page.test.tsx
+++ b/packages/pn-pa-webapp/src/pages/__test__/Dashboard.page.test.tsx
@@ -250,9 +250,8 @@ describe('Dashboard Page', () => {
 
     expect(screen.getByTestId('link-retry')).toBeInTheDocument();
 
-    // filters should be visible on desktop
-    const filterForm = screen.getByTestId('filter-form');
-    expect(filterForm).toBeInTheDocument();
+    // filters should be hidden when there are no notifications
+    expect(screen.queryByTestId('filter-form')).not.toBeInTheDocument();
   });
 
   it('shows timeout empty state when getSentNotifications times out', async () => {
@@ -298,7 +297,7 @@ describe('Dashboard Page', () => {
     expect(pageSelector).toBeInTheDocument();
   });
 
-  it('errors on api - mobile keeps filter toggle visible', async () => {
+  it('errors on api - mobile hides filter toggle', async () => {
     globalThis.matchMedia = createMatchMedia(800);
     mock.onGet(notificationsPath).reply(errorMock.status, errorMock.data);
 
@@ -321,9 +320,8 @@ describe('Dashboard Page', () => {
 
     expect(screen.getByTestId('link-retry')).toBeInTheDocument();
 
-    // On mobile we expect the toggle for filters to be visible
-    const toggle = screen.getByTestId('dialogToggle');
-    expect(toggle).toBeInTheDocument();
+    // On mobile filters are hidden when there are no notifications
+    expect(screen.queryByTestId('dialogToggle')).not.toBeInTheDocument();
   });
 
   it('mobile: opens filters drawer and applies recipientId filter', async () => {


### PR DESCRIPTION
## Short description
Hide notification filters when there are no notifications and no filters are applied.
Filters remain visible when an active filter returns no results, allowing the user to modify or clear the current filters.
Notification filters are also hidden in case of API errors.

## List of changes proposed in this pull request
- Added `showFilters` handling to PA notification filters
- Hidden filters when the notifications list is empty
- Kept filters visible when filters are active but return no results

## How to test
1. Open the PA Notifications page.
2. Verify that filters are displayed when notifications are available.
3. Verify that filters are hidden when there are no notifications and no active filters.
4. Apply a filter that returns no results and verify that the filters remain visible.
5. Verify that pagination is displayed only when notifications are available.