### PR TITLE
fix(PN-20001): add contact_details super property in PF onboarding

### DIFF
--- a/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/SendHasAddressesStrategy.ts
+++ b/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/SendHasAddressesStrategy.ts
@@ -1,6 +1,12 @@
 import { EventPropertyType, EventStrategy, TrackedEvent } from '@pagopa-pn/pn-commons';
 
-import { ChannelType, DigitalAddress, IOAllowedValues } from '../../../models/contacts';
+import {
+  AddressType,
+  ChannelType,
+  DigitalAddress,
+  IOAllowedValues,
+} from '../../../models/contacts';
+import { MixpanelConcatCourtesyContacts, concatCourtestyContacts } from '../../mixpanel';
 
 type SendHasAddresses = {
   SEND_HAS_PEC: 'yes' | 'no';
@@ -8,6 +14,7 @@ type SendHasAddresses = {
   SEND_HAS_EMAIL: 'yes' | 'no';
   SEND_HAS_SMS: 'yes' | 'no';
   SEND_APPIO_STATUS: 'nd' | 'deactivated' | 'activated';
+  contact_details: MixpanelConcatCourtesyContacts;
 };
 
 type SendHasAddressesData = {
@@ -31,6 +38,11 @@ export class SendHasAddressesStrategy implements EventStrategy {
       payload?.filter((address) => address.channelType === ChannelType.SMS).length > 0;
     const contactIO = payload?.find((address) => address.channelType === ChannelType.IOMSG);
 
+    const courtesyAddresses = payload.filter(
+      (address) => address.addressType === AddressType.COURTESY
+    );
+    const contactDetails = concatCourtestyContacts(courtesyAddresses);
+
     // eslint-disable-next-line functional/no-let
     let ioStatus: 'nd' | 'deactivated' | 'activated';
 
@@ -49,6 +61,7 @@ export class SendHasAddressesStrategy implements EventStrategy {
         SEND_HAS_EMAIL: hasCourtesyEmailAddresses ? 'yes' : 'no',
         SEND_HAS_SMS: hasCourtesySmsAddresses ? 'yes' : 'no',
         SEND_APPIO_STATUS: ioStatus,
+        contact_details: contactDetails,
       },
       [EventPropertyType.SUPER_PROPERTY]: {
         SEND_HAS_PEC: hasPecAddresses ? 'yes' : 'no',
@@ -56,6 +69,7 @@ export class SendHasAddressesStrategy implements EventStrategy {
         SEND_HAS_EMAIL: hasCourtesyEmailAddresses ? 'yes' : 'no',
         SEND_HAS_SMS: hasCourtesySmsAddresses ? 'yes' : 'no',
         SEND_APPIO_STATUS: ioStatus,
+        contact_details: contactDetails,
       },
     };
   }

--- a/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/__test__/SendHasAddressesStrategy.test.ts
+++ b/packages/pn-personafisica-webapp/src/utility/MixpanelUtils/Strategies/__test__/SendHasAddressesStrategy.test.ts
@@ -21,6 +21,7 @@ describe('Mixpanel - Has Addresses Strategy', () => {
         SEND_HAS_PEC: 'yes',
         SEND_HAS_SMS: 'yes',
         SEND_HAS_SERCQ_SEND: 'no',
+        contact_details: 'email_sms',
       },
       [EventPropertyType.SUPER_PROPERTY]: {
         SEND_APPIO_STATUS: 'deactivated',
@@ -28,6 +29,7 @@ describe('Mixpanel - Has Addresses Strategy', () => {
         SEND_HAS_PEC: 'yes',
         SEND_HAS_SMS: 'yes',
         SEND_HAS_SERCQ_SEND: 'no',
+        contact_details: 'email_sms',
       },
     });
   });
@@ -48,6 +50,7 @@ describe('Mixpanel - Has Addresses Strategy', () => {
         SEND_HAS_PEC: 'no',
         SEND_HAS_SMS: 'yes',
         SEND_HAS_SERCQ_SEND: 'no',
+        contact_details: 'email_sms',
       },
       [EventPropertyType.SUPER_PROPERTY]: {
         SEND_APPIO_STATUS: 'deactivated',
@@ -55,6 +58,7 @@ describe('Mixpanel - Has Addresses Strategy', () => {
         SEND_HAS_PEC: 'no',
         SEND_HAS_SMS: 'yes',
         SEND_HAS_SERCQ_SEND: 'no',
+        contact_details: 'email_sms',
       },
     });
   });
