### PR TITLE
chore(PN-21477): remove unused ONE_IDENTITY_CLIENT_ID config

### DIFF
--- a/packages/pn-personafisica-login/public/conf/config-dev.json
+++ b/packages/pn-personafisica-login/public/conf/config-dev.json
@@ -13,7 +13,6 @@
   "IS_SMART_APP_BANNER_ENABLED": false,
   "ACCESSIBILITY_LINK": "https://form.agid.gov.it/view/978876c0-df2d-11ef-8637-9f856ac3da10",
   "ONE_IDENTITY_LOGIN_ENABLED": true,
-  "ONE_IDENTITY_CLIENT_ID": "DFCUf4W3KHfKUl4USEVYrMgpMxvyKICHM_ZPiZ3ftm0",
   "ONE_IDENTITY_BASE_URL": "https://uat.oneid.pagopa.it",
   "SERCQ_SERVICE_STATEMENT_LINK": "https://notifichedigitali.it/assets/MO_006_Service_Practice_Statement_Pago_PA_S_p_A_v_1_6_signed_0d50fefc36.pdf",
   "DIGITAL_IDENTITY_LINK": "https://identitadigitale.gov.it/",

--- a/packages/pn-personafisica-login/src/services/configuration.service.ts
+++ b/packages/pn-personafisica-login/src/services/configuration.service.ts
@@ -16,7 +16,6 @@ export interface LoginConfiguration {
   IS_SMART_APP_BANNER_ENABLED?: boolean;
   ACCESSIBILITY_LINK: string;
   ONE_IDENTITY_LOGIN_ENABLED: boolean;
-  ONE_IDENTITY_CLIENT_ID?: string;
   ONE_IDENTITY_BASE_URL: string;
   SERCQ_SERVICE_STATEMENT_LINK: string;
   DIGITAL_IDENTITY_LINK: string;
@@ -46,14 +45,6 @@ class LoginConfigurationValidator extends Validator<LoginConfiguration> {
     this.ruleFor('IS_SMART_APP_BANNER_ENABLED').isBoolean();
     this.ruleFor('ACCESSIBILITY_LINK').isString().isRequired();
     this.ruleFor('ONE_IDENTITY_LOGIN_ENABLED').isBoolean();
-    this.ruleFor('ONE_IDENTITY_CLIENT_ID')
-      .isString()
-      .customValidator((value, model) => {
-        if (model.ONE_IDENTITY_LOGIN_ENABLED && !value) {
-          return 'ONE_IDENTITY_CLIENT_ID is required when ONE_IDENTITY_LOGIN_ENABLED is true';
-        }
-        return null;
-      });
     this.ruleFor('ONE_IDENTITY_BASE_URL').isString().isRequired().matches(dataRegex.htmlPageUrl);
     this.ruleFor('SERCQ_SERVICE_STATEMENT_LINK')
       .isString()

--- a/packages/pn-personafisica-login/src/setupTests.tsx
+++ b/packages/pn-personafisica-login/src/setupTests.tsx
@@ -39,7 +39,6 @@ beforeAll(async () => {
     IS_SMART_APP_BANNER_ENABLED: true,
     ACCESSIBILITY_LINK: 'https://accessibility-link.it',
     ONE_IDENTITY_LOGIN_ENABLED: true,
-    ONE_IDENTITY_CLIENT_ID: 'DFCUf4W3KHfKUl4USEVYrMgpMxvyKICHM_ZPiZ3ftm0',
     ONE_IDENTITY_BASE_URL: 'https://uat.oneid.pagopa.it',
     SERCQ_SERVICE_STATEMENT_LINK: 'https://fake.sercq-service-statement.pagopa.it',
     DIGITAL_IDENTITY_LINK: 'https://identitadigitale.gov.it/',


### PR DESCRIPTION
## Short description

Removes the `ONE_IDENTITY_CLIENT_ID` configuration key from `pn-personafisica-login`. The frontend never reads this value: the OneIdentity authorization URL is built server side, and `/oidc/authorize` already returns the full `location` with the client id in it, taken from the AWS secret.

## List of changes proposed in this pull request

## Checklist

- [x] No real people names are present in mock data, examples, fixtures, screenshots, or sample content.
- [x] No real company names are present unless explicitly required and approved.
- [x] No real public institution names, agencies, municipalities, or other real entities are present in fake/demo/mock content.
- [x] All placeholder content, examples, mock entities, and sample data are clearly fake and unmistakably non-real.
- [x] Any potentially ambiguous name has been reviewed and flagged if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
