### PR TITLE
fix(PN-14151): add scroll to top when step to next

### DIFF
--- a/packages/pn-pa-webapp/src/pages/NewNotification.page.tsx
+++ b/packages/pn-pa-webapp/src/pages/NewNotification.page.tsx
@@ -160,6 +160,10 @@ const NewNotification = () => {
     }
   }, [activeStep]);
 
+  useEffect(() => {
+    window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
+  }, [activeStep]);
+
   if (activeStep === steps.length) {
     return <SyncFeedback />;
   }


### PR DESCRIPTION
## Short description
add scroll to top when step to next

## How to test
Login as PA, and create a new notification: check when move to next step, the page scrolls to top of page

## Checklist
- [x] No real people names are present in mock data, examples, fixtures, screenshots, or sample content.
- [x] No real company names are present unless explicitly required and approved.
- [x] No real public institution names, agencies, municipalities, or other real entities are present in fake/demo/mock content.
- [x] All placeholder content, examples, mock entities, and sample data are clearly fake and unmistakably non-real.
- [x] Any potentially ambiguous name has been reviewed and flagged if needed.