### PR TITLE
fix(PN-21465): show event description when timeline status differs from DELIVERING

### DIFF
--- a/packages/pn-commons/src/components/NotificationDetail/NotificationEventsTimeline/NotificationEventsTimeline.tsx
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationEventsTimeline/NotificationEventsTimeline.tsx
@@ -3,6 +3,7 @@ import { Fragment, useMemo } from 'react';
 import { Box, Divider, Stack, Typography } from '@mui/material';
 import { MITimeline, MITimelineItem } from '@pagopa/mui-italia';
 
+import { NotificationStatus } from '../../../models';
 import { LegalFactId, NotificationDetailRecipient } from '../../../models/NotificationDetail';
 import { NotificationTimelineStatusHistory } from '../../../models/NotificationTimeline';
 import {
@@ -47,16 +48,7 @@ const NotificationEventsTimeline = ({
     <Box data-testid="NotificationEventsTimeline">
       <MITimeline>
         {timelineItems.map(
-          ({
-            status,
-            label,
-            description,
-            icon,
-            variant,
-            allEvents,
-            hasGroupedEvents,
-            recipientPerStep,
-          }) => (
+          ({ status, label, description, icon, variant, allEvents, recipientPerStep }) => (
             <MITimelineItem
               key={`timeline_step_${status.status}_${status.activeFrom}`}
               icon={icon}
@@ -75,8 +67,8 @@ const NotificationEventsTimeline = ({
                 </Stack>
               }
             >
-              <Stack gap={1.5} alignItems="flex-start" mt={hasGroupedEvents ? 1.5 : 0}>
-                {!hasGroupedEvents && (
+              <Stack gap={1.5} alignItems="flex-start">
+                {status.status !== NotificationStatus.DELIVERING && (
                   <Typography fontSize="14px" fontWeight={400}>
                     {description}{' '}
                     <NotificationTimelineEventDate date={status.activeFrom} language={language} />
@@ -90,7 +82,7 @@ const NotificationEventsTimeline = ({
                       variant="body2"
                       fontWeight={600}
                       data-testid="timeline-group-recipient"
-                      mt={3}
+                      mt={2}
                       sx={{ color: '#555C70' }}
                     >
                       {`${recipient.denomination} - ${recipient.taxId}`}

--- a/packages/pn-commons/src/components/NotificationDetail/NotificationEventsTimeline/__test__/timelineItem.config.test.ts
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationEventsTimeline/__test__/timelineItem.config.test.ts
@@ -42,35 +42,6 @@ describe('getTimelineItems', () => {
     expect(items.map((item) => item.status)).toStrictEqual(statusHistory);
   });
 
-  it('exposes hasGroupedEvents based on whether the status has a group step', () => {
-    const statusHistory = [
-      statusWithEvents(NotificationStatus.ACCEPTED, [
-        { stepType: 'EVENT', event: eventOfRecipient('event-1', 0) },
-      ]),
-      statusWithEvents(NotificationStatus.DELIVERING, [
-        {
-          stepType: 'GROUP',
-          group: {
-            groupId: 'group-1',
-            denomination: recipients[0].denomination,
-            taxId: recipients[0].taxId,
-            recIndex: 0,
-            category: 'ANALOG',
-            channel: 'AR_REGISTERED_LETTER',
-            hasReworkedEvents: false,
-            events: [],
-          },
-        },
-      ]),
-    ];
-    const legacyStatusHistory = toLegacyStatusHistory(statusHistory);
-
-    const items = getTimelineItems(statusHistory, legacyStatusHistory, [recipients[0]]);
-
-    expect(items[0].hasGroupedEvents).toBe(false);
-    expect(items[1].hasGroupedEvents).toBe(true);
-  });
-
   it('reuses the legacy status steps as allEvents, without flattening them again', () => {
     const statusHistory = [
       statusWithEvents(NotificationStatus.ACCEPTED, [
@@ -101,8 +72,12 @@ describe('getTimelineItems', () => {
       getTimelineItems(statusHistory, legacyStatusHistory, recipients, false)[0].recipientPerStep
     ).toStrictEqual([]);
 
-    const recipientPerStep = getTimelineItems(statusHistory, legacyStatusHistory, recipients, true)[0]
-      .recipientPerStep;
+    const recipientPerStep = getTimelineItems(
+      statusHistory,
+      legacyStatusHistory,
+      recipients,
+      true
+    )[0].recipientPerStep;
     expect(recipientPerStep).toStrictEqual([recipients[0], recipients[1]]);
   });
 

--- a/packages/pn-commons/src/components/NotificationDetail/NotificationEventsTimeline/timelineItem.config.ts
+++ b/packages/pn-commons/src/components/NotificationDetail/NotificationEventsTimeline/timelineItem.config.ts
@@ -5,10 +5,7 @@ import {
   NotificationTimelineStatusHistory,
 } from '../../../models/NotificationTimeline';
 import { getNotificationStatusInfos } from '../../../utility/notification.utility';
-import {
-  getRecipientPerStep,
-  isTimelineGroupStep,
-} from '../../../utility/notificationTimeline.utility';
+import { getRecipientPerStep } from '../../../utility/notificationTimeline.utility';
 import { getTimelineItemPresentation } from './notificationTimelineStatus.config';
 
 export type TimelineItem = {
@@ -16,7 +13,6 @@ export type TimelineItem = {
   label: string;
   description: string;
   allEvents: Array<NotificationTimelineEvent>;
-  hasGroupedEvents: boolean;
   recipientPerStep: Array<NotificationDetailRecipient | undefined>;
 } & ReturnType<typeof getTimelineItemPresentation>;
 
@@ -44,7 +40,6 @@ export const getTimelineItems = (
       label,
       description,
       allEvents: legacyStatus.steps,
-      hasGroupedEvents: status.steps.some(isTimelineGroupStep),
       recipientPerStep:
         isMultiRecipient && isSenderTimeline ? getRecipientPerStep(status.steps, recipients) : [],
       ...getTimelineItemPresentation(status.status, index === 0),


### PR DESCRIPTION
## Short description

Always show event descriptions when status differs from DELIVERING

## List of changes proposed in this pull request
- Remove hasGroupedEvents

## How to test
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist

- [x] No real people names are present in mock data, examples, fixtures, screenshots, or sample content.
- [x] No real company names are present unless explicitly required and approved.
- [x] No real public institution names, agencies, municipalities, or other real entities are present in fake/demo/mock content.
- [x] All placeholder content, examples, mock entities, and sample data are clearly fake and unmistakably non-real.
- [x] Any potentially ambiguous name has been reviewed and flagged if needed.