### PR TITLE
fix(PN-21428): fix padding in app io smart app banner

### DIFF
--- a/packages/pn-personafisica-login/src/components/IoSmartAppBanner.tsx
+++ b/packages/pn-personafisica-login/src/components/IoSmartAppBanner.tsx
@@ -14,7 +14,10 @@ const IOSmartAppBanner: React.FC<StackProps> = (props) => {
 
   return (
     <Stack id="ioSmartAppBanner" direction="row" alignItems="center" p={2} {...props}>
-      <Avatar variant="rounded" sx={{ bgcolor: 'primary.main', width: '30px', height: '30px' }}>
+      <Avatar
+        variant="rounded"
+        sx={{ bgcolor: 'primary.main', width: '30px', height: '30px', padding: '5px' }}
+      >
         <LogoIOApp title="AppIoLogo" color="light" />
       </Avatar>
       <Stack direction="column" mx={1}>


### PR DESCRIPTION
## Checklist
- [x] No real people names are present in mock data, examples, fixtures, screenshots, or sample content.
- [x] No real company names are present unless explicitly required and approved.
- [x] No real public institution names, agencies, municipalities, or other real entities are present in fake/demo/mock content.
- [x] All placeholder content, examples, mock entities, and sample data are clearly fake and unmistakably non-real.
- [x] Any potentially ambiguous name has been reviewed and flagged if needed.