@@ -77,6 +81,7 @@ describe('Mixpanel - Has Addresses Strategy', () => {
         SEND_HAS_PEC: 'yes',
         SEND_HAS_SMS: 'yes',
         SEND_HAS_SERCQ_SEND: 'no',
+        contact_details: 'sms',
       },
       [EventPropertyType.SUPER_PROPERTY]: {
         SEND_APPIO_STATUS: 'deactivated',
@@ -84,6 +89,7 @@ describe('Mixpanel - Has Addresses Strategy', () => {
         SEND_HAS_PEC: 'yes',
         SEND_HAS_SMS: 'yes',
         SEND_HAS_SERCQ_SEND: 'no',
+        contact_details: 'sms',
       },
     });
   });
@@ -106,6 +112,7 @@ describe('Mixpanel - Has Addresses Strategy', () => {
         SEND_HAS_PEC: 'yes',
         SEND_HAS_SMS: 'no',
         SEND_HAS_SERCQ_SEND: 'no',
+        contact_details: 'email',
       },
       [EventPropertyType.SUPER_PROPERTY]: {
         SEND_APPIO_STATUS: 'deactivated',
@@ -113,6 +120,7 @@ describe('Mixpanel - Has Addresses Strategy', () => {
         SEND_HAS_PEC: 'yes',
         SEND_HAS_SMS: 'no',
         SEND_HAS_SERCQ_SEND: 'no',
+        contact_details: 'email',
       },
     });
   });
@@ -135,6 +143,7 @@ describe('Mixpanel - Has Addresses Strategy', () => {
         SEND_HAS_PEC: 'yes',
         SEND_HAS_SMS: 'yes',
         SEND_HAS_SERCQ_SEND: 'no',
+        contact_details: 'email_sms',
       },
       [EventPropertyType.SUPER_PROPERTY]: {
         SEND_APPIO_STATUS: 'nd',
@@ -142,6 +151,7 @@ describe('Mixpanel - Has Addresses Strategy', () => {
         SEND_HAS_PEC: 'yes',
         SEND_HAS_SMS: 'yes',
         SEND_HAS_SERCQ_SEND: 'no',
+        contact_details: 'email_sms',
       },
     });
   });
@@ -170,6 +180,7 @@ describe('Mixpanel - Has Addresses Strategy', () => {
         SEND_HAS_PEC: 'yes',
         SEND_HAS_SMS: 'yes',
         SEND_HAS_SERCQ_SEND: 'no',
+        contact_details: 'app_io_email_sms',
       },
       [EventPropertyType.SUPER_PROPERTY]: {
         SEND_APPIO_STATUS: 'activated',
@@ -177,6 +188,7 @@ describe('Mixpanel - Has Addresses Strategy', () => {
         SEND_HAS_PEC: 'yes',
         SEND_HAS_SMS: 'yes',
         SEND_HAS_SERCQ_SEND: 'no',
+        contact_details: 'app_io_email_sms',
       },
     });
   });
@@ -195,6 +207,7 @@ describe('Mixpanel - Has Addresses Strategy', () => {
         SEND_HAS_PEC: 'no',
         SEND_HAS_SMS: 'yes',
         SEND_HAS_SERCQ_SEND: 'yes',
+        contact_details: 'email_sms',
       },
       [EventPropertyType.SUPER_PROPERTY]: {
         SEND_APPIO_STATUS: 'deactivated',
@@ -202,6 +215,7 @@ describe('Mixpanel - Has Addresses Strategy', () => {
         SEND_HAS_PEC: 'no',
         SEND_HAS_SMS: 'yes',
         SEND_HAS_SERCQ_SEND: 'yes',
+        contact_details: 'email_sms',
       },
     });
   });
@@ -227,6 +241,7 @@ describe('Mixpanel - Has Addresses Strategy', () => {
         SEND_HAS_PEC: 'yes',
         SEND_HAS_SMS: 'yes',
         SEND_HAS_SERCQ_SEND: 'no',
+        contact_details: 'email_sms',
       },
       [EventPropertyType.SUPER_PROPERTY]: {
         SEND_APPIO_STATUS: 'deactivated',
@@ -234,6 +249,7 @@ describe('Mixpanel - Has Addresses Strategy', () => {
         SEND_HAS_PEC: 'yes',
         SEND_HAS_SMS: 'yes',
         SEND_HAS_SERCQ_SEND: 'no',
+        contact_details: 'email_sms',
       },
     });
   });


### PR DESCRIPTION
## Short description
Add contact_details super property in PF onboarding

## How to test
Run PF and check during onboarding superproperty contact_details is added in events

## Checklist
- [x] No real people names are present in mock data, examples, fixtures, screenshots, or sample content.
- [x] No real company names are present unless explicitly required and approved.
- [x] No real public institution names, agencies, municipalities, or other real entities are present in fake/demo/mock content.
- [x] All placeholder content, examples, mock entities, and sample data are clearly fake and unmistakably non-real.
- [x] Any potentially ambiguous name has been reviewed and flagged if needed.