### PR TITLE
fix(PN-18449): add boldness in alert when errors in payment

### DIFF
--- a/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentRecipient.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationPaymentRecipient.tsx
@@ -1,4 +1,5 @@
 import React, { memo, useCallback, useEffect, useState } from 'react';
+import { Trans } from 'react-i18next';
 
 import SaveAltRoundedIcon from '@mui/icons-material/SaveAltRounded';
 import { Box, Divider, FormControl, RadioGroup, Stack, Typography } from '@mui/material';
@@ -63,7 +64,7 @@ type Props = {
 
 type PaymentError = {
   title?: string;
-  description: string;
+  description: React.ReactNode;
   source?: 'tpp' | 'default';
 } | null;
 
@@ -188,7 +189,7 @@ const NotificationPaymentRecipient: React.FC<Props> = ({
     }
   };
 
-  const getErrorMessage = () => {
+  const getErrorMessage = (): React.ReactNode => {
     const loadedPayments = pagoPaF24.filter((payment) => !payment.isLoading);
 
     const failedPayments = loadedPayments.filter(
@@ -197,12 +198,12 @@ const NotificationPaymentRecipient: React.FC<Props> = ({
 
     // All payments failed
     if (failedPayments.length === loadedPayments.length) {
-      return getLocalizedOrDefaultLabel(
-        'notifications',
+      const i18nKey =
         failedPayments.length === 1
           ? 'detail.payment.error-payment-failed-single'
-          : 'detail.payment.error-payment-failed-multiple'
-      );
+          : 'detail.payment.error-payment-failed-multiple';
+
+      return <Trans ns="notifiche" i18nKey={i18nKey} components={[<strong key="0" />]} />;
     }
 
     return getLocalizedOrDefaultLabel('notifications', 'detail.payment.error-payment');

--- a/packages/pn-commons/src/components/NotificationDetail/__test__/NotificationPaymentRecipient.test.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/__test__/NotificationPaymentRecipient.test.tsx
@@ -20,6 +20,14 @@ import {
 import { setPaymentCache } from '../../../utility/paymentCaching.utility';
 import NotificationPaymentRecipient from '../NotificationPaymentRecipient';
 
+vi.mock('react-i18next', async (importOriginal) => {
+  const original = await importOriginal<typeof import('react-i18next')>();
+  const TransComponent = ({ i18nKey }: { i18nKey?: string }) => (
+    <span data-testid="trans-component">{i18nKey}</span>
+  );
+  return { ...original, Trans: TransComponent };
+});
+
 describe('NotificationPaymentRecipient Component', () => {
   const paymentsData: PaymentsData = {
     pagoPaF24: populatePaymentsPagoPaF24(
@@ -533,8 +541,9 @@ describe('NotificationPaymentRecipient Component', () => {
     fireEvent.click(payButton);
 
     const errorMessage = getByTestId('payment-error');
-    expect(errorMessage).toBeInTheDocument();
-    expect(errorMessage).toHaveTextContent('detail.payment.error-payment-failed-single');
+    expect(within(errorMessage).getByTestId('trans-component')).toHaveTextContent(
+      'detail.payment.error-payment-failed-single'
+    );
   });
 
   it('should show multiple payments failure error when all payments fail', () => {
@@ -566,9 +575,9 @@ describe('NotificationPaymentRecipient Component', () => {
     const payButton = getByTestId('pay-button');
     fireEvent.click(payButton);
 
-    const errorMessage = getByTestId('payment-error');
-    expect(errorMessage).toBeInTheDocument();
-    expect(errorMessage).toHaveTextContent('detail.payment.error-payment-failed-multiple');
+    expect(within(getByTestId('payment-error')).getByTestId('trans-component')).toHaveTextContent(
+      'detail.payment.error-payment-failed-single'
+    );
   });
 
   it('should show default error when no payment is selected but payments are valid', () => {

--- a/packages/pn-pa-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-pa-webapp/public/locales/it/notifiche.json
@@ -457,7 +457,7 @@
     "notification-timeline-reworked-description": "Gli eventi contrassegnati come rettificati sostituiscono gli eventi precedenti indicati come non validi.",
     "reworked-status-valid": "Evento rettificato",
     "reworked-status-not-valid": "Evento non valido",
-    "reworked-status-group": "Uno o più eventi rettificati",
+    "reworked-status-group": "Uno o più eventi aggiornati",
     "cancellation-in-progress": "Annullata",
     "cancellation-in-progress-tooltip": "Annullamento in corso. Lo stato sarà aggiornato a breve.",
     "cancellation-in-progress-description": "Annullamento in corso. Lo stato sarà aggiornato a breve."

--- a/packages/pn-personafisica-webapp/public/locales/de/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/de/notifiche.json
@@ -145,8 +145,8 @@
         "duplicated": "Diese Benachrichtigung wurde bereits bezahlt. Der Status wird in Kürze aktualisiert."
       },
       "error-payment": "Wählen Sie eine Zahlungsaufforderung aus",
-      "error-payment-failed-single": "Es ist ein Problem mit einer Zahlungsaufforderung aufgetreten. Drücken Sie auf Neu laden, um es erneut zu versuchen. Wenn der Fehler weiterhin besteht, kontaktieren Sie den Support.",
-      "error-payment-failed-multiple": "Es ist ein Problem mit mehreren Zahlungsaufforderungen aufgetreten. Drücken Sie auf Neu laden, um es erneut zu versuchen. Wenn der Fehler weiterhin besteht, kontaktieren Sie den Support.",
+      "error-payment-failed-single": "Bei einer Zahlungsaufforderung ist ein Problem aufgetreten. Drücke auf <0>Neu laden</0>, um es erneut zu versuchen. Wenn der Fehler weiterhin besteht, kontaktiere den Support.",
+      "error-payment-failed-multiple": "Bei mehreren Zahlungsaufforderungen ist ein Problem aufgetreten. Drücke auf <0>Neu laden</0>, um es erneut zu versuchen. Wenn der Fehler weiterhin besteht, kontaktiere den Support.",
       "tpp-expired-error-title": "Die Verbindung zur Bank ist abgelaufen.",
       "tpp-expired-error-description": "Um sie wiederherzustellen, greife über die Nachricht, die du in deiner Bank-App erhalten hast, erneut auf diese Benachrichtigung zu."
     },

--- a/packages/pn-personafisica-webapp/public/locales/en/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/en/notifiche.json
@@ -145,8 +145,8 @@
         "duplicated": "This notification has already been paid. The status will be updated shortly."
       },
       "error-payment": "Select a Payment Notice",
-      "error-payment-failed-single": "There was a problem with a Payment Notice. Press Reload to try again. If the error persists, contact the support team.",
-      "error-payment-failed-multiple": "There was a problem with multiple Payment Notices. Press Reload to try again. If the error persists, contact the support team.",
+      "error-payment-failed-single": "There was a problem with a payment notice. Press <0>Reload</0> to try again; if the error persists, contact support.",
+      "error-payment-failed-multiple": "There was a problem with multiple payment notices. Press <0>Reload</0> to try again; if the error persists, contact support.",
       "tpp-expired-error-title": "The connection with the bank has expired.",
       "tpp-expired-error-description": "To restore it, access this notification again using the message you received on your bank's app."
     },

--- a/packages/pn-personafisica-webapp/public/locales/fr/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/fr/notifiche.json
@@ -145,8 +145,8 @@
         "duplicated": "Cette alerte a déjà été payée. L’état sera mis à jour sous peu."
       },
       "error-payment": "Sélectionnez un avis de paiement",
-      "error-payment-failed-single": "Un problème est survenu avec un avis de paiement. Appuyez sur Recharger pour réessayer. Si l’erreur persiste, contactez l’assistance.",
-      "error-payment-failed-multiple": "Un problème est survenu avec plusieurs avis de paiement. Appuyez sur Recharger pour réessayer. Si l’erreur persiste, contactez l’assistance.",
+      "error-payment-failed-single": "Un problème est survenu avec un avis de paiement. Appuie sur <0>Recharger</0> pour réessayer. Si l’erreur persiste, contacte l’assistance.",
+      "error-payment-failed-multiple": "Un problème est survenu avec plusieurs avis de paiement. Appuie sur <0>Recharger</0> pour réessayer. Si l’erreur persiste, contacte l’assistance.",
       "tpp-expired-error-title": "La connexion avec la banque a expiré.",
       "tpp-expired-error-description": "Pour la rétablir, accédez de nouveau à cette notification via le message que vous avez reçu sur l'application de votre banque."
     },

--- a/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
@@ -498,7 +498,7 @@
     "notification-timeline-reworked-description": "Gli eventi contrassegnati come rettificati sostituiscono gli eventi precedenti indicati come non validi.",
     "reworked-status-valid": "Evento rettificato",
     "reworked-status-not-valid": "Evento non valido",
-    "reworked-status-group": "Uno o più eventi rettificati",
+    "reworked-status-group": "Uno o più eventi aggiornati",
     "cancellation-in-progress": "Annullata",
     "cancellation-in-progress-tooltip": "Annullamento in corso. Lo stato sarà aggiornato a breve.",
     "cancellation-in-progress-description": "Annullamento in corso. Lo stato sarà aggiornato a breve."

--- a/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/it/notifiche.json
@@ -144,8 +144,8 @@
         "duplicated": "Questo avviso è già stato pagato. Lo stato verrà aggiornato a breve."
       },
       "error-payment": "Seleziona un avviso di pagamento",
-      "error-payment-failed-single": "Si è verificato un problema con un avviso di pagamento. Premi Ricarica per riprovare, se l’errore persiste contatta l’assistenza.",
-      "error-payment-failed-multiple": "Si è verificato un problema con più avvisi di pagamento. Premi Ricarica per riprovare, se l’errore persiste contatta l’assistenza.",
+      "error-payment-failed-single": "Si è verificato un problema con un avviso di pagamento. Premi <0>Ricarica</0> per riprovare, se l’errore persiste contatta l’assistenza.",
+      "error-payment-failed-multiple": "Si è verificato un problema con più avvisi di pagamento. Premi <0>Ricarica</0> per riprovare, se l’errore persiste contatta l’assistenza.",
       "tpp-expired-error-title": "La connesione con la banca è scaduta.",
       "tpp-expired-error-description": "Per ripristinarla, accedi di nuovo a questa notifica tramite il messaggio che hai ricevuto sull'app della banca."
     },

--- a/packages/pn-personafisica-webapp/public/locales/sl/notifiche.json
+++ b/packages/pn-personafisica-webapp/public/locales/sl/notifiche.json
@@ -145,8 +145,8 @@
         "duplicated": "To opozorilo je bilo že plačano. Stanje bo kmalu posodobljeno."
       },
       "error-payment": "Izberite obvestilo o plačilu",
-      "error-payment-failed-single": "Prišlo je do težave z obvestilom o plačilu. Pritisnite Ponovno naloži za nov poskus. Če se napaka ponovi, se obrnite na podporo.",
-      "error-payment-failed-multiple": "Prišlo je do težave z več obvestili o plačilu. Pritisnite Ponovno naloži za nov poskus. Če se napaka ponovi, se obrnite na podporo.",
+      "error-payment-failed-single": "Prišlo je do težave z obvestilom o plačilu. Pritisni <0>Ponovno naloži</0> za ponovni poskus. Če se napaka nadaljuje, kontaktiraj podporo.",
+      "error-payment-failed-multiple": "Prišlo je do težave z več obvestili o plačilu. Pritisni <0>Ponovno naloži</0> za ponovni poskus. Če se napaka nadaljuje, kontaktiraj podporo.",
       "tpp-expired-error-title": "Povezava z banko je potekla.",
       "tpp-expired-error-description": "Za ponovno vzpostavitev ponovno dostopajte do tega obvestila prek sporočila, ki ste ga prejeli v aplikaciji vaše banke."
     },

--- a/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
+++ b/packages/pn-personagiuridica-webapp/public/locales/it/notifiche.json
@@ -489,7 +489,7 @@
     "notification-timeline-reworked-description": "Gli eventi contrassegnati come rettificati sostituiscono gli eventi precedenti indicati come non validi.",
     "reworked-status-valid": "Evento rettificato",
     "reworked-status-not-valid": "Evento non valido",
-    "reworked-status-group": "Uno o più eventi rettificati",
+    "reworked-status-group": "Uno o più eventi aggiornati",
     "cancellation-in-progress": "Annullata",
     "cancellation-in-progress-tooltip": "Annullamento in corso. Lo stato sarà aggiornato a breve.",
     "cancellation-in-progress-description": "Annullamento in corso. Lo stato sarà aggiornato a breve."


### PR DESCRIPTION
## Short description
add boldness in alert when errors in payment

## How to test
Run PF and check notification in payments with errors has _Ricarica_ in bold. 
Example: ada → `VKEG-DNQN-GNTH-202601-M-1`

## Checklist
- [x] No real people names are present in mock data, examples, fixtures, screenshots, or sample content.
- [x] No real company names are present unless explicitly required and approved.
- [x] No real public institution names, agencies, municipalities, or other real entities are present in fake/demo/mock content.
- [x] All placeholder content, examples, mock entities, and sample data are clearly fake and unmistakably non-real.
- [x] Any potentially ambiguous name has been reviewed and flagged if needed.